### PR TITLE
Clean up the environment variable filtering system

### DIFF
--- a/internal/runner/environment/filter.go
+++ b/internal/runner/environment/filter.go
@@ -84,7 +84,7 @@ func (f *Filter) parseSystemEnvironment(predicate func(string) bool) map[string]
 // Note: No validation is performed on system environment variables as they are considered
 // trusted sources controlled by the execution environment. Only allowlist filtering is applied
 // for performance and security design reasons.
-func (f *Filter) FilterSystemEnvironment() (map[string]string, error) {
+func (f *Filter) FilterSystemEnvironment() map[string]string {
 	result := f.parseSystemEnvironment(func(variable string) bool {
 		return f.globalAllowlist[variable]
 	})
@@ -94,7 +94,7 @@ func (f *Filter) FilterSystemEnvironment() (map[string]string, error) {
 		"filtered_vars", len(result),
 		"allowlistSize", len(f.globalAllowlist))
 
-	return result, nil
+	return result
 }
 
 // FilterEnvFileVariables filters environment variables from .env file based on allowlist

--- a/internal/runner/environment/filter_test.go
+++ b/internal/runner/environment/filter_test.go
@@ -454,11 +454,7 @@ func TestFilterSystemEnvironment(t *testing.T) {
 				},
 			}
 			filter := NewFilter(config)
