### PR TITLE
runner: validate output path against command workdir and fix tests

### DIFF
--- a/internal/runner/group_executor.go
+++ b/internal/runner/group_executor.go
@@ -372,7 +372,7 @@ func (ge *DefaultGroupExecutor) executeCommandInGroup(ctx context.Context, cmd *
 
 	// Validate output path before command execution if output capture is requested
 	if cmd.Output() != "" {
-		if err := ge.resourceManager.ValidateOutputPath(cmd.Output(), groupSpec.WorkDir); err != nil {
+		if err := ge.resourceManager.ValidateOutputPath(cmd.Output(), cmd.EffectiveWorkDir); err != nil {
 			return nil, fmt.Errorf("output path validation failed: %w", err)
 		}
 	}

--- a/internal/runner/group_executor_test.go
+++ b/internal/runner/group_executor_test.go
@@ -624,8 +624,9 @@ func TestExecuteCommandInGroup_OutputPathValidationFailure(t *testing.T) {
 			Cmd:        "/bin/echo",
 			OutputFile: "/invalid/output/path",
 		},
-		ExpandedCmd:  "/bin/echo",
-		ExpandedArgs: []string{},
+		ExpandedCmd:      "/bin/echo",
+		ExpandedArgs:     []string{},
+		EffectiveWorkDir: "/work",
 	}
 
 	groupSpec := &runnertypes.GroupSpec{


### PR DESCRIPTION
- Use the command's EffectiveWorkDir when validating output paths in executeCommandInGroup.

- Update test fixture to set EffectiveWorkDir in the RuntimeCommand so the test matches the new validation context.

- Prevents incorrect validation against the group workdir and aligns runtime behavior with tests.