### PR TITLE
Add ExpandedVerifyFiles fields to runner config and mark task as comp…

### DIFF
--- a/docs/tasks/0030_verify_files_variable_expansion/04_implementation_plan.md
+++ b/docs/tasks/0030_verify_files_variable_expansion/04_implementation_plan.md
@@ -31,10 +31,10 @@ internal/runner/runnertypes/config.go
 - フィールドドキュメントコメントの追加
 
 #### 完了条件
-- [ ] `GlobalConfig` 構造体拡張完了
-- [ ] `CommandGroup` 構造体拡張完了
-- [ ] 構造体フィールドのドキュメント作成完了
-- [ ] 既存テストが全て成功
+- [x] `GlobalConfig` 構造体拡張完了
+- [x] `CommandGroup` 構造体拡張完了
+- [x] 構造体フィールドのドキュメント作成完了
+- [x] 既存テストが全て成功
 
 ### 2.2 Phase 2: 環境変数展開機能の実装 (2日)
 **目標**: verify_files専用の環境変数展開ロジックを実装

--- a/internal/runner/runnertypes/config.go
+++ b/internal/runner/runnertypes/config.go
@@ -26,6 +26,12 @@ type GlobalConfig struct {
 	SkipStandardPaths bool     `toml:"skip_standard_paths"` // Skip verification for standard system paths
 	EnvAllowlist      []string `toml:"env_allowlist"`       // Global environment variable allowlist
 	MaxOutputSize     int64    `toml:"max_output_size"`     // Default output size limit in bytes
+
+	// ExpandedVerifyFiles contains the verify_files paths with environment variable substitutions applied.
+	// It is the expanded version of the VerifyFiles field, populated during configuration loading
+	// and used during file verification to avoid re-expanding for each verification.
+	// The toml:"-" tag prevents this field from being set via TOML configuration.
+	ExpandedVerifyFiles []string `toml:"-"`
 }
 
 // CommandGroup represents a group of related commands with a name
@@ -41,6 +47,12 @@ type CommandGroup struct {
 	Commands     []Command `toml:"commands"`
 	VerifyFiles  []string  `toml:"verify_files"`  // Files to verify for this group
 	EnvAllowlist []string  `toml:"env_allowlist"` // Group-level environment variable allowlist
+
+	// ExpandedVerifyFiles contains the verify_files paths with environment variable substitutions applied.
+	// It is the expanded version of the VerifyFiles field, populated during configuration loading
+	// and used during file verification to avoid re-expanding for each verification.
+	// The toml:"-" tag prevents this field from being set via TOML configuration.
+	ExpandedVerifyFiles []string `toml:"-"`
 }
 
 // Command represents a single command to be executed


### PR DESCRIPTION
…leted

- Add ExpandedVerifyFiles []string to GlobalConfig and CommandGroup to hold verify_files with environment variables expanded during config load.
- Use toml:"-" tag to prevent TOML from setting the expanded fields.
- Update docs task plan to mark GlobalConfig/CommandGroup expansion and tests as completed.
- This avoids re-expanding variables on each verification and centralizes expansion at configuration load time.