### PR TITLE
Add AutoEnvProvider to generate DATETIME and PID environment variables

### DIFF
--- a/docs/tasks/0028_automatic_env_vars/04_implementation_plan.md
+++ b/docs/tasks/0028_automatic_env_vars/04_implementation_plan.md
@@ -16,7 +16,7 @@
 
 ### Phase 2: 自動環境変数生成（AutoEnvProvider）
 
-- [ ] **2.1 定数とClock関数型定義**
+- [x] **2.1 定数とClock関数型定義**
   - ファイル: `internal/runner/environment/autoenv.go`（新規作成）
   - タスク: 型定義と定数を追加
     - `Clock` 関数型定義（`type Clock func() time.Time`）
@@ -25,13 +25,13 @@
     - 定数 `AutoEnvKeyPID = "PID"`
     - 定数 `DatetimeLayout = "200601021504"`
 
-- [ ] **2.2 AutoEnvProviderインターフェース定義**
+- [x] **2.2 AutoEnvProviderインターフェース定義**
   - ファイル: `internal/runner/environment/autoenv.go`
   - タスク: インターフェースを定義
     - `AutoEnvProvider` インターフェース
     - `Generate() map[string]string` メソッド
 
-- [ ] **2.3 AutoEnvProvider実装（テスト作成）**
+- [x] **2.3 AutoEnvProvider実装（テスト作成）**
   - ファイル: `internal/runner/environment/autoenv_test.go`（新規作成）
   - タスク: `AutoEnvProvider` のテストケース作成
     - `Generate()` のテスト（DATETIME, PID が含まれることを確認）
@@ -40,7 +40,7 @@
     - エッジケース: 年末年始、ナノ秒精度
   - 状態: テスト失敗を確認（実装前）
 
-- [ ] **2.4 AutoEnvProvider実装**
+- [x] **2.4 AutoEnvProvider実装**
   - ファイル: `internal/runner/environment/autoenv.go`
   - タスク: `autoEnvProvider` 構造体と実装
     - `autoEnvProvider struct` 定義（logger, clock フィールド）

--- a/internal/runner/environment/autoenv.go
+++ b/internal/runner/environment/autoenv.go
@@ -1,0 +1,76 @@
+package environment
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"strconv"
+	"time"
+)
+
+// Clock is a function type that returns the current time.
+// This allows for dependency injection of time for testing.
+type Clock func() time.Time
+
+const (
+	// AutoEnvPrefix is the prefix for automatically generated environment variables
+	AutoEnvPrefix = "__RUNNER_"
+
+	// AutoEnvKeyDatetime is the key for the datetime auto environment variable (without prefix)
+	AutoEnvKeyDatetime = "DATETIME"
+	// AutoEnvKeyPID is the key for the PID auto environment variable (without prefix)
+	AutoEnvKeyPID = "PID"
+
+	// DatetimeLayout is the Go time format for __RUNNER_DATETIME
+	// Format: YYYYMMDDHHMM.msec (e.g., "202510051430.123")
+	DatetimeLayout = "200601021504" // Go time format for YYYYMMDDHHMM
+
+	// nanosToMillis is the conversion factor from nanoseconds to milliseconds
+	nanosToMillis = 1_000_000
+)
+
+// AutoEnvProvider provides automatic environment variables
+type AutoEnvProvider interface {
+	// Generate returns all auto environment variables as a map.
+	// All keys have the AutoEnvPrefix (__RUNNER_).
+	Generate() map[string]string
+}
+
+// autoEnvProvider implements AutoEnvProvider
+type autoEnvProvider struct {
+	logger *slog.Logger
+	clock  Clock
+}
+
+// NewAutoEnvProvider creates a new AutoEnvProvider.
+// If clock is nil, it defaults to time.Now.
+func NewAutoEnvProvider(clock Clock) AutoEnvProvider {
+	if clock == nil {
+		clock = time.Now
+	}
+	return &autoEnvProvider{
+		logger: slog.Default().With("component", "AutoEnvProvider"),
+		clock:  clock,
+	}
+}
+
+// Generate returns all auto environment variables as a map
+func (p *autoEnvProvider) Generate() map[string]string {
+	return map[string]string{
+		AutoEnvPrefix + AutoEnvKeyDatetime: p.generateDateTime(),
+		AutoEnvPrefix + AutoEnvKeyPID:      p.generatePID(),
+	}
+}
+
+// generateDateTime generates the datetime string in YYYYMMDDHHMM.msec format (UTC)
+func (p *autoEnvProvider) generateDateTime() string {
+	now := p.clock().UTC()
+	dateTimePart := now.Format(DatetimeLayout)
+	msec := now.Nanosecond() / nanosToMillis
+	return fmt.Sprintf("%s.%03d", dateTimePart, msec)
+}
+
+// generatePID generates the PID string
+func (p *autoEnvProvider) generatePID() string {
+	return strconv.Itoa(os.Getpid())
+}

