### PR TITLE
Add initial output capture types, interfaces, tests and update docs/plans

### DIFF
--- a/docs/tasks/0025_command_output/04_implementation_plan.md
+++ b/docs/tasks/0025_command_output/04_implementation_plan.md
@@ -34,43 +34,43 @@
 #### 3.1.2 実装項目
 
 **データ構造拡張**
-- [ ] `Command`構造体にoutputフィールドを追加
-- [ ] `GlobalConfig`構造体にmax_output_sizeフィールドを追加
-- [ ] TOML設定の解析機能拡張
+- [x] `Command`構造体にoutputフィールドを追加
+- [x] `GlobalConfig`構造体にmax_output_sizeフィールドを追加
+- [x] TOML設定の解析機能拡張
 
 **新規データ構造作成**
-- [ ] `OutputConfig`構造体の実装
-- [ ] `OutputCapture`構造体の実装
-- [ ] `OutputAnalysis`構造体の実装
-- [ ] `OutputCaptureError`エラー型の実装
+- [x] `Config`構造体の実装（旧`OutputConfig`、lintエラー修正）
+- [x] `Capture`構造体の実装（旧`OutputCapture`、lintエラー修正）
+- [x] `Analysis`構造体の実装（旧`OutputAnalysis`、lintエラー修正）
+- [x] `CaptureError`エラー型の実装（旧`OutputCaptureError`、lintエラー修正）
 
 **基本インターフェース定義**
-- [ ] `OutputCaptureManager`インターフェースの定義
-- [ ] `PathValidator`インターフェースの定義（簡素化版）
+- [x] `CaptureManager`インターフェースの定義（旧`OutputCaptureManager`、lintエラー修正）
+- [x] `PathValidator`インターフェースの定義（簡素化版）
 - [ ] 既存`security.Validator`の拡張（出力ファイル書き込み権限チェック機能追加）
-- [ ] `FileManager`インターフェース（safefileio活用版）の定義
+- [x] `FileManager`インターフェース（safefileio活用版）の定義
 
 #### 3.1.3 テスト作成（TDD）
 
 **単体テスト作成**
-- [ ] `internal/runner/output/types_test.go` - データ構造のテスト
-- [ ] `internal/runner/output/errors_test.go` - エラー型のテスト
-- [ ] `internal/runner/config/config_test.go` - 設定解析のテスト
+- [x] `internal/runner/output/types_test.go` - データ構造のテスト
+- [x] `internal/runner/output/errors_test.go` - エラー型のテスト
+- [x] `internal/runner/config/config_test.go` - 設定解析のテスト
 
 **テスト実行と確認**
-- [ ] テストを実行して期待通りに失敗することを確認
-- [ ] 基本構造のテストコミット
+- [x] テストを実行して期待通りに失敗することを確認
+- [x] 基本構造のテストコミット
 
 #### 3.1.4 実装
-- [ ] データ構造の実装
-- [ ] エラー型の実装
-- [ ] 設定解析機能の実装
-- [ ] 全テストが通過することを確認
+- [x] データ構造の実装
+- [x] エラー型の実装
+- [x] 設定解析機能の実装
+- [x] 全テストが通過することを確認
 
 #### 3.1.5 検証
-- [ ] `make test`実行とパス確認
-- [ ] `make lint`実行と問題修正
-- [ ] Phase 1完了コミット
+- [x] `make test`実行とパス確認
+- [x] `make lint`実行と問題修正（stuttering issues完全修正）
+- [x] Phase 1完了コミット
 
 ### Phase 2: パス処理とセキュリティ機能の実装
 

