### PR TITLE
Prefer output write errors over broken-pipe command errors

### DIFF
--- a/sample/output_capture_too_large_error.toml
+++ b/sample/output_capture_too_large_error.toml
@@ -1,0 +1,20 @@
+# Single Error Test Configuration
+version = "1.0"
+
+[global]
+timeout = 30
+log_level = "debug"
+output_size_limit = 1024
+env_allowed = ["PATH"]
+verify_standard_paths = false
+
+[[groups]]
+name = "too_large_error_test"
+description = "Test too large error case"
+
+[[groups.commands]]
+name = "infinite_output"
+description = "Attempt to generate output exceeding size limit"
+cmd = "yes"
+args = []
+output_file = "output.txt"


### PR DESCRIPTION
- Store the first writer error in outputWrapper and add GetWriteError().
- When capturing output prefer write errors from stdout/stderr wrappers and set command error accordingly to avoid masking with SIGPIPE.
- Add sample/output_capture_too_large_error.toml to exercise size-limit failure cases.