### PR TITLE
Add ExecutionError and HandleExecutionError for runtime execution failures

### DIFF
--- a/internal/logging/execution_error.go
+++ b/internal/logging/execution_error.go
@@ -1,0 +1,25 @@
+package logging
+
+import "fmt"
+
+// ExecutionError represents an error that occurs during command execution
+// (as opposed to pre-execution errors like configuration parsing or file access)
+type ExecutionError struct {
+	Message   string
+	Component string
+	RunID     string
+	Err       error // Wrapped error for better error context preservation
+}
+
+// Error implements the error interface
+func (e *ExecutionError) Error() string {
+	if e.Err != nil {
+		return fmt.Sprintf("execution error: %s: %v (component: %s, run_id: %s)", e.Message, e.Err, e.Component, e.RunID)
+	}
+	return fmt.Sprintf("execution error: %s (component: %s, run_id: %s)", e.Message, e.Component, e.RunID)
+}
+
+// Unwrap implements error wrapping for errors.Unwrap
+func (e *ExecutionError) Unwrap() error {
+	return e.Err
+}

--- a/internal/logging/pre_execution_error.go
+++ b/internal/logging/pre_execution_error.go
@@ -72,8 +72,9 @@ func (e *PreExecutionError) Unwrap() error {
 	return e.Err
 }
 
-// HandlePreExecutionError handles pre-execution errors by logging and notifying
-func HandlePreExecutionError(errorType ErrorType, errorMsg, component, runID string) {
+// handleErrorCommon is a private helper that contains the common error handling logic
+// for both pre-execution and execution errors
+func handleErrorCommon(errorType ErrorType, errorMsg, component, runID, slogMessage, slogMessageType, summaryStatus string) {
 	// Build stderr output atomically to prevent interleaved output in concurrent scenarios
 	var stderrBuilder strings.Builder
 	fmt.Fprintf(&stderrBuilder, "Error: %s\n", errorType)
@@ -89,54 +90,30 @@ func HandlePreExecutionError(errorType ErrorType, errorMsg, component, runID str
 
 	// Try to log through slog if available
 	if logger := slog.Default(); logger != nil {
-		slog.Error("Pre-execution error occurred",
+		slog.Error(slogMessage,
 			"error_type", string(errorType),
 			"error_message", errorMsg,
 			"component", component,
 			"run_id", runID,
 			"slack_notify", true,
-			"message_type", "pre_execution_error",
+			"message_type", slogMessageType,
 		)
 	}
 
 	// Build stdout output atomically to prevent interleaved output in concurrent scenarios
 	var stdoutBuilder strings.Builder
-	fmt.Fprintf(&stdoutBuilder, "Error: %s\nRUN_SUMMARY run_id=%s exit_code=1 status=pre_execution_error duration_ms=0 verified=0 skipped=0 failed=0 warnings=0 errors=1\n", errorType, runID)
+	fmt.Fprintf(&stdoutBuilder, "Error: %s\nRUN_SUMMARY run_id=%s exit_code=1 status=%s duration_ms=0 verified=0 skipped=0 failed=0 warnings=0 errors=1\n", errorType, runID, summaryStatus)
 	// Write to stdout atomically
 	fmt.Print(stdoutBuilder.String())
 }
 
+// HandlePreExecutionError handles pre-execution errors by logging and notifying
+func HandlePreExecutionError(errorType ErrorType, errorMsg, component, runID string) {
+	handleErrorCommon(errorType, errorMsg, component, runID, "Pre-execution error occurred", "pre_execution_error", "pre_execution_error")
+}
+
 // HandleExecutionError handles execution errors (errors that occur during command execution)
 // by logging and outputting appropriate summary information
-func HandleExecutionError(errorMsg, component, runID string) {
-	// Build stderr output atomically to prevent interleaved output in concurrent scenarios
-	var stderrBuilder strings.Builder
-	fmt.Fprintf(&stderrBuilder, "Error: %s\n", ErrorTypeSystemError)
-	if component != "" {
-		fmt.Fprintf(&stderrBuilder, "  Component: %s\n", component)
-	}
-	fmt.Fprintf(&stderrBuilder, "  Details: %s\n", errorMsg)
-	if runID != "" {
-		fmt.Fprintf(&stderrBuilder, "  Run ID: %s\n", runID)
-	}
-	// Write to stderr atomically
-	fmt.Fprint(os.Stderr, stderrBuilder.String())
-
-	// Try to log through slog if available
-	if logger := slog.Default(); logger != nil {
-		slog.Error("Execution error occurred",
-			"error_type", string(ErrorTypeSystemError),
-			"error_message", errorMsg,
-			"component", component,
-			"run_id", runID,
-			"slack_notify", true,
-			"message_type", "execution_error",
-		)
-	}
-
-	// Build stdout output atomically to prevent interleaved output in concurrent scenarios
-	var stdoutBuilder strings.Builder
-	fmt.Fprintf(&stdoutBuilder, "Error: %s\nRUN_SUMMARY run_id=%s exit_code=1 status=execution_error duration_ms=0 verified=0 skipped=0 failed=0 warnings=0 errors=1\n", ErrorTypeSystemError, runID)
-	// Write to stdout atomically
-	fmt.Print(stdoutBuilder.String())
+func HandleExecutionError(execErr *ExecutionError) {
+	handleErrorCommon(ErrorTypeSystemError, execErr.Message, execErr.Component, execErr.RunID, "Execution error occurred", "execution_error", "execution_error")
 }

--- a/internal/logging/pre_execution_error_test.go
+++ b/internal/logging/pre_execution_error_test.go
@@ -383,7 +383,12 @@ func TestHandleExecutionError(t *testing.T) {
 			// We can't easily capture these without complex setup,
 			// but we can at least verify it doesn't panic
 			assert.NotPanics(t, func() {
-				HandleExecutionError(tt.message, tt.component, tt.runID)
+				execErr := &ExecutionError{
+					Message:   tt.message,
+					Component: tt.component,
+					RunID:     tt.runID,
+				}
+				HandleExecutionError(execErr)
 			}, "HandleExecutionError should not panic")
 		})
 	}


### PR DESCRIPTION
This pull request introduces a new error type to distinguish execution errors from pre-execution errors, updates error handling logic in the main runner, and adds comprehensive logging and reporting for execution errors. It also includes new tests to ensure robust handling of execution errors.

**Error Handling Improvements**

* Added a new `ExecutionError` type to `cmd/runner/main.go` for representing errors that occur during command execution, with support for error wrapping and context preservation.
* Updated the error handling logic in the main function to specifically detect and handle `ExecutionError` instances, routing them to a new handler.
* Modified `executeRunner` to return an `ExecutionError` instead of a generic wrapped error, improving error context.

**Logging and Reporting Enhancements**

* Implemented `HandleExecutionError` in `internal/logging/pre_execution_error.go` to log execution errors, output detailed error information to stderr and stdout, and integrate with the slog logger for structured error reporting.

**Testing**

* Added `TestHandleExecutionError` in `internal/logging/pre_execution_error_test.go` to verify that execution errors are handled safely and do not cause panics across various scenarios.