--- a/internal/runner/config/config_test.go
+++ b/internal/runner/config/config_test.go
@@ -1,0 +1,274 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/isseis/go-safe-cmd-runner/internal/runner/runnertypes"
+	"github.com/pelletier/go-toml/v2"
+)
+
+// Test parsing Command with output field
+func TestCommandOutputFieldParsing(t *testing.T) {
+	tests := []struct {
+		name        string
+		tomlContent string
+		wantOutput  string
+		wantErr     bool
+	}{
+		{
+			name: "command with output field",
+			tomlContent: `
+[[groups]]
+name = "test"
+[[groups.commands]]
+name = "ls"
+cmd = "ls"
+args = ["-la"]
+output = "/tmp/ls-output.txt"
+`,
+			wantOutput: "/tmp/ls-output.txt",
+			wantErr:    false,
+		},
+		{
+			name: "command without output field",
+			tomlContent: `
+[[groups]]
+name = "test"
+[[groups.commands]]
+name = "ls"
+cmd = "ls"
+args = ["-la"]
+`,
+			wantOutput: "",
+			wantErr:    false,
+		},
+		{
+			name: "command with empty output field",
+			tomlContent: `
+[[groups]]
+name = "test"
+[[groups.commands]]
+name = "ls"
+cmd = "ls"
+args = ["-la"]
+output = ""
+`,
+			wantOutput: "",
+			wantErr:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			loader := NewLoader()
+			config, err := loader.LoadConfig([]byte(tt.tomlContent))
+
+			if tt.wantErr {
+				if err == nil {
+					t.Error("Expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			if len(config.Groups) == 0 {
+				t.Fatal("Expected at least one group")
+			}
+
+			if len(config.Groups[0].Commands) == 0 {
+				t.Fatal("Expected at least one command")
+			}
+
+			command := config.Groups[0].Commands[0]
+			if command.Output != tt.wantOutput {
+				t.Errorf("Expected output '%s', got '%s'", tt.wantOutput, command.Output)
+			}
+		})
+	}
+}
+
+// Test parsing GlobalConfig with max_output_size field
+func TestGlobalConfigMaxOutputSizeParsing(t *testing.T) {
+	tests := []struct {
+		name        string
+		tomlContent string
+		wantMaxSize int64
+		wantErr     bool
+	}{
+		{
+			name: "global config with max_output_size",
+			tomlContent: `
+[global]
+workdir = "/tmp"
+max_output_size = 10485760
+`,
+			wantMaxSize: 10485760, // 10MB
+			wantErr:     false,
+		},
+		{
+			name: "global config without max_output_size",
+			tomlContent: `
+[global]
+workdir = "/tmp"
+`,
+			wantMaxSize: 0, // Default value
+			wantErr:     false,
+		},
+		{
+			name: "global config with zero max_output_size",
+			tomlContent: `
+[global]
+workdir = "/tmp"
+max_output_size = 0
+`,
+			wantMaxSize: 0,
+			wantErr:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			loader := NewLoader()
+			config, err := loader.LoadConfig([]byte(tt.tomlContent))
+
+			if tt.wantErr {
+				if err == nil {
+					t.Error("Expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			if config.Global.MaxOutputSize != tt.wantMaxSize {
+				t.Errorf("Expected max_output_size %d, got %d", tt.wantMaxSize, config.Global.MaxOutputSize)
+			}
+		})
+	}
+}
+
+// Test complete TOML configuration with output fields
+func TestCompleteConfigWithOutput(t *testing.T) {
+	tomlContent := `
+version = "1.0"
+
+[global]
+workdir = "/tmp"
+timeout = 300
+max_output_size = 20971520
+
+[[groups]]
+name = "build"
+description = "Build commands"
+
+[[groups.commands]]
+name = "make"
+description = "Run make command"
+cmd = "make"
+args = ["all"]
+output = "/tmp/build.log"
+
+[[groups.commands]]
+name = "test"
+description = "Run tests"
+cmd = "make"
+args = ["test"]
+output = "/tmp/test.log"
+
+[[groups]]
+name = "utilities"
+description = "Utility commands"
+
+[[groups.commands]]
+name = "ls"
+description = "List files"
+cmd = "ls"
+args = ["-la"]
+# No output field - should default to empty string
+`
+
+	loader := NewLoader()
+	config, err := loader.LoadConfig([]byte(tomlContent))
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Test global configuration
+	if config.Global.MaxOutputSize != 20971520 {
+		t.Errorf("Expected max_output_size 20971520, got %d", config.Global.MaxOutputSize)
+	}
+
+	// Test first group commands
+	buildGroup := config.Groups[0]
+	if buildGroup.Name != "build" {
+		t.Errorf("Expected group name 'build', got '%s'", buildGroup.Name)
+	}
+
+	if len(buildGroup.Commands) != 2 {
+		t.Fatalf("Expected 2 commands in build group, got %d", len(buildGroup.Commands))
+	}
+
+	makeCmd := buildGroup.Commands[0]
+	if makeCmd.Output != "/tmp/build.log" {
+		t.Errorf("Expected make command output '/tmp/build.log', got '%s'", makeCmd.Output)
+	}
+
+	testCmd := buildGroup.Commands[1]
+	if testCmd.Output != "/tmp/test.log" {
+		t.Errorf("Expected test command output '/tmp/test.log', got '%s'", testCmd.Output)
+	}
+
+	// Test second group command (no output specified)
+	utilGroup := config.Groups[1]
+	if utilGroup.Name != "utilities" {
+		t.Errorf("Expected group name 'utilities', got '%s'", utilGroup.Name)
+	}
+
+	lsCmd := utilGroup.Commands[0]
+	if lsCmd.Output != "" {
+		t.Errorf("Expected ls command output to be empty, got '%s'", lsCmd.Output)
+	}
+}
+
+// Test direct unmarshaling of structures with new fields
+func TestDirectUnmarshalingOfNewFields(t *testing.T) {
+	t.Run("Command with output field", func(t *testing.T) {
+		tomlData := `
+name = "test-cmd"
+cmd = "echo"
+args = ["hello"]
+output = "/tmp/test.txt"
+`
+		var cmd runnertypes.Command
+		err := toml.Unmarshal([]byte(tomlData), &cmd)
+		if err != nil {
+			t.Fatalf("Failed to unmarshal command: %v", err)
+		}
+
+		if cmd.Output != "/tmp/test.txt" {
+			t.Errorf("Expected output '/tmp/test.txt', got '%s'", cmd.Output)
+		}
+	})
+
+	t.Run("GlobalConfig with max_output_size field", func(t *testing.T) {
+		tomlData := `
+workdir = "/tmp"
+timeout = 600
+max_output_size = 5242880
+`
+		var global runnertypes.GlobalConfig
+		err := toml.Unmarshal([]byte(tomlData), &global)
+		if err != nil {
+			t.Fatalf("Failed to unmarshal global config: %v", err)
+		}
+
+		if global.MaxOutputSize != 5242880 {
+			t.Errorf("Expected max_output_size 5242880, got %d", global.MaxOutputSize)
+		}
+	})
+}

--- a/internal/runner/output/errors.go
+++ b/internal/runner/output/errors.go
@@ -1,0 +1,93 @@
+// Package output provides functionality for capturing command output to files.
+// It includes types for output management, path validation, and error handling.
+package output
+
+import (
+	"fmt"
+)
+
+// ErrorType represents the type of output capture error
+type ErrorType int
+
+const (
+	// ErrorTypePathValidation indicates path validation errors
+	ErrorTypePathValidation ErrorType = iota
+	// ErrorTypePermission indicates permission-related errors
+	ErrorTypePermission
+	// ErrorTypeFileSystem indicates filesystem operation errors
+	ErrorTypeFileSystem
+	// ErrorTypeSizeLimit indicates size limit exceeded errors
+	ErrorTypeSizeLimit
+	// ErrorTypeCleanup indicates cleanup operation errors
+	ErrorTypeCleanup
+)
+
+// String returns a string representation of ErrorType
+func (e ErrorType) String() string {
+	switch e {
+	case ErrorTypePathValidation:
+		return "path validation"
+	case ErrorTypePermission:
+		return "permission denied"
+	case ErrorTypeFileSystem:
+		return "filesystem error"
+	case ErrorTypeSizeLimit:
+		return "size limit exceeded"
+	case ErrorTypeCleanup:
+		return "cleanup failed"
+	default:
+		return "unknown error"
+	}
+}
+
+// ExecutionPhase represents the phase during which an error occurred
+type ExecutionPhase int
+
+const (
+	// PhasePreparation indicates errors during preparation phase
+	PhasePreparation ExecutionPhase = iota
+	// PhaseExecution indicates errors during execution phase
+	PhaseExecution
+	// PhaseFinalization indicates errors during finalization phase
+	PhaseFinalization
+	// PhaseCleanup indicates errors during cleanup phase
+	PhaseCleanup
+)
+
+// String returns a string representation of ExecutionPhase
+func (p ExecutionPhase) String() string {
+	switch p {
+	case PhasePreparation:
+		return "preparation phase"
+	case PhaseExecution:
+		return "execution phase"
+	case PhaseFinalization:
+		return "finalization phase"
+	case PhaseCleanup:
+		return "cleanup phase"
+	default:
+		return "unknown phase"
+	}
+}
+
+// CaptureError represents an error that occurred during output capture
+type CaptureError struct {
+	Type  ErrorType      // Type of error
+	Path  string         // File path related to the error
+	Phase ExecutionPhase // Execution phase when error occurred
+	Cause error          // Underlying cause of the error
+}
+
+// Error implements the error interface
+func (e CaptureError) Error() string {
+	return fmt.Sprintf("output capture error during %s: %s for '%s': %s",
+		e.Phase.String(),
+		e.Type.String(),
+		e.Path,
+		e.Cause.Error())
+}
+
+// Unwrap implements the error unwrapping interface
+func (e CaptureError) Unwrap() error {
+	return e.Cause
+}

--- a/internal/runner/output/errors.go
+++ b/internal/runner/output/errors.go
@@ -80,11 +80,18 @@ type CaptureError struct {
 
 // Error implements the error interface
 func (e CaptureError) Error() string {
-	return fmt.Sprintf("output capture error during %s: %s for '%s': %s",
+	if e.Cause == nil {
+		return fmt.Sprintf("output capture error during %s: %s for '%s'",
+			e.Phase.String(),
+			e.Type.String(),
+			e.Path)
+	}
+
+	return fmt.Sprintf("output capture error during %s: %s for '%s': %v",
 		e.Phase.String(),
 		e.Type.String(),
 		e.Path,
-		e.Cause.Error())
+		e.Cause)
 }
 
 // Unwrap implements the error unwrapping interface

--- a/internal/runner/output/errors_test.go
+++ b/internal/runner/output/errors_test.go
@@ -1,0 +1,199 @@
+package output
+
+import (
+	"errors"
+	"testing"
+)
+
+// Define static test errors to satisfy linter requirements
+var (
+	errPathTraversalDetected = errors.New("path traversal detected")
+	errPermissionDenied      = errors.New("permission denied")
+	errDiskFull              = errors.New("disk full")
+	errSizeLimitExceeded     = errors.New("size limit exceeded: 10MB")
+	errFailedToRemoveTemp    = errors.New("failed to remove temp file")
+	errTestCause             = errors.New("test cause")
+)
+
+// Test for CaptureError type
+func TestCaptureError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      CaptureError
+		wantType ErrorType
+		wantMsg  string
+		testFunc func(t *testing.T, err CaptureError)
+	}{
+		{
+			name: "path validation error",
+			err: CaptureError{
+				Type:  ErrorTypePathValidation,
+				Path:  "../../../etc/passwd",
+				Phase: PhasePreparation,
+				Cause: errPathTraversalDetected,
+			},
+			wantType: ErrorTypePathValidation,
+			wantMsg:  "output capture error during preparation phase: path validation for '../../../etc/passwd': path traversal detected",
+			testFunc: func(t *testing.T, err CaptureError) {
+				if err.Type != ErrorTypePathValidation {
+					t.Errorf("Expected ErrorTypePathValidation, got %v", err.Type)
+				}
+				if err.Phase != PhasePreparation {
+					t.Errorf("Expected PhasePreparation, got %v", err.Phase)
+				}
+			},
+		},
+		{
+			name: "permission error",
+			err: CaptureError{
+				Type:  ErrorTypePermission,
+				Path:  "/root/protected.txt",
+				Phase: PhasePreparation,
+				Cause: errPermissionDenied,
+			},
+			wantType: ErrorTypePermission,
+			wantMsg:  "output capture error during preparation phase: permission denied for '/root/protected.txt': permission denied",
+			testFunc: func(t *testing.T, err CaptureError) {
+				if err.Type != ErrorTypePermission {
+					t.Errorf("Expected ErrorTypePermission, got %v", err.Type)
+				}
+			},
+		},
+		{
+			name: "filesystem error during execution",
+			err: CaptureError{
+				Type:  ErrorTypeFileSystem,
+				Path:  "/tmp/output.txt",
+				Phase: PhaseExecution,
+				Cause: errDiskFull,
+			},
+			wantType: ErrorTypeFileSystem,
+			wantMsg:  "output capture error during execution phase: filesystem error for '/tmp/output.txt': disk full",
+			testFunc: func(t *testing.T, err CaptureError) {
+				if err.Type != ErrorTypeFileSystem {
+					t.Errorf("Expected ErrorTypeFileSystem, got %v", err.Type)
+				}
+				if err.Phase != PhaseExecution {
+					t.Errorf("Expected PhaseExecution, got %v", err.Phase)
+				}
+			},
+		},
+		{
+			name: "size limit exceeded",
+			err: CaptureError{
+				Type:  ErrorTypeSizeLimit,
+				Path:  "/tmp/large-output.txt",
+				Phase: PhaseExecution,
+				Cause: errSizeLimitExceeded,
+			},
+			wantType: ErrorTypeSizeLimit,
+			wantMsg:  "output capture error during execution phase: size limit exceeded for '/tmp/large-output.txt': size limit exceeded: 10MB",
+			testFunc: func(t *testing.T, err CaptureError) {
+				if err.Type != ErrorTypeSizeLimit {
+					t.Errorf("Expected ErrorTypeSizeLimit, got %v", err.Type)
+				}
+			},
+		},
+		{
+			name: "cleanup error",
+			err: CaptureError{
+				Type:  ErrorTypeCleanup,
+				Path:  "/tmp/temp-file.tmp",
+				Phase: PhaseCleanup,
+				Cause: errFailedToRemoveTemp,
+			},
+			wantType: ErrorTypeCleanup,
+			wantMsg:  "output capture error during cleanup phase: cleanup failed for '/tmp/temp-file.tmp': failed to remove temp file",
+			testFunc: func(t *testing.T, err CaptureError) {
+				if err.Type != ErrorTypeCleanup {
+					t.Errorf("Expected ErrorTypeCleanup, got %v", err.Type)
+				}
+				if err.Phase != PhaseCleanup {
+					t.Errorf("Expected PhaseCleanup, got %v", err.Phase)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test Error() method
+			if tt.err.Error() != tt.wantMsg {
+				t.Errorf("Expected error message:\n'%s'\nGot:\n'%s'", tt.wantMsg, tt.err.Error())
+			}
+
+			// Test Unwrap() method
+			if !errors.Is(tt.err, tt.err.Cause) {
+				t.Error("Expected error to wrap the original cause")
+			}
+
+			// Run custom test function
+			if tt.testFunc != nil {
+				tt.testFunc(t, tt.err)
+			}
+		})
+	}
+}
+
+// Test error type constants
+func TestErrorTypes(t *testing.T) {
+	tests := []struct {
+		name      string
+		errorType ErrorType
+		expected  string
+	}{
+		{"PathValidation", ErrorTypePathValidation, "path validation"},
+		{"Permission", ErrorTypePermission, "permission denied"},
+		{"FileSystem", ErrorTypeFileSystem, "filesystem error"},
+		{"SizeLimit", ErrorTypeSizeLimit, "size limit exceeded"},
+		{"Cleanup", ErrorTypeCleanup, "cleanup failed"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.errorType.String() != tt.expected {
+				t.Errorf("Expected '%s', got '%s'", tt.expected, tt.errorType.String())
+			}
+		})
+	}
+}
+
+// Test execution phase constants
+func TestExecutionPhases(t *testing.T) {
+	tests := []struct {
+		name     string
+		phase    ExecutionPhase
+		expected string
+	}{
+		{"Preparation", PhasePreparation, "preparation phase"},
+		{"Execution", PhaseExecution, "execution phase"},
+		{"Finalization", PhaseFinalization, "finalization phase"},
+		{"Cleanup", PhaseCleanup, "cleanup phase"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.phase.String() != tt.expected {
+				t.Errorf("Expected '%s', got '%s'", tt.expected, tt.phase.String())
+			}
+		})
+	}
+}
+
+// Test if errors satisfy the error interface
+func TestCaptureErrorInterface(t *testing.T) {
+	err := CaptureError{
+		Type:  ErrorTypePathValidation,
+		Path:  "/test/path",
+		Phase: PhasePreparation,
+		Cause: errTestCause,
+	}
+
+	// Test that it implements error interface
+	var _ error = err
+
+	// Test that it implements fmt.Wrapper interface
+	if !errors.Is(err, err.Cause) {
+		t.Error("Expected Unwrap() to return the original cause")
+	}
+}

