### PR TITLE
feat: integrated a group membership checker in runner

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -74,16 +74,17 @@ type Option func(*runnerOptions)
 
 // runnerOptions holds all configuration options for creating a Runner
 type runnerOptions struct {
-	executor            executor.CommandExecutor
-	verificationManager *verification.Manager
-	privilegeManager    runnertypes.PrivilegeManager
-	auditLogger         *audit.Logger
-	runID               string
-	resourceManager     resource.ResourceManager
-	dryRun              bool
-	dryRunOptions       *resource.DryRunOptions
-	runtimeGlobal       *runnertypes.RuntimeGlobal
-	keepTempDirs        bool
+	executor                executor.CommandExecutor
+	verificationManager     *verification.Manager
+	privilegeManager        runnertypes.PrivilegeManager
+	auditLogger             *audit.Logger
+	runID                   string
+	resourceManager         resource.ResourceManager
+	dryRun                  bool
+	dryRunOptions           *resource.DryRunOptions
+	runtimeGlobal           *runnertypes.RuntimeGlobal
+	keepTempDirs            bool
+	groupMembershipProvider *groupmembership.GroupMembership
 }
 
 // WithVerificationManager sets a custom verification manager
@@ -140,6 +141,13 @@ func WithKeepTempDirs(keep bool) Option {
 func WithRuntimeGlobal(runtimeGlobal *runnertypes.RuntimeGlobal) Option {
 	return func(opts *runnerOptions) {
 		opts.runtimeGlobal = runtimeGlobal
+	}
+}
+
+// WithGroupMembershipProvider sets a custom group membership provider
+func WithGroupMembershipProvider(provider *groupmembership.GroupMembership) Option {
+	return func(opts *runnerOptions) {
+		opts.groupMembershipProvider = provider
 	}
 }
 
@@ -256,8 +264,14 @@ func NewRunner(configSpec *runnertypes.ConfigSpec, options ...Option) (*Runner, 
 		return nil, ErrRunIDRequired
 	}
 
+	// Initialize group membership provider if not provided
+	gmProvider := opts.groupMembershipProvider
+	if gmProvider == nil {
+		gmProvider = groupmembership.New()
+	}
+
 	// Create validator with default security config
-	validator, err := security.NewValidator(nil, security.WithGroupMembership(groupmembership.New()))
+	validator, err := security.NewValidator(nil, security.WithGroupMembership(gmProvider))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create security validator: %w", err)
 	}

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/isseis/go-safe-cmd-runner/internal/common"
+	"github.com/isseis/go-safe-cmd-runner/internal/groupmembership"
 
 	configpkg "github.com/isseis/go-safe-cmd-runner/internal/runner/config"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/output"
@@ -78,6 +79,18 @@ func TestNewRunner(t *testing.T) {
 			WithRunID("test-run-123"))
 		assert.NoError(t, err)
 		assert.NotNil(t, runner)
+	})
+
+	t.Run("with custom group membership provider", func(t *testing.T) {
+		// Create a custom group membership provider
+		customProvider := groupmembership.New()
+		runner, err := NewRunner(config,
+			WithVerificationManager(setupDryRunVerification(t)),
+			WithRunID("test-run-123"),
+			WithGroupMembershipProvider(customProvider))
+		require.NoError(t, err, "NewRunner should not return an error with custom group membership provider")
+		assert.NotNil(t, runner)
+		assert.NotNil(t, runner.validator)
 	})
 }
 


### PR DESCRIPTION
This pull request updates how the security validator is initialized in the `Runner` setup to support group membership checks. The main change is the introduction of a new group membership provider, which is now passed to the security validator during runner creation.

Security and group membership integration:

* Added import for the new `groupmembership` package to `internal/runner/runner.go`, enabling group membership features in the runner.
* Updated the initialization of the security validator in the `NewRunner` function to use `security.WithGroupMembership(groupmembership.New())`, allowing the validator to leverage group membership information for enhanced security checks.