### PR TITLE
fix: command results in slack post was empty

### DIFF
--- a/internal/common/logschema.go
+++ b/internal/common/logschema.go
@@ -1,6 +1,8 @@
 // Package common provides shared types and utilities used across the application
 package common
 
+import "log/slog"
+
 // Log field keys for CommandResult structured logging
 // These constants ensure consistency between log value creation (runner.CommandResult.LogValue())
 // and log attribute extraction (logging.extractCommandResults())
@@ -101,4 +103,21 @@ type CommandResultFields struct {
 	ExitCode int
 	Output   string
 	Stderr   string
+}
+
+// CommandResult holds the result of a single command execution
+// This type is used across packages (runner, logging) to avoid circular dependencies
+type CommandResult struct {
+	CommandResultFields
+}
+
+// LogValue implements slog.LogValuer to provide structured logging support
+// Field keys are defined in LogField* constants to ensure consistency
+func (c CommandResult) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.String(LogFieldName, c.Name),
+		slog.Int(LogFieldExitCode, c.ExitCode),
+		slog.String(LogFieldOutput, c.Output),
+		slog.String(LogFieldStderr, c.Stderr),
+	)
 }

--- a/internal/logging/slack_handler_test.go
+++ b/internal/logging/slack_handler_test.go
@@ -431,18 +431,22 @@ func TestSlackHandler_Handle_WithMockServer(t *testing.T) {
 				slog.String(common.GroupSummaryAttrs.Status, "success"),
 				slog.String(common.GroupSummaryAttrs.Group, "test-group"),
 				slog.Int64(common.GroupSummaryAttrs.DurationMs, 100),
-				slog.Any(common.GroupSummaryAttrs.Commands, []any{
-					[]slog.Attr{
-						slog.String(common.LogFieldName, "echo test"),
-						slog.Int(common.LogFieldExitCode, 0),
-						slog.String(common.LogFieldOutput, "test output"),
-						slog.String(common.LogFieldStderr, ""),
+				slog.Any(common.GroupSummaryAttrs.Commands, []common.CommandResult{
+					{
+						CommandResultFields: common.CommandResultFields{
+							Name:     "echo test",
+							ExitCode: 0,
+							Output:   "test output",
+							Stderr:   "",
+						},
 					},
-					[]slog.Attr{
-						slog.String(common.LogFieldName, "echo test2"),
-						slog.Int(common.LogFieldExitCode, 1),
-						slog.String(common.LogFieldOutput, ""),
-						slog.String(common.LogFieldStderr, "error output"),
+					{
+						CommandResultFields: common.CommandResultFields{
+							Name:     "echo test2",
+							ExitCode: 1,
+							Output:   "",
+							Stderr:   "error output",
+						},
 					},
 				}),
 			},

--- a/internal/runner/group_executor.go
+++ b/internal/runner/group_executor.go
@@ -220,8 +220,8 @@ func (ge *DefaultGroupExecutor) executeAllCommands(
 	groupSpec *runnertypes.GroupSpec,
 	runtimeGroup *runnertypes.RuntimeGroup,
 	runtimeGlobal *runnertypes.RuntimeGlobal,
-) ([]CommandResult, *groupExecutionResult, error) {
-	commandResults := make([]CommandResult, 0, len(groupSpec.Commands))
+) ([]common.CommandResult, *groupExecutionResult, error) {
+	commandResults := make([]common.CommandResult, 0, len(groupSpec.Commands))
 
 	for i := range groupSpec.Commands {
 		cmdSpec := &groupSpec.Commands[i]
@@ -258,7 +258,7 @@ func (ge *DefaultGroupExecutor) executeAllCommands(
 		stdout, stderr, exitCode, err := ge.executeSingleCommand(ctx, runtimeCmd, groupSpec, runtimeGroup, runtimeGlobal)
 
 		// Record command result
-		cmdResult := CommandResult{
+		cmdResult := common.CommandResult{
 			CommandResultFields: common.CommandResultFields{
 				Name:     cmdSpec.Name,
 				ExitCode: exitCode,

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -46,28 +46,10 @@ const (
 	GroupExecutionStatusError GroupExecutionStatus = "error"
 )
 
-// CommandResult holds the result of a single command execution
-// This is exported to allow the logging package to access command results
-// It embeds common.CommandResultFields to ensure type consistency across the codebase
-type CommandResult struct {
-	common.CommandResultFields
-}
-
-// LogValue implements slog.LogValuer to provide structured logging support
-// Field keys are defined in common.LogField* constants to ensure consistency
-func (c CommandResult) LogValue() slog.Value {
-	return slog.GroupValue(
-		slog.String(common.LogFieldName, c.Name),
-		slog.Int(common.LogFieldExitCode, c.ExitCode),
-		slog.String(common.LogFieldOutput, c.Output),
-		slog.String(common.LogFieldStderr, c.Stderr),
-	)
-}
-
 // groupExecutionResult holds the result of group execution for notification
 type groupExecutionResult struct {
 	status   GroupExecutionStatus
-	commands []CommandResult // All commands executed in the group
+	commands []common.CommandResult // All commands executed in the group
 	errorMsg string
 }
 

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -1981,12 +1981,12 @@ func TestRunner_ExecutorUsesDefaultLogger(t *testing.T) {
 func TestCommandResult_LogValue(t *testing.T) {
 	tests := []struct {
 		name     string
-		result   CommandResult
+		result   common.CommandResult
 		expected map[string]any
 	}{
 		{
 			name: "complete result",
-			result: CommandResult{
+			result: common.CommandResult{
 				CommandResultFields: common.CommandResultFields{
 					Name:     "test-cmd",
 					ExitCode: 0,
@@ -2003,7 +2003,7 @@ func TestCommandResult_LogValue(t *testing.T) {
 		},
 		{
 			name: "failed command with stderr",
-			result: CommandResult{
+			result: common.CommandResult{
 				CommandResultFields: common.CommandResultFields{
 					Name:     "failing-cmd",
 					ExitCode: 1,
@@ -2020,7 +2020,7 @@ func TestCommandResult_LogValue(t *testing.T) {
 		},
 		{
 			name: "command with both output and stderr",
-			result: CommandResult{
+			result: common.CommandResult{
 				CommandResultFields: common.CommandResultFields{
 					Name:     "mixed-cmd",
 					ExitCode: 2,


### PR DESCRIPTION
This pull request refactors the `CommandResult` type to centralize its definition in `internal/common/logschema.go`, improving type consistency and reducing code duplication across packages. All usages of `CommandResult` in `runner`, `logging`, and related tests are updated to use the shared type. The logging logic for command results is simplified, making structured logging more reliable and easier to maintain.

### Type unification and code deduplication

* Moved the definition of `CommandResult` and its `LogValue` implementation from `internal/runner/runner.go` to `internal/common/logschema.go`, making it accessible across packages and preventing circular dependencies. [[1]](diffhunk://#diff-af74af838d2cde6dadd16c7221df6e5f7f5d2844e4d0c248e571c83f66b98bd2R4-R5) [[2]](diffhunk://#diff-af74af838d2cde6dadd16c7221df6e5f7f5d2844e4d0c248e571c83f66b98bd2R107-R123) [[3]](diffhunk://#diff-ddc7e46dbd3f77cb194815142eb06ccf62e24963d16039f1ff41266e4ec3d7a6L49-R52)
* Updated all references and usages of `CommandResult` in `runner`, `logging`, and tests to use `common.CommandResult` instead of local definitions, ensuring consistent type usage. [[1]](diffhunk://#diff-0cfd0a2cc4c95e9ec2f75fc9449a3ea9818527656cc3a7b9160b47917ea1e87eL223-R224) [[2]](diffhunk://#diff-0cfd0a2cc4c95e9ec2f75fc9449a3ea9818527656cc3a7b9160b47917ea1e87eL261-R261) [[3]](diffhunk://#diff-ddc7e46dbd3f77cb194815142eb06ccf62e24963d16039f1ff41266e4ec3d7a6L49-R52) [[4]](diffhunk://#diff-3b8985514864e913f3a3b3463fc897dd19897655c1b71ae44b0928b5b5a94f7fL1984-R1989) [[5]](diffhunk://#diff-3b8985514864e913f3a3b3463fc897dd19897655c1b71ae44b0928b5b5a94f7fL2006-R2006) [[6]](diffhunk://#diff-3b8985514864e913f3a3b3463fc897dd19897655c1b71ae44b0928b5b5a94f7fL2023-R2023) [[7]](diffhunk://#diff-1441a1d257bdb608e4ddaa9ba9d9c7f5a2450639dedf78d286e1e33019b77841L434-R449)

### Logging improvements

* Simplified the extraction of command results in `internal/logging/slack_handler.go` by directly working with `[]common.CommandResult` and calling `LogValue()` for structured logging, replacing previous reflection-based logic. [[1]](diffhunk://#diff-abd56e1f2bd3073159d128aa669c5be6c9381671b5679d7c413ae44590518568L245-R245) [[2]](diffhunk://#diff-abd56e1f2bd3073159d128aa669c5be6c9381671b5679d7c413ae44590518568L264-R285) [[3]](diffhunk://#diff-abd56e1f2bd3073159d128aa669c5be6c9381671b5679d7c413ae44590518568L291-R301)

### Test updates

* Updated all related tests to use the unified `common.CommandResult` type and adjusted test data accordingly for structured logging and command result handling. [[1]](diffhunk://#diff-3b8985514864e913f3a3b3463fc897dd19897655c1b71ae44b0928b5b5a94f7fL1984-R1989) [[2]](diffhunk://#diff-3b8985514864e913f3a3b3463fc897dd19897655c1b71ae44b0928b5b5a94f7fL2006-R2006) [[3]](diffhunk://#diff-3b8985514864e913f3a3b3463fc897dd19897655c1b71ae44b0928b5b5a94f7fL2023-R2023) [[4]](diffhunk://#diff-1441a1d257bdb608e4ddaa9ba9d9c7f5a2450639dedf78d286e1e33019b77841L434-R449)

These changes make the codebase more maintainable and ensure that command execution results are logged and processed consistently throughout the application.