### PR TITLE
refactor: remove unused EnvironmentManager

### DIFF
--- a/internal/runner/executor/executor.go
+++ b/internal/runner/executor/executor.go
@@ -27,7 +27,6 @@ var (
 type DefaultExecutor struct {
 	FS  FileSystem
 	Out OutputWriter
-	Env EnvironmentManager
 }
 
 // NewDefaultExecutor creates a new default command executor
@@ -35,7 +34,6 @@ func NewDefaultExecutor() CommandExecutor {
 	return &DefaultExecutor{
 		FS:  &osFileSystem{},
 		Out: &consoleOutputWriter{},
-		Env: &envManager{},
 	}
 }
 
@@ -214,27 +212,4 @@ func (w *outputWrapper) GetBuffer() []byte {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	return w.buffer.Bytes()
-}
-
-// envManager implements EnvironmentManager
-type envManager struct{}
-
-func (m *envManager) LoadFromFile(_ string) (map[string]string, error) {
-	// TODO: Implement environment variable loading from file
-	return map[string]string{}, nil
-}
-
-func (m *envManager) Merge(envs ...map[string]string) map[string]string {
-	result := make(map[string]string)
-	for _, env := range envs {
-		for k, v := range env {
-			result[k] = v
-		}
-	}
-	return result
-}
-
-func (m *envManager) Resolve(s string, _ map[string]string) (string, error) {
-	// TODO: Implement environment variable resolution
-	return s, nil
 }

--- a/internal/runner/executor/executor_test.go
+++ b/internal/runner/executor/executor_test.go
@@ -50,31 +50,6 @@ func (m *mockOutputWriter) Close() error {
 	return nil
 }
 
-type mockEnvManager struct{}
-
-func (m *mockEnvManager) LoadFromFile(_ string) (map[string]string, error) {
-	return map[string]string{"FROM_FILE": "value"}, nil
-}
-
-func (m *mockEnvManager) Merge(envs ...map[string]string) map[string]string {
-	result := make(map[string]string)
-	for _, env := range envs {
-		for k, v := range env {
-			result[k] = v
-		}
-	}
-	return result
-}
-
-func (m *mockEnvManager) Resolve(s string, _ map[string]string) (string, error) {
-	return s, nil
-}
-
-func TestNewDefaultExecutor(t *testing.T) {
-	exec := executor.NewDefaultExecutor()
-	assert.NotNil(t, exec, "NewDefaultExecutor should return a non-nil executor")
-}
-
 func TestExecute_Success(t *testing.T) {
 	tests := []struct {
 		name             string
@@ -140,7 +115,6 @@ func TestExecute_Success(t *testing.T) {
 			e := &executor.DefaultExecutor{
 				FS:  fileSystem,
 				Out: outputWriter,
-				Env: &mockEnvManager{},
 			}
 
 			result, err := e.Execute(context.Background(), tt.cmd, tt.env)
@@ -231,7 +205,6 @@ func TestExecute_Failure(t *testing.T) {
 			e := &executor.DefaultExecutor{
 				FS:  fileSystem,
 				Out: outputWriter,
-				Env: &mockEnvManager{},
 			}
 
 			ctx := context.Background()
@@ -269,7 +242,6 @@ func TestExecute_ContextCancellation(t *testing.T) {
 	e := &executor.DefaultExecutor{
 		FS:  fileSystem,
 		Out: &mockOutputWriter{},
-		Env: &mockEnvManager{},
 	}
 
 	// Create a context that we'll cancel
@@ -338,7 +310,6 @@ func TestValidate(t *testing.T) {
 			e := &executor.DefaultExecutor{
 				FS:  fileSystem,
 				Out: &mockOutputWriter{},
-				Env: &mockEnvManager{},
 			}
 
 			err := e.Validate(tt.cmd)

--- a/internal/runner/executor/interface.go
+++ b/internal/runner/executor/interface.go
@@ -49,15 +49,3 @@ type FileSystem interface {
 	// FileExists checks if a file exists
 	FileExists(path string) (bool, error)
 }
-
-// EnvironmentManager handles environment variable operations
-type EnvironmentManager interface {
-	// LoadFromFile loads environment variables from a file
-	LoadFromFile(path string) (map[string]string, error)
-
-	// Merge merges multiple environment variable maps
-	Merge(envs ...map[string]string) map[string]string
-
-	// Resolve resolves environment variable references in a string
-	Resolve(s string, env map[string]string) (string, error)
-}


### PR DESCRIPTION
This pull request removes the `EnvironmentManager` interface and its associated implementations, simplifying the `DefaultExecutor` class and its tests. The changes focus on eliminating unused code and streamlining the executor's functionality.

### Removal of `EnvironmentManager` Interface and Related Code:

* [`internal/runner/executor/executor.go`](diffhunk://#diff-3f391f7ebb7c3fe2bd0c385f2140366acc9a67b7f8504f87d41d1f3a38e07980L30-L38): Removed the `Env` field from the `DefaultExecutor` struct and the `envManager` implementation, including methods for loading, merging, and resolving environment variables. [[1]](diffhunk://#diff-3f391f7ebb7c3fe2bd0c385f2140366acc9a67b7f8504f87d41d1f3a38e07980L30-L38) [[2]](diffhunk://#diff-3f391f7ebb7c3fe2bd0c385f2140366acc9a67b7f8504f87d41d1f3a38e07980L218-L240)

* [`internal/runner/executor/interface.go`](diffhunk://#diff-6dec7bdb17257f594acc38adc68eae3f8ddc6890ed4563d5ef3ba6342ee604d9L52-L63): Deleted the `EnvironmentManager` interface definition, as it is no longer needed.

### Simplification of Tests:

* [`internal/runner/executor/executor_test.go`](diffhunk://#diff-30f1c0669a34484661be4df4c0967c7d743b92669630bd600705973710fc581cL53-L77): Removed the `mockEnvManager` implementation and updated test cases (`TestExecute_Success`, `TestExecute_Failure`, `TestExecute_ContextCancellation`, and `TestValidate`) to exclude the `Env` field from the `DefaultExecutor` setup. Additionally, deleted the `TestNewDefaultExecutor` test, which validated the creation of the executor with the removed `Env` field. [[1]](diffhunk://#diff-30f1c0669a34484661be4df4c0967c7d743b92669630bd600705973710fc581cL53-L77) [[2]](diffhunk://#diff-30f1c0669a34484661be4df4c0967c7d743b92669630bd600705973710fc581cL143) [[3]](diffhunk://#diff-30f1c0669a34484661be4df4c0967c7d743b92669630bd600705973710fc581cL234) [[4]](diffhunk://#diff-30f1c0669a34484661be4df4c0967c7d743b92669630bd600705973710fc581cL272) [[5]](diffhunk://#diff-30f1c0669a34484661be4df4c0967c7d743b92669630bd600705973710fc581cL341)