### PR TITLE
refactor: remove obsolete CommandRiskProfile

### DIFF
--- a/internal/runner/security/command_analysis.go
+++ b/internal/runner/security/command_analysis.go
@@ -21,7 +21,7 @@ const (
 )
 
 // commandProfileDefinitions defines command risk profiles using the new builder pattern
-// This uses CommandRiskProfileNew with explicit risk factor separation
+// This uses CommandRiskProfile with explicit risk factor separation
 var commandProfileDefinitions = []CommandProfileDef{
 	// Phase 2.2.1: Privilege escalation commands
 	NewProfile("sudo", "su", "doas").
@@ -80,8 +80,8 @@ var commandProfileDefinitions = []CommandProfileDef{
 // commandRiskProfilesNew is built from commandProfileDefinitions (new structure)
 var commandRiskProfilesNew = buildCommandRiskProfilesNew()
 
-func buildCommandRiskProfilesNew() map[string]CommandRiskProfileNew {
-	profiles := make(map[string]CommandRiskProfileNew)
+func buildCommandRiskProfilesNew() map[string]CommandRiskProfile {
+	profiles := make(map[string]CommandRiskProfile)
 	for _, def := range commandProfileDefinitions {
 		// Profile is already validated in Build()
 		for _, cmd := range def.Commands() {
@@ -297,7 +297,7 @@ func IsNetworkOperation(cmdName string, args []string) (bool, bool) {
 	}
 
 	// Check command profiles for network type using unified profiles
-	var conditionalProfile *CommandRiskProfileNew
+	var conditionalProfile *CommandRiskProfile
 	for name := range commandNames {
 		if profile, exists := commandRiskProfilesNew[name]; exists {
 			switch profile.NetworkType {

--- a/internal/runner/security/command_analysis_test.go
+++ b/internal/runner/security/command_analysis_test.go
@@ -2031,12 +2031,12 @@ func TestGetCommandRiskOverride(t *testing.T) {
 
 func TestCommandRiskProfiles_Completeness(t *testing.T) {
 	// Ensure all defined profiles are valid
-	for cmdName, profile := range commandRiskProfiles {
+	for cmdName, profile := range commandRiskProfilesNew {
 		t.Run("validate_"+cmdName, func(t *testing.T) {
 			assert.NotEmpty(t, cmdName, "command name should not be empty")
-			assert.True(t, profile.BaseRiskLevel > runnertypes.RiskLevelUnknown && profile.BaseRiskLevel <= runnertypes.RiskLevelCritical,
-				"risk level should be valid: %d", profile.BaseRiskLevel)
-			assert.NotEmpty(t, profile.Reason, "reason should not be empty")
+			assert.True(t, profile.BaseRiskLevel() > runnertypes.RiskLevelUnknown && profile.BaseRiskLevel() <= runnertypes.RiskLevelCritical,
+				"risk level should be valid: %d", profile.BaseRiskLevel())
+			assert.NotEmpty(t, profile.GetRiskReasons(), "reasons should not be empty")
 			assert.True(t, profile.NetworkType >= NetworkTypeNone && profile.NetworkType <= NetworkTypeConditional,
 				"network type should be valid: %d", profile.NetworkType)
 		})
@@ -2048,11 +2048,11 @@ func TestCommandRiskProfiles_PrivilegeEscalation(t *testing.T) {
 	privilegeCommands := []string{"sudo", "su", "doas"}
 	for _, cmd := range privilegeCommands {
 		t.Run(cmd, func(t *testing.T) {
-			profile, exists := commandRiskProfiles[cmd]
+			profile, exists := commandRiskProfilesNew[cmd]
 			assert.True(t, exists, "privilege command %s should exist in profiles", cmd)
 			if exists {
-				assert.True(t, profile.IsPrivilege, "command %s should be marked as privilege escalation", cmd)
-				assert.Equal(t, runnertypes.RiskLevelCritical, profile.BaseRiskLevel, "privilege command %s should have critical risk", cmd)
+				assert.True(t, profile.IsPrivilege(), "command %s should be marked as privilege escalation", cmd)
+				assert.Equal(t, runnertypes.RiskLevelCritical, profile.BaseRiskLevel(), "privilege command %s should have critical risk", cmd)
 			}
 		})
 	}
@@ -2077,7 +2077,7 @@ func TestCommandRiskProfiles_NetworkCommands(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			profile, exists := commandRiskProfiles[tc.cmd]
+			profile, exists := commandRiskProfilesNew[tc.cmd]
 			assert.True(t, exists, "network command %s should exist in profiles", tc.cmd)
 			if exists {
 				assert.Equal(t, tc.networkType, profile.NetworkType, "command %s should have correct network type", tc.cmd)
@@ -2154,10 +2154,10 @@ func TestMigration_RiskLevelConsistency(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.command, func(t *testing.T) {
-			profile, exists := commandRiskProfiles[tt.command]
+			profile, exists := commandRiskProfilesNew[tt.command]
 			assert.True(t, exists, "Command %s should exist in profiles", tt.command)
 			if exists {
-				assert.Equal(t, tt.expectedRisk, profile.BaseRiskLevel,
+				assert.Equal(t, tt.expectedRisk, profile.BaseRiskLevel(),
 					"Risk level mismatch for command %s", tt.command)
 			}
 		})
@@ -2175,7 +2175,7 @@ func TestMigration_NetworkTypeConsistency(t *testing.T) {
 
 	for _, cmd := range alwaysNetwork {
 		t.Run("AlwaysNetwork_"+cmd, func(t *testing.T) {
-			profile, exists := commandRiskProfiles[cmd]
+			profile, exists := commandRiskProfilesNew[cmd]
 			assert.True(t, exists)
 			assert.Equal(t, NetworkTypeAlways, profile.NetworkType)
 		})
@@ -2183,7 +2183,7 @@ func TestMigration_NetworkTypeConsistency(t *testing.T) {
 
 	for _, cmd := range conditionalNetwork {
 		t.Run("ConditionalNetwork_"+cmd, func(t *testing.T) {
-			profile, exists := commandRiskProfiles[cmd]
+			profile, exists := commandRiskProfilesNew[cmd]
 			assert.True(t, exists)
 			assert.Equal(t, NetworkTypeConditional, profile.NetworkType)
 		})
@@ -2191,7 +2191,7 @@ func TestMigration_NetworkTypeConsistency(t *testing.T) {
 
 	for _, cmd := range noneNetwork {
 		t.Run("NoneNetwork_"+cmd, func(t *testing.T) {
-			profile, exists := commandRiskProfiles[cmd]
+			profile, exists := commandRiskProfilesNew[cmd]
 			assert.True(t, exists)
 			assert.Equal(t, NetworkTypeNone, profile.NetworkType)
 		})
@@ -2210,7 +2210,7 @@ func TestMigration_NetworkSubcommandsConsistency(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.command, func(t *testing.T) {
-			profile, exists := commandRiskProfiles[tt.command]
+			profile, exists := commandRiskProfilesNew[tt.command]
 			assert.True(t, exists)
 			if exists {
 				if tt.subcommands == nil {
@@ -2232,17 +2232,17 @@ func TestMigration_IsPrivilegeConsistency(t *testing.T) {
 
 	for _, cmd := range privilegeCommands {
 		t.Run("Privilege_"+cmd, func(t *testing.T) {
-			profile, exists := commandRiskProfiles[cmd]
+			profile, exists := commandRiskProfilesNew[cmd]
 			assert.True(t, exists)
-			assert.True(t, profile.IsPrivilege, "Command %s should have IsPrivilege=true", cmd)
+			assert.True(t, profile.IsPrivilege(), "Command %s should have IsPrivilege=true", cmd)
 		})
 	}
 
 	for _, cmd := range nonPrivilegeCommands {
 		t.Run("NonPrivilege_"+cmd, func(t *testing.T) {
-			profile, exists := commandRiskProfiles[cmd]
+			profile, exists := commandRiskProfilesNew[cmd]
 			assert.True(t, exists)
-			assert.False(t, profile.IsPrivilege, "Command %s should have IsPrivilege=false", cmd)
+			assert.False(t, profile.IsPrivilege(), "Command %s should have IsPrivilege=false", cmd)
 		})
 	}
 }

--- a/internal/runner/security/command_profile_def.go
+++ b/internal/runner/security/command_profile_def.go
@@ -3,7 +3,7 @@ package security
 // CommandProfileDef associates a list of commands with their risk profile
 type CommandProfileDef struct {
 	commands []string
-	profile  CommandRiskProfileNew
+	profile  CommandRiskProfile
 }
 
 // Commands returns a copy of the list of commands for this profile
@@ -17,6 +17,6 @@ func (d CommandProfileDef) Commands() []string {
 }
 
 // Profile returns the risk profile
-func (d CommandProfileDef) Profile() CommandRiskProfileNew {
+func (d CommandProfileDef) Profile() CommandRiskProfile {
 	return d.profile
 }

--- a/internal/runner/security/command_profile_def_test.go
+++ b/internal/runner/security/command_profile_def_test.go
@@ -31,7 +31,7 @@ func TestCommandProfileDef_Commands_NilSlice(t *testing.T) {
 	// Create a profile with empty commands (shouldn't normally happen, but test the nil case)
 	def := CommandProfileDef{
 		commands: nil,
-		profile: CommandRiskProfileNew{
+		profile: CommandRiskProfile{
 			NetworkRisk: RiskFactor{Level: runnertypes.RiskLevelLow},
 		},
 	}
@@ -44,7 +44,7 @@ func TestCommandProfileDef_Commands_EmptySlice(t *testing.T) {
 	// Create a profile with empty commands slice
 	def := CommandProfileDef{
 		commands: []string{},
-		profile: CommandRiskProfileNew{
+		profile: CommandRiskProfile{
 			NetworkRisk: RiskFactor{Level: runnertypes.RiskLevelLow},
 		},
 	}

--- a/internal/runner/security/command_risk_profile.go
+++ b/internal/runner/security/command_risk_profile.go
@@ -7,7 +7,7 @@ import (
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/runnertypes"
 )
 
-// Validation errors for CommandRiskProfileNew
+// Validation errors for CommandRiskProfile
 var (
 	// ErrNetworkAlwaysRequiresMediumRiskNew is returned when NetworkTypeAlways has NetworkRisk < Medium
 	ErrNetworkAlwaysRequiresMediumRiskNew = errors.New("NetworkTypeAlways commands must have NetworkRisk >= Medium")
@@ -16,7 +16,7 @@ var (
 	ErrNetworkSubcommandsOnlyForConditionalNew = errors.New("NetworkSubcommands should only be set for NetworkTypeConditional")
 )
 
-// CommandRiskProfileNew defines comprehensive risk information for a command.
+// CommandRiskProfile defines comprehensive risk information for a command.
 // This is the new structure that will replace CommandRiskProfile after migration.
 //
 // The profile separates risk into distinct factors:
@@ -28,7 +28,7 @@ var (
 //
 // The overall risk level is computed as the maximum of all risk factors.
 // Use ProfileBuilder and NewProfile() to create instances with validation.
-type CommandRiskProfileNew struct {
+type CommandRiskProfile struct {
 	// Individual risk factors (explicit separation)
 	PrivilegeRisk   RiskFactor // Risk from privilege escalation (sudo, su, doas)
 	NetworkRisk     RiskFactor // Risk from network operations
@@ -45,12 +45,12 @@ type CommandRiskProfileNew struct {
 const defaultRiskReasonsCap = 5
 
 // IsPrivilege returns true if the command involves privilege escalation
-func (p CommandRiskProfileNew) IsPrivilege() bool {
+func (p CommandRiskProfile) IsPrivilege() bool {
 	return p.PrivilegeRisk.Level >= runnertypes.RiskLevelHigh
 }
 
 // BaseRiskLevel computes the overall risk level as the maximum of all risk factors
-func (p CommandRiskProfileNew) BaseRiskLevel() runnertypes.RiskLevel {
+func (p CommandRiskProfile) BaseRiskLevel() runnertypes.RiskLevel {
 	return max(
 		p.PrivilegeRisk.Level,
 		p.NetworkRisk.Level,
@@ -61,7 +61,7 @@ func (p CommandRiskProfileNew) BaseRiskLevel() runnertypes.RiskLevel {
 }
 
 // GetRiskReasons returns all non-empty reasons contributing to the risk level
-func (p CommandRiskProfileNew) GetRiskReasons() []string {
+func (p CommandRiskProfile) GetRiskReasons() []string {
 	reasons := make([]string, 0, defaultRiskReasonsCap)
 
 	// Helper function to add non-empty reasons
@@ -82,7 +82,7 @@ func (p CommandRiskProfileNew) GetRiskReasons() []string {
 }
 
 // Validate ensures consistency between risk factors and configuration
-func (p CommandRiskProfileNew) Validate() error {
+func (p CommandRiskProfile) Validate() error {
 	// Rule 1: NetworkTypeAlways implies NetworkRisk >= Medium
 	if p.NetworkType == NetworkTypeAlways && p.NetworkRisk.Level < runnertypes.RiskLevelMedium {
 		return fmt.Errorf("%w (got %v)", ErrNetworkAlwaysRequiresMediumRiskNew, p.NetworkRisk.Level)

--- a/internal/runner/security/command_risk_profile_test.go
+++ b/internal/runner/security/command_risk_profile_test.go
@@ -7,15 +7,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCommandRiskProfileNew_BaseRiskLevel(t *testing.T) {
+func TestCommandRiskProfile_BaseRiskLevel(t *testing.T) {
 	tests := []struct {
 		name    string
-		profile CommandRiskProfileNew
+		profile CommandRiskProfile
 		want    runnertypes.RiskLevel
 	}{
 		{
 			name: "all unknown",
-			profile: CommandRiskProfileNew{
+			profile: CommandRiskProfile{
 				PrivilegeRisk:   RiskFactor{Level: runnertypes.RiskLevelUnknown},
 				NetworkRisk:     RiskFactor{Level: runnertypes.RiskLevelUnknown},
 				DestructionRisk: RiskFactor{Level: runnertypes.RiskLevelUnknown},
@@ -26,14 +26,14 @@ func TestCommandRiskProfileNew_BaseRiskLevel(t *testing.T) {
 		},
 		{
 			name: "single medium risk",
-			profile: CommandRiskProfileNew{
+			profile: CommandRiskProfile{
 				NetworkRisk: RiskFactor{Level: runnertypes.RiskLevelMedium},
 			},
 			want: runnertypes.RiskLevelMedium,
 		},
 		{
 			name: "multiple risks - max is high",
-			profile: CommandRiskProfileNew{
+			profile: CommandRiskProfile{
 				NetworkRisk:   RiskFactor{Level: runnertypes.RiskLevelMedium},
 				DataExfilRisk: RiskFactor{Level: runnertypes.RiskLevelHigh},
 			},
@@ -41,7 +41,7 @@ func TestCommandRiskProfileNew_BaseRiskLevel(t *testing.T) {
 		},
 		{
 			name: "critical privilege risk",
-			profile: CommandRiskProfileNew{
+			profile: CommandRiskProfile{
 				PrivilegeRisk: RiskFactor{Level: runnertypes.RiskLevelCritical},
 				NetworkRisk:   RiskFactor{Level: runnertypes.RiskLevelMedium},
 			},
@@ -56,29 +56,29 @@ func TestCommandRiskProfileNew_BaseRiskLevel(t *testing.T) {
 	}
 }
 
-func TestCommandRiskProfileNew_GetRiskReasons(t *testing.T) {
+func TestCommandRiskProfile_GetRiskReasons(t *testing.T) {
 	tests := []struct {
 		name    string
-		profile CommandRiskProfileNew
+		profile CommandRiskProfile
 		want    []string
 	}{
 		{
 			name: "no risks",
-			profile: CommandRiskProfileNew{
+			profile: CommandRiskProfile{
 				PrivilegeRisk: RiskFactor{Level: runnertypes.RiskLevelUnknown},
 			},
 			want: []string{},
 		},
 		{
 			name: "single risk",
-			profile: CommandRiskProfileNew{
+			profile: CommandRiskProfile{
 				NetworkRisk: RiskFactor{Level: runnertypes.RiskLevelMedium, Reason: "Network access"},
 			},
 			want: []string{"Network access"},
 		},
 		{
 			name: "multiple risks",
-			profile: CommandRiskProfileNew{
+			profile: CommandRiskProfile{
 				NetworkRisk:   RiskFactor{Level: runnertypes.RiskLevelMedium, Reason: "Network access"},
 				DataExfilRisk: RiskFactor{Level: runnertypes.RiskLevelHigh, Reason: "Data exfiltration"},
 			},
@@ -86,7 +86,7 @@ func TestCommandRiskProfileNew_GetRiskReasons(t *testing.T) {
 		},
 		{
 			name: "all risk types",
-			profile: CommandRiskProfileNew{
+			profile: CommandRiskProfile{
 				PrivilegeRisk:   RiskFactor{Level: runnertypes.RiskLevelCritical, Reason: "Privilege escalation"},
 				NetworkRisk:     RiskFactor{Level: runnertypes.RiskLevelMedium, Reason: "Network access"},
 				DestructionRisk: RiskFactor{Level: runnertypes.RiskLevelHigh, Reason: "File deletion"},
@@ -103,7 +103,7 @@ func TestCommandRiskProfileNew_GetRiskReasons(t *testing.T) {
 		},
 		{
 			name: "empty reason is excluded",
-			profile: CommandRiskProfileNew{
+			profile: CommandRiskProfile{
 				NetworkRisk:   RiskFactor{Level: runnertypes.RiskLevelMedium, Reason: ""},
 				DataExfilRisk: RiskFactor{Level: runnertypes.RiskLevelHigh, Reason: "Data exfiltration"},
 			},
@@ -111,7 +111,7 @@ func TestCommandRiskProfileNew_GetRiskReasons(t *testing.T) {
 		},
 		{
 			name: "mixed empty and non-empty reasons",
-			profile: CommandRiskProfileNew{
+			profile: CommandRiskProfile{
 				PrivilegeRisk:   RiskFactor{Level: runnertypes.RiskLevelHigh, Reason: ""},
 				NetworkRisk:     RiskFactor{Level: runnertypes.RiskLevelMedium, Reason: "Network access"},
 				DestructionRisk: RiskFactor{Level: runnertypes.RiskLevelHigh, Reason: ""},
@@ -129,43 +129,43 @@ func TestCommandRiskProfileNew_GetRiskReasons(t *testing.T) {
 	}
 }
 
-func TestCommandRiskProfileNew_IsPrivilege(t *testing.T) {
+func TestCommandRiskProfile_IsPrivilege(t *testing.T) {
 	tests := []struct {
 		name    string
-		profile CommandRiskProfileNew
+		profile CommandRiskProfile
 		want    bool
 	}{
 		{
 			name: "critical privilege risk is privilege",
-			profile: CommandRiskProfileNew{
+			profile: CommandRiskProfile{
 				PrivilegeRisk: RiskFactor{Level: runnertypes.RiskLevelCritical},
 			},
 			want: true,
 		},
 		{
 			name: "high privilege risk is privilege",
-			profile: CommandRiskProfileNew{
+			profile: CommandRiskProfile{
 				PrivilegeRisk: RiskFactor{Level: runnertypes.RiskLevelHigh},
 			},
 			want: true,
 		},
 		{
 			name: "medium privilege risk is not privilege",
-			profile: CommandRiskProfileNew{
+			profile: CommandRiskProfile{
 				PrivilegeRisk: RiskFactor{Level: runnertypes.RiskLevelMedium},
 			},
 			want: false,
 		},
 		{
 			name: "low privilege risk is not privilege",
-			profile: CommandRiskProfileNew{
+			profile: CommandRiskProfile{
 				PrivilegeRisk: RiskFactor{Level: runnertypes.RiskLevelLow},
 			},
 			want: false,
 		},
 		{
 			name: "unknown privilege risk is not privilege",
-			profile: CommandRiskProfileNew{
+			profile: CommandRiskProfile{
 				PrivilegeRisk: RiskFactor{Level: runnertypes.RiskLevelUnknown},
 			},
 			want: false,
@@ -179,22 +179,22 @@ func TestCommandRiskProfileNew_IsPrivilege(t *testing.T) {
 	}
 }
 
-func TestCommandRiskProfileNew_Validate(t *testing.T) {
+func TestCommandRiskProfile_Validate(t *testing.T) {
 	tests := []struct {
 		name    string
-		profile CommandRiskProfileNew
+		profile CommandRiskProfile
 		wantErr error
 	}{
 		{
 			name: "valid profile - all unknown",
-			profile: CommandRiskProfileNew{
+			profile: CommandRiskProfile{
 				NetworkType: NetworkTypeNone,
 			},
 			wantErr: nil,
 		},
 		{
 			name: "valid profile - privilege escalation",
-			profile: CommandRiskProfileNew{
+			profile: CommandRiskProfile{
 				PrivilegeRisk: RiskFactor{Level: runnertypes.RiskLevelCritical},
 				NetworkType:   NetworkTypeNone,
 			},
@@ -202,7 +202,7 @@ func TestCommandRiskProfileNew_Validate(t *testing.T) {
 		},
 		{
 			name: "valid profile - always network",
-			profile: CommandRiskProfileNew{
+			profile: CommandRiskProfile{
 				NetworkRisk: RiskFactor{Level: runnertypes.RiskLevelMedium},
 				NetworkType: NetworkTypeAlways,
 			},
@@ -210,7 +210,7 @@ func TestCommandRiskProfileNew_Validate(t *testing.T) {
 		},
 		{
 			name: "valid profile - conditional network",
-			profile: CommandRiskProfileNew{
+			profile: CommandRiskProfile{
 				NetworkRisk:        RiskFactor{Level: runnertypes.RiskLevelMedium},
 				NetworkType:        NetworkTypeConditional,
 				NetworkSubcommands: []string{"clone", "fetch"},
@@ -219,7 +219,7 @@ func TestCommandRiskProfileNew_Validate(t *testing.T) {
 		},
 		{
 			name: "invalid - NetworkTypeAlways with low NetworkRisk",
-			profile: CommandRiskProfileNew{
+			profile: CommandRiskProfile{
 				NetworkRisk: RiskFactor{Level: runnertypes.RiskLevelLow},
 				NetworkType: NetworkTypeAlways,
 			},
@@ -227,7 +227,7 @@ func TestCommandRiskProfileNew_Validate(t *testing.T) {
 		},
 		{
 			name: "invalid - NetworkSubcommands without Conditional",
-			profile: CommandRiskProfileNew{
+			profile: CommandRiskProfile{
 				NetworkType:        NetworkTypeNone,
 				NetworkSubcommands: []string{"clone"},
 			},

--- a/internal/runner/security/profile_builder.go
+++ b/internal/runner/security/profile_builder.go
@@ -6,7 +6,7 @@ import (
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/runnertypes"
 )
 
-// ProfileBuilder provides a fluent API for building CommandRiskProfileNew.
+// ProfileBuilder provides a fluent API for building CommandRiskProfile.
 //
 // Example usage:
 //
@@ -91,7 +91,7 @@ func (b *ProfileBuilder) ConditionalNetwork(subcommands ...string) *ProfileBuild
 
 // Build creates the final CommandProfileDef with validation
 func (b *ProfileBuilder) Build() CommandProfileDef {
-	profile := CommandRiskProfileNew{
+	profile := CommandRiskProfile{
 		PrivilegeRisk:      b.getOrDefault(b.privilegeRisk),
 		NetworkRisk:        b.getOrDefault(b.networkRisk),
 		DestructionRisk:    b.getOrDefault(b.destructionRisk),

--- a/internal/runner/security/risk_factor.go
+++ b/internal/runner/security/risk_factor.go
@@ -8,7 +8,7 @@ import "github.com/isseis/go-safe-cmd-runner/internal/runner/runnertypes"
 //   - Level: The severity of this specific risk (Unknown, Low, Medium, High, Critical)
 //   - Reason: A human-readable explanation of why this risk exists
 //
-// Risk factors are combined in CommandRiskProfileNew to provide a comprehensive
+// Risk factors are combined in CommandRiskProfile to provide a comprehensive
 // risk assessment. The overall risk level is the maximum of all factor levels.
 type RiskFactor struct {
 	Level  runnertypes.RiskLevel // Risk level for this specific factor


### PR DESCRIPTION
This pull request completes the migration to the new `CommandRiskProfile` structure, removing the legacy `CommandRiskProfileNew` type and updating all references and logic to use the unified risk profile. This streamlines risk analysis for commands and ensures all code and tests use the new, more granular risk factor separation.

Migration to unified risk profile structure:

* Removed the legacy `CommandRiskProfileNew` type and replaced it everywhere with the new `CommandRiskProfile` type, including its methods and validation logic. (`internal/runner/security/command_risk_profile.go`, [[1]](diffhunk://#diff-6cd9c7cb1aea6d2c8d4fb60ae0a2807600a006b567f8b40617afe5cb58ee262fL19-R19) [[2]](diffhunk://#diff-6cd9c7cb1aea6d2c8d4fb60ae0a2807600a006b567f8b40617afe5cb58ee262fL31-R31) [[3]](diffhunk://#diff-6cd9c7cb1aea6d2c8d4fb60ae0a2807600a006b567f8b40617afe5cb58ee262fL48-R53) [[4]](diffhunk://#diff-6cd9c7cb1aea6d2c8d4fb60ae0a2807600a006b567f8b40617afe5cb58ee262fL64-R64) [[5]](diffhunk://#diff-6cd9c7cb1aea6d2c8d4fb60ae0a2807600a006b567f8b40617afe5cb58ee262fL85-R85)
* Updated all logic and references in `command_analysis.go` to use `commandRiskProfilesNew` (now the canonical map of profiles) and removed the old conversion and compatibility layer. (`internal/runner/security/command_analysis.go`, [[1]](diffhunk://#diff-3e9fdee1040d6b864582399879be9e45f09737b13f56828c4c07bc4ef2f323a3L151-R84) [[2]](diffhunk://#diff-3e9fdee1040d6b864582399879be9e45f09737b13f56828c4c07bc4ef2f323a3L162-L193) [[3]](diffhunk://#diff-3e9fdee1040d6b864582399879be9e45f09737b13f56828c4c07bc4ef2f323a3L342-R244) [[4]](diffhunk://#diff-3e9fdee1040d6b864582399879be9e45f09737b13f56828c4c07bc4ef2f323a3L379-R279) [[5]](diffhunk://#diff-3e9fdee1040d6b864582399879be9e45f09737b13f56828c4c07bc4ef2f323a3L402-R302)
* Updated the `CommandProfileDef` struct and its usage to reference the new `CommandRiskProfile` type. (`internal/runner/security/command_profile_def.go`, [[1]](diffhunk://#diff-6a534e5a6f80f2254550964e660688d64fa82616369a7993bb63d73be2460690L6-R6) [[2]](diffhunk://#diff-6a534e5a6f80f2254550964e660688d64fa82616369a7993bb63d73be2460690L20-R20)

Test suite modernization:

* Refactored all tests to use `commandRiskProfilesNew` and the new methods (`BaseRiskLevel()`, `IsPrivilege()`, `GetRiskReasons()`), ensuring consistency and coverage for the new structure. (`internal/runner/security/command_analysis_test.go`, [[1]](diffhunk://#diff-d777335bcb4e2f2eb3f7c5e68e1803501994319090cc64de601e407450ca46f1L2034-R2039) [[2]](diffhunk://#diff-d777335bcb4e2f2eb3f7c5e68e1803501994319090cc64de601e407450ca46f1L2051-R2055) [[3]](diffhunk://#diff-d777335bcb4e2f2eb3f7c5e68e1803501994319090cc64de601e407450ca46f1L2080-R2080) [[4]](diffhunk://#diff-d777335bcb4e2f2eb3f7c5e68e1803501994319090cc64de601e407450ca46f1L2157-R2160) [[5]](diffhunk://#diff-d777335bcb4e2f2eb3f7c5e68e1803501994319090cc64de601e407450ca46f1L2178-R2194) [[6]](diffhunk://#diff-d777335bcb4e2f2eb3f7c5e68e1803501994319090cc64de601e407450ca46f1L2213-R2213) [[7]](diffhunk://#diff-d777335bcb4e2f2eb3f7c5e68e1803501994319090cc64de601e407450ca46f1L2235-R2245); `internal/runner/security/command_profile_def_test.go`, [[8]](diffhunk://#diff-d5e12104771c1bc429877a33e2bd47c6251ee0151745bfb76806c8a19ad99642L34-R34) [[9]](diffhunk://#diff-d5e12104771c1bc429877a33e2bd47c6251ee0151745bfb76806c8a19ad99642L47-R47)

Code cleanup:

* Removed unused error definitions and outdated documentation/comments for the old risk profile logic. (`internal/runner/security/command_analysis.go`, [[1]](diffhunk://#diff-3e9fdee1040d6b864582399879be9e45f09737b13f56828c4c07bc4ef2f323a3L4) [[2]](diffhunk://#diff-3e9fdee1040d6b864582399879be9e45f09737b13f56828c4c07bc4ef2f323a3L14-L20) [[3]](diffhunk://#diff-3e9fdee1040d6b864582399879be9e45f09737b13f56828c4c07bc4ef2f323a3L31-R24)
* Updated error comments and validation error names to reflect the new structure. (`internal/runner/security/command_risk_profile.go`, [internal/runner/security/command_risk_profile.goL10-R10](diffhunk://#diff-6cd9c7cb1aea6d2c8d4fb60ae0a2807600a006b567f8b40617afe5cb58ee262fL10-R10))

These changes make the codebase simpler and ensure all risk analysis is performed using the new, unified risk profile type.