### PR TITLE
Add ReservedEnvPrefixError for automatic env var prefix conflicts

### DIFF
--- a/docs/tasks/0028_automatic_env_vars/04_implementation_plan.md
+++ b/docs/tasks/0028_automatic_env_vars/04_implementation_plan.md
@@ -8,8 +8,8 @@
 
 ### Phase 1: エラー型定義
 
-- [ ] **1.1 エラー型定義**
-  - ファイル: `internal/runner/errors/errors.go`
+- [x] **1.1 エラー型定義**
+  - ファイル: `internal/runner/runnertypes/errors.go` (実際の実装場所)
   - タスク: `ReservedEnvPrefixError` 構造体とコンストラクタを追加
   - テスト: エラーメッセージのフォーマット確認
   - 注: エラー型は `AutoEnvPrefix` 定数を参照する

--- a/internal/runner/runnertypes/errors.go
+++ b/internal/runner/runnertypes/errors.go
@@ -95,3 +95,38 @@ func AsSecurityViolationError(err error) (*SecurityViolationError, bool) {
 	}
 	return nil, false
 }
+
+// ReservedEnvPrefixError represents an error when user tries to use reserved env prefix
+type ReservedEnvPrefixError struct {
+	VarName string
+	Prefix  string
+}
+
+// NewReservedEnvPrefixError creates a new ReservedEnvPrefixError
+func NewReservedEnvPrefixError(varName, prefix string) *ReservedEnvPrefixError {
+	return &ReservedEnvPrefixError{
+		VarName: varName,
+		Prefix:  prefix,
+	}
+}
+
+// Error implements the error interface
+func (e *ReservedEnvPrefixError) Error() string {
+	return fmt.Sprintf(
+		"environment variable %q uses reserved prefix %q; "+
+			"this prefix is reserved for automatically generated variables",
+		e.VarName,
+		e.Prefix,
+	)
+}
+
+// Is implements the error comparison interface
+func (e *ReservedEnvPrefixError) Is(target error) bool {
+	var rpe *ReservedEnvPrefixError
+	return errors.As(target, &rpe)
+}
+
+// Unwrap returns the underlying error (if any)
+func (e *ReservedEnvPrefixError) Unwrap() error {
+	return nil
+}

--- a/internal/runner/runnertypes/errors_test.go
+++ b/internal/runner/runnertypes/errors_test.go
@@ -51,14 +51,19 @@ func TestReservedEnvPrefixError(t *testing.T) {
 func TestReservedEnvPrefixError_Is(t *testing.T) {
 	err1 := NewReservedEnvPrefixError("__RUNNER_CUSTOM", "__RUNNER_")
 	err2 := NewReservedEnvPrefixError("__RUNNER_OTHER", "__RUNNER_")
-
-	// Test Is() with same error type
-	assert.True(t, err1.Is(err1))
-	assert.True(t, err1.Is(err2))
-
-	// Test Is() with different error types
 	otherErr := errors.New("different error")
-	assert.False(t, err1.Is(otherErr))
+
+	// Test with errors.Is for type checking
+	var target *ReservedEnvPrefixError
+	assert.True(t, errors.Is(err1, target))
+	assert.True(t, errors.Is(err2, target))
+	assert.False(t, errors.Is(otherErr, target))
+
+	// Test with errors.As for extracting the error
+	var gotErr *ReservedEnvPrefixError
+	assert.True(t, errors.As(err1, &gotErr))
+	assert.Equal(t, err1, gotErr)
+	assert.False(t, errors.As(otherErr, &gotErr))
 }
 
 func TestReservedEnvPrefixError_Unwrap(t *testing.T) {

--- a/internal/runner/runnertypes/errors_test.go
+++ b/internal/runner/runnertypes/errors_test.go
@@ -1,0 +1,69 @@
+package runnertypes
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReservedEnvPrefixError(t *testing.T) {
+	tests := []struct {
+		name        string
+		varName     string
+		prefix      string
+		expectedMsg string
+	}{
+		{
+			name:        "simple reserved prefix error",
+			varName:     "__RUNNER_CUSTOM",
+			prefix:      "__RUNNER_",
+			expectedMsg: `environment variable "__RUNNER_CUSTOM" uses reserved prefix "__RUNNER_"; this prefix is reserved for automatically generated variables`,
+		},
+		{
+			name:        "datetime variable error",
+			varName:     "__RUNNER_DATETIME",
+			prefix:      "__RUNNER_",
+			expectedMsg: `environment variable "__RUNNER_DATETIME" uses reserved prefix "__RUNNER_"; this prefix is reserved for automatically generated variables`,
+		},
+		{
+			name:        "PID variable error",
+			varName:     "__RUNNER_PID",
+			prefix:      "__RUNNER_",
+			expectedMsg: `environment variable "__RUNNER_PID" uses reserved prefix "__RUNNER_"; this prefix is reserved for automatically generated variables`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := NewReservedEnvPrefixError(tt.varName, tt.prefix)
+
+			// Check error message
+			assert.Equal(t, tt.expectedMsg, err.Error())
+
+			// Check VarName and Prefix fields
+			assert.Equal(t, tt.varName, err.VarName)
+			assert.Equal(t, tt.prefix, err.Prefix)
+		})
+	}
+}
+
+func TestReservedEnvPrefixError_Is(t *testing.T) {
+	err1 := NewReservedEnvPrefixError("__RUNNER_CUSTOM", "__RUNNER_")
+	err2 := NewReservedEnvPrefixError("__RUNNER_OTHER", "__RUNNER_")
+
+	// Test Is() with same error type
+	assert.True(t, err1.Is(err1))
+	assert.True(t, err1.Is(err2))
+
+	// Test Is() with different error types
+	otherErr := errors.New("different error")
+	assert.False(t, err1.Is(otherErr))
+}
+
+func TestReservedEnvPrefixError_Unwrap(t *testing.T) {
+	err := NewReservedEnvPrefixError("__RUNNER_CUSTOM", "__RUNNER_")
+
+	// Unwrap should return nil as there's no underlying error
+	assert.Nil(t, err.Unwrap())
+}


### PR DESCRIPTION
Add ReservedEnvPrefixError type to internal/runner/runnertypes/errors.go with constructor and methods.

Add unit tests in internal/runner/runnertypes/errors_test.go for message, fields, Is(), and Unwrap().

Update implementation plan doc to mark the error-type task completed and fix file path.

Ensure consistent handling when user sets env vars using reserved automatic prefix.