--- a/internal/runner/output/interfaces.go
+++ b/internal/runner/output/interfaces.go
@@ -1,0 +1,53 @@
+package output
+
+import (
+	"os"
+)
+
+// CaptureManager manages the complete lifecycle of output capture
+type CaptureManager interface {
+	// PrepareOutput validates paths and prepares for output capture
+	PrepareOutput(outputPath string, workDir string, maxSize int64) (*Capture, error)
+
+	// WriteOutput writes data to the output capture session
+	WriteOutput(capture *Capture, data []byte) error
+
+	// FinalizeOutput completes the capture session and moves temp file to final location
+	FinalizeOutput(capture *Capture) error
+
+	// CleanupOutput cleans up resources in case of error
+	CleanupOutput(capture *Capture) error
+
+	// AnalyzeOutput performs dry-run analysis of output configuration
+	AnalyzeOutput(outputPath string, workDir string) (*Analysis, error)
+}
+
+// PathValidator validates and normalizes file paths for security
+type PathValidator interface {
+	// ValidatePath performs basic path validation and normalization
+	ValidatePath(path string, workDir string) (string, error)
+
+	// IsPathTraversal detects path traversal attempts
+	IsPathTraversal(path string) bool
+
+	// NormalizePath normalizes a path to canonical form
+	NormalizePath(path string, workDir string) (string, error)
+}
+
+// FileManager handles safe file system operations using safefileio
+type FileManager interface {
+	// CreateTempFile creates a temporary file for output capture
+	CreateTempFile(dir string, pattern string) (*os.File, error)
+
+	// WriteToTemp writes data to temporary file
+	WriteToTemp(file *os.File, data []byte) (int, error)
+
+	// MoveToFinal atomically moves temp file to final location
+	MoveToFinal(tempPath, finalPath string) error
+
+	// EnsureDirectory ensures directory exists with proper permissions
+	EnsureDirectory(path string) error
+
+	// RemoveTemp removes temporary file
+	RemoveTemp(path string) error
+}

