### PR TITLE
Add spec layer types and tests for runner configuration

### DIFF
--- a/docs/tasks/0035_spec_runtime_separation/04_implementation_plan.md
+++ b/docs/tasks/0035_spec_runtime_separation/04_implementation_plan.md
@@ -737,12 +737,12 @@ Phase 1 → Phase 2 → Phase 3 → Phase 5 → Phase 6 → Phase 7
 ## 7. 実装チェックリスト
 
 ### Phase 1: Spec層の型定義
-- [ ] `ConfigSpec` を定義
-- [ ] `GlobalSpec` を定義
-- [ ] `GroupSpec` を定義
-- [ ] `CommandSpec` を定義
-- [ ] `GetMaxRiskLevel()`, `HasUserGroupSpecification()` を実装
-- [ ] Spec層のテストを実装
+- [x] `ConfigSpec` を定義
+- [x] `GlobalSpec` を定義
+- [x] `GroupSpec` を定義
+- [x] `CommandSpec` を定義
+- [x] `GetMaxRiskLevel()`, `HasUserGroupSpecification()` を実装
+- [x] Spec層のテストを実装
 
 ### Phase 2: Runtime層の型定義
 - [ ] `RuntimeGlobal` を定義

--- a/internal/runner/runnertypes/spec.go
+++ b/internal/runner/runnertypes/spec.go
@@ -1,0 +1,106 @@
+// Package runnertypes defines the core data structures used throughout the command runner.
+// It includes types for configuration, commands, and other domain-specific structures.
+package runnertypes
+
+// ConfigSpec represents the root configuration structure loaded from TOML file.
+// This is an immutable representation of the configuration file and should not be modified after loading.
+//
+// All fields in this struct correspond directly to TOML file structure.
+// For runtime-expanded values, see RuntimeGlobal and RuntimeGroup instead.
+type ConfigSpec struct {
+	// Version specifies the configuration file version (e.g., "1.0")
+	Version string `toml:"version"`
+
+	// Global contains global-level configuration
+	Global GlobalSpec `toml:"global"`
+
+	// Groups contains all command groups defined in the configuration
+	Groups []GroupSpec `toml:"groups"`
+}
+
+// GlobalSpec contains global configuration options loaded from TOML file.
+// This is an immutable representation and should not be modified after loading.
+//
+// For runtime-expanded values (e.g., ExpandedEnv, ExpandedVars), see RuntimeGlobal instead.
+type GlobalSpec struct {
+	// Execution control
+	Timeout           int    `toml:"timeout"`             // Global timeout in seconds (0 = no timeout)
+	LogLevel          string `toml:"log_level"`           // Log level: debug, info, warn, error
+	SkipStandardPaths bool   `toml:"skip_standard_paths"` // Skip verification for standard system paths
+	MaxOutputSize     int64  `toml:"max_output_size"`     // Maximum output size in bytes (0 = unlimited)
+
+	// Security
+	VerifyFiles  []string `toml:"verify_files"`  // Files to verify before execution (raw paths)
+	EnvAllowlist []string `toml:"env_allowlist"` // Allowed environment variables
+
+	// Variable definitions (raw values, not yet expanded)
+	Env     []string `toml:"env"`      // Environment variables in KEY=VALUE format
+	FromEnv []string `toml:"from_env"` // System env var imports in internal_name=SYSTEM_VAR format
+	Vars    []string `toml:"vars"`     // Internal variables in VAR=value format
+}
+
+// GroupSpec represents a command group configuration loaded from TOML file.
+// This is an immutable representation and should not be modified after loading.
+//
+// For runtime-expanded values, see RuntimeGroup instead.
+type GroupSpec struct {
+	// Basic information
+	Name        string `toml:"name"`        // Group name (must be unique within the config)
+	Description string `toml:"description"` // Human-readable description
+	Priority    int    `toml:"priority"`    // Execution priority (lower number = higher priority)
+
+	// Resource management
+	WorkDir string `toml:"workdir"` // Working directory for this group (raw value, not yet expanded)
+
+	// Command definitions
+	Commands []CommandSpec `toml:"commands"` // Commands in this group
+
+	// Security
+	VerifyFiles  []string `toml:"verify_files"`  // Files to verify for this group (raw paths)
+	EnvAllowlist []string `toml:"env_allowlist"` // Group-level environment variable allowlist
+
+	// Variable definitions (raw values, not yet expanded)
+	Env     []string `toml:"env"`      // Group-level environment variables in KEY=VALUE format
+	FromEnv []string `toml:"from_env"` // System env var imports in internal_name=SYSTEM_VAR format
+	Vars    []string `toml:"vars"`     // Group-level internal variables in VAR=value format
+}
+
+// CommandSpec represents a single command configuration loaded from TOML file.
+// This is an immutable representation and should not be modified after loading.
+//
+// For runtime-expanded values (e.g., ExpandedCmd, ExpandedArgs), see RuntimeCommand instead.
+type CommandSpec struct {
+	// Basic information
+	Name        string `toml:"name"`        // Command name (must be unique within the group)
+	Description string `toml:"description"` // Human-readable description
+
+	// Command definition (raw values, not yet expanded)
+	Cmd  string   `toml:"cmd"`  // Command path (may contain variables like %{VAR})
+	Args []string `toml:"args"` // Command arguments (may contain variables)
+
+	// Execution settings
+	WorkDir      string `toml:"workdir"`        // Working directory for this command (raw value)
+	Timeout      int    `toml:"timeout"`        // Command-specific timeout in seconds (overrides global/group)
+	RunAsUser    string `toml:"run_as_user"`    // User to execute command as (using seteuid)
+	RunAsGroup   string `toml:"run_as_group"`   // Group to execute command as (using setegid)
+	MaxRiskLevel string `toml:"max_risk_level"` // Maximum allowed risk level: low, medium, high
+	Output       string `toml:"output"`         // Standard output file path for capture
+
+	// Variable definitions (raw values, not yet expanded)
+	Env     []string `toml:"env"`      // Command-level environment variables in KEY=VALUE format
+	FromEnv []string `toml:"from_env"` // System env var imports in internal_name=SYSTEM_VAR format
+	Vars    []string `toml:"vars"`     // Command-level internal variables in VAR=value format
+}
+
+// GetMaxRiskLevel parses and returns the maximum risk level for this command.
+// Returns RiskLevelUnknown and an error if the risk level string is invalid.
+//
+// Critical risk level cannot be set in configuration (reserved for internal use only).
+func (s *CommandSpec) GetMaxRiskLevel() (RiskLevel, error) {
+	return ParseRiskLevel(s.MaxRiskLevel)
+}
+
+// HasUserGroupSpecification returns true if either run_as_user or run_as_group is specified.
+func (s *CommandSpec) HasUserGroupSpecification() bool {
+	return s.RunAsUser != "" || s.RunAsGroup != ""
+}

