### PR TITLE
Improve Mermaid flowchart node formatting in group-level TOML docs

### DIFF
--- a/docs/user/toml_config/05_group_level.ja.md
+++ b/docs/user/toml_config/05_group_level.ja.md
@@ -580,7 +580,7 @@ args = ["完全に隔離された実行"]
 
 ```mermaid
 flowchart TD
-    A[env_allowlist の確認] --> B{"グループレベルで<br/>env_allowlist が<br/>定義されているか?"}
+    A["env_allowlist の確認"] --> B{"グループレベルで<br/>env_allowlist が<br/>定義されているか?"}
     B -->|No| C["継承モード<br/>inherit"]
     B -->|Yes| D{"値は空配列<br/>[] か?"}
     D -->|Yes| E["拒否モード<br/>reject"]

--- a/docs/user/toml_config/05_group_level.md
+++ b/docs/user/toml_config/05_group_level.md
@@ -580,7 +580,7 @@ Mode determination follows this logic:
 
 ```mermaid
 flowchart TD
-    A[Check env_allowlist] --> B{"Is env_allowlist<br/>defined at<br/>group level?"}
+    A["Check env_allowlist"] --> B{"Is env_allowlist<br/>defined at<br/>group level?"}
     B -->|No| C["Inherit Mode<br/>inherit"]
     B -->|Yes| D{"Is value<br/>empty array<br/>[]?"}
     D -->|Yes| E["Reject Mode<br/>reject"]


### PR DESCRIPTION
- Normalize Mermaid node labels to use quoted strings for consistency
- Escape/format line breaks inside node labels for clearer rendering
- Apply identical changes to Japanese and English docs under docs/user/toml_config