### PR TITLE
feat: improve text output for pre-execution error message

### DIFF
--- a/internal/logging/pre_execution_error.go
+++ b/internal/logging/pre_execution_error.go
@@ -73,8 +73,15 @@ func (e *PreExecutionError) Unwrap() error {
 
 // HandlePreExecutionError handles pre-execution errors by logging and notifying
 func HandlePreExecutionError(errorType ErrorType, errorMsg, component, runID string) {
-	// Log to stderr as fallback (in case logging system isn't set up yet)
-	fmt.Fprintf(os.Stderr, "Error: %s - %s (run_id: %s)\n", errorType, errorMsg, runID)
+	// Log to stderr with hierarchical format for better readability
+	fmt.Fprintf(os.Stderr, "Error: %s\n", errorType)
+	if component != "" {
+		fmt.Fprintf(os.Stderr, "  Component: %s\n", component)
+	}
+	fmt.Fprintf(os.Stderr, "  Details: %s\n", errorMsg)
+	if runID != "" {
+		fmt.Fprintf(os.Stderr, "  Run ID: %s\n", runID)
+	}
 
 	// Try to log through slog if available
 	if logger := slog.Default(); logger != nil {


### PR DESCRIPTION
This pull request improves the error logging format in the `HandlePreExecutionError` function to make logs more readable and structured. The main change is the switch to a hierarchical format when logging errors to stderr, which makes it easier to identify error details, component, and run ID.

Logging improvements:

* Updated the stderr output in `HandlePreExecutionError` in `internal/logging/pre_execution_error.go` to use a hierarchical format, displaying error type, component, details, and run ID on separate indented lines for better readability.