--- a/internal/runner/output/types.go
+++ b/internal/runner/output/types.go
@@ -1,0 +1,46 @@
+package output
+
+import (
+	"os"
+	"time"
+
+	"github.com/isseis/go-safe-cmd-runner/internal/runner/runnertypes"
+)
+
+// Config represents configuration for output capture
+type Config struct {
+	Path    string // Output file path
+	MaxSize int64  // Maximum output size in bytes
+}
+
+// Capture represents an active output capture session
+type Capture struct {
+	OutputPath  string    // Final output file path
+	TempPath    string    // Temporary file path during capture
+	TempFile    *os.File  // File handle to temporary file
+	MaxSize     int64     // Maximum allowed output size
+	CurrentSize int64     // Current accumulated output size
+	StartTime   time.Time // Start time of capture session
+}
+
+// Analysis represents the analysis result for Dry-Run mode
+type Analysis struct {
+	OutputPath      string                // Configured output path
+	ResolvedPath    string                // Resolved absolute path
+	DirectoryExists bool                  // Whether target directory exists
+	WritePermission bool                  // Whether we have write permission
+	SecurityRisk    runnertypes.RiskLevel // Assessed security risk level
+	MaxSizeLimit    int64                 // Effective size limit
+}
+
+// RiskLevel is an alias to the existing runnertypes.RiskLevel for convenience
+type RiskLevel = runnertypes.RiskLevel
+
+// Risk level constants for convenience
+const (
+	RiskLevelUnknown  = runnertypes.RiskLevelUnknown
+	RiskLevelLow      = runnertypes.RiskLevelLow
+	RiskLevelMedium   = runnertypes.RiskLevelMedium
+	RiskLevelHigh     = runnertypes.RiskLevelHigh
+	RiskLevelCritical = runnertypes.RiskLevelCritical
+)

