### PR TITLE
Refactor: risk profile to detect git network operation correctly

### DIFF
--- a/internal/runner/security/command_analysis_test.go
+++ b/internal/runner/security/command_analysis_test.go
@@ -570,6 +570,46 @@ func TestIsNetworkOperation(t *testing.T) {
 			expectedRisk: false,
 			description:  "git local operation should not be detected as network",
 		},
+		{
+			name:         "git fetch without URL",
+			cmdName:      "git",
+			args:         []string{"fetch"},
+			expectedNet:  true,
+			expectedRisk: false,
+			description:  "git fetch should be detected as network even without URL",
+		},
+		{
+			name:         "git pull without URL",
+			cmdName:      "git",
+			args:         []string{"pull"},
+			expectedNet:  true,
+			expectedRisk: false,
+			description:  "git pull should be detected as network even without URL",
+		},
+		{
+			name:         "git push without URL",
+			cmdName:      "git",
+			args:         []string{"push"},
+			expectedNet:  true,
+			expectedRisk: false,
+			description:  "git push should be detected as network even without URL",
+		},
+		{
+			name:         "git clone with https URL",
+			cmdName:      "git",
+			args:         []string{"clone", "https://github.com/user/repo.git"},
+			expectedNet:  true,
+			expectedRisk: false,
+			description:  "git clone with URL should be detected as network",
+		},
+		{
+			name:         "git remote update",
+			cmdName:      "git",
+			args:         []string{"remote", "update"},
+			expectedNet:  true,
+			expectedRisk: false,
+			description:  "git remote update should be detected as network",
+		},
 
 		// Non-network commands
 		{


### PR DESCRIPTION
This pull request refactors and improves the way command risk profiles are defined and used in the security analysis logic. It replaces scattered risk level overrides and network command lists with a unified, extensible data structure that associates each command with its risk level, privilege escalation status, and network operation type. The logic for detecting network operations and privilege escalation is updated accordingly, and the test suite is enhanced to verify the correctness and completeness of these profiles.

### Core Refactoring and Data Structure Improvements

* Introduced a unified `CommandRiskProfile` struct and the `commandGroupDefinitions` list, consolidating risk level, privilege escalation, and network operation type for each command. This replaces the previous separate maps and lists for risk overrides and network commands. (`internal/runner/security/command_analysis.go`, [internal/runner/security/command_analysis.goR12-L27](diffhunk://#diff-3e9fdee1040d6b864582399879be9e45f09737b13f56828c4c07bc4ef2f323a3R12-L27))
* Added logic to build the `commandRiskProfiles` map from the unified group definitions, ensuring all command profiles are defined in one place. (`internal/runner/security/command_analysis.go`, [internal/runner/security/command_analysis.goR12-L27](diffhunk://#diff-3e9fdee1040d6b864582399879be9e45f09737b13f56828c4c07bc4ef2f323a3R12-L27))
* Removed legacy maps and lists for privilege escalation and network commands, now superseded by the new unified structure. (`internal/runner/security/command_analysis.go`, [internal/runner/security/command_analysis.goL49-L69](diffhunk://#diff-3e9fdee1040d6b864582399879be9e45f09737b13f56828c4c07bc4ef2f323a3L49-L69))

### Command Analysis Logic Updates

* Updated `getCommandRiskOverride` to use command basename lookup in `commandRiskProfiles` instead of full path, improving flexibility and accuracy. (`internal/runner/security/command_analysis.go`, [internal/runner/security/command_analysis.goR257-R267](diffhunk://#diff-3e9fdee1040d6b864582399879be9e45f09737b13f56828c4c07bc4ef2f323a3R257-R267))
* Refactored privilege escalation and network operation detection functions to use the new unified profiles, including more accurate detection of git subcommands that perform network operations. (`internal/runner/security/command_analysis.go`, [[1]](diffhunk://#diff-3e9fdee1040d6b864582399879be9e45f09737b13f56828c4c07bc4ef2f323a3L218-R318) [[2]](diffhunk://#diff-3e9fdee1040d6b864582399879be9e45f09737b13f56828c4c07bc4ef2f323a3L240-L256)

### Test Suite Enhancements

* Expanded tests for network operation detection, including cases for git subcommands and various network-related commands, verifying correct detection even without explicit URLs. (`internal/runner/security/command_analysis_test.go`, [internal/runner/security/command_analysis_test.goR573-R612](diffhunk://#diff-d777335bcb4e2f2eb3f7c5e68e1803501994319090cc64de601e407450ca46f1R573-R612))
* Improved risk override tests to check both full path and basename lookups, and added coverage for all newly profiled commands. (`internal/runner/security/command_analysis_test.go`, [[1]](diffhunk://#diff-d777335bcb4e2f2eb3f7c5e68e1803501994319090cc64de601e407450ca46f1L1858-R1920) [[2]](diffhunk://#diff-d777335bcb4e2f2eb3f7c5e68e1803501994319090cc64de601e407450ca46f1R1945-R1974)
* Added new tests to verify the completeness and correctness of all command risk profiles, including privilege escalation and network operation types. (`internal/runner/security/command_analysis_test.go`, [internal/runner/security/command_analysis_test.goL1905-R2052](diffhunk://#diff-d777335bcb4e2f2eb3f7c5e68e1803501994319090cc64de601e407450ca46f1L1905-R2052))