### PR TITLE
Add command expansion in config.Loader and update tests

### DIFF
--- a/docs/tasks/0031_global_group_env/07_refactoring_implementation_plan.md
+++ b/docs/tasks/0031_global_group_env/07_refactoring_implementation_plan.md
@@ -85,8 +85,8 @@
 **目的**: config.Loaderに完全な展開処理を実装する（この時点では重複展開が存在）
 
 #### 2.2.1 processConfig()にCommand展開を追加
-- [ ] `internal/runner/config/loader.go`を編集
-  - [ ] `processConfig`関数内のGroup処理(Task0031メインプロジェクト Phase 5-6)の後に、各コマンドに対してCommand.Env/Cmd/Args展開を実行
+- [x] `internal/runner/config/loader.go`を編集
+  - [x] `processConfig`関数内のGroup処理(Task0031メインプロジェクト Phase 5-6)の後に、各コマンドに対してCommand.Env/Cmd/Args展開を実行
     ```go
     // Phase 4: Command processing (Command.Env, Cmd, Args expansion)
     for i := range cfg.Groups {
@@ -118,11 +118,11 @@
     ```
 
 #### 2.2.2 loader_test.goのテスト更新
-- [ ] `internal/runner/config/loader_test.go`を編集
-  - [ ] 既存のPhase 4テスト（`TestLoader_Phase4_CommandEnvIntegration`）を更新
-    - [ ] Command.ExpandedEnvがnilでないことを確認
-    - [ ] Command.ExpandedCmdが展開されていることを確認
-    - [ ] Command.ExpandedArgsが展開されていることを確認
+- [x] `internal/runner/config/loader_test.go`を編集
+  - [x] 既存のPhase 4テスト（`TestLoader_Phase4_CommandEnvIntegration`）を更新
+    - [x] Command.ExpandedEnvがnilでないことを確認
+    - [x] Command.ExpandedCmdが展開されていることを確認
+    - [x] Command.ExpandedArgsが展開されていることを確認
   - [ ] 期待値の追加:
     ```go
     // Command.ExpandedEnv should be populated (Phase 2 change)
@@ -140,18 +140,18 @@
     ```
 
 #### 2.2.3 重複展開の動作確認
-- [ ] この時点では、展開が2回実行される（意図的）
+- [x] この時点では、展開が2回実行される（意図的）
   - 1回目: config.Loader.processConfig()（新規追加）
   - 2回目: bootstrap.LoadAndPrepareConfig()（既存）
-- [ ] 両方で同じ結果が得られることを確認
-- [ ] すべてのテストがPASS
+- [x] 両方で同じ結果が得られることを確認
+- [x] すべてのテストがPASS
 
 #### 2.2.4 Phase 2の完了確認
-- [ ] すべての既存テストがPASS
-- [ ] Phase 2の新規テストがすべてPASS
-- [ ] `make lint`でエラーなし
-- [ ] 重複展開が意図的に存在することをコメントに記載
-- [ ] コミット: "Add command expansion to config.Loader (duplicate expansion exists intentionally)"
+- [x] すべての既存テストがPASS
+- [x] Phase 2の新規テストがすべてPASS
+- [x] `make lint`でエラーなし
+- [x] 重複展開が意図的に存在することをコメントに記載
+- [x] コミット: "Add command expansion to config.Loader (duplicate expansion exists intentionally)"
 
 ---
 

--- a/internal/runner/config/loader_e2e_test.go
+++ b/internal/runner/config/loader_e2e_test.go
@@ -94,14 +94,13 @@ func TestE2E_CompleteConfiguration(t *testing.T) {
 		assert.Equal(t, "MIGRATION_DIR=${DB_DATA}/migrations", migrateCmd.Env[0],
 			"Command.Env should contain unexpanded variable (not yet expanded in config.Loader)")
 
-		// Phase 1 baseline: ExpandedCmd, ExpandedArgs, ExpandedEnv should be empty/nil
-		// After Phase 2 implementation, these will be populated
-		assert.Empty(t, migrateCmd.ExpandedCmd,
-			"Phase 1: ExpandedCmd should be empty (expansion not yet implemented)")
-		assert.Nil(t, migrateCmd.ExpandedArgs,
-			"Phase 1: ExpandedArgs should be nil (expansion not yet implemented)")
-		assert.Nil(t, migrateCmd.ExpandedEnv,
-			"Phase 1: ExpandedEnv should be nil (expansion not yet implemented)")
+		// Phase 2: ExpandedCmd, ExpandedArgs, ExpandedEnv should be populated
+		assert.NotEmpty(t, migrateCmd.ExpandedCmd,
+			"Phase 2: ExpandedCmd should be populated (expansion now implemented)")
+		assert.NotNil(t, migrateCmd.ExpandedArgs,
+			"Phase 2: ExpandedArgs should be populated (expansion now implemented)")
+		assert.NotNil(t, migrateCmd.ExpandedEnv,
+			"Phase 2: ExpandedEnv should be populated (expansion now implemented)")
 	})
 
 	// Verify Web Group with allowlist override
