### PR TITLE
record and verify use DefaultHashDirectory as default

### DIFF
--- a/cmd/record/main.go
+++ b/cmd/record/main.go
@@ -23,6 +23,7 @@ var (
 	validatorFactory   = func(hashDir string) (hashRecorder, error) {
 		return cmdcommon.CreateValidator(hashDir)
 	}
+	mkdirAll = os.MkdirAll
 )
 
 type hashRecorder interface {
@@ -96,7 +97,7 @@ func parseArgs(args []string, stderr io.Writer) (*recordConfig, *flag.FlagSet, e
 		dir = cmdcommon.DefaultHashDirectory
 	}
 
-	if err := os.MkdirAll(dir, hashDirPermissions); err != nil {
+	if err := mkdirAll(dir, hashDirPermissions); err != nil {
 		return nil, fs, fmt.Errorf("%w: %w", errEnsureHashDir, err)
 	}
 

--- a/cmd/record/main_test.go
+++ b/cmd/record/main_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -117,6 +118,13 @@ func TestRunUsesDefaultHashDirectoryWhenNotSpecified(t *testing.T) {
 	recorder := &fakeRecorder{responses: map[string]error{}}
 	cleanup := overrideValidatorFactory(t, recorder)
 	defer cleanup()
+
+	// Override mkdirAll to avoid permission issues in CI
+	originalMkdirAll := mkdirAll
+	mkdirAll = func(_ string, _ os.FileMode) error {
+		return nil
+	}
+	defer func() { mkdirAll = originalMkdirAll }()
 
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}

--- a/cmd/verify/main.go
+++ b/cmd/verify/main.go
@@ -21,6 +21,7 @@ var (
 	validatorFactory   = func(hashDir string) (hashValidator, error) {
 		return cmdcommon.CreateValidator(hashDir)
 	}
+	mkdirAll = os.MkdirAll
 )
 
 type hashValidator interface {
@@ -91,7 +92,7 @@ func parseArgs(args []string, stderr io.Writer) (*verifyConfig, *flag.FlagSet, e
 		dir = cmdcommon.DefaultHashDirectory
 	}
 
-	if err := os.MkdirAll(dir, hashDirPermissions); err != nil {
+	if err := mkdirAll(dir, hashDirPermissions); err != nil {
 		return nil, fs, fmt.Errorf("%w: %w", errEnsureHashDir, err)
 	}
 

--- a/cmd/verify/main_test.go
+++ b/cmd/verify/main_test.go
@@ -129,6 +129,13 @@ func TestRunUsesDefaultHashDirectoryWhenNotSpecified(t *testing.T) {
 	cleanup := overrideValidatorFactory(t, validator)
 	defer cleanup()
 
+	// Override mkdirAll to avoid permission issues in CI
+	originalMkdirAll := mkdirAll
+	mkdirAll = func(_ string, _ os.FileMode) error {
+		return nil
+	}
+	defer func() { mkdirAll = originalMkdirAll }()
+
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
 


### PR DESCRIPTION
- Before this change, runenr used DefaultHashDirectory but record and verify used current directory as a default hash directory.