--- a/internal/runner/output/types_test.go
+++ b/internal/runner/output/types_test.go
@@ -1,0 +1,179 @@
+package output
+
+import (
+	"testing"
+	"time"
+)
+
+// Test for Config struct
+func TestConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   Config
+		wantErr  bool
+		testFunc func(t *testing.T, config Config)
+	}{
+		{
+			name: "valid config with file output",
+			config: Config{
+				Path:    "/tmp/test-output.txt",
+				MaxSize: 1024 * 1024, // 1MB
+			},
+			wantErr: false,
+			testFunc: func(t *testing.T, config Config) {
+				if config.Path != "/tmp/test-output.txt" {
+					t.Errorf("Expected Path '/tmp/test-output.txt', got '%s'", config.Path)
+				}
+				if config.MaxSize != 1024*1024 {
+					t.Errorf("Expected MaxSize 1048576, got %d", config.MaxSize)
+				}
+			},
+		},
+		{
+			name: "default config values",
+			config: Config{
+				Path:    "",
+				MaxSize: 0,
+			},
+			wantErr: false,
+			testFunc: func(t *testing.T, config Config) {
+				if config.Path != "" {
+					t.Errorf("Expected empty Path, got '%s'", config.Path)
+				}
+				if config.MaxSize != 0 {
+					t.Errorf("Expected MaxSize 0, got %d", config.MaxSize)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.testFunc != nil {
+				tt.testFunc(t, tt.config)
+			}
+		})
+	}
+}
+
+// Test for Capture struct
+func TestCapture(t *testing.T) {
+	tests := []struct {
+		name     string
+		capture  Capture
+		testFunc func(t *testing.T, capture Capture)
+	}{
+		{
+			name: "new output capture with temp file",
+			capture: Capture{
+				OutputPath:  "/tmp/final-output.txt",
+				TempPath:    "/tmp/temp-123456.tmp",
+				MaxSize:     10 * 1024 * 1024, // 10MB
+				CurrentSize: 0,
+				StartTime:   time.Now(),
+			},
+			testFunc: func(t *testing.T, capture Capture) {
+				if capture.OutputPath != "/tmp/final-output.txt" {
+					t.Errorf("Expected OutputPath '/tmp/final-output.txt', got '%s'", capture.OutputPath)
+				}
+				if capture.TempPath != "/tmp/temp-123456.tmp" {
+					t.Errorf("Expected TempPath '/tmp/temp-123456.tmp', got '%s'", capture.TempPath)
+				}
+				if capture.MaxSize != 10*1024*1024 {
+					t.Errorf("Expected MaxSize 10485760, got %d", capture.MaxSize)
+				}
+				if capture.CurrentSize != 0 {
+					t.Errorf("Expected CurrentSize 0, got %d", capture.CurrentSize)
+				}
+			},
+		},
+		{
+			name: "capture with accumulated size",
+			capture: Capture{
+				OutputPath:  "/var/log/command.log",
+				TempPath:    "/tmp/temp-789012.tmp",
+				MaxSize:     1024 * 1024, // 1MB
+				CurrentSize: 512 * 1024,  // 512KB
+				StartTime:   time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC),
+			},
+			testFunc: func(t *testing.T, capture Capture) {
+				if capture.CurrentSize != 512*1024 {
+					t.Errorf("Expected CurrentSize 524288, got %d", capture.CurrentSize)
+				}
+				if capture.MaxSize <= capture.CurrentSize {
+					t.Errorf("CurrentSize (%d) should be less than MaxSize (%d)", capture.CurrentSize, capture.MaxSize)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.testFunc != nil {
+				tt.testFunc(t, tt.capture)
+			}
+		})
+	}
+}
+
+// Test for Analysis struct (Dry-Run用)
+func TestAnalysis(t *testing.T) {
+	tests := []struct {
+		name     string
+		analysis Analysis
+		testFunc func(t *testing.T, analysis Analysis)
+	}{
+		{
+			name: "safe output analysis",
+			analysis: Analysis{
+				OutputPath:      "/home/user/output.txt",
+				ResolvedPath:    "/home/user/output.txt",
+				DirectoryExists: true,
+				WritePermission: true,
+				SecurityRisk:    RiskLevelLow,
+				MaxSizeLimit:    10 * 1024 * 1024, // 10MB
+			},
+			testFunc: func(t *testing.T, analysis Analysis) {
+				if !analysis.DirectoryExists {
+					t.Error("Expected DirectoryExists to be true")
+				}
+				if !analysis.WritePermission {
+					t.Error("Expected WritePermission to be true")
+				}
+				if analysis.SecurityRisk != RiskLevelLow {
+					t.Errorf("Expected SecurityRisk Low, got %v", analysis.SecurityRisk)
+				}
+			},
+		},
+		{
+			name: "risky output analysis",
+			analysis: Analysis{
+				OutputPath:      "../../../etc/passwd",
+				ResolvedPath:    "/etc/passwd",
+				DirectoryExists: false,
+				WritePermission: false,
+				SecurityRisk:    RiskLevelHigh,
+				MaxSizeLimit:    1024 * 1024, // 1MB
+			},
+			testFunc: func(t *testing.T, analysis Analysis) {
+				if analysis.DirectoryExists {
+					t.Error("Expected DirectoryExists to be false")
+				}
+				if analysis.WritePermission {
+					t.Error("Expected WritePermission to be false")
+				}
+				if analysis.SecurityRisk != RiskLevelHigh {
+					t.Errorf("Expected SecurityRisk High, got %v", analysis.SecurityRisk)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.testFunc != nil {
+				tt.testFunc(t, tt.analysis)
+			}
+		})
+	}
+}

--- a/internal/runner/output/types_test.go
+++ b/internal/runner/output/types_test.go
@@ -116,7 +116,7 @@ func TestCapture(t *testing.T) {
 	}
 }
 