--- a/internal/runner/runnertypes/spec_test.go
+++ b/internal/runner/runnertypes/spec_test.go
@@ -1,0 +1,168 @@
+package runnertypes
+
+import (
+	"testing"
+)
+
+func TestCommandSpec_GetMaxRiskLevel(t *testing.T) {
+	tests := []struct {
+		name        string
+		cmd         *CommandSpec
+		expectErr   bool
+		expectLevel RiskLevel
+	}{
+		{
+			name: "low risk level",
+			cmd: &CommandSpec{
+				MaxRiskLevel: "low",
+			},
+			expectErr:   false,
+			expectLevel: RiskLevelLow,
+		},
+		{
+			name: "medium risk level",
+			cmd: &CommandSpec{
+				MaxRiskLevel: "medium",
+			},
+			expectErr:   false,
+			expectLevel: RiskLevelMedium,
+		},
+		{
+			name: "high risk level",
+			cmd: &CommandSpec{
+				MaxRiskLevel: "high",
+			},
+			expectErr:   false,
+			expectLevel: RiskLevelHigh,
+		},
+		{
+			name: "empty string defaults to low",
+			cmd: &CommandSpec{
+				MaxRiskLevel: "",
+			},
+			expectErr:   false,
+			expectLevel: RiskLevelLow,
+		},
+		{
+			name: "invalid risk level",
+			cmd: &CommandSpec{
+				MaxRiskLevel: "invalid",
+			},
+			expectErr:   true,
+			expectLevel: RiskLevelUnknown,
+		},
+		{
+			name: "critical risk level is prohibited",
+			cmd: &CommandSpec{
+				MaxRiskLevel: "critical",
+			},
+			expectErr:   true,
+			expectLevel: RiskLevelUnknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			level, err := tt.cmd.GetMaxRiskLevel()
+			if (err != nil) != tt.expectErr {
+				t.Errorf("GetMaxRiskLevel() error = %v, expectErr %v", err, tt.expectErr)
+			}
+			if level != tt.expectLevel {
+				t.Errorf("GetMaxRiskLevel() = %v, want %v", level, tt.expectLevel)
+			}
+		})
+	}
+}
+
+func TestCommandSpec_HasUserGroupSpecification(t *testing.T) {
+	tests := []struct {
+		name     string
+		cmd      *CommandSpec
+		expected bool
+	}{
+		{
+			name: "both user and group specified",
+			cmd: &CommandSpec{
+				RunAsUser:  "nobody",
+				RunAsGroup: "nogroup",
+			},
+			expected: true,
+		},
+		{
+			name: "only user specified",
+			cmd: &CommandSpec{
+				RunAsUser:  "nobody",
+				RunAsGroup: "",
+			},
+			expected: true,
+		},
+		{
+			name: "only group specified",
+			cmd: &CommandSpec{
+				RunAsUser:  "",
+				RunAsGroup: "nogroup",
+			},
+			expected: true,
+		},
+		{
+			name: "neither user nor group specified",
+			cmd: &CommandSpec{
+				RunAsUser:  "",
+				RunAsGroup: "",
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.cmd.HasUserGroupSpecification()
+			if result != tt.expected {
+				t.Errorf("HasUserGroupSpecification() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestConfigSpec_Structure(t *testing.T) {
+	// Test that ConfigSpec can be created with nested Spec types
+	config := &ConfigSpec{
+		Version: "1.0",
+		Global: GlobalSpec{
+			Timeout:     30,
+			LogLevel:    "info",
+			Env:         []string{"KEY=VALUE"},
+			VerifyFiles: []string{"/path/to/file"},
+		},
+		Groups: []GroupSpec{
+			{
+				Name:     "test-group",
+				Priority: 1,
+				Commands: []CommandSpec{
+					{
+						Name:         "test-cmd",
+						Cmd:          "/bin/echo",
+						Args:         []string{"hello"},
+						MaxRiskLevel: "low",
+					},
+				},
+			},
+		},
+	}
+
+	if config.Version != "1.0" {
+		t.Errorf("Version = %v, want 1.0", config.Version)
+	}
+	if config.Global.Timeout != 30 {
+		t.Errorf("Global.Timeout = %v, want 30", config.Global.Timeout)
+	}
+	if len(config.Groups) != 1 {
+		t.Errorf("len(Groups) = %v, want 1", len(config.Groups))
+	}
+	if config.Groups[0].Name != "test-group" {
+		t.Errorf("Groups[0].Name = %v, want test-group", config.Groups[0].Name)
+	}
+	if len(config.Groups[0].Commands) != 1 {
+		t.Errorf("len(Groups[0].Commands) = %v, want 1", len(config.Groups[0].Commands))
+	}
+}


### PR DESCRIPTION
Add ConfigSpec, GlobalSpec, GroupSpec, and CommandSpec types to internal/runner/runnertypes/spec.go with TOML tags and doc comments

Implement GetMaxRiskLevel() and HasUserGroupSpecification() on CommandSpec

Add unit tests for spec types in internal/runner/runnertypes/spec_test.go

Mark Phase 1 items as completed in the implementation plan document