### PR TITLE
refactor: ValidateUserEnvNames() takes map to prevent map -> slice conversion

### DIFF
--- a/internal/runner/config/loader.go
+++ b/internal/runner/config/loader.go
@@ -107,14 +107,8 @@ func (l *Loader) validateEnvironmentVariables(cfg *runnertypes.Config) error {
 				return fmt.Errorf("failed to build environment map for command %q: %w", cmd.Name, err)
 			}
 
-			// Extract environment variable names
-			envNames := make([]string, 0, len(envMap))
-			for key := range envMap {
-				envNames = append(envNames, key)
-			}
-
 			// Validate using EnvironmentManager
-			if err := l.envManager.ValidateUserEnvNames(envNames); err != nil {
+			if err := l.envManager.ValidateUserEnvNames(envMap); err != nil {
 				return fmt.Errorf("invalid environment variable in command %q: %w", cmd.Name, err)
 			}
 		}

--- a/internal/runner/environment/manager.go
+++ b/internal/runner/environment/manager.go
@@ -9,7 +9,7 @@ import (
 // Manager manages environment variables for command execution
 type Manager interface {
 	// ValidateUserEnvNames validates that user-defined env variable names do not use reserved prefixes.
-	ValidateUserEnvNames(envNames []string) error
+	ValidateUserEnvNames(userEnv map[string]string) error
 
 	// BuildEnv builds the final environment for a command, merging auto-generated
 	// and user-defined variables. The returned map includes all auto env variables
@@ -31,8 +31,8 @@ func NewManager(clock Clock) Manager {
 }
 
 // ValidateUserEnvNames validates that user-defined env variable names do not use the reserved prefix
-func (m *manager) ValidateUserEnvNames(envNames []string) error {
-	for _, name := range envNames {
+func (m *manager) ValidateUserEnvNames(userEnv map[string]string) error {
+	for name := range userEnv {
 		if strings.HasPrefix(name, AutoEnvPrefix) {
 			return runnertypes.NewReservedEnvPrefixError(name, AutoEnvPrefix)
 		}

--- a/internal/runner/environment/manager_test.go
+++ b/internal/runner/environment/manager_test.go
@@ -13,32 +13,32 @@ import (
 func TestManagerValidateUserEnvNames(t *testing.T) {
 	tests := []struct {
 		name         string
-		envNames     []string
+		envMap       map[string]string
 		wantErr      bool
 		errType      error
 		invalidNames []string // Expected invalid names in error
 	}{
 		{
 			name: "valid environment variable names",
-			envNames: []string{
-				"PATH",
-				"HOME",
-				"CUSTOM",
-				"GO_PATH",
-				"__CUSTOM", // Not using the reserved prefix
+			envMap: map[string]string{
+				"PATH":     "/usr/bin",
+				"HOME":     "/home/user",
+				"CUSTOM":   "value",
+				"GO_PATH":  "/go",
+				"__CUSTOM": "value", // Not using the reserved prefix
 			},
 			wantErr: false,
 		},
 		{
-			name:     "empty environment names",
-			envNames: []string{},
-			wantErr:  false,
+			name:    "empty environment names",
+			envMap:  map[string]string{},
+			wantErr: false,
 		},
 		{
 			name: "reserved prefix DATETIME",
-			envNames: []string{
-				"PATH",
-				"__RUNNER_DATETIME",
+			envMap: map[string]string{
+				"PATH":              "/usr/bin",
+				"__RUNNER_DATETIME": "value",
 			},
 			wantErr:      true,
 			errType:      &runnertypes.ReservedEnvPrefixError{},
@@ -46,9 +46,9 @@ func TestManagerValidateUserEnvNames(t *testing.T) {
 		},
 		{
 			name: "reserved prefix PID",
-			envNames: []string{
-				"PATH",
-				"__RUNNER_PID",
+			envMap: map[string]string{
+				"PATH":         "/usr/bin",
+				"__RUNNER_PID": "value",
 			},
 			wantErr:      true,
 			errType:      &runnertypes.ReservedEnvPrefixError{},
@@ -56,9 +56,9 @@ func TestManagerValidateUserEnvNames(t *testing.T) {
 		},
 		{
 			name: "reserved prefix custom variable",
-			envNames: []string{
-				"PATH",
-				"__RUNNER_CUSTOM",
+			envMap: map[string]string{
+				"PATH":            "/usr/bin",
+				"__RUNNER_CUSTOM": "value",
 			},
 			wantErr:      true,
 			errType:      &runnertypes.ReservedEnvPrefixError{},
@@ -66,9 +66,9 @@ func TestManagerValidateUserEnvNames(t *testing.T) {
 		},
 		{
 			name: "multiple reserved prefix violations",
-			envNames: []string{
-				"__RUNNER_VAR1",
-				"__RUNNER_VAR2",
+			envMap: map[string]string{
+				"__RUNNER_VAR1": "value1",
+				"__RUNNER_VAR2": "value2",
 			},
 			wantErr:      true,
 			errType:      &runnertypes.ReservedEnvPrefixError{},
@@ -79,7 +79,7 @@ func TestManagerValidateUserEnvNames(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			manager := NewManager(nil)
-			err := manager.ValidateUserEnvNames(tt.envNames)
+			err := manager.ValidateUserEnvNames(tt.envMap)
 
 			if tt.wantErr {
 				require.Error(t, err)


### PR DESCRIPTION
This pull request refactors the environment variable validation logic to improve clarity and consistency. The main change is that environment variable validation methods now accept a map of environment variables (`map[string]string`) instead of a slice of names (`[]string`). This affects the interface, implementation, and related tests.

**Environment variable validation refactor:**

* Updated the `Manager` interface, its implementation, and all usages so that `ValidateUserEnvNames` now takes a `map[string]string` (the environment variable map) rather than a `[]string` of names. This simplifies the method signature and usage throughout the codebase. [[1]](diffhunk://#diff-fe333b44eb6349e1998996a56575b128378eabfe15a607de740f1e8de55e9a6fL12-R12) [[2]](diffhunk://#diff-fe333b44eb6349e1998996a56575b128378eabfe15a607de740f1e8de55e9a6fL34-R35) [[3]](diffhunk://#diff-427aea31a1ed4f76dec0a74702ac4db42bd4ba4d8c18d1c4240d7a64ce13ee83L110-R111)
* Refactored corresponding unit tests in `manager_test.go` to use environment variable maps instead of slices, ensuring test coverage remains accurate after the signature change. [[1]](diffhunk://#diff-f1bea5a6747497c468278d242b8a134a598b001358be0997ff2acc36467e0decL16-R71) [[2]](diffhunk://#diff-f1bea5a6747497c468278d242b8a134a598b001358be0997ff2acc36467e0decL82-R82)