### PR TITLE
Refactor: Unify RiskLevel type across modules

### DIFF
--- a/internal/runner/resource/dryrun_manager.go
+++ b/internal/runner/resource/dryrun_manager.go
@@ -195,7 +195,7 @@ func (d *DryRunResourceManager) analyzeCommandSecurity(cmd runnertypes.Command, 
 	if err != nil {
 		return fmt.Errorf("security analysis failed for command '%s': %w", cmd.Cmd, err)
 	}
-	if riskLevel != security.RiskLevelNone {
+	if riskLevel != runnertypes.RiskLevelUnknown {
 		analysis.Impact.SecurityRisk = riskLevel.String()
 		analysis.Impact.Description += fmt.Sprintf(" [WARNING: %s - %s]", reason, pattern)
 	}

--- a/internal/runner/resource/formatter.go
+++ b/internal/runner/resource/formatter.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/isseis/go-safe-cmd-runner/internal/redaction"
+	"github.com/isseis/go-safe-cmd-runner/internal/runner/runnertypes"
 )
 
 // Global sensitive patterns instance for reuse
@@ -103,7 +104,7 @@ func (f *TextFormatter) writeSummary(buf *strings.Builder, result *DryRunResult)
 
 	// Security summary
 	if result.SecurityAnalysis != nil {
-		riskCounts := make(map[RiskLevel]int)
+		riskCounts := make(map[runnertypes.RiskLevel]int)
 		for _, risk := range result.SecurityAnalysis.Risks {
 			riskCounts[risk.Level]++
 		}

--- a/internal/runner/resource/security_test.go
+++ b/internal/runner/resource/security_test.go
@@ -226,7 +226,7 @@ func TestCommandSecurityAnalysis(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify direct security analysis works
-	assert.Equal(t, security.RiskLevelHigh, riskLevel, "should detect high risk for rm -rf")
+	assert.Equal(t, runnertypes.RiskLevelHigh, riskLevel, "should detect high risk for rm -rf")
 	assert.Contains(t, pattern, "rm -rf", "should identify rm -rf pattern")
 	assert.NotEmpty(t, reason, "should provide reason for risk")
 

--- a/internal/runner/resource/types.go
+++ b/internal/runner/resource/types.go
@@ -2,6 +2,8 @@ package resource
 
 import (
 	"time"
+
+	"github.com/isseis/go-safe-cmd-runner/internal/runner/runnertypes"
 )
 
 // ResourceAnalysis captures analysis of a resource operation
@@ -184,42 +186,12 @@ type SecurityAnalysis struct {
 
 // SecurityRisk represents a security risk
 type SecurityRisk struct {
-	Level       RiskLevel `json:"level"`
-	Type        RiskType  `json:"type"`
-	Description string    `json:"description"`
-	Command     string    `json:"command"`
-	Group       string    `json:"group"`
-	Mitigation  string    `json:"mitigation"`
-}
-
-// RiskLevel represents the severity level of a security risk
-type RiskLevel int
-
-const (
-	// RiskLevelLow represents low risk
-	RiskLevelLow RiskLevel = iota
-	// RiskLevelMedium represents medium risk
-	RiskLevelMedium
-	// RiskLevelHigh represents high risk
-	RiskLevelHigh
-	// RiskLevelCritical represents critical risk
-	RiskLevelCritical
-)
-
-// String returns the string representation of RiskLevel
-func (r RiskLevel) String() string {
-	switch r {
-	case RiskLevelLow:
-		return "low"
-	case RiskLevelMedium:
-		return "medium"
-	case RiskLevelHigh:
-		return "high"
-	case RiskLevelCritical:
-		return "critical"
-	default:
-		return unknownString
-	}
+	Level       runnertypes.RiskLevel `json:"level"`
+	Type        RiskType              `json:"type"`
+	Description string                `json:"description"`
+	Command     string                `json:"command"`
+	Group       string                `json:"group"`
+	Mitigation  string                `json:"mitigation"`
 }
 
 // RiskType represents the type of security risk

--- a/internal/runner/resource/types_test.go
+++ b/internal/runner/resource/types_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/isseis/go-safe-cmd-runner/internal/runner/runnertypes"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -120,14 +121,14 @@ func TestDryRunOptions(t *testing.T) {
 
 func TestRiskLevelString(t *testing.T) {
 	tests := []struct {
-		level    RiskLevel
+		level    runnertypes.RiskLevel
 		expected string
 	}{
-		{RiskLevelLow, "low"},
-		{RiskLevelMedium, "medium"},
-		{RiskLevelHigh, "high"},
-		{RiskLevelCritical, "critical"},
-		{RiskLevel(999), "unknown"},
+		{runnertypes.RiskLevelLow, "low"},
+		{runnertypes.RiskLevelMedium, "medium"},
+		{runnertypes.RiskLevelHigh, "high"},
+		{runnertypes.RiskLevelCritical, "critical"},
+		{runnertypes.RiskLevel(999), "unknown"},
 	}
 
 	for _, test := range tests {

--- a/internal/runner/security/command_analysis_test.go
+++ b/internal/runner/security/command_analysis_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/isseis/go-safe-cmd-runner/internal/runner/runnertypes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -21,7 +22,7 @@ func TestAnalyzeCommandSecurity_SetuidSetgid(t *testing.T) {
 
 		risk, pattern, reason, err := AnalyzeCommandSecurity(normalExec, []string{})
 		require.NoError(t, err)
-		assert.Equal(t, RiskLevelNone, risk)
+		assert.Equal(t, runnertypes.RiskLevelUnknown, risk)
 		assert.Empty(t, pattern)
 		assert.Empty(t, reason)
 	})
@@ -43,7 +44,7 @@ func TestAnalyzeCommandSecurity_SetuidSetgid(t *testing.T) {
 
 		risk, pattern, reason, err := AnalyzeCommandSecurity(setuidExec, []string{})
 		require.NoError(t, err)
-		assert.Equal(t, RiskLevelHigh, risk)
+		assert.Equal(t, runnertypes.RiskLevelHigh, risk)
 		assert.Equal(t, setuidExec, pattern)
 		assert.Equal(t, "Executable has setuid or setgid bit set", reason)
 	})
@@ -65,7 +66,7 @@ func TestAnalyzeCommandSecurity_SetuidSetgid(t *testing.T) {
 
 		risk, pattern, reason, err := AnalyzeCommandSecurity(setgidExec, []string{})
 		require.NoError(t, err)
-		assert.Equal(t, RiskLevelHigh, risk)
+		assert.Equal(t, runnertypes.RiskLevelHigh, risk)
 		assert.Equal(t, setgidExec, pattern)
 		assert.Equal(t, "Executable has setuid or setgid bit set", reason)
 	})
@@ -88,7 +89,7 @@ func TestAnalyzeCommandSecurity_SetuidSetgid(t *testing.T) {
 
 		risk, pattern, reason, err := AnalyzeCommandSecurity(setuidSetgidExec, []string{})
 		require.NoError(t, err)
-		assert.Equal(t, RiskLevelHigh, risk)
+		assert.Equal(t, runnertypes.RiskLevelHigh, risk)
 		assert.Equal(t, setuidSetgidExec, pattern)
 		assert.Equal(t, "Executable has setuid or setgid bit set", reason)
 	})
@@ -113,7 +114,7 @@ func TestAnalyzeCommandSecurity_SetuidSetgid(t *testing.T) {
 		// because the security risk comes from the setuid bit itself
 		risk, pattern, reason, err := AnalyzeCommandSecurity(nonExecFile, []string{})
 		require.NoError(t, err)
-		assert.Equal(t, RiskLevelHigh, risk)
+		assert.Equal(t, runnertypes.RiskLevelHigh, risk)
 		assert.Equal(t, nonExecFile, pattern)
 		assert.Equal(t, "Executable has setuid or setgid bit set", reason)
 	})
@@ -138,7 +139,7 @@ func TestAnalyzeCommandSecurity_SetuidSetgid(t *testing.T) {
 		// because hasSetuidOrSetgidBit only checks regular files
 		risk, pattern, reason, err := AnalyzeCommandSecurity(setgidDir, []string{})
 		require.NoError(t, err)
-		assert.Equal(t, RiskLevelNone, risk)
+		assert.Equal(t, runnertypes.RiskLevelUnknown, risk)
 		assert.Empty(t, pattern)
 		assert.Empty(t, reason)
 	})
