### PR TITLE
doc: Update risk classifications in documents to reflect the current …

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -197,11 +197,11 @@ max_risk_level = "low"
 # 空のenv_allowlistのため環境変数は利用不可
 
 [[groups.commands]]
-name = "system_maintenance"
+name = "package_update"
 cmd = "/usr/bin/apt"
 args = ["update"]
-# システムコマンドは通常高リスク
-max_risk_level = "high"
+# パッケージ管理操作は中リスク
+max_risk_level = "medium"
 # 必要時に昇格された権限で実行
 run_as_user = "root"
 ```
@@ -222,8 +222,8 @@ run_as_user = "root"
 3. **自動ブロック**: リスク閾値を超えるコマンドは自動的にブロック
 4. **リスクカテゴリ**:
    - **低リスク**: 基本ファイル操作（ls、cat、grep）
-   - **中リスク**: ファイル変更（cp、mv、chmod）
-   - **高リスク**: システム管理（mount、systemctl、apt）
+   - **中リスク**: ファイル変更（cp、mv、chmod）、パッケージ管理（apt、yum）
+   - **高リスク**: システム管理（mount、systemctl）、破壊的操作（rm -rf）
    - **クリティカルリスク**: 特権昇格コマンド（sudo、su）- 常にブロック
 
 ### ユーザーとグループ実行

--- a/README.md
+++ b/README.md
@@ -197,11 +197,11 @@ max_risk_level = "low"
 # No environment variables available due to empty env_allowlist
 
 [[groups.commands]]
-name = "system_maintenance"
+name = "package_update"
 cmd = "/usr/bin/apt"
 args = ["update"]
-# System commands are typically high-risk
-max_risk_level = "high"
+# Package management operations are medium-risk
+max_risk_level = "medium"
 # Execute with elevated privileges when needed
 run_as_user = "root"
 ```
@@ -222,8 +222,8 @@ The system automatically assesses and controls command execution based on securi
 3. **Automatic Blocking**: Commands exceeding their risk threshold are automatically blocked
 4. **Risk Categories**:
    - **Low Risk**: Basic file operations (ls, cat, grep)
-   - **Medium Risk**: File modifications (cp, mv, chmod)
-   - **High Risk**: System administration (mount, systemctl, apt)
+   - **Medium Risk**: File modifications (cp, mv, chmod), package management (apt, yum)
+   - **High Risk**: System administration (mount, systemctl), destructive operations (rm -rf)
    - **Critical Risk**: Privilege escalation commands (sudo, su) - always blocked
 
 ### User and Group Execution

--- a/docs/security-architecture-ja.md
+++ b/docs/security-architecture-ja.md
@@ -342,8 +342,8 @@ type SecurityPattern struct {
 
 **コマンドリスク分析**:
 - 低リスク: 標準システムユーティリティ（ls、cat、grep）
-- 中リスク: ファイル変更コマンド（cp、mv、chmod）
-- 高リスク: システム管理コマンド（mount、systemctl）
+- 中リスク: ファイル変更コマンド（cp、mv、chmod）、パッケージ管理（apt、yum）
+- 高リスク: システム管理コマンド（mount、systemctl）、破壊的操作（rm -rf）
 - クリティカルリスク: 特権昇格コマンド（sudo、su）- 自動的にブロック
 
 **リスクレベル設定**:

--- a/docs/security-architecture.md
+++ b/docs/security-architecture.md
@@ -342,8 +342,8 @@ type SecurityPattern struct {
 
 **Command Risk Analysis**:
 - Low Risk: Standard system utilities (ls, cat, grep)
-- Medium Risk: File modification commands (cp, mv, chmod)
-- High Risk: System administration commands (mount, systemctl)
+- Medium Risk: File modification commands (cp, mv, chmod), package management (apt, yum)
+- High Risk: System administration commands (mount, systemctl), destructive operations (rm -rf)
 - Critical Risk: Privilege escalation commands (sudo, su) - automatically blocked
 
 **Risk Level Configuration**:


### PR DESCRIPTION
…implementation

- Adjusted risk level for package management commands (e.g., apt, yum) from high to medium.
- Classified destructive operations (e.g., rm -rf) as high risk.
- Updated documentation and examples in both English and Japanese to reflect these changes.