--- a/internal/runner/environment/autoenv_test.go
+++ b/internal/runner/environment/autoenv_test.go
@@ -1,0 +1,113 @@
+package environment
+
+import (
+	"os"
+	"regexp"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAutoEnvProvider_Generate(t *testing.T) {
+	t.Run("contains all required keys", func(t *testing.T) {
+		provider := NewAutoEnvProvider(nil)
+		result := provider.Generate()
+
+		assert.Contains(t, result, AutoEnvPrefix+AutoEnvKeyDatetime)
+		assert.Contains(t, result, AutoEnvPrefix+AutoEnvKeyPID)
+	})
+
+	t.Run("DATETIME has correct format", func(t *testing.T) {
+		provider := NewAutoEnvProvider(nil)
+		result := provider.Generate()
+
+		datetime := result[AutoEnvPrefix+AutoEnvKeyDatetime]
+		// Format: YYYYMMDDHHMM.msec (e.g., "202510051430.123")
+		pattern := `^\d{12}\.\d{3}$`
+		matched, err := regexp.MatchString(pattern, datetime)
+		require.NoError(t, err)
+		assert.True(t, matched, "DATETIME should match pattern YYYYMMDDHHMM.msec, got: %s", datetime)
+	})
+
+	t.Run("PID is valid", func(t *testing.T) {
+		provider := NewAutoEnvProvider(nil)
+		result := provider.Generate()
+
+		pid := result[AutoEnvPrefix+AutoEnvKeyPID]
+		expectedPID := strconv.Itoa(os.Getpid())
+		assert.Equal(t, expectedPID, pid)
+	})
+}
+
+func TestAutoEnvProvider_WithFixedClock(t *testing.T) {
+	tests := []struct {
+		name         string
+		fixedTime    time.Time
+		expectedDate string
+	}{
+		{
+			name:         "normal time with milliseconds",
+			fixedTime:    time.Date(2025, 10, 5, 14, 30, 22, 123000000, time.UTC),
+			expectedDate: "202510051430.123",
+		},
+		{
+			name:         "zero milliseconds",
+			fixedTime:    time.Date(2025, 10, 5, 14, 30, 22, 0, time.UTC),
+			expectedDate: "202510051430.000",
+		},
+		{
+			name:         "year end boundary",
+			fixedTime:    time.Date(2025, 12, 31, 23, 59, 59, 999000000, time.UTC),
+			expectedDate: "202512312359.999",
+		},
+		{
+			name:         "year start boundary",
+			fixedTime:    time.Date(2025, 1, 1, 0, 0, 0, 1000000, time.UTC),
+			expectedDate: "202501010000.001",
+		},
+		{
+			name:         "nanosecond precision truncation",
+			fixedTime:    time.Date(2025, 10, 5, 14, 30, 22, 123456789, time.UTC),
+			expectedDate: "202510051430.123",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clock := func() time.Time { return tt.fixedTime }
+			provider := NewAutoEnvProvider(clock)
+
+			result := provider.Generate()
+			datetime := result[AutoEnvPrefix+AutoEnvKeyDatetime]
+			assert.Equal(t, tt.expectedDate, datetime)
+		})
+	}
+}
+
+func TestAutoEnvProvider_UTCTimezone(t *testing.T) {
+	// Use non-UTC time to ensure conversion happens
+	jst := time.FixedZone("JST", 9*60*60) // UTC+9
+	fixedTime := time.Date(2025, 10, 5, 23, 30, 22, 123000000, jst)
+
+	clock := func() time.Time { return fixedTime }
+	provider := NewAutoEnvProvider(clock)
+
+	result := provider.Generate()
+	datetime := result[AutoEnvPrefix+AutoEnvKeyDatetime]
+
+	// JST 23:30 = UTC 14:30
+	expected := "202510051430.123"
+	assert.Equal(t, expected, datetime, "should convert to UTC")
+}
+
+func TestNewAutoEnvProvider_NilClock(t *testing.T) {
+	provider := NewAutoEnvProvider(nil)
+	result := provider.Generate()
+
+	// Should use time.Now() as default
+	assert.NotEmpty(t, result[AutoEnvPrefix+AutoEnvKeyDatetime])
+	assert.NotEmpty(t, result[AutoEnvPrefix+AutoEnvKeyPID])
+}


### PR DESCRIPTION
This pull request implements the automatic environment variable provider (`AutoEnvProvider`) for the runner, along with comprehensive tests and updates to the implementation plan documentation. The main changes include defining the provider interface and its implementation, adding a function type for time injection, and ensuring robust test coverage for various edge cases.

**Implementation of automatic environment variable provider:**

* Added new file `autoenv.go` with the definition and implementation of `AutoEnvProvider`, including the `Clock` function type for dependency injection, constants for environment variable keys, and methods to generate current datetime (in UTC, formatted as `YYYYMMDDHHMM.msec`) and process ID. (`internal/runner/environment/autoenv.go`)

**Testing and validation:**

* Added comprehensive tests in `autoenv_test.go` to verify correct generation of environment variables, formatting of the datetime value, correct PID, handling of edge cases (such as year boundaries and nanosecond truncation), UTC conversion, and default clock behavior. (`internal/runner/environment/autoenv_test.go`)

**Documentation updates:**

* Updated the implementation plan (`04_implementation_plan.md`) to mark the completion of tasks related to the definition of constants and types, interface definition, implementation, and test creation for `AutoEnvProvider`. (`docs/tasks/0028_automatic_env_vars/04_implementation_plan.md`) [[1]](diffhunk://#diff-9c6e28d156467e1b0cf5e147fde4826e8eae3f88fefdf74657fa52d605d32131L19-R19) [[2]](diffhunk://#diff-9c6e28d156467e1b0cf5e147fde4826e8eae3f88fefdf74657fa52d605d32131L28-R34) [[3]](diffhunk://#diff-9c6e28d156467e1b0cf5e147fde4826e8eae3f88fefdf74657fa52d605d32131L43-R43)