### PR TITLE
Simplify executor logging and initialization; use NewDefaultExecutor factory

### DIFF
--- a/internal/runner/executor/executor_logging_test.go
+++ b/internal/runner/executor/executor_logging_test.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"context"
 	"log/slog"
-	"strings"
 	"testing"
 
 	"github.com/isseis/go-safe-cmd-runner/internal/common"
@@ -181,49 +180,4 @@ func TestExecutor_ErrorLogging_WithStderr(t *testing.T) {
 	assert.Contains(t, logOutput, "Command execution failed")
 	assert.Contains(t, logOutput, "stderr")
 	// Note: stderr content appears in the log structured output
-}
-
-// TestFormatCommandForLog_CopyPasteable verifies that logged commands can be copy-pasted
-func TestFormatCommandForLog_CopyPasteable(t *testing.T) {
-	tests := []struct {
-		name        string
-		path        string
-		args        []string
-		description string
-	}{
-		{
-			name:        "simple command",
-			path:        "/bin/ls",
-			args:        []string{"-la"},
-			description: "Should produce: /bin/ls -la",
-		},
-		{
-			name:        "command with spaces in args",
-			path:        "/bin/grep",
-			args:        []string{"-r", "search pattern", "/path/to/dir"},
-			description: "Should properly quote arguments with spaces",
-		},
-		{
-			name:        "command with special chars",
-			path:        "/bin/sh",
-			args:        []string{"-c", "echo $HOME && ls -la"},
-			description: "Should escape shell special characters",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := FormatCommandForLog(tt.path, tt.args)
-
-			// Result should not be empty
-			assert.NotEmpty(t, result)
-
-			// Result should start with the path
-			assert.True(t, strings.HasPrefix(result, ShellEscape(tt.path)),
-				"Result should start with escaped path")
-
-			t.Logf("Command: %s", result)
-			t.Logf("Description: %s", tt.description)
-		})
-	}
 }

--- a/internal/runner/executor/executor_test.go
+++ b/internal/runner/executor/executor_test.go
@@ -68,9 +68,9 @@ func TestExecute_Success(t *testing.T) {
 
 			outputWriter := &executortesting.MockOutputWriter{}
 
-			e := &executor.DefaultExecutor{
-				FS: fileSystem,
-			}
+			e := executor.NewDefaultExecutor(
+				executor.WithFileSystem(fileSystem),
+			).(*executor.DefaultExecutor)
 
 			result, err := e.Execute(context.Background(), tt.cmd, tt.env, outputWriter)
 			if tt.wantErr {
@@ -145,9 +145,9 @@ func TestExecute_Failure(t *testing.T) {
 
 			outputWriter := &executortesting.MockOutputWriter{}
 
-			e := &executor.DefaultExecutor{
-				FS: fileSystem,
-			}
+			e := executor.NewDefaultExecutor(
+				executor.WithFileSystem(fileSystem),
+			).(*executor.DefaultExecutor)
 
 			ctx := context.Background()
 			if tt.timeout > 0 {
@@ -181,9 +181,9 @@ func TestExecute_ContextCancellation(t *testing.T) {
 		ExistingPaths: make(map[string]bool),
 	}
 
-	e := &executor.DefaultExecutor{
-		FS: fileSystem,
-	}
+	e := executor.NewDefaultExecutor(
+		executor.WithFileSystem(fileSystem),
+	).(*executor.DefaultExecutor)
 
 	// Create a context that we'll cancel
 	ctx, cancel := context.WithCancel(context.Background())
@@ -209,9 +209,9 @@ func TestExecute_EnvironmentVariables(t *testing.T) {
 		ExistingPaths: make(map[string]bool),
 	}
 
-	e := &executor.DefaultExecutor{
-		FS: fileSystem,
-	}
+	e := executor.NewDefaultExecutor(
+		executor.WithFileSystem(fileSystem),
+	).(*executor.DefaultExecutor)
 
 	// Set a test environment variable in the runner process
 	t.Setenv("LEAKED_VAR", "should_not_appear")
@@ -271,9 +271,9 @@ func TestValidate(t *testing.T) {
 				fileSystem.ExistingPaths[tt.cmd.EffectiveWorkDir] = !tt.wantErr
 			}
 
-			e := &executor.DefaultExecutor{
-				FS: fileSystem,
-			}
+			e := executor.NewDefaultExecutor(
+				executor.WithFileSystem(fileSystem),
+			).(*executor.DefaultExecutor)
 
 			err := e.Validate(tt.cmd)
 			if tt.wantErr {

--- a/internal/runner/executor/shell_escape.go
+++ b/internal/runner/executor/shell_escape.go
@@ -44,10 +44,10 @@ func isSafeChar(r rune) bool {
 // FormatCommandForLog formats a command with arguments for logging
 // Returns a string that can be copy-pasted into a shell
 func FormatCommandForLog(path string, args []string) string {
-	var parts []string
-	parts = append(parts, ShellEscape(path))
-	for _, arg := range args {
-		parts = append(parts, ShellEscape(arg))
+	parts := make([]string, 1+len(args))
+	parts[0] = ShellEscape(path)
+	for i, arg := range args {
+		parts[i+1] = ShellEscape(arg)
 	}
 	return strings.Join(parts, " ")
 }


### PR DESCRIPTION
- Add default no-op logger and remove repetitive nil-checks around Logger to simplify flow.
- Use factory NewDefaultExecutor with WithFileSystem in tests for clarity.
- Optimize FormatCommandForLog by pre-allocating the slice.
- Remove unused import and an obsolete test in executor logging tests.