### PR TITLE
Add environment Manager to handle auto and user env variables

### DIFF
--- a/docs/tasks/0028_automatic_env_vars/04_implementation_plan.md
+++ b/docs/tasks/0028_automatic_env_vars/04_implementation_plan.md
@@ -52,26 +52,26 @@
 
 ### Phase 3: EnvironmentManager実装
 
-- [ ] **3.1 EnvironmentManagerインターフェース定義**
+- [x] **3.1 EnvironmentManagerインターフェース定義**
   - ファイル: `internal/runner/environment/manager.go`（新規作成）
   - タスク: インターフェースを定義
-    - `EnvironmentManager` インターフェース
+    - `Manager` インターフェース (lint対応のため`EnvironmentManager`から変更)
     - `ValidateUserEnv(userEnv map[string]string) error` メソッド
     - `BuildEnv(userEnv map[string]string) (map[string]string, error)` メソッド
 
-- [ ] **3.2 EnvironmentManager実装（テスト作成）**
+- [x] **3.2 EnvironmentManager実装（テスト作成）**
   - ファイル: `internal/runner/environment/manager_test.go`（新規作成）
-  - タスク: `EnvironmentManager` のテストケース作成
+  - タスク: `Manager` のテストケース作成
     - `ValidateUserEnv` のテスト（予約プレフィックス `AutoEnvPrefix` を使用した検証）
     - `BuildEnv` のテスト（自動環境変数とユーザー環境変数のマージ）
     - Clock関数を注入したテスト
   - 状態: テスト失敗を確認（実装前）
 
-- [ ] **3.3 EnvironmentManager実装**
+- [x] **3.3 EnvironmentManager実装**
   - ファイル: `internal/runner/environment/manager.go`
-  - タスク: `environmentManager` 構造体と実装
-    - `environmentManager struct` 定義（autoProvider フィールド）
-    - `NewEnvironmentManager(clock Clock)` コンストラクタ（clockがnilの場合は内部で `time.Now` を使用）
+  - タスク: `manager` 構造体と実装
+    - `manager struct` 定義（autoProvider フィールド）
+    - `NewManager(clock Clock)` コンストラクタ（clockがnilの場合は内部で `time.Now` を使用）
     - `ValidateUserEnv` メソッド実装（`AutoEnvPrefix` を使用した予約プレフィックスチェック、`manager.go` 内に実装）
     - `BuildEnv` メソッド実装（`autoProvider.Generate()` 呼び出しとマージ）
   - 状態: テスト成功を確認

--- a/internal/runner/environment/manager.go
+++ b/internal/runner/environment/manager.go
@@ -1,0 +1,63 @@
+package environment
+
+import (
+	"strings"
+
+	"github.com/isseis/go-safe-cmd-runner/internal/runner/runnertypes"
+)
+
+// Manager manages environment variables for command execution
+type Manager interface {
+	// ValidateUserEnvNames validates that user-defined env variable names do not use reserved prefixes.
+	ValidateUserEnvNames(envNames []string) error
+
+	// BuildEnv builds the final environment for a command, merging auto-generated
+	// and user-defined variables. The returned map includes all auto env variables
+	// and can be used directly by VariableExpander.
+	BuildEnv(userEnv map[string]string) (map[string]string, error)
+}
+
+// manager implements Manager
+type manager struct {
+	autoProvider AutoEnvProvider
+}
+
+// NewManager creates a new Manager.
+// If clock is nil, the default time.Now will be used internally.
+func NewManager(clock Clock) Manager {
+	return &manager{
+		autoProvider: NewAutoEnvProvider(clock),
+	}
+}
+
+// ValidateUserEnvNames validates that user-defined env variable names do not use the reserved prefix
+func (m *manager) ValidateUserEnvNames(envNames []string) error {
+	for _, name := range envNames {
+		if strings.HasPrefix(name, AutoEnvPrefix) {
+			return runnertypes.NewReservedEnvPrefixError(name, AutoEnvPrefix)
+		}
+	}
+	return nil
+}
+
+// BuildEnv builds the final environment map by merging auto-generated and user-defined variables
+func (m *manager) BuildEnv(userEnv map[string]string) (map[string]string, error) {
+	// Generate auto environment variables
+	autoEnv := m.autoProvider.Generate()
+
+	// Create result map with capacity for both auto and user env
+	result := make(map[string]string, len(autoEnv)+len(userEnv))
+
+	// Add auto-generated variables first
+	for k, v := range autoEnv {
+		result[k] = v
+	}
+
+	// Add user-defined variables
+	// Note: No conflicts possible due to ValidateUserEnv being called earlier
+	for k, v := range userEnv {
+		result[k] = v
+	}
+
+	return result, nil
+}

