### PR TITLE
test: skip hash verification for standard files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,17 +27,6 @@ GO_SOURCES := $(shell find . -type f -name '*.go' -not -name '*_test.go')
 
 HASH_TARGETS := \
 	/etc/passwd \
-	/bin/ls \
-	/bin/sleep \
-	/bin/mkdir \
-	/bin/touch \
-	/bin/id \
-	/bin/sh \
-	/bin/echo \
-	/bin/env \
-	/bin/pwd \
-	/bin/printenv \
-	/usr/bin/whoami \
 	./sample/comprehensive.toml
 
 .PHONY: all lint build run clean test hash integration-test

--- a/sample/comprehensive.toml
+++ b/sample/comprehensive.toml
@@ -6,7 +6,7 @@ version = "1.0"
 timeout = 60
 workdir = "/tmp/cmd-runner-comprehensive"
 log_level = "debug"
-skip_standard_paths = false
+skip_standard_paths = true
 # Global environment variables - comprehensive list for testing
 env_allowlist = [
     "PATH",


### PR DESCRIPTION
This pull request makes targeted adjustments to both the `Makefile` and the `sample/comprehensive.toml` configuration file, primarily to streamline the hash target list and update the test configuration for standard paths. The changes simplify the build process and modify the behavior of comprehensive tests.

Makefile simplification:

* Removed multiple standard system binaries from the `HASH_TARGETS` list in the `Makefile`, leaving only `/etc/passwd` and `./sample/comprehensive.toml` as hash targets. This reduces the scope of files being hashed during builds.

Test configuration update:

* Changed the `skip_standard_paths` setting in `sample/comprehensive.toml` from `false` to `true`, ensuring that standard system paths are skipped during comprehensive testing.