-// Test for Analysis struct (Dry-Run用)
+// Test for Analysis struct (for Dry-Run)
 func TestAnalysis(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/runner/runnertypes/config.go
+++ b/internal/runner/runnertypes/config.go
@@ -23,6 +23,7 @@ type GlobalConfig struct {
 	VerifyFiles       []string `toml:"verify_files"`        // Files to verify at global level
 	SkipStandardPaths bool     `toml:"skip_standard_paths"` // Skip verification for standard system paths
 	EnvAllowlist      []string `toml:"env_allowlist"`       // Global environment variable allowlist
+	MaxOutputSize     int64    `toml:"max_output_size"`     // Default output size limit in bytes
 }
 
 // CommandGroup represents a group of related commands with a name
@@ -52,6 +53,7 @@ type Command struct {
 	RunAsUser    string   `toml:"run_as_user"`    // User to execute command as (using seteuid)
 	RunAsGroup   string   `toml:"run_as_group"`   // Group to execute command as (using setegid)
 	MaxRiskLevel string   `toml:"max_risk_level"` // Maximum allowed risk level (low, medium, high)
+	Output       string   `toml:"output"`         // Standard output file path for capture
 }
 
 // GetMaxRiskLevel returns the parsed maximum risk level for this command


### PR DESCRIPTION
This pull request introduces a comprehensive refactor and lint-driven renaming of the output capture subsystem, along with new tests and documentation updates. The main theme is the replacement of the old `OutputCapture*` naming with more concise `Capture*` names, addressing Go stuttering lint issues. It also adds and verifies new fields for output management in configuration, and provides robust error handling and testing for output capture errors.

### Naming and API Refactor

* All references to `OutputCaptureManager`, `OutputCapture`, `OutputAnalysis`, and related types have been renamed to `CaptureManager`, `Capture`, and `Analysis` throughout the architecture documentation and code, including interfaces, structs, error types, and test mocks. This resolves Go lint stuttering issues and improves code clarity. [[1]](diffhunk://#diff-cd367ef5aeaf1148e491afea756d842610c8eca409fc6705aedb1c866009fda4L28-R28) [[2]](diffhunk://#diff-cd367ef5aeaf1148e491afea756d842610c8eca409fc6705aedb1c866009fda4L67-R89) [[3]](diffhunk://#diff-cd367ef5aeaf1148e491afea756d842610c8eca409fc6705aedb1c866009fda4L99-R101) [[4]](diffhunk://#diff-cd367ef5aeaf1148e491afea756d842610c8eca409fc6705aedb1c866009fda4L289-R289) [[5]](diffhunk://#diff-cd367ef5aeaf1148e491afea756d842610c8eca409fc6705aedb1c866009fda4L395-R395) [[6]](diffhunk://#diff-cd367ef5aeaf1148e491afea756d842610c8eca409fc6705aedb1c866009fda4L433-R437) [[7]](diffhunk://#diff-cd367ef5aeaf1148e491afea756d842610c8eca409fc6705aedb1c866009fda4L461-R461)

### Configuration and TOML Parsing Enhancements

* The `Command` struct now includes an `output` field, and the `GlobalConfig` struct includes a `max_output_size` field. TOML parsing logic and tests verify correct handling of these fields, supporting both presence and absence of output configuration. [[1]](diffhunk://#diff-29937a85b5ca6f6d10dc7e2e70e68e3b78f926b9f3cd9e49a35c9be4841dac61L37-R73) [[2]](diffhunk://#diff-809402495c9190606ada58146b5f4affc0db4284b7aaaa35544e87d4ce7f7680R1-R274)

### Error Handling Improvements

* New error types and phases for output capture have been defined (`CaptureError`, `ErrorType`, `ExecutionPhase`), with comprehensive string representations and error wrapping. Unit tests ensure correct behavior and interface compliance. [[1]](diffhunk://#diff-56bd0a2c7114e4d7c99c600b41fe9f7dda62dd4dd83d5d44a7aa4fa84ffffc03R1-R93) [[2]](diffhunk://#diff-8244f73c49719defb11ba1ac9f680f833237bb06d86a8cd6d17938925cca57a1R1-R199)

### Documentation Updates

* Architecture diagrams and component descriptions in `docs/tasks/0025_command_output/02_architecture.md` have been updated to reflect the new naming and design, including interface and struct definitions. [[1]](diffhunk://#diff-cd367ef5aeaf1148e491afea756d842610c8eca409fc6705aedb1c866009fda4L28-R28) [[2]](diffhunk://#diff-cd367ef5aeaf1148e491afea756d842610c8eca409fc6705aedb1c866009fda4L54-R54) [[3]](diffhunk://#diff-cd367ef5aeaf1148e491afea756d842610c8eca409fc6705aedb1c866009fda4L67-R89) [[4]](diffhunk://#diff-cd367ef5aeaf1148e491afea756d842610c8eca409fc6705aedb1c866009fda4L99-R101) [[5]](diffhunk://#diff-cd367ef5aeaf1148e491afea756d842610c8eca409fc6705aedb1c866009fda4L289-R289)

### Test Coverage

* Added and extended unit tests for config parsing, error types, and error handling logic in `internal/runner/config/config_test.go` and `internal/runner/output/errors_test.go`, confirming the new fields and error types work as intended. [[1]](diffhunk://#diff-809402495c9190606ada58146b5f4affc0db4284b7aaaa35544e87d4ce7f7680R1-R274) [[2]](diffhunk://#diff-8244f73c49719defb11ba1ac9f680f833237bb06d86a8cd6d17938925cca57a1R1-R199)

These changes collectively modernize and standardize the output capture subsystem, making it easier to maintain and extend while ensuring robust error handling and configuration support.