### PR TITLE
Remove timestamp from hash manifest and related validation/tests

### DIFF
--- a/internal/filevalidator/errors.go
+++ b/internal/filevalidator/errors.go
@@ -37,9 +37,6 @@ var (
 	// ErrUnsupportedVersion indicates that the hash file version is not supported.
 	ErrUnsupportedVersion = errors.New("unsupported hash file version")
 
-	// ErrInvalidTimestamp indicates that the timestamp in the hash file is invalid.
-	ErrInvalidTimestamp = errors.New("invalid timestamp in hash file")
-
 	// ErrJSONParseError indicates that JSON parsing failed.
 	ErrJSONParseError = errors.New("failed to parse JSON hash file")
 

--- a/internal/filevalidator/hash_manifest.go
+++ b/internal/filevalidator/hash_manifest.go
@@ -3,7 +3,6 @@ package filevalidator
 import (
 	"encoding/json"
 	"fmt"
-	"time"
 
 	"github.com/isseis/go-safe-cmd-runner/internal/common"
 )
@@ -17,10 +16,9 @@ const (
 
 // HashManifest defines the JSON format for hash files
 type HashManifest struct {
-	Version   string    `json:"version"`
-	Format    string    `json:"format"`
-	Timestamp time.Time `json:"timestamp"`
-	File      FileInfo  `json:"file"`
+	Version string   `json:"version"`
+	Format  string   `json:"format"`
+	File    FileInfo `json:"file"`
 }
 
 // FileInfo defines file information
@@ -38,9 +36,8 @@ type HashInfo struct {
 // createHashManifest creates a hash manifest structure
 func createHashManifest(path common.ResolvedPath, hash, algorithm string) HashManifest {
 	return HashManifest{
-		Version:   HashManifestVersion,
-		Format:    HashManifestFormat,
-		Timestamp: time.Now().UTC(),
+		Version: HashManifestVersion,
+		Format:  HashManifestFormat,
 		File: FileInfo{
 			Path: path.String(),
 			Hash: HashInfo{
@@ -97,11 +94,6 @@ func validateHashManifest(manifest HashManifest, algoName string, targetPath com
 	// Hash value validation
 	if manifest.File.Hash.Value == "" {
 		return fmt.Errorf("%w: empty hash value", ErrInvalidManifestFormat)
-	}
-
-	// Timestamp validation
-	if manifest.Timestamp.IsZero() {
-		return fmt.Errorf("%w: zero timestamp", ErrInvalidTimestamp)
 	}
 
 	return nil

--- a/internal/verification/manager_test.go
+++ b/internal/verification/manager_test.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/isseis/go-safe-cmd-runner/internal/common"
 	commontesting "github.com/isseis/go-safe-cmd-runner/internal/common/testing"
@@ -35,9 +34,8 @@ func createRuntimeGlobal(verifyFiles []string) *runnertypes.RuntimeGlobal {
 // Returns the path of the created hash file
 func createWrongHashManifest(hashDir, filePath, wrongHash string) (string, error) {
 	manifest := filevalidator.HashManifest{
-		Version:   "1.0",
-		Format:    "file-hash",
-		Timestamp: time.Now().UTC(),
+		Version: "1.0",
+		Format:  "file-hash",
 		File: filevalidator.FileInfo{
 			Path: filePath,
 			Hash: filevalidator.HashInfo{


### PR DESCRIPTION
This pull request removes the `Timestamp` field from the `HashManifest` structure and all related validation, error handling, and tests. The change simplifies the hash manifest format and eliminates timestamp-based validation logic.

**Hash manifest structure and validation changes:**
* Removed the `Timestamp` field from the `HashManifest` struct in `hash_manifest.go`, as well as its initialization and validation logic. This also removes the associated error `ErrInvalidTimestamp` and its usage. [[1]](diffhunk://#diff-49903fb19ab0ba7d5a9070b18ab2762a3155660ad1132d8915fa6a9bcbbb92efL22) [[2]](diffhunk://#diff-49903fb19ab0ba7d5a9070b18ab2762a3155660ad1132d8915fa6a9bcbbb92efL43) [[3]](diffhunk://#diff-49903fb19ab0ba7d5a9070b18ab2762a3155660ad1132d8915fa6a9bcbbb92efL102-L106) [[4]](diffhunk://#diff-8798e6946b2b56d33b50689d3d31339fc3a8ab852b38d800583ab82c764a2e99L40-L42)

**Test updates:**
* Removed all timestamp-related test code, including the test case for invalid timestamps and all usages of the `Timestamp` field in test manifests. [[1]](diffhunk://#diff-bb57ec3f326dbfc2ea1ed8fd23e6d783b02a55ae6ba8b620e71329f708debc67L284) [[2]](diffhunk://#diff-bb57ec3f326dbfc2ea1ed8fd23e6d783b02a55ae6ba8b620e71329f708debc67L371-L405) [[3]](diffhunk://#diff-004faebd70b94804a0c86730d93e462f3f36361b1c14ef1f773074b960099ad5L40)
* Cleaned up imports by removing `time` where it is no longer needed in test files. [[1]](diffhunk://#diff-bb57ec3f326dbfc2ea1ed8fd23e6d783b02a55ae6ba8b620e71329f708debc67L10) [[2]](diffhunk://#diff-004faebd70b94804a0c86730d93e462f3f36361b1c14ef1f773074b960099ad5L10)

**Dependency cleanup:**
* Removed the unnecessary import of `time` from files that no longer require it. [[1]](diffhunk://#diff-49903fb19ab0ba7d5a9070b18ab2762a3155660ad1132d8915fa6a9bcbbb92efL6) [[2]](diffhunk://#diff-bb57ec3f326dbfc2ea1ed8fd23e6d783b02a55ae6ba8b620e71329f708debc67L10) [[3]](diffhunk://#diff-004faebd70b94804a0c86730d93e462f3f36361b1c14ef1f773074b960099ad5L10)