### PR TITLE
Validate user environment variables during config load and add tests

### DIFF
--- a/docs/tasks/0028_automatic_env_vars/04_implementation_plan.md
+++ b/docs/tasks/0028_automatic_env_vars/04_implementation_plan.md
@@ -92,28 +92,28 @@
 
 ### Phase 5: 設定ロード時の検証統合
 
-- [ ] **5.1 Config検証統合（テスト作成）**
+- [x] **5.1 Config検証統合（テスト作成）**
   - ファイル: `internal/runner/config/loader_test.go`
   - タスク: 設定ロード時の予約プレフィックス検証テスト
     - コマンドレベル環境変数の検証
     - グループレベル環境変数の検証（存在する場合）
     - エラーケース: 予約プレフィックス使用
-  - 状態: テスト失敗を確認（実装前）
+  - 状態: テスト作成完了、検証ロジック動作確認
 
-- [ ] **5.2 Config検証統合（実装）**
+- [x] **5.2 Config検証統合（実装）**
   - ファイル: `internal/runner/config/loader.go`
   - タスク: 設定ロード時に環境変数を検証
     - EnvironmentManagerを使用して各コマンドの環境変数を検証
     - エラー時は設定ロードを中止
   - 状態: テスト成功を確認
 
-- [ ] **5.3 依存性注入の更新（実装）**
+- [x] **5.3 依存性注入の更新（実装）**
   - ファイル: `cmd/runner/main.go`
   - タスク: EnvironmentManagerを各コンポーネントに注入
     - EnvironmentManagerの生成（`NewEnvironmentManager(nil)` - clockはnilでデフォルトの `time.Now` を使用）
     - VariableExpanderへの注入
     - Config Loaderへの注入
-  - 状態: ビルド成功を確認
+  - 状態: ビルド成功を確認（注: bootstrap/config.goを通じて既に統合済み）
 
 ### Phase 6: 統合テストとサンプル
 

--- a/internal/runner/config/loader_test.go
+++ b/internal/runner/config/loader_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/isseis/go-safe-cmd-runner/internal/runner/runnertypes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -55,4 +56,120 @@ version = "1.0"
 	assert.Equal(t, "test_cmd", cmd.Name, "expected command name 'test_cmd'")
 	assert.Equal(t, "root", cmd.RunAsUser, "expected run_as_user to be 'root'")
 	assert.True(t, cmd.HasUserGroupSpecification(), "expected command to have user/group specification")
+}
+
+// TestValidateReservedPrefix tests that config loading validates reserved prefix usage in env vars
+func TestValidateReservedPrefix(t *testing.T) {
+	tests := []struct {
+		name        string
+		configTOML  string
+		expectError bool
+		errorType   error
+	}{
+		{
+			name: "valid_command_level_env",
+			configTOML: `
+version = "1.0"
+[global]
+  workdir = "/tmp"
+
+[[groups]]
+  name = "test"
+  [[groups.commands]]
+    name = "test_cmd"
+    cmd = "echo"
+    args = ["hello"]
+    env = ["NORMAL_VAR=value", "PATH=/usr/bin"]
+`,
+			expectError: false,
+		},
+		{
+			name: "reserved_prefix_at_command_level",
+			configTOML: `
+version = "1.0"
+[global]
+  workdir = "/tmp"
+
+[[groups]]
+  name = "test"
+  [[groups.commands]]
+    name = "test_cmd"
+    cmd = "echo"
+    args = ["hello"]
+    env = ["__RUNNER_CUSTOM=value"]
+`,
+			expectError: true,
+			errorType:   &runnertypes.ReservedEnvPrefixError{},
+		},
+		{
+			name: "reserved_prefix_DATETIME",
+			configTOML: `
+version = "1.0"
+[global]
+  workdir = "/tmp"
+
+[[groups]]
+  name = "test"
+  [[groups.commands]]
+    name = "test_cmd"
+    cmd = "echo"
+    env = ["__RUNNER_DATETIME=override"]
+`,
+			expectError: true,
+			errorType:   &runnertypes.ReservedEnvPrefixError{},
+		},
+		{
+			name: "reserved_prefix_PID",
+			configTOML: `
+version = "1.0"
+[global]
+  workdir = "/tmp"
+
+[[groups]]
+  name = "test"
+  [[groups.commands]]
+    name = "test_cmd"
+    cmd = "echo"
+    env = ["__RUNNER_PID=12345"]
+`,
+			expectError: true,
+			errorType:   &runnertypes.ReservedEnvPrefixError{},
+		},
+		{
+			name: "similar_but_not_reserved",
+			configTOML: `
+version = "1.0"
+[global]
+  workdir = "/tmp"
+
+[[groups]]
+  name = "test"
+  [[groups.commands]]
+    name = "test_cmd"
+    cmd = "echo"
+    env = ["GO_RUNNER_VAR=value", "RUNNER_VAR=value"]
+`,
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			loader := NewLoader()
+
+			// Load the config (validation is performed inside LoadConfig now)
+			cfg, err := loader.LoadConfig([]byte(tt.configTOML))
+
+			if tt.expectError {
+				require.Error(t, err, "expected LoadConfig to fail with validation error")
+				if tt.errorType != nil {
+					assert.ErrorAs(t, err, &tt.errorType, "expected error type to match")
+				}
+				assert.Nil(t, cfg, "expected cfg to be nil when error occurs")
+			} else {
+				require.NoError(t, err, "expected LoadConfig to succeed")
+				require.NotNil(t, cfg, "expected cfg to be non-nil")
+			}
+		})
+	}
 }


### PR DESCRIPTION
This pull request implements environment variable validation to prevent the use of reserved prefixes in configuration files. It introduces new validation logic in the config loader, updates dependency injection to support environment management, and adds thorough unit tests to ensure correct behavior.

**Environment variable validation and integration:**

* Added a validation step in `Loader.LoadConfig` (in `loader.go`) to ensure that user-defined environment variables do not use reserved prefixes, using the new `validateEnvironmentVariables` method and the `EnvironmentManager`. If invalid variables are found, config loading fails with a descriptive error.
* Updated the `Loader` struct to include an `envManager` field and provided new constructors (`NewLoaderWithOptions`) to allow injection of a custom `EnvironmentManager`. [[1]](diffhunk://#diff-427aea31a1ed4f76dec0a74702ac4db42bd4ba4d8c18d1c4240d7a64ce13ee83R12) [[2]](diffhunk://#diff-427aea31a1ed4f76dec0a74702ac4db42bd4ba4d8c18d1c4240d7a64ce13ee83R21) [[3]](diffhunk://#diff-427aea31a1ed4f76dec0a74702ac4db42bd4ba4d8c18d1c4240d7a64ce13ee83R46-R53)

**Testing:**

* Added comprehensive unit tests (`TestValidateReservedPrefix` in `loader_test.go`) to verify that configs with reserved environment variable prefixes are correctly rejected, and valid cases pass as expected. [[1]](diffhunk://#diff-50f09ece3b7be79cbec538593873d75b7823a9f03b982e2f8d064605f1d9932eR60-R175) [[2]](diffhunk://#diff-50f09ece3b7be79cbec538593873d75b7823a9f03b982e2f8d064605f1d9932eR10)

**Documentation and implementation plan:**

* Updated the implementation plan (`04_implementation_plan.md`) to mark the config validation integration and dependency injection tasks as completed, reflecting the new test coverage and implementation status.