### PR TITLE
runner: wire output manager with validator into resource manager

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -199,13 +199,13 @@ func createResourceManager(opts *runnerOptions, configSpec *runnertypes.ConfigSp
 	}
 
 	if opts.dryRun {
-		return createDryRunResourceManager(opts, getPathResolver())
+		return createDryRunResourceManager(opts, getPathResolver(), validator)
 	}
 	return createNormalResourceManager(opts, configSpec, getPathResolver(), validator)
 }
 
 // createDryRunResourceManager creates a resource manager for dry-run mode
-func createDryRunResourceManager(opts *runnerOptions, pathResolver resource.PathResolver) error {
+func createDryRunResourceManager(opts *runnerOptions, pathResolver resource.PathResolver, validator *security.Validator) error {
 	if opts.dryRunOptions == nil {
 		opts.dryRunOptions = &resource.DryRunOptions{
 			DetailLevel:  resource.DetailLevelDetailed,
@@ -213,10 +213,14 @@ func createDryRunResourceManager(opts *runnerOptions, pathResolver resource.Path
 		}
 	}
 
-	resourceManager, err := resource.NewDryRunResourceManager(
+	// Create output manager with the same validator that has group membership support
+	outputMgr := output.NewDefaultOutputCaptureManager(validator)
+
+	resourceManager, err := resource.NewDryRunResourceManagerWithOutput(
 		opts.executor,
 		opts.privilegeManager,
 		pathResolver,
+		outputMgr,
 		opts.dryRunOptions,
 	)
 	if err != nil {


### PR DESCRIPTION
This pull request updates the resource manager creation logic in `internal/runner/runner.go` to ensure that both dry-run and normal execution modes use an output manager initialized with a security validator. This change improves output handling by supporting group membership validation for command execution output.

**Output management improvements:**

* Added import of the `output` package to support output manager functionality.
* Updated both `createDryRunResourceManager` and `createNormalResourceManager` functions to accept a `validator` parameter and initialize an `outputMgr` using `output.NewDefaultOutputCaptureManager(validator)`. This ensures output handling is consistent and secure for both execution modes. [[1]](diffhunk://#diff-ddc7e46dbd3f77cb194815142eb06ccf62e24963d16039f1ff41266e4ec3d7a6L201-R223) [[2]](diffhunk://#diff-ddc7e46dbd3f77cb194815142eb06ccf62e24963d16039f1ff41266e4ec3d7a6L229-R243)
* Modified resource manager initialization to pass the new `outputMgr` instead of `nil`, enabling output capture with security validation.