@@ -150,7 +151,7 @@ func TestAnalyzeCommandSecurity_SetuidSetgid(t *testing.T) {
 		risk, pattern, reason, err := AnalyzeCommandSecurity(nonExistentFile, []string{})
 		require.NoError(t, err)
 		// After the fix, stat errors are treated as high risk
-		assert.Equal(t, RiskLevelHigh, risk)
+		assert.Equal(t, runnertypes.RiskLevelHigh, risk)
 		assert.Equal(t, nonExistentFile, pattern)
 		assert.Contains(t, reason, "Unable to check setuid/setgid status")
 	})
@@ -168,7 +169,7 @@ func TestAnalyzeCommandSecurity_SetuidSetgid(t *testing.T) {
 		if fileInfo, err := os.Stat(passwdPath); err == nil && fileInfo.Mode()&os.ModeSetuid != 0 {
 			risk, pattern, reason, err := AnalyzeCommandSecurity(passwdPath, []string{})
 			require.NoError(t, err)
-			assert.Equal(t, RiskLevelHigh, risk)
+			assert.Equal(t, runnertypes.RiskLevelHigh, risk)
 			assert.Equal(t, passwdPath, pattern)
 			assert.Equal(t, "Executable has setuid or setgid bit set", reason)
 		} else {
@@ -197,7 +198,7 @@ func TestAnalyzeCommandSecurity_SetuidSetgid(t *testing.T) {
 		require.NoError(t, err)
 
 		// Should be classified as high risk due to setuid bit, not medium risk due to pattern
-		assert.Equal(t, RiskLevelHigh, risk)
+		assert.Equal(t, runnertypes.RiskLevelHigh, risk)
 		assert.Equal(t, setuidExec, pattern)
 		assert.Equal(t, "Executable has setuid or setgid bit set", reason)
 
@@ -208,7 +209,7 @@ func TestAnalyzeCommandSecurity_SetuidSetgid(t *testing.T) {
 
 		riskNormal, patternNormal, reasonNormal, errNormal := AnalyzeCommandSecurity(normalExec, []string{"777"})
 		require.NoError(t, errNormal)
-		assert.Equal(t, RiskLevelMedium, riskNormal)
+		assert.Equal(t, runnertypes.RiskLevelMedium, riskNormal)
 		assert.Equal(t, "chmod 777", patternNormal)
 		assert.Equal(t, "Overly permissive file permissions", reasonNormal)
 	})
@@ -226,7 +227,7 @@ func TestAnalyzeCommandSecurity_SetuidSetgid(t *testing.T) {
 		// Analyze the non-existent file - should be treated as high risk due to stat error
 		risk, pattern, reason, err := AnalyzeCommandSecurity(tempFile, []string{})
 		require.NoError(t, err)
-		assert.Equal(t, RiskLevelHigh, risk)
+		assert.Equal(t, runnertypes.RiskLevelHigh, risk)
 		assert.Equal(t, tempFile, pattern)
 		assert.Contains(t, reason, "Unable to check setuid/setgid status")
 	})

--- a/internal/runner/security/security_test.go
+++ b/internal/runner/security/security_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/isseis/go-safe-cmd-runner/internal/common"
+	"github.com/isseis/go-safe-cmd-runner/internal/runner/runnertypes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -1043,7 +1044,7 @@ func TestAnalyzeCommandSecurityWithDeepSymlinks(t *testing.T) {
 		echoPath := "/bin/echo"
 		risk, pattern, reason, err := AnalyzeCommandSecurity(echoPath, []string{"hello"})
 		require.NoError(t, err)
-		assert.Equal(t, RiskLevelNone, risk)
+		assert.Equal(t, runnertypes.RiskLevelUnknown, risk)
 		assert.Empty(t, pattern)
 		assert.Empty(t, reason)
 	})