-			result, err := filter.FilterSystemEnvironment()
-			if err != nil {
-				t.Errorf("FilterSystemEnvironment() error = %v", err)
-				return
-			}
+			result := filter.FilterSystemEnvironment()
 
 			// Check expected variables are present
 			for _, expectedVar := range tt.expectedVars {
@@ -544,11 +540,7 @@ func TestFilterSystemEnvironmentSkipsValidation(t *testing.T) {
 			filter := NewFilter(config)
 
 			// Execute FilterSystemEnvironment
-			result, err := filter.FilterSystemEnvironment()
-			if err != nil {
-				t.Errorf("FilterSystemEnvironment() should not return error for dangerous patterns, got: %v", err)
-				return
-			}
+			result := filter.FilterSystemEnvironment()
 
 			// Verify expected variables are present with their dangerous values intact
 			for _, expectedVar := range tt.expectedVars {
@@ -601,10 +593,7 @@ func TestFilterSystemEnvironmentVsEnvFileValidationDifference(t *testing.T) {
 	filter := NewFilter(config)
 
 	// Test 1: FilterSystemEnvironment should allow dangerous value through allowlist
-	systemResult, err := filter.FilterSystemEnvironment()
-	if err != nil {
-		t.Errorf("FilterSystemEnvironment() should not validate dangerous patterns, got error: %v", err)
-	}
+	systemResult := filter.FilterSystemEnvironment()
 	if value, exists := systemResult[varName]; !exists {
 		t.Error("System environment variable with dangerous pattern should be allowed through allowlist")
 	} else if value != dangerousValue {
@@ -616,7 +605,7 @@ func TestFilterSystemEnvironmentVsEnvFileValidationDifference(t *testing.T) {
 		varName: dangerousValue,
 	}
 
-	_, err = filter.FilterEnvFileVariables(envFileVars, []string{varName})
+	_, err := filter.FilterEnvFileVariables(envFileVars, []string{varName})
 	if err == nil {
 		t.Error("FilterEnvFileVariables() should reject dangerous patterns and return error")
 	}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -175,10 +175,7 @@ func (r *Runner) LoadEnvironment(envFile string, loadSystemEnv bool) error {
 
 	// Load and filter system environment variables if requested
 	if loadSystemEnv {
-		filteredSystemEnv, err := r.envFilter.FilterSystemEnvironment()
-		if err != nil {
-			return fmt.Errorf("failed to filter system environment variables: %w", err)
-		}
+		filteredSystemEnv := r.envFilter.FilterSystemEnvironment()
 		maps.Copy(envMap, filteredSystemEnv)
 	}
 


### PR DESCRIPTION
This pull request refactors the environment variable filtering system in the `internal/runner/environment` package and updates related tests and usage in the `runner` package. The changes focus on simplifying the filtering logic, improving the security model, and enhancing test coverage. Key highlights include replacing group-specific allowlist filtering with a global-only approach for system environment variables, introducing a reusable parsing function, and clarifying the security model in comments.

### Refactoring and Simplification:
* Replaced the `FilterSystemEnvironment` method with a global-only allowlist approach, removing group-specific filtering logic. Introduced a new `parseSystemEnvironment` helper function to handle common parsing logic. (`internal/runner/environment/filter.go`, [internal/runner/environment/filter.goL64-R102](diffhunk://#diff-69da7e416757ad3c1fbacd8a51a5e67192e0ffda2a3696cdc408a4902b1624caL64-R102))
* Removed the `logDeniedEnvironmentVariableAccess` function and inlined its logic into `resolveEnvironmentVars`, simplifying the code. (`internal/runner/runner.go`, [internal/runner/runner.goL423-L435](diffhunk://#diff-ddc7e46dbd3f77cb194815142eb06ccf62e24963d16039f1ff41266e4ec3d7a6L423-L435))
* Updated `resolveVariableReferencesWithDepth` to remove redundant group checks and simplify error handling. (`internal/runner/runner.go`, [internal/runner/runner.goL478-R450](diffhunk://#diff-ddc7e46dbd3f77cb194815142eb06ccf62e24963d16039f1ff41266e4ec3d7a6L478-R450))

### Security Model Enhancements:
* Clarified the security model in comments: system environment variables are trusted and only filtered by the allowlist, while `.env` file variables undergo full validation. (`internal/runner/environment/filter.go`, [[1]](diffhunk://#diff-69da7e416757ad3c1fbacd8a51a5e67192e0ffda2a3696cdc408a4902b1624caR146-R162) [[2]](diffhunk://#diff-69da7e416757ad3c1fbacd8a51a5e67192e0ffda2a3696cdc408a4902b1624caR171)
* Added a new test, `TestFilterSystemEnvironmentSkipsValidation`, to ensure that system environment variables bypass validation and rely solely on the allowlist. (`internal/runner/environment/filter_test.go`, [internal/runner/environment/filter_test.goR412-R625](diffhunk://#diff-6e622a157cd1eb97a1502a3172439cb783f90e59af86ad63cfd04c4873bac0a4R412-R625))

### Test Suite Updates:
* Removed redundant tests for group-specific allowlist filtering in `FilterSystemEnvironment` and replaced them with new tests for the updated global-only filtering logic. (`internal/runner/environment/filter_test.go`, [[1]](diffhunk://#diff-6e622a157cd1eb97a1502a3172439cb783f90e59af86ad63cfd04c4873bac0a4L22-L146) [[2]](diffhunk://#diff-6e622a157cd1eb97a1502a3172439cb783f90e59af86ad63cfd04c4873bac0a4L268-L309)
* Added tests to demonstrate the difference between system environment variable filtering and `.env` file variable validation. (`internal/runner/environment/filter_test.go`, [internal/runner/environment/filter_test.goR412-R625](diffhunk://#diff-6e622a157cd1eb97a1502a3172439cb783f90e59af86ad63cfd04c4873bac0a4R412-R625))

### Codebase Cleanup:
* Removed the unused `maps` import and other redundant code in `filter.go`. (`internal/runner/environment/filter.go`, [internal/runner/environment/filter.goL9](diffhunk://#diff-69da7e416757ad3c1fbacd8a51a5e67192e0ffda2a3696cdc408a4902b1624caL9))
* Streamlined the `resolveEnvironmentVars` method by removing unnecessary branches and consolidating logic. (`internal/runner/runner.go`, [internal/runner/runner.goL379-L398](diffhunk://#diff-ddc7e46dbd3f77cb194815142eb06ccf62e24963d16039f1ff41266e4ec3d7a6L379-L398))

These changes improve maintainability, enhance security, and ensure better test coverage for the environment variable filtering system.