### PR TITLE
feat: enhance audit logging and add risk statistics

### DIFF
--- a/docs/tasks/0029_risk_profile_redesign/04_implementation_plan.md
+++ b/docs/tasks/0029_risk_profile_redesign/04_implementation_plan.md
@@ -1068,10 +1068,10 @@ func (l *AuditLogger) logRiskProfile(profile CommandRiskProfile) {
 ```
 
 **チェックリスト:**
-- [ ] ログ出力メソッド実装
-- [ ] テストケース追加
-- [ ] ログフォーマットの確認
-- [ ] `make test`実行（成功を確認）
+- [x] ログ出力メソッド実装
+- [x] テストケース追加
+- [x] ログフォーマットの確認
+- [x] `make test`実行（成功を確認）
 - [ ] コミット作成
 
 #### タスク3.1.2: リスク要因別の統計情報
@@ -1083,9 +1083,9 @@ func (l *AuditLogger) logRiskProfile(profile CommandRiskProfile) {
 - レポート生成機能（オプション）
 
 **チェックリスト:**
-- [ ] 統計機能実装
-- [ ] テストケース追加
-- [ ] `make test`実行（成功を確認）
+- [x] 統計機能実装
+- [x] テストケース追加
+- [x] `make test`実行（成功を確認）
 - [ ] コミット作成
 
 ### 5.2 Phase 3.2: ドキュメント整備
@@ -1116,11 +1116,11 @@ func (l *AuditLogger) logRiskProfile(profile CommandRiskProfile) {
 
 ### 5.3 Phase 3 完了チェック
 
-- [ ] 監査ログ拡張完了
+- [x] 監査ログ拡張完了
 - [ ] 全ドキュメント整備完了
-- [ ] 全ユニットテストがパス
-- [ ] 全統合テストがパス
-- [ ] `make lint`でエラーなし
+- [x] 全ユニットテストがパス
+- [x] 全統合テストがパス
+- [x] `make lint`でエラーなし
 - [ ] コミット作成（"feat: enhance audit logging with risk factor details"）
 
 ## 6. 最終検証

--- a/docs/tasks/0029_risk_profile_redesign/04_implementation_plan.md
+++ b/docs/tasks/0029_risk_profile_redesign/04_implementation_plan.md
@@ -1072,7 +1072,7 @@ func (l *AuditLogger) logRiskProfile(profile CommandRiskProfile) {
 - [x] テストケース追加
 - [x] ログフォーマットの確認
 - [x] `make test`実行（成功を確認）
-- [ ] コミット作成
+- [x] コミット作成
 
 #### タスク3.1.2: リスク要因別の統計情報
 
@@ -1086,7 +1086,7 @@ func (l *AuditLogger) logRiskProfile(profile CommandRiskProfile) {
 - [x] 統計機能実装
 - [x] テストケース追加
 - [x] `make test`実行（成功を確認）
-- [ ] コミット作成
+- [x] コミット作成
 
 ### 5.2 Phase 3.2: ドキュメント整備
 

--- a/internal/runner/audit/statistics.go
+++ b/internal/runner/audit/statistics.go
@@ -1,0 +1,115 @@
+package audit
+
+import (
+	"sort"
+	"sync"
+
+	"github.com/isseis/go-safe-cmd-runner/internal/runner/runnertypes"
+)
+
+// RiskFactorCount represents a risk factor and its occurrence count
+type RiskFactorCount struct {
+	Factor string
+	Count  int
+}
+
+// RiskStatistics tracks command execution statistics by risk factors
+type RiskStatistics struct {
+	mu               sync.RWMutex
+	totalCommands    int
+	riskLevelCounts  map[runnertypes.RiskLevel]int
+	riskFactorCounts map[string]int
+	commandsByRisk   map[runnertypes.RiskLevel]map[string]bool
+}
+
+// NewRiskStatistics creates a new risk statistics tracker
+func NewRiskStatistics() *RiskStatistics {
+	return &RiskStatistics{
+		riskLevelCounts:  make(map[runnertypes.RiskLevel]int),
+		riskFactorCounts: make(map[string]int),
+		commandsByRisk:   make(map[runnertypes.RiskLevel]map[string]bool),
+	}
+}
+
+// RecordCommand records a command execution with its risk level and factors
+func (s *RiskStatistics) RecordCommand(commandName string, riskLevel runnertypes.RiskLevel, riskFactors []string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.totalCommands++
+	s.riskLevelCounts[riskLevel]++
+
+	// Track risk factors
+	for _, factor := range riskFactors {
+		if factor != "" {
+			s.riskFactorCounts[factor]++
+		}
+	}
+
+	// Track commands by risk level
+	if s.commandsByRisk[riskLevel] == nil {
+		s.commandsByRisk[riskLevel] = make(map[string]bool)
+	}
+	s.commandsByRisk[riskLevel][commandName] = true
+}
+
+// TotalCommands returns the total number of commands recorded
+func (s *RiskStatistics) TotalCommands() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.totalCommands
+}
+
+// GetRiskLevelCounts returns the count of commands by risk level
+func (s *RiskStatistics) GetRiskLevelCounts() map[runnertypes.RiskLevel]int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	// Create a copy to avoid race conditions
+	counts := make(map[runnertypes.RiskLevel]int, len(s.riskLevelCounts))
+	for level, count := range s.riskLevelCounts {
+		counts[level] = count
+	}
+	return counts
+}
+
+// GetTopRiskFactors returns the most common risk factors up to the specified limit
+func (s *RiskStatistics) GetTopRiskFactors(limit int) []RiskFactorCount {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	// Convert map to slice
+	factors := make([]RiskFactorCount, 0, len(s.riskFactorCounts))
+	for factor, count := range s.riskFactorCounts {
+		factors = append(factors, RiskFactorCount{
+			Factor: factor,
+			Count:  count,
+		})
+	}
+
+	// Sort by count (descending)
+	sort.Slice(factors, func(i, j int) bool {
+		return factors[i].Count > factors[j].Count
+	})
+
+	// Apply limit
+	if limit > 0 && limit < len(factors) {
+		return factors[:limit]
+	}
+	return factors
+}
+
+// GetCommandsByRiskLevel returns unique command names for a given risk level
+func (s *RiskStatistics) GetCommandsByRiskLevel(riskLevel runnertypes.RiskLevel) []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	commands := make([]string, 0)
+	if cmdMap, exists := s.commandsByRisk[riskLevel]; exists {
+		for cmd := range cmdMap {
+			commands = append(commands, cmd)
+		}
+		sort.Strings(commands)
+	}
+	return commands
+}

--- a/internal/runner/audit/statistics.go
+++ b/internal/runner/audit/statistics.go
@@ -87,9 +87,12 @@ func (s *RiskStatistics) GetTopRiskFactors(limit int) []RiskFactorCount {
 		})
 	}
 
-	// Sort by count (descending)
+	// Sort by count (descending), then by factor name (ascending) for deterministic order
 	sort.Slice(factors, func(i, j int) bool {
-		return factors[i].Count > factors[j].Count
+		if factors[i].Count != factors[j].Count {
+			return factors[i].Count > factors[j].Count
+		}
+		return factors[i].Factor < factors[j].Factor
 	})
 
 	// Apply limit

--- a/internal/runner/audit/statistics_test.go
+++ b/internal/runner/audit/statistics_test.go
@@ -1,0 +1,77 @@
+package audit_test
+
+import (
+	"testing"
+
+	"github.com/isseis/go-safe-cmd-runner/internal/runner/audit"
+	"github.com/isseis/go-safe-cmd-runner/internal/runner/runnertypes"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRiskStatistics(t *testing.T) {
+	t.Run("new statistics", func(t *testing.T) {
+		stats := audit.NewRiskStatistics()
+		assert.NotNil(t, stats)
+		assert.Equal(t, 0, stats.TotalCommands())
+	})
+
+	t.Run("record command execution", func(t *testing.T) {
+		stats := audit.NewRiskStatistics()
+
+		stats.RecordCommand("curl", runnertypes.RiskLevelMedium, []string{"Always performs network operations"})
+		stats.RecordCommand("sudo", runnertypes.RiskLevelCritical, []string{"Privilege escalation"})
+		stats.RecordCommand("ls", runnertypes.RiskLevelUnknown, []string{})
+
+		assert.Equal(t, 3, stats.TotalCommands())
+	})
+
+	t.Run("get risk level counts", func(t *testing.T) {
+		stats := audit.NewRiskStatistics()
+
+		stats.RecordCommand("curl", runnertypes.RiskLevelMedium, []string{"Network"})
+		stats.RecordCommand("wget", runnertypes.RiskLevelMedium, []string{"Network"})
+		stats.RecordCommand("sudo", runnertypes.RiskLevelCritical, []string{"Privilege"})
+		stats.RecordCommand("rm", runnertypes.RiskLevelHigh, []string{"Destructive"})
+		stats.RecordCommand("ls", runnertypes.RiskLevelUnknown, []string{})
+
+		counts := stats.GetRiskLevelCounts()
+		assert.Equal(t, 1, counts[runnertypes.RiskLevelUnknown])
+		assert.Equal(t, 2, counts[runnertypes.RiskLevelMedium])
+		assert.Equal(t, 1, counts[runnertypes.RiskLevelHigh])
+		assert.Equal(t, 1, counts[runnertypes.RiskLevelCritical])
+	})
+
+	t.Run("get most common risk factors", func(t *testing.T) {
+		stats := audit.NewRiskStatistics()
+
+		stats.RecordCommand("curl", runnertypes.RiskLevelMedium, []string{"Network operations"})
+		stats.RecordCommand("wget", runnertypes.RiskLevelMedium, []string{"Network operations"})
+		stats.RecordCommand("ssh", runnertypes.RiskLevelMedium, []string{"Network operations"})
+		stats.RecordCommand("rm", runnertypes.RiskLevelHigh, []string{"Destructive operations"})
+		stats.RecordCommand("dd", runnertypes.RiskLevelCritical, []string{"Destructive operations"})
+
+		topFactors := stats.GetTopRiskFactors(3)
+		assert.Equal(t, 2, len(topFactors))
+		assert.Equal(t, "Network operations", topFactors[0].Factor)
+		assert.Equal(t, 3, topFactors[0].Count)
+		assert.Equal(t, "Destructive operations", topFactors[1].Factor)
+		assert.Equal(t, 2, topFactors[1].Count)
+	})
+
+	t.Run("get command counts by risk level", func(t *testing.T) {
+		stats := audit.NewRiskStatistics()
+
+		stats.RecordCommand("curl", runnertypes.RiskLevelMedium, []string{"Network"})
+		stats.RecordCommand("curl", runnertypes.RiskLevelMedium, []string{"Network"})
+		stats.RecordCommand("sudo", runnertypes.RiskLevelCritical, []string{"Privilege"})
+		stats.RecordCommand("ls", runnertypes.RiskLevelUnknown, []string{})
+
+		commands := stats.GetCommandsByRiskLevel(runnertypes.RiskLevelMedium)
+		assert.Contains(t, commands, "curl")
+		assert.Equal(t, 1, len(commands))
+
+		commands = stats.GetCommandsByRiskLevel(runnertypes.RiskLevelCritical)
+		assert.Contains(t, commands, "sudo")
+		assert.Equal(t, 1, len(commands))
+	})
+}


### PR DESCRIPTION
This pull request enhances the audit logging system by introducing a new risk profile logging feature and a statistics tracker for command risk factors. It also adds thorough unit tests for these new functionalities. The documentation has been updated to reflect the completion of these tasks, ensuring better traceability and maintainability.

### Audit Logging Enhancements
* Added `LogRiskProfile` method to `Logger`, which logs detailed command risk profile information including risk level, risk factors, network type, and user/process IDs. The log level is dynamically set based on risk severity. (`internal/runner/audit/logger.go`)

### Risk Statistics Tracking
* Introduced the `RiskStatistics` struct to track command execution counts by risk level, most common risk factors, and unique commands per risk level. Includes thread-safe methods for recording and retrieving statistics. (`internal/runner/audit/statistics.go`)

### Unit Testing
* Added comprehensive unit tests for both the new risk profile logging and the risk statistics tracker to ensure correct behavior and coverage. (`internal/runner/audit/logger_test.go`, `internal/runner/audit/statistics_test.go`) [[1]](diffhunk://#diff-c35e9e17994829a9ce0979496fd16f86db74583b64cbc53a89a10099fa21ed05R193-R264) [[2]](diffhunk://#diff-b89f5379677725970541c571c6ce4577b83860075ae919dbe5d85b6f1661e799R1-R77)

### Documentation Updates
* Updated implementation plan checklists to mark the completion of logging, statistics, testing, and linting tasks, reflecting the current status of the redesign. (`docs/tasks/0029_risk_profile_redesign/04_implementation_plan.md`) [[1]](diffhunk://#diff-fe3a401b33ede0a9d943c7bb8dc3fbe362ecc05db9abe26f7f4d4a76140933c9L1071-R1074) [[2]](diffhunk://#diff-fe3a401b33ede0a9d943c7bb8dc3fbe362ecc05db9abe26f7f4d4a76140933c9L1086-R1088) [[3]](diffhunk://#diff-fe3a401b33ede0a9d943c7bb8dc3fbe362ecc05db9abe26f7f4d4a76140933c9L1119-R1123)