### PR TITLE
docs: Remove references to -validate option from user documentation

### DIFF
--- a/docs/user/README.ja.md
+++ b/docs/user/README.ja.md
@@ -37,9 +37,6 @@ runner -config config.toml
 
 # ドライラン（実行内容の確認）
 runner -config config.toml -dry-run
-
-# 設定ファイルの検証
-runner -config config.toml -validate
 ```
 
 **こんな時に:**
@@ -258,16 +255,13 @@ $ ./runner --config backup.toml --keep-temp-dirs
 2. ハッシュ値を記録
    └─ record コマンドで実行ファイルと設定ファイルのハッシュを記録
 
-3. 設定を検証
-   └─ runner -config config.toml -validate
-
-4. ドライランで確認
+3. ドライランで確認
    └─ runner -config config.toml -dry-run
 
-5. 本番実行
+4. 本番実行
    └─ runner -config config.toml
 
-6. トラブルシューティング（必要に応じて）
+5. トラブルシューティング（必要に応じて）
    └─ verify コマンドでファイル整合性を確認
 ```
 
@@ -304,13 +298,10 @@ sudo record -file /etc/go-safe-cmd-runner/backup.toml \
 sudo record -file /usr/bin/pg_dump \
     -hash-dir /usr/local/etc/go-safe-cmd-runner/hashes
 
-# 4. 設定を検証
-runner -config /etc/go-safe-cmd-runner/backup.toml -validate
-
-# 5. ドライランで確認
+# 4. ドライランで確認
 runner -config /etc/go-safe-cmd-runner/backup.toml -dry-run
 
-# 6. 本番実行
+# 5. 本番実行
 runner -config /etc/go-safe-cmd-runner/backup.toml
 ```
 
@@ -335,7 +326,7 @@ A: はい、プロジェクトの `sample/` ディレクトリに多数のサン
 
 A: 以下の順序で確認してください：
 
-1. **設定検証**: `runner -config config.toml -validate`
+1. **設定検証**: `runner -config config.toml -dry-run`
 2. **ファイル検証**: `verify -file <path> -hash-dir <hash-dir>`
 3. **デバッグログ**: `runner -config config.toml -log-level debug`
 4. **トラブルシューティングガイド**:

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -37,9 +37,6 @@ runner -config config.toml
 
 # Dry run (verify execution plan)
 runner -config config.toml -dry-run
-
-# Validate configuration file
-runner -config config.toml -validate
 ```
 
 **Use this when:**
@@ -258,16 +255,13 @@ Explains command risk levels and evaluation criteria.
 2. Record hash values
    └─ Use record command to record hashes of executables and configuration files
 
-3. Validate configuration
-   └─ runner -config config.toml -validate
-
-4. Verify with dry run
+3. Verify with dry run
    └─ runner -config config.toml -dry-run
 
-5. Production execution
+4. Production execution
    └─ runner -config config.toml
 
-6. Troubleshooting (as needed)
+5. Troubleshooting (as needed)
    └─ Use verify command to check file integrity
 ```
 
@@ -304,13 +298,10 @@ sudo record -file /etc/go-safe-cmd-runner/backup.toml \
 sudo record -file /usr/bin/pg_dump \
     -hash-dir /usr/local/etc/go-safe-cmd-runner/hashes
 
-# 4. Validate configuration
-runner -config /etc/go-safe-cmd-runner/backup.toml -validate
-
-# 5. Verify with dry run
+# 4. Verify with dry run
 runner -config /etc/go-safe-cmd-runner/backup.toml -dry-run
 
-# 6. Production execution
+# 5. Production execution
 runner -config /etc/go-safe-cmd-runner/backup.toml
 ```
 
@@ -335,7 +326,7 @@ See the [TOML Configuration File Guide](toml_config/README.md) for details.
 
 A: Check in the following order:
 
