### PR TITLE
chore: minor edit on github instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,3 +1,4 @@
-コード中のコメントは英語で記述してください。/ や ` などの特殊文字の使用は認められます。
-
-ルートディレクトリにある CLAUDE.md をシステムプロンプトとして使用して下さい。
+# GitHub Copilot Instructions
+- Use CLAUDE.md in the root directory as system prompt.
+- Write comment in source code in English. Special characters such as '/', '*', and '#'  etc. are allowed.
+    - Write comments in Japanese only in code snippets appeared in *-ja.md files.


### PR DESCRIPTION
This pull request updates the Copilot instructions to clarify language requirements for code comments and the use of the system prompt file. The main changes are:

**Documentation updates:**

* Revised `.github/copilot-instructions.md` to specify that source code comments should be written in English, with exceptions for Japanese comments only in code snippets within `*-ja.md` files.
* Clarified that `CLAUDE.md` in the root directory should be used as the system prompt.