### PR TITLE
Use NewRuntimeGlobal constructor in ExpandGlobal to ensure proper init

### DIFF
--- a/internal/runner/config/expansion.go
+++ b/internal/runner/config/expansion.go
@@ -357,10 +357,10 @@ func determineEffectiveEnvAllowlist(groupAllowlist []string, globalAllowlist []s
 //   - *RuntimeGlobal: The expanded runtime global configuration
 //   - error: An error if expansion fails (e.g., undefined variable reference)
 func ExpandGlobal(spec *runnertypes.GlobalSpec) (*runnertypes.RuntimeGlobal, error) {
-	runtime := &runnertypes.RuntimeGlobal{
-		Spec:         spec,
-		ExpandedVars: make(map[string]string),
-		ExpandedEnv:  make(map[string]string),
+	// Use constructor to ensure proper initialization (including timeout field)
+	runtime, err := runnertypes.NewRuntimeGlobal(spec)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create RuntimeGlobal: %w", err)
 	}
 
 	// 0. Parse system environment once and cache it


### PR DESCRIPTION
Replace direct struct literal with call to runnertypes.NewRuntimeGlobal

Capture and return constructor error with a descriptive message

Ensures runtime.timeout and other fields are initialized consistently