### PR TITLE
refactor: Stop stack check to detect runtime environment

### DIFF
--- a/internal/verification/errors.go
+++ b/internal/verification/errors.go
@@ -40,34 +40,6 @@ func (e *SecurityViolationError) Error() string {
 	return fmt.Sprintf("security violation in %s: %s (at %s)", e.Op, e.Context, e.Time.Format(time.RFC3339))
 }
 
-// ProductionAPIViolationError is returned when testing APIs are used in production builds
-type ProductionAPIViolationError struct {
-	SecurityViolationError
-	APIName    string // name of the API that was misused
-	CallerFile string // file that made the invalid call
-	CallerLine int    // line number that made the invalid call
-}
-
-// NewProductionAPIViolationError creates a new ProductionAPIViolationError
-func NewProductionAPIViolationError(apiName, callerFile string, callerLine int) *ProductionAPIViolationError {
-	return &ProductionAPIViolationError{
-		SecurityViolationError: SecurityViolationError{
-			Op:      "APIViolation",
-			Context: fmt.Sprintf("testing API %s called from production code", apiName),
-			Time:    time.Now(),
-		},
-		APIName:    apiName,
-		CallerFile: callerFile,
-		CallerLine: callerLine,
-	}
-}
-
-// Error returns the error message
-func (e *ProductionAPIViolationError) Error() string {
-	return fmt.Sprintf("production API violation: testing API %s called from %s:%d (at %s)",
-		e.APIName, e.CallerFile, e.CallerLine, e.Time.Format(time.RFC3339))
-}
-
 // HashDirectorySecurityError is returned when hash directory security constraints are violated
 type HashDirectorySecurityError struct {
 	SecurityViolationError

--- a/internal/verification/errors_test.go
+++ b/internal/verification/errors_test.go
@@ -106,20 +106,6 @@ func TestSecurityViolationError(t *testing.T) {
 	assert.Contains(t, err.Error(), "at")
 }
 
-// Test ProductionAPIViolationError
-func TestProductionAPIViolationError(t *testing.T) {
-	err := NewProductionAPIViolationError("NewManagerForTest", "/path/to/test.go", 42)
-
-	assert.Equal(t, "NewManagerForTest", err.APIName)
-	assert.Equal(t, "/path/to/test.go", err.CallerFile)
-	assert.Equal(t, 42, err.CallerLine)
-
-	errorMsg := err.Error()
-	assert.Contains(t, errorMsg, "production API violation")
-	assert.Contains(t, errorMsg, "testing API NewManagerForTest")
-	assert.Contains(t, errorMsg, "/path/to/test.go:42")
-}
-
 // Test HashDirectorySecurityError
 func TestHashDirectorySecurityError(t *testing.T) {
 	err := NewHashDirectorySecurityError(
@@ -203,35 +189,6 @@ func TestSecurityViolationErrorAdvanced(t *testing.T) {
 
 		expectedMessage := "security violation in TestOperation: test security violation (at 2025-09-15T12:00:00Z)"
 		assert.Equal(t, expectedMessage, err.Error())
-	})
-}
-
-// TestProductionAPIViolationErrorAdvanced tests additional ProductionAPIViolationError functionality
-func TestProductionAPIViolationErrorAdvanced(t *testing.T) {
-	t.Run("creation_and_error_message", func(t *testing.T) {
-		err := NewProductionAPIViolationError("NewManagerForTest", "/path/to/file.go", 42)
-
-		// Verify fields are set correctly
-		assert.Equal(t, "APIViolation", err.Op)
-		assert.Equal(t, "NewManagerForTest", err.APIName)
-		assert.Equal(t, "/path/to/file.go", err.CallerFile)
-		assert.Equal(t, 42, err.CallerLine)
-		assert.Contains(t, err.Context, "testing API NewManagerForTest called from production code")
-		assert.False(t, err.Time.IsZero())
-
-		// Verify error message format
-		errorMsg := err.Error()
-		assert.Contains(t, errorMsg, "production API violation")
-		assert.Contains(t, errorMsg, "NewManagerForTest")
-		assert.Contains(t, errorMsg, "/path/to/file.go:42")
-	})
-
-	t.Run("error_interface_compliance", func(t *testing.T) {
-		err := NewProductionAPIViolationError("TestAPI", "test.go", 1)
-
-		// Should implement error interface
-		var _ error = err
-		assert.NotEmpty(t, err.Error())
 	})
 }
 
@@ -502,16 +459,5 @@ func TestErrorWrappingBehavior(t *testing.T) {
 		// Test direct unwrapping
 		assert.Equal(t, verifyErr, verificationErr.Unwrap())
 		assert.Equal(t, rootErr, verifyErr.Unwrap())
-	})
-
-	t.Run("security_error_isolation", func(t *testing.T) {
-		// Security errors should not wrap other errors (they are root causes)
-		secErr := NewProductionAPIViolationError("TestAPI", "file.go", 1)
-		hashErr := NewHashDirectorySecurityError("/custom", "/default", "reason")
-
-		// Security errors should not have Unwrap methods or should return nil
-		// (they are designed to be root security violations)
-		assert.IsType(t, &ProductionAPIViolationError{}, secErr)
-		assert.IsType(t, &HashDirectorySecurityError{}, hashErr)
 	})
 }

--- a/internal/verification/manager_testing.go
+++ b/internal/verification/manager_testing.go
@@ -4,34 +4,9 @@ package verification
 
 import (
 	"log/slog"
-	"runtime"
-	"strings"
 
 	"github.com/isseis/go-safe-cmd-runner/internal/common"
 )
-
-// isCallerInTestFile checks if the caller is in a test file
-// This prevents testing APIs from being called from production code
-func isCallerInTestFile() bool {
-	// Iterate through the entire call stack until no more frames are available
-	for i := 2; ; i++ {
-		_, file, _, ok := runtime.Caller(i)
-		if !ok {
-			// No more stack frames available
-			break
-		}
-
-		// Check if the file is a test file
-		if strings.HasSuffix(file, "_test.go") {
-			return true
-		}
-		// Also allow calls from testing infrastructure files
-		if strings.Contains(file, "/testing/") {
-			return true
-		}
-	}
-	return false
-}
 
 // TestOption is a function type for configuring Manager instances for testing
 type TestOption func(*managerInternalOptions)
@@ -81,14 +56,6 @@ func WithPathResolver(pathResolver *PathResolver) TestOption {
 // NewManagerForTest creates a new verification manager for testing with a custom hash directory
 // This API allows custom hash directories for testing purposes and uses relaxed security constraints
 func NewManagerForTest(hashDir string, options ...TestOption) (*Manager, error) {
-	// Verify that this API is being called from test code
-	if !isCallerInTestFile() {
-		if _, file, line, ok := runtime.Caller(1); ok {
-			return nil, NewProductionAPIViolationError("NewManagerForTest", file, line)
-		}
-		return nil, NewProductionAPIViolationError("NewManagerForTest", "unknown", 0)
-	}
-
 	// Log testing manager creation for audit trail
 	slog.Info("Testing verification manager created",
 		"api", "NewManagerForTest",


### PR DESCRIPTION
- We'll rely on build tag "test" for runtime environment detection.