### PR TITLE
executor: use typed OutputStream enum for OutputWriter and update callers

### DIFF
--- a/cmd/runner/integration_workdir_test.go
+++ b/cmd/runner/integration_workdir_test.go
@@ -82,7 +82,7 @@ type captureOutputWriter struct {
 }
 
 // Write writes data to both the wrapped writer and capture buffer
-func (w *captureOutputWriter) Write(stream string, data []byte) error {
+func (w *captureOutputWriter) Write(stream executor.OutputStream, data []byte) error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 

--- a/internal/runner/executor/executor.go
+++ b/internal/runner/executor/executor.go
@@ -285,7 +285,7 @@ func (fs *osFileSystem) FileExists(path string) (bool, error) {
 // and writes to an OutputWriter with a specific stream name
 type outputWrapper struct {
 	writer OutputWriter
-	stream string
+	stream OutputStream
 	buffer bytes.Buffer
 	mu     sync.Mutex
 }

--- a/internal/runner/executor/interface.go
+++ b/internal/runner/executor/interface.go
@@ -13,13 +13,28 @@ const (
 	ExitCodeUnknown = -1
 )
 
-// Stream names for command output
+// OutputStream represents the type of output stream (stdout or stderr)
+type OutputStream int
+
+// Output stream constants
 const (
-	// StdoutStream is the name of the standard output stream
-	StdoutStream = "stdout"
-	// StderrStream is the name of the standard error stream
-	StderrStream = "stderr"
+	// StdoutStream represents the standard output stream
+	StdoutStream OutputStream = iota
+	// StderrStream represents the standard error stream
+	StderrStream
 )
+
+// String returns the string representation of the output stream
+func (s OutputStream) String() string {
+	switch s {
+	case StdoutStream:
+		return "stdout"
+	case StderrStream:
+		return "stderr"
+	default:
+		return "unknown"
+	}
+}
 
 // CommandExecutor defines the interface for executing commands
 type CommandExecutor interface {
@@ -59,7 +74,7 @@ type OutputWriter interface {
 	// stream will be either StdoutStream or StderrStream.
 	// data contains the raw output bytes and may include partial lines.
 	// Returns an error if writing fails or if the writer has been closed.
-	Write(stream string, data []byte) error
+	Write(stream OutputStream, data []byte) error
 
 	// Close closes the output writer and releases any resources.
 	// Must be idempotent and thread-safe.

--- a/internal/runner/executor/testing/mocks.go
+++ b/internal/runner/executor/testing/mocks.go
@@ -4,6 +4,8 @@ package testing
 
 import (
 	"os"
+
+	"github.com/isseis/go-safe-cmd-runner/internal/runner/executor"
 )
 
 // Mock implementations for executor interfaces used in testing.
@@ -15,7 +17,7 @@ type MockOutputWriter struct {
 }
 
 // Write implements the executor.OutputWriter interface for testing
-func (m *MockOutputWriter) Write(_ string, data []byte) error {
+func (m *MockOutputWriter) Write(_ executor.OutputStream, data []byte) error {
 	if m.Outputs == nil {
 		m.Outputs = make([]string, 0)
 	}

--- a/internal/runner/output/capture.go
+++ b/internal/runner/output/capture.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"sync"
 	"time"
+
+	"github.com/isseis/go-safe-cmd-runner/internal/runner/executor"
 )
 
 // Capture represents an active output capture session using temporary file
@@ -15,6 +17,12 @@ type Capture struct {
 	CurrentSize  int64      // Current accumulated output size
 	StartTime    time.Time  // Start time of capture session
 	mutex        sync.Mutex // Protects concurrent access to file and size
+}
+
+// Write implements executor.OutputWriter interface
+// The stream parameter is ignored since Capture does not distinguish between stdout/stderr
+func (c *Capture) Write(_ executor.OutputStream, data []byte) error {
+	return c.WriteOutput(data)
 }
 
 // WriteOutput writes data to the capture (implements CaptureWriter interface)
@@ -49,7 +57,7 @@ func (c *Capture) WriteOutput(data []byte) error {
 	return nil
 }
 
-// Close closes the capture (implements CaptureWriter interface)
+// Close closes the capture (implements both CaptureWriter and executor.OutputWriter interfaces)
 func (c *Capture) Close() error {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()

--- a/internal/runner/output/console.go
+++ b/internal/runner/output/console.go
@@ -18,7 +18,7 @@ func NewConsoleOutputWriter() executor.OutputWriter {
 }
 
 // Write implements executor.OutputWriter.Write
-func (c *ConsoleOutputWriter) Write(stream string, data []byte) error {
+func (c *ConsoleOutputWriter) Write(stream executor.OutputStream, data []byte) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 

--- a/internal/runner/output/console_test.go
+++ b/internal/runner/output/console_test.go
@@ -23,7 +23,7 @@ func TestNewConsoleOutputWriter(t *testing.T) {
 func TestConsoleOutputWriter_Write(t *testing.T) {
 	tests := []struct {
 		name   string
-		stream string
+		stream executor.OutputStream
 	}{
 		{
 			name:   "stdout stream",

--- a/internal/runner/output/writer.go
+++ b/internal/runner/output/writer.go
@@ -32,7 +32,7 @@ func NewTeeOutputWriter(capture CaptureWriter, writer executor.OutputWriter) exe
 
 // Write implements executor.OutputWriter.Write
 // It writes data to both the capture writer and the output writer
-func (t *TeeOutputWriter) Write(stream string, data []byte) error {
+func (t *TeeOutputWriter) Write(stream executor.OutputStream, data []byte) error {
 	// Write to capture first (file output)
 	if t.capture != nil {
 		if err := t.capture.WriteOutput(data); err != nil {

--- a/internal/runner/output/writer_test.go
+++ b/internal/runner/output/writer_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/isseis/go-safe-cmd-runner/internal/runner/executor"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -24,7 +25,7 @@ type mockOutputWriter struct {
 	closed      bool
 }
 
-func (m *mockOutputWriter) Write(_ string, data []byte) error {
+func (m *mockOutputWriter) Write(_ executor.OutputStream, data []byte) error {
 	if m.writeError != nil {
 		return m.writeError
 	}
@@ -41,7 +42,7 @@ func TestTeeOutputWriter_Write(t *testing.T) {
 	tests := []struct {
 		name          string
 		data          []byte
-		stream        string
+		stream        executor.OutputStream
 		bufferWritten bool
 		captureError  error
 		writerError   error
@@ -50,7 +51,7 @@ func TestTeeOutputWriter_Write(t *testing.T) {
 		{
 			name:          "successful write to both",
 			data:          []byte("test output"),
-			stream:        "stdout",
+			stream:        executor.StdoutStream,
 			bufferWritten: true,
 			captureError:  nil,
 			writerError:   nil,
@@ -59,7 +60,7 @@ func TestTeeOutputWriter_Write(t *testing.T) {
 		{
 			name:          "capture error",
 			data:          []byte("test output"),
-			stream:        "stdout",
+			stream:        executor.StdoutStream,
 			bufferWritten: false,
 			captureError:  errMockCapture,
 			writerError:   nil,
@@ -68,7 +69,7 @@ func TestTeeOutputWriter_Write(t *testing.T) {
 		{
 			name:          "writer error",
 			data:          []byte("test output"),
-			stream:        "stdout",
+			stream:        executor.StdoutStream,
 			bufferWritten: true,
 			captureError:  nil,
 			writerError:   errMockWriter,
@@ -77,7 +78,7 @@ func TestTeeOutputWriter_Write(t *testing.T) {
 		{
 			name:          "empty data",
 			data:          []byte{},
-			stream:        "stdout",
+			stream:        executor.StdoutStream,
 			bufferWritten: true,
 			captureError:  nil,
 			writerError:   nil,
@@ -216,7 +217,7 @@ func TestTeeOutputWriter_NilCapture(t *testing.T) {
 
 	// Write should only write to writer
 	data := []byte("test output")
-	err := teeWriter.Write("stdout", data)
+	err := teeWriter.Write(executor.StdoutStream, data)
 	require.NoError(t, err)
 
 	// Check that data was written only to writer
@@ -238,7 +239,7 @@ func TestTeeOutputWriter_NilWriter(t *testing.T) {
 
 	// Write should only write to capture
 	data := []byte("test output")
-	err := teeWriter.Write("stdout", data)
+	err := teeWriter.Write(executor.StdoutStream, data)
 	require.NoError(t, err)
 
 	// Check that data was written only to capture


### PR DESCRIPTION
This pull request refactors the output stream handling in the command runner and output modules to use a new strongly-typed `OutputStream` enum instead of plain strings for distinguishing between stdout and stderr. This improves type safety and consistency throughout the codebase. The change also updates all relevant interfaces, implementations, and tests to use the new type.

### Output stream type refactoring

* Introduced the `OutputStream` type as an `int` enum in `internal/runner/executor/interface.go`, replacing string constants for stdout and stderr, and added a `String()` method for easy conversion to string representations.
* Updated the `OutputWriter` interface and all its implementations (`captureOutputWriter`, `outputWrapper`, `ConsoleOutputWriter`, `TeeOutputWriter`, and mocks) to use `OutputStream` instead of string for the stream parameter in the `Write` method. [[1]](diffhunk://#diff-6dec7bdb17257f594acc38adc68eae3f8ddc6890ed4563d5ef3ba6342ee604d9L62-R77) [[2]](diffhunk://#diff-51fc2c1f179c42eddc608b5f449f482f0b42704db54e8e3f63b9d2b9936ceca2L85-R85) [[3]](diffhunk://#diff-3f391f7ebb7c3fe2bd0c385f2140366acc9a67b7f8504f87d41d1f3a38e07980L288-R288) [[4]](diffhunk://#diff-c7e2c97c4aac3d70c733791ab27bc90c0423555e7f44e861bf4ff87b1e845973L21-R21) [[5]](diffhunk://#diff-2aff02b98f198ec734fce7a7bb016993b11dbd9ef4861fefbd20d86e7d4be012L35-R35) [[6]](diffhunk://#diff-888630e822c4da251a881c905fc33dcd6346d763156e58ff0c81ca00fb7154dcL18-R20) [[7]](diffhunk://#diff-874460a07950873e71ae69c3d4157c55352b4cdea293beb3f6db947650ae0321L27-R28) [[8]](diffhunk://#diff-40ae1bd3abae023a2cece4b0a6b51e71e324beb6289652ffdd07088519c401a6R22-R27)

### Test and usage updates

* Refactored all test cases and usages to pass `OutputStream` values (e.g., `executor.StdoutStream`) instead of string literals for stream selection, ensuring compatibility with the new type. [[1]](diffhunk://#diff-e68eac5bd64d8f817114c3f3af6a3329e6033c150d95b51b633dda881457593dL26-R26) [[2]](diffhunk://#diff-874460a07950873e71ae69c3d4157c55352b4cdea293beb3f6db947650ae0321L44-R45) [[3]](diffhunk://#diff-874460a07950873e71ae69c3d4157c55352b4cdea293beb3f6db947650ae0321L53-R54) [[4]](diffhunk://#diff-874460a07950873e71ae69c3d4157c55352b4cdea293beb3f6db947650ae0321L62-R63) [[5]](diffhunk://#diff-874460a07950873e71ae69c3d4157c55352b4cdea293beb3f6db947650ae0321L71-R72) [[6]](diffhunk://#diff-874460a07950873e71ae69c3d4157c55352b4cdea293beb3f6db947650ae0321L80-R81) [[7]](diffhunk://#diff-874460a07950873e71ae69c3d4157c55352b4cdea293beb3f6db947650ae0321L219-R220) [[8]](diffhunk://#diff-874460a07950873e71ae69c3d4157c55352b4cdea293beb3f6db947650ae0321L241-R242)

### Integration and interface improvements

* Updated the `Capture` type in `internal/runner/output/capture.go` to implement the new `OutputWriter` interface, explicitly ignoring the stream parameter since it does not distinguish between stdout and stderr.
* Improved comments and documentation to clarify the new interface and usage patterns, including the dual implementation of `CaptureWriter` and `OutputWriter` for the `Capture` type.

### Resource manager output handling

* Simplified the resource manager's command execution logic to use the `Capture` type directly as an `OutputWriter` when an output file is specified, removing unnecessary teeing to console output and updating error handling accordingly.

### Dependency injection and imports

* Updated import statements across files to bring in the new `OutputStream` type from the executor package where needed, ensuring all references are consistent and type-safe. [[1]](diffhunk://#diff-888630e822c4da251a881c905fc33dcd6346d763156e58ff0c81ca00fb7154dcR7-R8) [[2]](diffhunk://#diff-40ae1bd3abae023a2cece4b0a6b51e71e324beb6289652ffdd07088519c401a6R7-R8) [[3]](diffhunk://#diff-874460a07950873e71ae69c3d4157c55352b4cdea293beb3f6db947650ae0321R7)