--- a/internal/runner/environment/manager_test.go
+++ b/internal/runner/environment/manager_test.go
@@ -1,0 +1,247 @@
+package environment
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/isseis/go-safe-cmd-runner/internal/runner/runnertypes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestManagerValidateUserEnvNames(t *testing.T) {
+	tests := []struct {
+		name         string
+		envNames     []string
+		wantErr      bool
+		errType      error
+		invalidNames []string // Expected invalid names in error
+	}{
+		{
+			name: "valid environment variable names",
+			envNames: []string{
+				"PATH",
+				"HOME",
+				"CUSTOM",
+				"GO_PATH",
+				"__CUSTOM", // Not using the reserved prefix
+			},
+			wantErr: false,
+		},
+		{
+			name:     "empty environment names",
+			envNames: []string{},
+			wantErr:  false,
+		},
+		{
+			name: "reserved prefix DATETIME",
+			envNames: []string{
+				"PATH",
+				"__RUNNER_DATETIME",
+			},
+			wantErr:      true,
+			errType:      &runnertypes.ReservedEnvPrefixError{},
+			invalidNames: []string{"__RUNNER_DATETIME"},
+		},
+		{
+			name: "reserved prefix PID",
+			envNames: []string{
+				"PATH",
+				"__RUNNER_PID",
+			},
+			wantErr:      true,
+			errType:      &runnertypes.ReservedEnvPrefixError{},
+			invalidNames: []string{"__RUNNER_PID"},
+		},
+		{
+			name: "reserved prefix custom variable",
+			envNames: []string{
+				"PATH",
+				"__RUNNER_CUSTOM",
+			},
+			wantErr:      true,
+			errType:      &runnertypes.ReservedEnvPrefixError{},
+			invalidNames: []string{"__RUNNER_CUSTOM"},
+		},
+		{
+			name: "multiple reserved prefix violations",
+			envNames: []string{
+				"__RUNNER_VAR1",
+				"__RUNNER_VAR2",
+			},
+			wantErr:      true,
+			errType:      &runnertypes.ReservedEnvPrefixError{},
+			invalidNames: []string{"__RUNNER_VAR1", "__RUNNER_VAR2"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manager := NewManager(nil)
+			err := manager.ValidateUserEnvNames(tt.envNames)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.True(t, errors.Is(err, tt.errType), "error type mismatch")
+
+				// Check that the error contains the reserved prefix
+				var rpe *runnertypes.ReservedEnvPrefixError
+				if errors.As(err, &rpe) {
+					assert.Equal(t, AutoEnvPrefix, rpe.Prefix)
+					// Check that the error references one of the invalid names
+					found := false
+					for _, invalidName := range tt.invalidNames {
+						if rpe.VarName == invalidName {
+							found = true
+							break
+						}
+					}
+					assert.True(t, found, "error should reference one of the invalid variables: %v, got: %s", tt.invalidNames, rpe.VarName)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestManagerBuildEnv(t *testing.T) {
+	// Fixed time for testing: 2025-10-05 14:30:22.123456789 UTC
+	fixedTime := time.Date(2025, 10, 5, 14, 30, 22, 123456789, time.UTC)
+	fixedClock := func() time.Time { return fixedTime }
+
+	tests := []struct {
+		name        string
+		userEnv     map[string]string
+		clock       Clock
+		wantAutoEnv map[string]string
+		wantErr     bool
+	}{
+		{
+			name: "merge auto and user env",
+			userEnv: map[string]string{
+				"PATH":   "/usr/bin",
+				"HOME":   "/home/user",
+				"CUSTOM": "value",
+			},
+			clock: fixedClock,
+			wantAutoEnv: map[string]string{
+				"__RUNNER_DATETIME": "202510051430.123",
+				// PID is dynamic, checked separately
+			},
+			wantErr: false,
+		},
+		{
+			name:    "empty user env",
+			userEnv: map[string]string{},
+			clock:   fixedClock,
+			wantAutoEnv: map[string]string{
+				"__RUNNER_DATETIME": "202510051430.123",
+			},
+			wantErr: false,
+		},
+		{
+			name: "user env with many variables",
+			userEnv: map[string]string{
+				"VAR1": "value1",
+				"VAR2": "value2",
+				"VAR3": "value3",
+			},
+			clock: fixedClock,
+			wantAutoEnv: map[string]string{
+				"__RUNNER_DATETIME": "202510051430.123",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manager := NewManager(tt.clock)
+			result, err := manager.BuildEnv(tt.userEnv)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+
+			// Check that all auto env variables are present
+			for key, expectedValue := range tt.wantAutoEnv {
+				actualValue, ok := result[key]
+				assert.True(t, ok, "auto env variable %q should be present", key)
+				assert.Equal(t, expectedValue, actualValue, "auto env variable %q value mismatch", key)
+			}
+
+			// Check that __RUNNER_PID is present and is a valid number
+			pid, ok := result["__RUNNER_PID"]
+			assert.True(t, ok, "__RUNNER_PID should be present")
+			assert.Regexp(t, `^\d+$`, pid, "__RUNNER_PID should be a number")
+
+			// Check that all user env variables are present
+			for key, expectedValue := range tt.userEnv {
+				actualValue, ok := result[key]
+				assert.True(t, ok, "user env variable %q should be present", key)
+				assert.Equal(t, expectedValue, actualValue, "user env variable %q value mismatch", key)
+			}
+
+			// Check that the result contains both auto and user env
+			expectedCount := len(tt.wantAutoEnv) + 1 + len(tt.userEnv) // +1 for PID
+			assert.Equal(t, expectedCount, len(result), "environment map size mismatch")
+		})
+	}
+}
+
+func TestManagerBuildEnvWithDefaultClock(t *testing.T) {
+	manager := NewManager(nil)
+	userEnv := map[string]string{
+		"PATH": "/usr/bin",
+	}
+
+	result, err := manager.BuildEnv(userEnv)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// Check that auto env variables are present with valid formats
+	datetime, ok := result["__RUNNER_DATETIME"]
+	assert.True(t, ok, "__RUNNER_DATETIME should be present")
+	assert.Regexp(t, `^\d{12}\.\d{3}$`, datetime, "__RUNNER_DATETIME should match format YYYYMMDDHHMM.mmm")
+
+	pid, ok := result["__RUNNER_PID"]
+	assert.True(t, ok, "__RUNNER_PID should be present")
+	assert.Regexp(t, `^\d+$`, pid, "__RUNNER_PID should be a number")
+
+	// Check user env
+	path, ok := result["PATH"]
+	assert.True(t, ok, "PATH should be present")
+	assert.Equal(t, "/usr/bin", path)
+}
+
+func TestManagerBuildEnvNoConflict(t *testing.T) {
+	// This test verifies that user env cannot override auto env
+	// However, validation should catch this before BuildEnv is called
+	// BuildEnv assumes userEnv has already been validated
+
+	fixedTime := time.Date(2025, 10, 5, 14, 30, 22, 123456789, time.UTC)
+	fixedClock := func() time.Time { return fixedTime }
+
+	manager := NewManager(fixedClock)
+
+	// User env with regular variables (no reserved prefix)
+	userEnv := map[string]string{
+		"PATH": "/usr/bin",
+	}
+
+	result, err := manager.BuildEnv(userEnv)
+	require.NoError(t, err)
+
+	// Auto env should always be present with correct values
+	assert.Equal(t, "202510051430.123", result["__RUNNER_DATETIME"])
+	assert.Regexp(t, `^\d+$`, result["__RUNNER_PID"])
+
+	// User env should also be present
+	assert.Equal(t, "/usr/bin", result["PATH"])
+}


### PR DESCRIPTION
This pull request implements the core logic and tests for managing environment variables in the command runner. It introduces a new `Manager` interface and its implementation for handling both user-defined and auto-generated environment variables, along with comprehensive unit tests to ensure correct validation and merging behavior.

**Environment Variable Management Implementation:**

* Added a new `Manager` interface in `internal/runner/environment/manager.go` to manage environment variables, including methods for validating user environment variable names and building the final merged environment.
* Implemented the `manager` struct and its methods, including validation to prevent user variables from using reserved prefixes and logic to merge user and auto-generated variables.

**Testing and Validation:**

* Created comprehensive tests in `internal/runner/environment/manager_test.go` covering validation of reserved prefixes, correct merging of user and auto-generated variables, and handling of edge cases such as empty inputs and default clock usage.

**Documentation and Planning Updates:**

* Updated the implementation plan in `docs/tasks/0028_automatic_env_vars/04_implementation_plan.md` to reflect completion of the interface definition, implementation, and testing phases, and to align naming with linting requirements (renaming `EnvironmentManager` to `Manager`).