### PR TITLE
refactor: simplify runner interface and cleanup handling

### DIFF
--- a/cmd/runner/main.go
+++ b/cmd/runner/main.go
@@ -135,9 +135,9 @@ func run() error {
 		return nil
 	}
 
-	// Ensure cleanup of resources on exit
+	// Ensure cleanup of all resources on exit (both auto-cleanup and manual cleanup resources)
 	defer func() {
-		if err := runner.CleanupAutoCleanupResources(); err != nil {
+		if err := runner.CleanupAllResources(); err != nil {
 			log.Printf("Warning: Failed to cleanup resources: %v", err)
 		}
 	}()

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -500,27 +500,7 @@ func (r *Runner) GetConfig() *runnertypes.Config {
 	return r.config
 }
 
-// GetSanitizedEnvironmentVars returns environment variables with sensitive values redacted
-func (r *Runner) GetSanitizedEnvironmentVars() map[string]string {
-	return r.validator.SanitizeEnvironmentVariables(r.envVars)
-}
-
-// GetTemplateEngine returns the template engine instance
-func (r *Runner) GetTemplateEngine() *template.Engine {
-	return r.templateEngine
-}
-
-// GetResourceManager returns the resource manager instance
-func (r *Runner) GetResourceManager() *resource.Manager {
-	return r.resourceManager
-}
-
 // CleanupAllResources cleans up all managed resources
 func (r *Runner) CleanupAllResources() error {
 	return r.resourceManager.CleanupAll()
-}
-
-// CleanupAutoCleanupResources cleans up resources marked for auto cleanup
-func (r *Runner) CleanupAutoCleanupResources() error {
-	return r.resourceManager.CleanupAutoCleanup()
 }

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -688,22 +688,6 @@ func TestRunner_SecurityIntegration(t *testing.T) {
 		assert.Error(t, err)
 		assert.True(t, errors.Is(err, security.ErrUnsafeEnvironmentVar), "expected error to wrap security.ErrUnsafeEnvironmentVar")
 	})
-
-	t.Run("environment variable sanitization", func(t *testing.T) {
-		runner, err := NewRunner(config)
-		require.NoError(t, err)
-		runner.envVars = map[string]string{
-			"PATH":        "/usr/bin:/bin",
-			"API_KEY":     "secret123",
-			"DB_PASSWORD": "password456",
-		}
-
-		sanitized := runner.GetSanitizedEnvironmentVars()
-
-		assert.Equal(t, "/usr/bin:/bin", sanitized["PATH"])
-		assert.Equal(t, "[REDACTED]", sanitized["API_KEY"])
-		assert.Equal(t, "[REDACTED]", sanitized["DB_PASSWORD"])
-	})
 }
 
 func TestRunner_LoadEnvironmentWithSecurity(t *testing.T) {


### PR DESCRIPTION
This pull request refactors the `Runner` component by simplifying resource cleanup and removing unused methods related to environment variable sanitization, template engine access, and resource management. It also updates associated tests to reflect these changes.

### Resource cleanup improvements:
* Updated the `run` function in `cmd/runner/main.go` to consolidate resource cleanup into a single method, `CleanupAllResources`, replacing the previous `CleanupAutoCleanupResources` method. This ensures both auto-cleanup and manual cleanup resources are handled.

### Codebase simplification:
* Removed unused methods from `Runner` in `internal/runner/runner.go`, including `GetSanitizedEnvironmentVars`, `GetTemplateEngine`, `GetResourceManager`, and `CleanupAutoCleanupResources`. These methods were deemed unnecessary and have been removed to simplify the codebase.

### Test updates:
* Removed the test case for environment variable sanitization from `TestRunner_SecurityIntegration` in `internal/runner/runner_test.go`, as the related functionality has been removed.