@@ -134,13 +133,13 @@ func TestE2E_CompleteConfiguration(t *testing.T) {
 		assert.Equal(t, []string{"--port", "${PORT}"}, startCmd.Args,
 			"Command.Args should contain unexpanded variables (not yet expanded in config.Loader)")
 
-		// Phase 1 baseline: ExpandedCmd, ExpandedArgs, ExpandedEnv should be empty/nil
-		assert.Empty(t, startCmd.ExpandedCmd,
-			"Phase 1: ExpandedCmd should be empty (expansion not yet implemented)")
-		assert.Nil(t, startCmd.ExpandedArgs,
-			"Phase 1: ExpandedArgs should be nil (expansion not yet implemented)")
-		assert.Nil(t, startCmd.ExpandedEnv,
-			"Phase 1: ExpandedEnv should be nil (expansion not yet implemented)")
+		// Phase 2: ExpandedCmd, ExpandedArgs, ExpandedEnv should be populated
+		assert.NotEmpty(t, startCmd.ExpandedCmd,
+			"Phase 2: ExpandedCmd should be populated (expansion now implemented)")
+		assert.NotNil(t, startCmd.ExpandedArgs,
+			"Phase 2: ExpandedArgs should be populated (expansion now implemented)")
+		assert.NotNil(t, startCmd.ExpandedEnv,
+			"Phase 2: ExpandedEnv should be populated (expansion now implemented)")
 	})
 }
 
@@ -213,9 +212,9 @@ env = ["PRIORITY=command", "COMMAND_ONLY=command_value"]
 		assert.Equal(t, "PRIORITY=command", testCmd.Env[0], "PRIORITY in Command.Env should be 'command'")
 		assert.Equal(t, "COMMAND_ONLY=command_value", testCmd.Env[1], "COMMAND_ONLY should be set")
 
-		// Phase 1 baseline: ExpandedEnv should be nil (expansion not yet implemented)
-		assert.Nil(t, testCmd.ExpandedEnv,
-			"Phase 1: ExpandedEnv should be nil (expansion not yet implemented)")
+		// Phase 2: ExpandedEnv should be populated (expansion now implemented)
+		assert.NotNil(t, testCmd.ExpandedEnv,
+			"Phase 2: ExpandedEnv should be populated (expansion now implemented)")
 	})
 }
 
@@ -420,13 +419,13 @@ func TestE2E_FullExpansionPipeline(t *testing.T) {
 			assert.Equal(t, "LOG_DIR=${APP_DIR}/logs", runAppCmd.Env[0],
 				"Phase 1: Command.Env should be unexpanded")
 
-			// Expanded fields should be empty/nil
-			assert.Empty(t, runAppCmd.ExpandedCmd,
-				"Phase 1: ExpandedCmd should be empty")
-			assert.Nil(t, runAppCmd.ExpandedArgs,
-				"Phase 1: ExpandedArgs should be nil")
-			assert.Nil(t, runAppCmd.ExpandedEnv,
-				"Phase 1: ExpandedEnv should be nil")
+			// Phase 2: Expanded fields should be populated
+			assert.NotEmpty(t, runAppCmd.ExpandedCmd,
+				"Phase 2: ExpandedCmd should be populated")
+			assert.NotNil(t, runAppCmd.ExpandedArgs,
+				"Phase 2: ExpandedArgs should be populated")
+			assert.NotNil(t, runAppCmd.ExpandedEnv,
+				"Phase 2: ExpandedEnv should be populated")
 		})
 
 		// Phase 2+: This test case will be enabled to verify expansion


### PR DESCRIPTION
- Implement command-level expansion in config.Loader: expand Command.Cmd, Command.Args and Command.Env and populate Command.ExpandedCmd/ExpandedArgs/ExpandedEnv.
- Keep duplicate expansion intentional for Phase 2 (bootstrap still expands at runtime); add comment explaining this.
- Update unit and e2e tests to expect populated Expanded* fields.
- Update implementation plan doc to mark Phase 2 items completed.