-1. **Validate configuration**: `runner -config config.toml -validate`
+1. **Validate configuration**: `runner -config config.toml -dry-run`
 2. **Verify files**: `verify -file <path> -hash-dir <hash-dir>`
 3. **Debug logging**: `runner -config config.toml -log-level debug`
 4. **Troubleshooting guides**:

--- a/docs/user/record_command.ja.md
+++ b/docs/user/record_command.ja.md
@@ -303,7 +303,7 @@ sudo record -file /usr/local/bin/backup.sh \
     -force
 
 # 4. 動作確認
-runner -config /etc/go-safe-cmd-runner/backup.toml -validate
+runner -config /etc/go-safe-cmd-runner/backup.toml -dry-run
 ```
 
 ### 4.3 複数ファイルの一括記録

--- a/docs/user/record_command.md
+++ b/docs/user/record_command.md
@@ -303,7 +303,7 @@ sudo record -file /usr/local/bin/backup.sh \
     -force
 
 # 4. Verify operation
-runner -config /etc/go-safe-cmd-runner/backup.toml -validate
+runner -config /etc/go-safe-cmd-runner/backup.toml -dry-run
 ```
 
 ### 4.3 Batch Recording of Multiple Files

--- a/docs/user/runner_command.md
+++ b/docs/user/runner_command.md
@@ -35,11 +35,9 @@ User guide for the main execution command `runner` of go-safe-cmd-runner.
    - Hash of executable binaries
    - Hash of files specified in verify_files
    ↓
-3. Validate configuration file (-validate flag)
+3. Verify operation with dry run (-dry-run flag)
    ↓
-4. Verify operation with dry run (-dry-run flag)
-   ↓
-5. Production execution (runner command)
+4. Production execution (runner command)
 ```
 
 ## 2. Quick Start
@@ -542,66 +540,6 @@ runner -config config.toml -dry-run -dry-run-format json -dry-run-detail detaile
 # Check final environment variables
 runner -config config.toml -dry-run -dry-run-format json -dry-run-detail full | \
   jq '.resource_analyses[] | select(.debug_info.final_environment != null) | .debug_info.final_environment.variables'
-```
-
-#### `-validate`
-
-**Overview**
-
-Validates the syntax and consistency of the configuration file, displays results, and exits. Commands are not executed.
-
-**Syntax**
-
-```bash
-runner -config <path> -validate
-```
-
-**Usage Examples**
-
-```bash
-# Validate configuration file
-runner -config config.toml -validate
-```
-
-Success output:
-```
-Configuration validation successful
-  Version: 1.0
-  Groups: 3
-  Total Commands: 8
-  Verified Files: 5
-```
-
-Error output:
-```
-Configuration validation failed:
-  - Group 'backup': command 'db_backup' has invalid timeout: -1
-  - Group 'deploy': duplicate command name 'deploy_app'
-  - Global: invalid log level 'trace' (must be: debug, info, warn, error)
-```
-
-**Use Cases**
-
-- **CI/CD Pipeline**: Automatically validate configuration files before commit
-- **Confirmation after configuration changes**: Verify configuration validity before production execution
-- **Development Testing**: Validate immediately while editing configuration files
-
-**CI/CD Usage Example**
-
-```yaml
-# .github/workflows/validate-config.yml
-name: Validate Runner Config
-
-on: [push, pull_request]
-
-jobs:
-  validate:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Validate configuration
-        run: |
-          runner -config config.toml -validate
 ```
 
 #### `-show-sensitive`