@@ -1052,7 +1053,7 @@ func TestAnalyzeCommandSecurityWithDeepSymlinks(t *testing.T) {
 		rmPath := "/bin/rm"
 		risk, pattern, reason, err := AnalyzeCommandSecurity(rmPath, []string{"-rf", "/"})
 		require.NoError(t, err)
-		assert.Equal(t, RiskLevelHigh, risk)
+		assert.Equal(t, runnertypes.RiskLevelHigh, risk)
 		assert.Equal(t, "rm -rf", pattern)
 		assert.Equal(t, "Recursive file removal", reason)
 	})
@@ -1075,7 +1076,7 @@ func TestAnalyzeCommandSecuritySetuidSetgid(t *testing.T) {
 
 		risk, pattern, reason, err := AnalyzeCommandSecurity(normalExec, []string{})
 		require.NoError(t, err)
-		assert.Equal(t, RiskLevelNone, risk)
+		assert.Equal(t, runnertypes.RiskLevelUnknown, risk)
 		assert.Empty(t, pattern)
 		assert.Empty(t, reason)
 	})
@@ -1086,7 +1087,7 @@ func TestAnalyzeCommandSecuritySetuidSetgid(t *testing.T) {
 		if fileInfo, err := os.Stat(passwdPath); err == nil && fileInfo.Mode()&os.ModeSetuid != 0 {
 			risk, pattern, reason, err := AnalyzeCommandSecurity(passwdPath, []string{})
 			require.NoError(t, err)
-			assert.Equal(t, RiskLevelHigh, risk)
+			assert.Equal(t, runnertypes.RiskLevelHigh, risk)
 			assert.Equal(t, passwdPath, pattern)
 			assert.Equal(t, "Executable has setuid or setgid bit set", reason)
 		} else {
@@ -1099,7 +1100,7 @@ func TestAnalyzeCommandSecuritySetuidSetgid(t *testing.T) {
 		risk, pattern, reason, err := AnalyzeCommandSecurity("/non/existent/file", []string{})
 		require.NoError(t, err)
 		// After the fix, stat errors are treated as high risk
-		assert.Equal(t, RiskLevelHigh, risk)
+		assert.Equal(t, runnertypes.RiskLevelHigh, risk)
 		assert.Equal(t, "/non/existent/file", pattern)
 		assert.Contains(t, reason, "Unable to check setuid/setgid status")
 	})

--- a/internal/runner/security/types.go
+++ b/internal/runner/security/types.go
@@ -6,6 +6,8 @@ package security
 import (
 	"errors"
 	"os"
+
+	"github.com/isseis/go-safe-cmd-runner/internal/runner/runnertypes"
 )
 
 // Error definitions
@@ -129,39 +131,10 @@ type Config struct {
 	LoggingOptions LoggingOptions
 }
 
-// RiskLevel represents the security risk level of a command pattern
-type RiskLevel string
-
-const (
-	// RiskLevelNone indicates no security risk
-	RiskLevelNone RiskLevel = ""
-	// RiskLevelLow indicates low security risk
-	RiskLevelLow RiskLevel = "low"
-	// RiskLevelMedium indicates medium security risk
-	RiskLevelMedium RiskLevel = "medium"
-	// RiskLevelHigh indicates high security risk
-	RiskLevelHigh RiskLevel = "high"
-)
-
-// String returns the string representation of the risk level
-func (r RiskLevel) String() string {
-	return string(r)
-}
-
-// IsValid checks if the risk level is valid
-func (r RiskLevel) IsValid() bool {
-	switch r {
-	case RiskLevelNone, RiskLevelLow, RiskLevelMedium, RiskLevelHigh:
-		return true
-	default:
-		return false
-	}
-}
-
 // DangerousCommandPattern represents a dangerous command pattern with its risk level
 type DangerousCommandPattern struct {
 	Pattern   []string // Full command pattern including command name and arguments
-	RiskLevel RiskLevel
+	RiskLevel runnertypes.RiskLevel
 	Reason    string
 }
 


### PR DESCRIPTION
- Replaced local RiskLevel definitions with runnertypes.RiskLevel.
- Updated all references and tests to use the unified type.
- Removed redundant RiskLevel definitions in `resource` and `security` packages.