### PR TITLE
refactor(filevalidator): Extract hash file path generation logic

### DIFF
--- a/internal/filevalidator/validator_test.go
+++ b/internal/filevalidator/validator_test.go
@@ -265,7 +265,6 @@ func TestValidator_Verify_Symlink(t *testing.T) {
 type testValidator struct {
 	*Validator
 	hashDir string
-	t       *testing.T // Add testing.T for logging
 }
 
 // GetHashFilePath overrides the original method to always return the same hash file path for testing.


### PR DESCRIPTION
- Introduced HashFilePathGetter interface for flexible hash file path generation
- Moved hash file path generation logic to ProductionHashFilePathGetter
- Made validatePath a package-level function for broader use
- Simplified test code by removing testValidator wrapper
- Added GetHashAlgorithm and GetHashDir getters for better testability
- Improved error handling and code organization

This refactoring improves testability and separation of concerns by:
1. Making the hash file path generation strategy configurable
2. Reducing test boilerplate
3. Making the code more maintainable and easier to test