@@ -1563,65 +1501,7 @@ cat /var/log/runner/runner-*.json | jq 'select(.level == "ERROR")'
 cat /var/log/runner/runner-01K2YK812JA735M4TWZ6BK0JH9.json | jq '.'
 ```
 
-### 5.4 Configuration File Validation
-
-**Basic Validation**
-
-```bash
-# Validate configuration file
-runner -config config.toml -validate
-```
-
-**Validation in CI/CD Pipeline**
-
-**GitHub Actions**
-
-```yaml
-name: Validate Configuration
-
-on: [push, pull_request]
-
-jobs:
-  validate:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Install runner
-        run: |
-          # Download or build pre-built binary
-          make build
-
-      - name: Validate configuration
-        run: |
-          ./build/runner -config config.toml -validate
-```
-
-**GitLab CI**
-
-```yaml
-validate-config:
-  stage: test
-  script:
-    - runner -config config.toml -validate
-  rules:
-    - changes:
-      - config.toml
-```
-
-**pre-commit hook**
-
-```bash
-#!/bin/bash
-# .git/hooks/pre-commit
-
-if git diff --cached --name-only | grep -q "config.toml"; then
-  echo "Validating configuration..."
-  runner -config config.toml -validate || exit 1
-fi
-```
-
-### 5.5 Usage in CI/CD Environment
+### 5.4 Usage in CI/CD Environment
 
 **Execution in Non-Interactive Mode**
 
@@ -1658,10 +1538,6 @@ jobs:
           # Record hash of executable binaries
           sudo ./build/record -file /usr/local/bin/backup.sh -hash-dir /usr/local/etc/go-safe-cmd-runner/hashes
 
-      - name: Validate configuration
-        run: |
-          runner -config config.toml -validate
-
       - name: Dry run
         run: |
           runner -config config.toml -dry-run -dry-run-format json > dryrun.json
@@ -1688,12 +1564,6 @@ pipeline {
     agent any
 
     stages {
-        stage('Validate') {
-            steps {
-                sh 'runner -config config.toml -validate'
-            }
-        }
-
         stage('Dry Run') {
             steps {
                 sh 'runner -config config.toml -dry-run'
@@ -1720,7 +1590,7 @@ pipeline {
 }
 ```
 
-### 5.6 Color Output Control
+### 5.5 Color Output Control
 
 **Output Adjustment According to Environment**
 
@@ -1790,11 +1660,11 @@ Configuration validation failed:
 **Solutions**
 
 ```bash
-# Validate configuration file
-runner -config config.toml -validate
+# Validate configuration file with dry run
+runner -config config.toml -dry-run
 
 # Check detailed error messages
-runner -config config.toml -validate -log-level debug
+runner -config config.toml -dry-run -log-level debug
 ```
 
 For detailed configuration methods, see [TOML Configuration File Guide](toml_config/README.md).

--- a/docs/user/toml_config/10_troubleshooting.ja.md
+++ b/docs/user/toml_config/10_troubleshooting.ja.md
@@ -344,9 +344,6 @@ risk_level = "low"
 設定ファイルの文法を検証:
 
 ```bash
-# 設定ファイルの読み込みテスト
-go-safe-cmd-runner --validate config.toml
-
 # ドライランで実行前検証
 go-safe-cmd-runner --dry-run --file config.toml
 ```

--- a/docs/user/toml_config/10_troubleshooting.md
+++ b/docs/user/toml_config/10_troubleshooting.md
@@ -344,9 +344,6 @@ risk_level = "low"
 Validate configuration file syntax:
 
 ```bash
-# Test configuration file loading
-go-safe-cmd-runner --validate config.toml
-
 # Pre-execution validation with dry run
 go-safe-cmd-runner --dry-run --file config.toml
 ```


### PR DESCRIPTION
The -validate command-line option has been removed from the runner command. This commit updates all user-facing documentation to reflect this change.

Changes:
- Removed -validate flag documentation section from runner_command.md
- Updated basic usage flow to remove validation step
- Replaced -validate with -dry-run in examples and troubleshooting
- Updated CI/CD examples to use dry-run instead of validate
- Removed validation step from typical usage workflows
- Updated FAQ sections to recommend -dry-run for validation

Files updated:
- docs/user/runner_command.{ja,}.md (removed ~60 lines each)
- docs/user/README.{ja,}.md
- docs/user/record_command.{ja,}.md
- docs/user/toml_config/10_troubleshooting.{ja,}.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)