### PR TITLE
fix: refine integration test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ GO_SOURCES := $(shell find . -type f -name '*.go' -not -name '*_test.go')
 
 HASH_TARGETS := \
 	/etc/passwd \
+	/bin/ls \
 	/bin/sleep \
 	/bin/mkdir \
 	/bin/touch \
@@ -37,8 +38,6 @@ HASH_TARGETS := \
 	/bin/pwd \
 	/bin/printenv \
 	/usr/bin/whoami \
-	./sample/test.toml \
-	./sample/config.toml \
 	./sample/comprehensive.toml
 
 .PHONY: all lint build run clean test hash integration-test

--- a/sample/comprehensive.toml
+++ b/sample/comprehensive.toml
@@ -19,6 +19,7 @@ env_allowlist = [
     "COMPREHENSIVE_TEST",
     "NODE_ENV",
     "DEBUG_MODE",
+    "GOTRACEBACK",
 ]
 verify_files = ["/etc/passwd", "/bin/sh"]
 


### PR DESCRIPTION
- remove non-existent file from hash target
- add GOTRACEBACK environment variable to global allow list