### PR TITLE
refactor: replaced interface{} by any

### DIFF
--- a/cmd/runner/dry_run_integration_test.go
+++ b/cmd/runner/dry_run_integration_test.go
@@ -466,7 +466,7 @@ func TestJSONValidStructure(t *testing.T) {
 	require.NoError(t, err, "dry-run execution should succeed")
 
 	// Test 1: Valid JSON structure
-	var jsonData interface{}
+	var jsonData any
 	err = json.Unmarshal([]byte(output), &jsonData)
 	require.NoError(t, err, "output should be valid JSON")
 

--- a/internal/logging/pre_execution_error.go
+++ b/internal/logging/pre_execution_error.go
@@ -61,7 +61,7 @@ func (e *PreExecutionError) Is(target error) bool {
 }
 
 // As implements error wrapping for errors.As
-func (e *PreExecutionError) As(target interface{}) bool {
+func (e *PreExecutionError) As(target any) bool {
 	if preExecErr, ok := target.(**PreExecutionError); ok {
 		*preExecErr = e
 		return true

--- a/internal/redaction/redactor_test.go
+++ b/internal/redaction/redactor_test.go
@@ -1388,7 +1388,7 @@ func TestRedactingHandler_MixedSlice(t *testing.T) {
 	logger := slog.New(redactingHandler)
 
 	// Test with mixed slice (interfaces)
-	mixedSlice := []interface{}{
+	mixedSlice := []any{
 		"string_value",
 		123,
 		true,
@@ -1530,14 +1530,14 @@ func TestRedactingHandler_SliceTypeConversion(t *testing.T) {
 		logger := slog.New(handler)
 
 		// Test with interface slice containing some LogValuers
-		mixedSlice := []interface{}{
+		mixedSlice := []any{
 			sensitiveLogValuer{data: "alice"},
 			"plain_string",
 			123,
 		}
 		logger.Info("Test message", "data", slog.AnyValue(mixedSlice))
 
-		// Verify: []interface{} is similar to []any, should handle gracefully
+		// Verify: []any is similar to []any, should handle gracefully
 		require.Len(t, mock.records, 1)
 		record := mock.records[0]
 
@@ -1596,7 +1596,7 @@ func TestRedactingHandler_TwoTierLogging(t *testing.T) {
 	require.GreaterOrEqual(t, len(failureLines), 1, "Expected at least 1 detailed log entry")
 
 	// Verify detailed log (in failureLogger)
-	var detailedLog map[string]interface{}
+	var detailedLog map[string]any
 	err := json.Unmarshal([]byte(failureLines[0]), &detailedLog)
 	require.NoError(t, err)
 
@@ -1608,9 +1608,9 @@ func TestRedactingHandler_TwoTierLogging(t *testing.T) {
 
 	// Verify summary log (in main logger via slog.Default)
 	// Find the summary log in main output
-	var summaryLog map[string]interface{}
+	var summaryLog map[string]any
 	for _, line := range mainLines {
-		var entry map[string]interface{}
+		var entry map[string]any
 		if err := json.Unmarshal([]byte(line), &entry); err == nil {
 			if msg, ok := entry["msg"].(string); ok && strings.Contains(msg, "see logs for details") {
 				summaryLog = entry

--- a/internal/runner/bootstrap/logger_test.go
+++ b/internal/runner/bootstrap/logger_test.go
@@ -296,9 +296,9 @@ func TestSetupLoggerWithConfig_FailureLoggerUsesMultiHandler(t *testing.T) {
 	require.NotEmpty(t, lines, "Expected at least one log entry")
 
 	// Find the test warning message in the log entries
-	var testLogEntry map[string]interface{}
+	var testLogEntry map[string]any
 	for _, line := range lines {
-		var entry map[string]interface{}
+		var entry map[string]any
 		err := json.Unmarshal([]byte(line), &entry)
 		require.NoError(t, err)
 

--- a/internal/runner/command_output_capture_test.go
+++ b/internal/runner/command_output_capture_test.go
@@ -129,14 +129,14 @@ func TestIntegration_CommandOutputCapture(t *testing.T) {
 	logOutput := logBuffer.String()
 	logLines := strings.Split(logOutput, "\n")
 
-	var errorLogs []map[string]interface{}
-	var debugLogs []map[string]interface{}
+	var errorLogs []map[string]any
+	var debugLogs []map[string]any
 
 	for _, line := range logLines {
 		if line == "" {
 			continue
 		}
-		var logEntry map[string]interface{}
+		var logEntry map[string]any
 		if err := json.Unmarshal([]byte(line), &logEntry); err != nil {
 			continue
 		}

--- a/internal/runner/config/auto_vars_test.go
+++ b/internal/runner/config/auto_vars_test.go
@@ -53,7 +53,7 @@ func TestExpandGlobal_AutoVarsReservedPrefix(t *testing.T) {
 	timeout := int32(3600)
 	spec := &runnertypes.GlobalSpec{
 		Timeout: &timeout,
-		Vars: map[string]interface{}{
+		Vars: map[string]any{
 			"__runner_datetime": "user_value",
 		},
 	}
@@ -70,7 +70,7 @@ func TestExpandGlobal_AutoVarsAvailableForVarsExpansion(t *testing.T) {
 	timeout := int32(3600)
 	spec := &runnertypes.GlobalSpec{
 		Timeout: &timeout,
-		Vars: map[string]interface{}{
+		Vars: map[string]any{
 			"output_file": "/tmp/backup-%{__runner_datetime}.tar.gz",
 			"lock_file":   "/var/run/myapp-%{__runner_pid}.lock",
 		},
@@ -109,7 +109,7 @@ func TestExpandGlobal_AutoVarsConsistentAcrossExpansions(t *testing.T) {
 	timeout := int32(3600)
 	spec := &runnertypes.GlobalSpec{
 		Timeout: &timeout,
-		Vars: map[string]interface{}{
+		Vars: map[string]any{
 			"file1": "/tmp/file1-%{__runner_datetime}.log",
 			"file2": "/tmp/file2-%{__runner_datetime}.log",
 			"lock1": "/tmp/lock1-%{__runner_pid}.pid",
@@ -156,7 +156,7 @@ func TestExpandGlobal_AutoVarsWithEnvImport(t *testing.T) {
 		Timeout:    &timeout,
 		EnvAllowed: []string{"TEST_VAR"},
 		EnvImport:  []string{"test_var=TEST_VAR"}, // Correct format: internal_name=SYSTEM_VAR
-		Vars: map[string]interface{}{
+		Vars: map[string]any{
 			"combined": "%{test_var}-%{__runner_datetime}",
 		},
 	}

--- a/internal/runner/config/expansion.go
+++ b/internal/runner/config/expansion.go
@@ -319,7 +319,7 @@ type varExpander struct {
 	expandedArrayVars map[string][]string
 
 	// rawVars contains not-yet-expanded variable definitions.
-	rawVars map[string]interface{}
+	rawVars map[string]any
 
 	// level is the context for error messages (e.g., "global", "group[deploy]").
 	level string
@@ -329,7 +329,7 @@ type varExpander struct {
 func newVarExpander(
 	expandedVars map[string]string,
 	expandedArrayVars map[string][]string,
-	rawVars map[string]interface{},
+	rawVars map[string]any,
 	level string,
 ) *varExpander {
 	return &varExpander{
@@ -441,7 +441,7 @@ func (e *varExpander) resolveVariable(
 
 		return expanded, nil
 
-	case []interface{}:
+	case []any:
 		// Array variable referenced in string context
 		return "", &ErrArrayVariableInStringContextDetail{
 			Level:        e.level,
@@ -464,7 +464,7 @@ func (e *varExpander) resolveVariable(
 // using baseExpandedVars and baseExpandedArrays.
 //
 // Parameters:
-//   - vars: Variable definitions from TOML (map[string]interface{})
+//   - vars: Variable definitions from TOML (map[string]any)
 //   - baseExpandedVars: Previously expanded string variables (inherited)
 //   - baseExpandedArrays: Previously expanded array variables (inherited)
 //   - envImportVars: Variables defined via env_import at any level (for conflict detection)
@@ -481,7 +481,7 @@ func (e *varExpander) resolveVariable(
 //     a. Validate variable name using ValidateVariableName
 //     b. Check for conflicts with env_import variables
 //     c. Check type consistency with base variables
-//     d. Validate value type (string or []interface{})
+//     d. Validate value type (string or []any)
 //     e. Validate size limits
 //     f. Expand using ExpandString
 //     g. Store in appropriate output map
@@ -493,7 +493,7 @@ func (e *varExpander) resolveVariable(
 //
 // Empty arrays are allowed and useful for clearing inherited variables.
 func ProcessVars(
-	vars map[string]interface{},
+	vars map[string]any,
 	baseExpandedVars map[string]string,
 	baseExpandedArrays map[string][]string,
 	envImportVars map[string]string,
@@ -542,14 +542,14 @@ func cloneBaseVars(
 
 // validateAndClassifyVars validates all variables and classifies them by type.
 func validateAndClassifyVars(
-	vars map[string]interface{},
+	vars map[string]any,
 	baseExpandedVars map[string]string,
 	baseExpandedArrays map[string][]string,
 	envImportVars map[string]string,
 	level string,
-) (map[string]string, map[string][]interface{}, error) {
+) (map[string]string, map[string][]any, error) {
 	stringVars := make(map[string]string)
-	arrayVars := make(map[string][]interface{})
+	arrayVars := make(map[string][]any)
 
 	for varName, rawValue := range vars {
 		// Validate variable name
@@ -577,7 +577,7 @@ func validateAndClassifyVars(
 			}
 			stringVars[varName] = v
 
-		case []interface{}:
+		case []any:
 			if err := validateArrayVar(varName, v, baseExpandedVars, level); err != nil {
 				return nil, nil, err
 			}
@@ -628,7 +628,7 @@ func validateStringVar(
 // validateArrayVar validates an array variable.
 func validateArrayVar(
 	varName string,
-	value []interface{},
+	value []any,
 	baseExpandedVars map[string]string,
 	level string,
 ) error {
@@ -680,9 +680,9 @@ func validateArrayVar(
 
 // expandVarsWithLazyResolution expands variables using lazy resolution.
 func expandVarsWithLazyResolution(
-	vars map[string]interface{},
+	vars map[string]any,
 	stringVars map[string]string,
-	arrayVars map[string][]interface{},
+	arrayVars map[string][]any,
 	baseExpandedVars map[string]string,
 	baseExpandedArrays map[string][]string,
 	level string,

--- a/internal/runner/config/expansion_bench_test.go
+++ b/internal/runner/config/expansion_bench_test.go
@@ -11,7 +11,7 @@ import (
 // BenchmarkExpandGlobal measures the performance of global configuration expansion
 func BenchmarkExpandGlobal(b *testing.B) {
 	spec := &runnertypes.GlobalSpec{
-		Vars:    map[string]interface{}{"VAR1": "value1", "VAR2": "value2", "VAR3": "%{VAR1}/subdir"},
+		Vars:    map[string]any{"VAR1": "value1", "VAR2": "value2", "VAR3": "%{VAR1}/subdir"},
 		EnvVars: []string{"PATH=%{VAR1}/bin:%{VAR2}/bin", "HOME=/home/user"},
 	}
 
@@ -25,7 +25,7 @@ func BenchmarkExpandGlobal(b *testing.B) {
 func BenchmarkExpandGlobalWithFromEnv(b *testing.B) {
 	spec := &runnertypes.GlobalSpec{
 		EnvImport:  []string{"MY_PATH=PATH", "MY_HOME=HOME"},
-		Vars:       map[string]interface{}{"VAR1": "%{MY_PATH}", "VAR2": "%{MY_HOME}/local"},
+		Vars:       map[string]any{"VAR1": "%{MY_PATH}", "VAR2": "%{MY_HOME}/local"},
 		EnvVars:    []string{"NEW_PATH=%{VAR1}:%{VAR2}/bin"},
 		EnvAllowed: []string{"PATH", "HOME"},
 	}
@@ -44,7 +44,7 @@ func BenchmarkExpandGlobalWithFromEnv(b *testing.B) {
 func BenchmarkExpandGroup(b *testing.B) {
 	spec := &runnertypes.GroupSpec{
 		Name:    "test_group",
-		Vars:    map[string]interface{}{"GROUP_VAR": "group_value", "DERIVED": "%{GROUP_VAR}/subdir"},
+		Vars:    map[string]any{"GROUP_VAR": "group_value", "DERIVED": "%{GROUP_VAR}/subdir"},
 		EnvVars: []string{"GROUP_ENV=%{DERIVED}"},
 	}
 	globalVars := map[string]string{
@@ -71,7 +71,7 @@ func BenchmarkExpandCommand(b *testing.B) {
 		Cmd:     "/usr/bin/test",
 		Args:    []string{"%{ARG1}", "%{ARG2}"},
 		EnvVars: []string{"CMD_ENV=%{CMD_VAR}"},
-		Vars:    map[string]interface{}{"CMD_VAR": "cmd_value", "ARG1": "arg1", "ARG2": "arg2"},
+		Vars:    map[string]any{"CMD_VAR": "cmd_value", "ARG1": "arg1", "ARG2": "arg2"},
 	}
 	groupVars := map[string]string{
 		"GROUP_VAR": "group_value",
@@ -94,7 +94,7 @@ func BenchmarkExpandCommand(b *testing.B) {
 // BenchmarkExpandGlobalComplex measures performance with complex variable expansion
 func BenchmarkExpandGlobalComplex(b *testing.B) {
 	spec := &runnertypes.GlobalSpec{
-		Vars: map[string]interface{}{
+		Vars: map[string]any{
 			"BASE":   "/opt/app",
 			"BIN":    "%{BASE}/bin",
 			"LIB":    "%{BASE}/lib",
@@ -131,7 +131,7 @@ func BenchmarkExpandCommandWithEnvImport(b *testing.B) {
 	globalSpec := &runnertypes.GlobalSpec{
 		EnvAllowed: []string{"PATH", "HOME", "USER"},
 		EnvImport:  []string{"MY_PATH=PATH"},
-		Vars:       map[string]interface{}{"GLOBAL_VAR": "global_value"},
+		Vars:       map[string]any{"GLOBAL_VAR": "global_value"},
 	}
 
 	// Set environment variables for benchmark
@@ -148,7 +148,7 @@ func BenchmarkExpandCommandWithEnvImport(b *testing.B) {
 	// Prepare group runtime
 	groupSpec := &runnertypes.GroupSpec{
 		Name: "test_group",
-		Vars: map[string]interface{}{"GROUP_VAR": "group_value"},
+		Vars: map[string]any{"GROUP_VAR": "group_value"},
 	}
 	groupRuntime, err := ExpandGroup(groupSpec, globalRuntime)
 	if err != nil {
@@ -161,7 +161,7 @@ func BenchmarkExpandCommandWithEnvImport(b *testing.B) {
 		Cmd:       "/usr/bin/test",
 		Args:      []string{"%{CMD_ARG}"},
 		EnvImport: []string{"CMD_PATH=PATH"},
-		Vars:      map[string]interface{}{"CMD_ARG": "arg_value"},
+		Vars:      map[string]any{"CMD_ARG": "arg_value"},
 		EnvVars:   []string{"CMD_ENV=%{CMD_ARG}"},
 	}
 
@@ -180,7 +180,7 @@ func BenchmarkExpandMultipleCommandsWithEnvImport(b *testing.B) {
 	globalSpec := &runnertypes.GlobalSpec{
 		EnvAllowed: []string{"PATH", "HOME", "USER", "LANG"},
 		EnvImport:  []string{"MY_PATH=PATH"},
-		Vars:       map[string]interface{}{"GLOBAL_VAR": "global_value"},
+		Vars:       map[string]any{"GLOBAL_VAR": "global_value"},
 	}
 
 	// Set environment variables
@@ -198,7 +198,7 @@ func BenchmarkExpandMultipleCommandsWithEnvImport(b *testing.B) {
 	// Prepare group runtime
 	groupSpec := &runnertypes.GroupSpec{
 		Name: "test_group",
-		Vars: map[string]interface{}{"GROUP_VAR": "group_value"},
+		Vars: map[string]any{"GROUP_VAR": "group_value"},
 	}
 	groupRuntime, err := ExpandGroup(groupSpec, globalRuntime)
 	if err != nil {
@@ -213,7 +213,7 @@ func BenchmarkExpandMultipleCommandsWithEnvImport(b *testing.B) {
 			Cmd:       "/usr/bin/test",
 			Args:      []string{"%{CMD_ARG}"},
 			EnvImport: []string{"CMD_PATH=PATH", "CMD_HOME=HOME"},
-			Vars:      map[string]interface{}{"CMD_ARG": "arg_value"},
+			Vars:      map[string]any{"CMD_ARG": "arg_value"},
 			EnvVars:   []string{"CMD_ENV=%{CMD_ARG}"},
 		}
 	}

--- a/internal/runner/config/expansion_cmd_allowed_test.go
+++ b/internal/runner/config/expansion_cmd_allowed_test.go
@@ -190,7 +190,7 @@ func TestExpandGroup_WithCmdAllowed(t *testing.T) {
 		spec := &runnertypes.GroupSpec{
 			Name:       "testgroup",
 			CmdAllowed: []string{"%{bindir}/tool"},
-			Vars:       map[string]interface{}{"bindir": tmpDir},
+			Vars:       map[string]any{"bindir": tmpDir},
 		}
 
 		runtime, err := ExpandGroup(spec, nil)

--- a/internal/runner/config/expansion_env_import_vars_conflict_test.go
+++ b/internal/runner/config/expansion_env_import_vars_conflict_test.go
@@ -16,7 +16,7 @@ func TestExpandGlobal_EnvImportVarsConflict(t *testing.T) {
 	spec := &runnertypes.GlobalSpec{
 		EnvAllowed: []string{"PATH"},
 		EnvImport:  []string{"my_path=PATH"},
-		Vars: map[string]interface{}{
+		Vars: map[string]any{
 			"my_path": "/custom/path", // Conflicts with env_import
 		},
 	}
@@ -39,7 +39,7 @@ func TestExpandGroup_EnvImportVarsConflict(t *testing.T) {
 	// Group tries to define same variable in vars
 	groupSpec := &runnertypes.GroupSpec{
 		Name: "test_group",
-		Vars: map[string]interface{}{
+		Vars: map[string]any{
 			"global_var": "override_value", // Conflicts with global env_import
 		},
 		Commands: []runnertypes.CommandSpec{},
@@ -64,7 +64,7 @@ func TestExpandGroup_SameLevelConflict(t *testing.T) {
 		Name:       "test_group",
 		EnvAllowed: []string{"USER"},
 		EnvImport:  []string{"my_user=USER"},
-		Vars: map[string]interface{}{
+		Vars: map[string]any{
 			"my_user": "custom_user", // Conflicts with group-level env_import
 		},
 		Commands: []runnertypes.CommandSpec{},
@@ -81,7 +81,7 @@ func TestExpandGlobal_NoConflict(t *testing.T) {
 	spec := &runnertypes.GlobalSpec{
 		EnvAllowed: []string{"PATH"},
 		EnvImport:  []string{"sys_path=PATH"},
-		Vars: map[string]interface{}{
+		Vars: map[string]any{
 			"custom_path": "/custom/path", // Different name - no conflict
 		},
 	}
@@ -111,7 +111,7 @@ func TestExpandGroup_InheritedEnvImportVarsTracking(t *testing.T) {
 		Name:       "test_group",
 		EnvAllowed: []string{"HOME"},
 		EnvImport:  []string{"group_home=HOME"},
-		Vars: map[string]interface{}{
+		Vars: map[string]any{
 			"group_var": "value",
 		},
 		Commands: []runnertypes.CommandSpec{},

--- a/internal/runner/config/expansion_integration_test.go
+++ b/internal/runner/config/expansion_integration_test.go
@@ -30,7 +30,7 @@ func TestExpandTemplateToSpec(t *testing.T) {
 			command: &runnertypes.CommandSpec{
 				Name:     "backup",
 				Template: "backup_tmpl",
-				Params: map[string]interface{}{
+				Params: map[string]any{
 					"source": "/data",
 					"dest":   "/backup",
 				},
@@ -52,7 +52,7 @@ func TestExpandTemplateToSpec(t *testing.T) {
 			command: &runnertypes.CommandSpec{
 				Name:     "verbose_cmd",
 				Template: "optional_tmpl",
-				Params: map[string]interface{}{
+				Params: map[string]any{
 					"verbose": "true",
 				},
 			},
@@ -73,7 +73,7 @@ func TestExpandTemplateToSpec(t *testing.T) {
 			command: &runnertypes.CommandSpec{
 				Name:     "quiet_cmd",
 				Template: "optional_tmpl",
-				Params:   map[string]interface{}{},
+				Params:   map[string]any{},
 			},
 			template: &runnertypes.CommandTemplate{
 				Cmd:  "echo",
@@ -92,8 +92,8 @@ func TestExpandTemplateToSpec(t *testing.T) {
 			command: &runnertypes.CommandSpec{
 				Name:     "multi_arg",
 				Template: "array_tmpl",
-				Params: map[string]interface{}{
-					"flags": []interface{}{"--verbose", "--force"},
+				Params: map[string]any{
+					"flags": []any{"--verbose", "--force"},
 				},
 			},
 			template: &runnertypes.CommandTemplate{
@@ -113,7 +113,7 @@ func TestExpandTemplateToSpec(t *testing.T) {
 			command: &runnertypes.CommandSpec{
 				Name:     "workdir_cmd",
 				Template: "workdir_tmpl",
-				Params: map[string]interface{}{
+				Params: map[string]any{
 					"project": "myapp",
 				},
 			},
@@ -135,7 +135,7 @@ func TestExpandTemplateToSpec(t *testing.T) {
 				Name:     "custom_workdir_cmd",
 				Template: "workdir_tmpl",
 				WorkDir:  "/custom/dir",
-				Params: map[string]interface{}{
+				Params: map[string]any{
 					"project": "myapp",
 				},
 			},
@@ -157,7 +157,7 @@ func TestExpandTemplateToSpec(t *testing.T) {
 				Name:     "cmd_only_workdir",
 				Template: "no_workdir_tmpl",
 				WorkDir:  "/my/workdir",
-				Params:   map[string]interface{}{},
+				Params:   map[string]any{},
 			},
 			template: &runnertypes.CommandTemplate{
 				Cmd: "echo",
@@ -175,7 +175,7 @@ func TestExpandTemplateToSpec(t *testing.T) {
 			command: &runnertypes.CommandSpec{
 				Name:     "unused_param",
 				Template: "simple_tmpl",
-				Params: map[string]interface{}{
+				Params: map[string]any{
 					"used":   "value1",
 					"unused": "value2",
 				},
@@ -199,7 +199,7 @@ func TestExpandTemplateToSpec(t *testing.T) {
 			command: &runnertypes.CommandSpec{
 				Name:     "missing_param",
 				Template: "required_tmpl",
-				Params:   map[string]interface{}{},
+				Params:   map[string]any{},
 			},
 			template: &runnertypes.CommandTemplate{
 				Cmd:  "echo",
@@ -214,7 +214,7 @@ func TestExpandTemplateToSpec(t *testing.T) {
 			command: &runnertypes.CommandSpec{
 				Name:     "invalid_array",
 				Template: "array_tmpl",
-				Params: map[string]interface{}{
+				Params: map[string]any{
 					"flags": "not-an-array",
 				},
 			},
@@ -278,7 +278,7 @@ func TestExpandCommandWithTemplate(t *testing.T) {
 			spec: &runnertypes.CommandSpec{
 				Name:     "hello",
 				Template: "echo_tmpl",
-				Params: map[string]interface{}{
+				Params: map[string]any{
 					"message": "Hello World",
 				},
 			},
@@ -290,7 +290,7 @@ func TestExpandCommandWithTemplate(t *testing.T) {
 			spec: &runnertypes.CommandSpec{
 				Name:     "missing",
 				Template: "nonexistent",
-				Params:   map[string]interface{}{},
+				Params:   map[string]any{},
 			},
 			expectErr:   true,
 			wantErrType: &ErrTemplateNotFound{},
@@ -301,7 +301,7 @@ func TestExpandCommandWithTemplate(t *testing.T) {
 				Name:     "invalid",
 				Template: "echo_tmpl",
 				Cmd:      "ls",
-				Params:   map[string]interface{}{},
+				Params:   map[string]any{},
 			},
 			expectErr:   true,
 			wantErrType: &ErrTemplateFieldConflict{},
@@ -311,7 +311,7 @@ func TestExpandCommandWithTemplate(t *testing.T) {
 			spec: &runnertypes.CommandSpec{
 				Name:     "with_unused",
 				Template: "echo_tmpl",
-				Params: map[string]interface{}{
+				Params: map[string]any{
 					"message": "Hello",
 					"unused":  "ignored",
 				},
@@ -374,8 +374,8 @@ func TestExpandTemplateToSpec_ArrayInEnvWorkdir(t *testing.T) {
 			command: &runnertypes.CommandSpec{
 				Name:     "bad_env",
 				Template: "env_tmpl",
-				Params: map[string]interface{}{
-					"paths": []interface{}{"/path1", "/path2"},
+				Params: map[string]any{
+					"paths": []any{"/path1", "/path2"},
 				},
 			},
 			template: &runnertypes.CommandTemplate{
@@ -391,8 +391,8 @@ func TestExpandTemplateToSpec_ArrayInEnvWorkdir(t *testing.T) {
 			command: &runnertypes.CommandSpec{
 				Name:     "bad_workdir",
 				Template: "workdir_tmpl",
-				Params: map[string]interface{}{
-					"dirs": []interface{}{"/dir1", "/dir2"},
+				Params: map[string]any{
+					"dirs": []any{"/dir1", "/dir2"},
 				},
 			},
 			template: &runnertypes.CommandTemplate{
@@ -408,8 +408,8 @@ func TestExpandTemplateToSpec_ArrayInEnvWorkdir(t *testing.T) {
 			command: &runnertypes.CommandSpec{
 				Name:     "single_array_env",
 				Template: "env_tmpl",
-				Params: map[string]interface{}{
-					"path": []interface{}{"/single/path"},
+				Params: map[string]any{
+					"path": []any{"/single/path"},
 				},
 			},
 			template: &runnertypes.CommandTemplate{
@@ -425,8 +425,8 @@ func TestExpandTemplateToSpec_ArrayInEnvWorkdir(t *testing.T) {
 			command: &runnertypes.CommandSpec{
 				Name:     "single_array_workdir",
 				Template: "workdir_tmpl",
-				Params: map[string]interface{}{
-					"dir": []interface{}{"/single/dir"},
+				Params: map[string]any{
+					"dir": []any{"/single/dir"},
 				},
 			},
 			template: &runnertypes.CommandTemplate{
@@ -442,7 +442,7 @@ func TestExpandTemplateToSpec_ArrayInEnvWorkdir(t *testing.T) {
 			command: &runnertypes.CommandSpec{
 				Name:     "good_env",
 				Template: "env_tmpl",
-				Params: map[string]interface{}{
+				Params: map[string]any{
 					"value": "test123",
 				},
 			},
@@ -458,7 +458,7 @@ func TestExpandTemplateToSpec_ArrayInEnvWorkdir(t *testing.T) {
 			command: &runnertypes.CommandSpec{
 				Name:     "good_workdir",
 				Template: "workdir_tmpl",
-				Params: map[string]interface{}{
+				Params: map[string]any{
 					"path": "/working/dir",
 				},
 			},

--- a/internal/runner/config/expansion_unit_test.go
+++ b/internal/runner/config/expansion_unit_test.go
@@ -361,26 +361,26 @@ func TestProcessEnvImport_DuplicateDefinition(t *testing.T) {
 }
 
 // TestProcessVars_DuplicateDefinition tests duplicate variable detection in vars
-// Note: With map[string]interface{}, duplicate keys are inherently impossible in Go,
+// Note: With map[string]any, duplicate keys are inherently impossible in Go,
 // so this test is no longer applicable and has been removed.
 
 // TestProcessVars_InvalidVariableName tests invalid variable names in vars
 func TestProcessVars_InvalidVariableName(t *testing.T) {
 	tests := []struct {
 		name string
-		vars map[string]interface{}
+		vars map[string]any
 	}{
 		{
 			name: "variable with dash",
-			vars: map[string]interface{}{"my-var": "value"},
+			vars: map[string]any{"my-var": "value"},
 		},
 		{
 			name: "variable with space",
-			vars: map[string]interface{}{"my var": "value"},
+			vars: map[string]any{"my var": "value"},
 		},
 		{
 			name: "empty variable name",
-			vars: map[string]interface{}{"": "value"},
+			vars: map[string]any{"": "value"},
 		},
 	}
 
@@ -399,7 +399,7 @@ func TestProcessVars_InvalidVariableName(t *testing.T) {
 func TestProcessVars_ComplexReferenceChain(t *testing.T) {
 	tests := []struct {
 		name     string
-		vars     map[string]interface{}
+		vars     map[string]any
 		baseVars map[string]string
 		checkVar string
 		wantVal  string
@@ -407,7 +407,7 @@ func TestProcessVars_ComplexReferenceChain(t *testing.T) {
 	}{
 		{
 			name: "linear chain",
-			vars: map[string]interface{}{
+			vars: map[string]any{
 				"A": "base",
 				"B": "%{A}/level1",
 				"C": "%{B}/level2",
@@ -420,7 +420,7 @@ func TestProcessVars_ComplexReferenceChain(t *testing.T) {
 		},
 		{
 			name: "reference base variables",
-			vars: map[string]interface{}{
+			vars: map[string]any{
 				"NEW_VAR": "%{BASE1}/%{BASE2}",
 			},
 			baseVars: map[string]string{
@@ -433,7 +433,7 @@ func TestProcessVars_ComplexReferenceChain(t *testing.T) {
 		},
 		{
 			name: "override base variable",
-			vars: map[string]interface{}{
+			vars: map[string]any{
 				"BASE": "%{BASE}_extended",
 			},
 			baseVars: map[string]string{
@@ -461,7 +461,7 @@ func TestProcessVars_ComplexReferenceChain(t *testing.T) {
 
 // TestProcessVars_UndefinedReference tests undefined variable references
 func TestProcessVars_UndefinedReference(t *testing.T) {
-	vars := map[string]interface{}{
+	vars := map[string]any{
 		"VAR": "%{UNDEFINED}",
 	}
 	baseVars := make(map[string]string)
@@ -476,13 +476,13 @@ func TestProcessVars_UndefinedReference(t *testing.T) {
 func TestProcessVars_EnvImportVarsConflict(t *testing.T) {
 	tests := []struct {
 		name          string
-		vars          map[string]interface{}
+		vars          map[string]any
 		envImportVars map[string]string
 		wantErr       bool
 	}{
 		{
 			name: "conflict with env_import variable",
-			vars: map[string]interface{}{
+			vars: map[string]any{
 				"MY_VAR": "value_from_vars",
 			},
 			envImportVars: map[string]string{
@@ -492,7 +492,7 @@ func TestProcessVars_EnvImportVarsConflict(t *testing.T) {
 		},
 		{
 			name: "no conflict - different variable names",
-			vars: map[string]interface{}{
+			vars: map[string]any{
 				"VAR1": "value1",
 			},
 			envImportVars: map[string]string{
@@ -502,7 +502,7 @@ func TestProcessVars_EnvImportVarsConflict(t *testing.T) {
 		},
 		{
 			name: "no conflict - empty env_import",
-			vars: map[string]interface{}{
+			vars: map[string]any{
 				"MY_VAR": "value",
 			},
 			envImportVars: map[string]string{},
@@ -510,7 +510,7 @@ func TestProcessVars_EnvImportVarsConflict(t *testing.T) {
 		},
 		{
 			name:          "no conflict - nil env_import",
-			vars:          map[string]interface{}{"MY_VAR": "value"},
+			vars:          map[string]any{"MY_VAR": "value"},
 			envImportVars: nil,
 			wantErr:       false,
 		},
@@ -641,7 +641,7 @@ func TestIntegration_FullExpansionChain(t *testing.T) {
 			"sys_path=PATH",
 			"sys_home=HOME",
 		},
-		Vars: map[string]interface{}{
+		Vars: map[string]any{
 			"base_dir": "%{sys_home}/app",
 			"bin_dir":  "%{base_dir}/bin",
 		},

--- a/internal/runner/config/loader.go
+++ b/internal/runner/config/loader.go
@@ -85,7 +85,7 @@ func (l *Loader) LoadConfig(content []byte) (*runnertypes.ConfigSpec, error) {
 // This is done by parsing the TOML content as a map to detect fields that would be
 // ignored by the struct unmarshaling.
 func checkTemplateNameField(content []byte) error {
-	var raw map[string]interface{}
+	var raw map[string]any
 	if err := toml.Unmarshal(content, &raw); err != nil {
 		// If we can't parse as map, the structured parse will also fail
 		// so we can skip this check
@@ -93,13 +93,13 @@ func checkTemplateNameField(content []byte) error {
 	}
 
 	// Check command_templates section
-	templates, ok := raw["command_templates"].(map[string]interface{})
+	templates, ok := raw["command_templates"].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	for templateName, templateData := range templates {
-		templateMap, ok := templateData.(map[string]interface{})
+		templateMap, ok := templateData.(map[string]any)
 		if !ok {
 			continue
 		}

--- a/internal/runner/config/template_env_expansion_test.go
+++ b/internal/runner/config/template_env_expansion_test.go
@@ -12,7 +12,7 @@ func TestExpandTemplateEnv(t *testing.T) {
 	tests := []struct {
 		name         string
 		env          []string
-		params       map[string]interface{}
+		params       map[string]any
 		templateName string
 		want         []string
 		wantErr      bool
@@ -22,14 +22,14 @@ func TestExpandTemplateEnv(t *testing.T) {
 		{
 			name:         "simple string parameter",
 			env:          []string{"PATH=${path}"},
-			params:       map[string]interface{}{"path": "/usr/bin"},
+			params:       map[string]any{"path": "/usr/bin"},
 			templateName: "test",
 			want:         []string{"PATH=/usr/bin"},
 		},
 		{
 			name:         "multiple env entries",
 			env:          []string{"PATH=${path}", "HOME=${home}"},
-			params:       map[string]interface{}{"path": "/usr/bin", "home": "/home/user"},
+			params:       map[string]any{"path": "/usr/bin", "home": "/home/user"},
 			templateName: "test",
 			want:         []string{"PATH=/usr/bin", "HOME=/home/user"},
 		},
@@ -38,35 +38,35 @@ func TestExpandTemplateEnv(t *testing.T) {
 		{
 			name:         "pure array placeholder - single element",
 			env:          []string{"REQUIRED=foo", "${@opts}"},
-			params:       map[string]interface{}{"opts": []string{"DEBUG=1"}},
+			params:       map[string]any{"opts": []string{"DEBUG=1"}},
 			templateName: "test",
 			want:         []string{"REQUIRED=foo", "DEBUG=1"},
 		},
 		{
 			name:         "pure array placeholder - multiple elements",
 			env:          []string{"REQUIRED=foo", "${@opts}"},
-			params:       map[string]interface{}{"opts": []string{"DEBUG=1", "VERBOSE=1"}},
+			params:       map[string]any{"opts": []string{"DEBUG=1", "VERBOSE=1"}},
 			templateName: "test",
 			want:         []string{"REQUIRED=foo", "DEBUG=1", "VERBOSE=1"},
 		},
 		{
 			name:         "pure array placeholder - empty array",
 			env:          []string{"REQUIRED=foo", "${@opts}"},
-			params:       map[string]interface{}{"opts": []string{}},
+			params:       map[string]any{"opts": []string{}},
 			templateName: "test",
 			want:         []string{"REQUIRED=foo"},
 		},
 		{
 			name:         "pure array placeholder - not provided",
 			env:          []string{"REQUIRED=foo", "${@opts}"},
-			params:       map[string]interface{}{},
+			params:       map[string]any{},
 			templateName: "test",
 			want:         []string{"REQUIRED=foo"},
 		},
 		{
 			name: "multiple array placeholders",
 			env:  []string{"${@common}", "${@app_specific}"},
-			params: map[string]interface{}{
+			params: map[string]any{
 				"common":       []string{"PATH=/usr/bin", "HOME=/home/user"},
 				"app_specific": []string{"DEBUG=1"},
 			},
@@ -78,21 +78,21 @@ func TestExpandTemplateEnv(t *testing.T) {
 		{
 			name:         "optional parameter - VALUE part",
 			env:          []string{"PATH=${?path}"},
-			params:       map[string]interface{}{"path": "/usr/bin"},
+			params:       map[string]any{"path": "/usr/bin"},
 			templateName: "test",
 			want:         []string{"PATH=/usr/bin"},
 		},
 		{
 			name:         "optional parameter - VALUE part - empty",
 			env:          []string{"REQUIRED=foo", "PATH=${?path}"},
-			params:       map[string]interface{}{"path": ""},
+			params:       map[string]any{"path": ""},
 			templateName: "test",
 			want:         []string{"REQUIRED=foo"},
 		},
 		{
 			name:         "optional parameter - VALUE part - not provided",
 			env:          []string{"REQUIRED=foo", "PATH=${?path}"},
-			params:       map[string]interface{}{},
+			params:       map[string]any{},
 			templateName: "test",
 			want:         []string{"REQUIRED=foo"},
 		},
@@ -101,7 +101,7 @@ func TestExpandTemplateEnv(t *testing.T) {
 		{
 			name: "combined string and array parameters",
 			env:  []string{"STATIC=value", "DYNAMIC=${param}", "${@opts}"},
-			params: map[string]interface{}{
+			params: map[string]any{
 				"param": "/usr/bin",
 				"opts":  []string{"DEBUG=1", "VERBOSE=1"},
 			},
@@ -113,7 +113,7 @@ func TestExpandTemplateEnv(t *testing.T) {
 		{
 			name:         "invalid format - no equals sign",
 			env:          []string{"INVALID"},
-			params:       map[string]interface{}{},
+			params:       map[string]any{},
 			templateName: "test",
 			wantErr:      true,
 			errType:      &ErrTemplateInvalidEnvFormat{},
@@ -121,7 +121,7 @@ func TestExpandTemplateEnv(t *testing.T) {
 		{
 			name:         "invalid format after expansion",
 			env:          []string{"${entry}"},
-			params:       map[string]interface{}{"entry": "INVALID"},
+			params:       map[string]any{"entry": "INVALID"},
 			templateName: "test",
 			wantErr:      true,
 			errType:      &ErrTemplateInvalidEnvFormat{},
@@ -129,7 +129,7 @@ func TestExpandTemplateEnv(t *testing.T) {
 		{
 			name:         "invalid format in array element",
 			env:          []string{"${@opts}"},
-			params:       map[string]interface{}{"opts": []string{"DEBUG=1", "INVALID"}},
+			params:       map[string]any{"opts": []string{"DEBUG=1", "INVALID"}},
 			templateName: "test",
 			wantErr:      true,
 			errType:      &ErrTemplateInvalidEnvFormat{},
@@ -139,7 +139,7 @@ func TestExpandTemplateEnv(t *testing.T) {
 		{
 			name:         "placeholder in KEY part - required",
 			env:          []string{"${key}=value"},
-			params:       map[string]interface{}{"key": "PATH"},
+			params:       map[string]any{"key": "PATH"},
 			templateName: "test",
 			wantErr:      true,
 			errType:      &ErrPlaceholderInEnvKey{},
@@ -147,7 +147,7 @@ func TestExpandTemplateEnv(t *testing.T) {
 		{
 			name:         "placeholder in KEY part - optional",
 			env:          []string{"${?key}=value"},
-			params:       map[string]interface{}{"key": "PATH"},
+			params:       map[string]any{"key": "PATH"},
 			templateName: "test",
 			wantErr:      true,
 			errType:      &ErrPlaceholderInEnvKey{},
@@ -155,7 +155,7 @@ func TestExpandTemplateEnv(t *testing.T) {
 		{
 			name:         "placeholder in KEY part - array",
 			env:          []string{"${@keys}=value"},
-			params:       map[string]interface{}{"keys": []string{"PATH"}},
+			params:       map[string]any{"keys": []string{"PATH"}},
 			templateName: "test",
 			wantErr:      true,
 			errType:      &ErrPlaceholderInEnvKey{},
@@ -163,7 +163,7 @@ func TestExpandTemplateEnv(t *testing.T) {
 		{
 			name:         "placeholder in middle of KEY",
 			env:          []string{"PREFIX_${key}_SUFFIX=value"},
-			params:       map[string]interface{}{"key": "PATH"},
+			params:       map[string]any{"key": "PATH"},
 			templateName: "test",
 			wantErr:      true,
 			errType:      &ErrPlaceholderInEnvKey{},
@@ -173,7 +173,7 @@ func TestExpandTemplateEnv(t *testing.T) {
 		{
 			name:         "array in VALUE part",
 			env:          []string{"PATH=${@paths}"},
-			params:       map[string]interface{}{"paths": []string{"/usr/bin", "/bin"}},
+			params:       map[string]any{"paths": []string{"/usr/bin", "/bin"}},
 			templateName: "test",
 			wantErr:      true,
 			errType:      &ErrArrayInMixedContext{},
@@ -183,7 +183,7 @@ func TestExpandTemplateEnv(t *testing.T) {
 		{
 			name:         "duplicate key in template",
 			env:          []string{"PATH=/usr/bin", "PATH=/bin"},
-			params:       map[string]interface{}{},
+			params:       map[string]any{},
 			templateName: "test",
 			wantErr:      true,
 			errType:      &ErrDuplicateEnvVariableDetail{},
@@ -191,7 +191,7 @@ func TestExpandTemplateEnv(t *testing.T) {
 		{
 			name:         "duplicate key from array expansion",
 			env:          []string{"REQUIRED=value", "${@optional_env}"},
-			params:       map[string]interface{}{"optional_env": []string{"REQUIRED=foo"}},
+			params:       map[string]any{"optional_env": []string{"REQUIRED=foo"}},
 			templateName: "test",
 			wantErr:      true,
 			errType:      &ErrDuplicateEnvVariableDetail{},
@@ -199,7 +199,7 @@ func TestExpandTemplateEnv(t *testing.T) {
 		{
 			name: "duplicate key from multiple array placeholders",
 			env:  []string{"${@common}", "${@app_specific}"},
-			params: map[string]interface{}{
+			params: map[string]any{
 				"common":       []string{"PATH=/usr/bin", "HOME=/home/user"},
 				"app_specific": []string{"PATH=/usr/local/bin"},
 			},

--- a/internal/runner/config/template_expansion.go
+++ b/internal/runner/config/template_expansion.go
@@ -200,7 +200,7 @@ func applyEscapeSequences(input string) string {
 //     - ${@param} in mixed context is an error
 func expandSingleArg(
 	arg string,
-	params map[string]interface{},
+	params map[string]any,
 	templateName string,
 	field string,
 ) ([]string, error) {
@@ -245,7 +245,7 @@ func expandSingleArg(
 // expandArrayPlaceholder expands a ${@param} placeholder.
 func expandArrayPlaceholder(
 	name string,
-	params map[string]interface{},
+	params map[string]any,
 	templateName string,
 	field string,
 ) ([]string, error) {
@@ -267,7 +267,7 @@ func expandArrayPlaceholder(
 
 	// Type check
 	switch v := value.(type) {
-	case []interface{}:
+	case []any:
 		result := make([]string, len(v))
 		for i, elem := range v {
 			str, ok := elem.(string)
@@ -309,7 +309,7 @@ func expandArrayPlaceholder(
 // expandOptionalPlaceholder expands a ${?param} placeholder.
 func expandOptionalPlaceholder(
 	name string,
-	params map[string]interface{},
+	params map[string]any,
 	templateName string,
 	field string,
 ) ([]string, error) {
@@ -340,7 +340,7 @@ func expandOptionalPlaceholder(
 func expandStringPlaceholders(
 	input string,
 	placeholders []placeholder,
-	params map[string]interface{},
+	params map[string]any,
 	templateName string,
 	field string,
 ) ([]string, error) {
@@ -415,7 +415,7 @@ func expandStringPlaceholders(
 // ExpandTemplateArgs expands all placeholders in a template's args array.
 func ExpandTemplateArgs(
 	args []string,
-	params map[string]interface{},
+	params map[string]any,
 	templateName string,
 ) ([]string, error) {
 	var result []string
@@ -437,7 +437,7 @@ func ExpandTemplateArgs(
 // Placeholders in the KEY part are forbidden for security reasons.
 func ExpandTemplateEnv(
 	env []string,
-	params map[string]interface{},
+	params map[string]any,
 	templateName string,
 ) ([]string, error) {
 	result := make([]string, 0, len(env))
@@ -670,11 +670,11 @@ func ValidateTemplateDefinition(
 //
 // This function validates:
 //  1. Parameter names must be valid variable names (letter/underscore start, alphanumeric)
-//  2. Parameter values must be string or []string ([]interface{} with string elements)
+//  2. Parameter values must be string or []string ([]any with string elements)
 //
 // NOTE: %{var} references in params values ARE allowed (NF-006) because they
 // will be expanded after template expansion using the group's variable context.
-func ValidateParams(params map[string]interface{}, templateName string) error {
+func ValidateParams(params map[string]any, templateName string) error {
 	for paramName, value := range params {
 		// Validate parameter name
 		if err := security.ValidateVariableName(paramName); err != nil {
@@ -690,7 +690,7 @@ func ValidateParams(params map[string]interface{}, templateName string) error {
 		case string:
 			// String is valid, %{var} references allowed (NF-006)
 			continue
-		case []interface{}:
+		case []any:
 			// Check that all elements are strings
 			for i, elem := range v {
 				if _, ok := elem.(string); !ok {

--- a/internal/runner/config/template_field_constraints_test.go
+++ b/internal/runner/config/template_field_constraints_test.go
@@ -211,7 +211,7 @@ func TestTemplateFieldConstraints(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create test template based on field
 			var template *runnertypes.CommandTemplate
-			params := map[string]interface{}{}
+			params := map[string]any{}
 
 			switch tt.field {
 			case "cmd":
@@ -294,7 +294,7 @@ func TestTemplateFieldConstraints(t *testing.T) {
 }
 
 // setupParams creates appropriate parameter values based on placeholder content
-func setupParams(params map[string]interface{}, placeholder string) {
+func setupParams(params map[string]any, placeholder string) {
 	// Extract parameter names from placeholder
 	placeholders, _ := parsePlaceholders(placeholder)
 
@@ -309,7 +309,7 @@ func setupParams(params map[string]interface{}, placeholder string) {
 }
 
 // setupParamsForEnvElement creates env-appropriate parameter values (KEY=VALUE format)
-func setupParamsForEnvElement(params map[string]interface{}, placeholder string) {
+func setupParamsForEnvElement(params map[string]any, placeholder string) {
 	// Extract parameter names from placeholder
 	placeholders, _ := parsePlaceholders(placeholder)
 

--- a/internal/runner/config/template_optional_test.go
+++ b/internal/runner/config/template_optional_test.go
@@ -24,7 +24,7 @@ func TestOptionalParameter_InEnv(t *testing.T) {
 			command: &runnertypes.CommandSpec{
 				Name:     "test_cmd",
 				Template: "env_tmpl",
-				Params: map[string]interface{}{
+				Params: map[string]any{
 					"value": "myvalue",
 				},
 			},
@@ -40,7 +40,7 @@ func TestOptionalParameter_InEnv(t *testing.T) {
 			command: &runnertypes.CommandSpec{
 				Name:     "test_cmd",
 				Template: "env_tmpl",
-				Params:   map[string]interface{}{},
+				Params:   map[string]any{},
 			},
 			template: &runnertypes.CommandTemplate{
 				Cmd: "echo",
@@ -54,7 +54,7 @@ func TestOptionalParameter_InEnv(t *testing.T) {
 			command: &runnertypes.CommandSpec{
 				Name:     "test_cmd",
 				Template: "env_tmpl",
-				Params: map[string]interface{}{
+				Params: map[string]any{
 					"value": "",
 				},
 			},
@@ -70,7 +70,7 @@ func TestOptionalParameter_InEnv(t *testing.T) {
 			command: &runnertypes.CommandSpec{
 				Name:     "test_cmd",
 				Template: "env_tmpl",
-				Params: map[string]interface{}{
+				Params: map[string]any{
 					"value": "myvalue",
 				},
 			},
@@ -86,7 +86,7 @@ func TestOptionalParameter_InEnv(t *testing.T) {
 			command: &runnertypes.CommandSpec{
 				Name:     "test_cmd",
 				Template: "env_tmpl",
-				Params:   map[string]interface{}{},
+				Params:   map[string]any{},
 			},
 			template: &runnertypes.CommandTemplate{
 				Cmd: "echo",
@@ -100,7 +100,7 @@ func TestOptionalParameter_InEnv(t *testing.T) {
 			command: &runnertypes.CommandSpec{
 				Name:     "test_cmd",
 				Template: "env_tmpl",
-				Params: map[string]interface{}{
+				Params: map[string]any{
 					"val1": "first",
 				},
 			},
@@ -136,7 +136,7 @@ func TestOptionalParameter_EnvKeyWithPlaceholder(t *testing.T) {
 			command: &runnertypes.CommandSpec{
 				Name:     "test_cmd",
 				Template: "env_tmpl",
-				Params: map[string]interface{}{
+				Params: map[string]any{
 					"key": "MYKEY",
 				},
 			},
@@ -152,7 +152,7 @@ func TestOptionalParameter_EnvKeyWithPlaceholder(t *testing.T) {
 			command: &runnertypes.CommandSpec{
 				Name:     "test_cmd",
 				Template: "env_tmpl",
-				Params: map[string]interface{}{
+				Params: map[string]any{
 					"key": "MYKEY",
 				},
 			},
@@ -168,8 +168,8 @@ func TestOptionalParameter_EnvKeyWithPlaceholder(t *testing.T) {
 			command: &runnertypes.CommandSpec{
 				Name:     "test_cmd",
 				Template: "env_tmpl",
-				Params: map[string]interface{}{
-					"keys": []interface{}{"KEY1", "KEY2"},
+				Params: map[string]any{
+					"keys": []any{"KEY1", "KEY2"},
 				},
 			},
 			template: &runnertypes.CommandTemplate{
@@ -184,7 +184,7 @@ func TestOptionalParameter_EnvKeyWithPlaceholder(t *testing.T) {
 			command: &runnertypes.CommandSpec{
 				Name:     "test_cmd",
 				Template: "env_tmpl",
-				Params: map[string]interface{}{
+				Params: map[string]any{
 					"prefix": "MY",
 				},
 			},
@@ -222,7 +222,7 @@ func TestOptionalParameter_InWorkDir(t *testing.T) {
 			command: &runnertypes.CommandSpec{
 				Name:     "test_cmd",
 				Template: "dir_tmpl",
-				Params: map[string]interface{}{
+				Params: map[string]any{
 					"dir": "/my/dir",
 				},
 			},
@@ -238,7 +238,7 @@ func TestOptionalParameter_InWorkDir(t *testing.T) {
 			command: &runnertypes.CommandSpec{
 				Name:     "test_cmd",
 				Template: "dir_tmpl",
-				Params:   map[string]interface{}{},
+				Params:   map[string]any{},
 			},
 			template: &runnertypes.CommandTemplate{
 				Cmd:     "echo",
@@ -252,7 +252,7 @@ func TestOptionalParameter_InWorkDir(t *testing.T) {
 			command: &runnertypes.CommandSpec{
 				Name:     "test_cmd",
 				Template: "dir_tmpl",
-				Params: map[string]interface{}{
+				Params: map[string]any{
 					"subdir": "myproject",
 				},
 			},
@@ -268,7 +268,7 @@ func TestOptionalParameter_InWorkDir(t *testing.T) {
 			command: &runnertypes.CommandSpec{
 				Name:     "test_cmd",
 				Template: "dir_tmpl",
-				Params:   map[string]interface{}{},
+				Params:   map[string]any{},
 			},
 			template: &runnertypes.CommandTemplate{
 				Cmd:     "echo",
@@ -304,7 +304,7 @@ func TestOptionalParameter_InCmd(t *testing.T) {
 			command: &runnertypes.CommandSpec{
 				Name:     "test_cmd",
 				Template: "cmd_tmpl",
-				Params: map[string]interface{}{
+				Params: map[string]any{
 					"cmd": "echo",
 				},
 			},
@@ -319,7 +319,7 @@ func TestOptionalParameter_InCmd(t *testing.T) {
 			command: &runnertypes.CommandSpec{
 				Name:     "test_cmd",
 				Template: "cmd_tmpl",
-				Params:   map[string]interface{}{},
+				Params:   map[string]any{},
 			},
 			template: &runnertypes.CommandTemplate{
 				Cmd: "${?cmd}",
@@ -333,7 +333,7 @@ func TestOptionalParameter_InCmd(t *testing.T) {
 			command: &runnertypes.CommandSpec{
 				Name:     "test_cmd",
 				Template: "cmd_tmpl",
-				Params: map[string]interface{}{
+				Params: map[string]any{
 					"prefix": "/usr/local/bin/",
 				},
 			},
@@ -377,7 +377,7 @@ func TestOptionalParameter_InArgs(t *testing.T) {
 			command: &runnertypes.CommandSpec{
 				Name:     "test_cmd",
 				Template: "args_tmpl",
-				Params: map[string]interface{}{
+				Params: map[string]any{
 					"flag": "--verbose",
 				},
 			},
@@ -393,7 +393,7 @@ func TestOptionalParameter_InArgs(t *testing.T) {
 			command: &runnertypes.CommandSpec{
 				Name:     "test_cmd",
 				Template: "args_tmpl",
-				Params:   map[string]interface{}{},
+				Params:   map[string]any{},
 			},
 			template: &runnertypes.CommandTemplate{
 				Cmd:  "echo",
@@ -407,7 +407,7 @@ func TestOptionalParameter_InArgs(t *testing.T) {
 			command: &runnertypes.CommandSpec{
 				Name:     "test_cmd",
 				Template: "args_tmpl",
-				Params: map[string]interface{}{
+				Params: map[string]any{
 					"level": "3",
 				},
 			},
@@ -423,7 +423,7 @@ func TestOptionalParameter_InArgs(t *testing.T) {
 			command: &runnertypes.CommandSpec{
 				Name:     "test_cmd",
 				Template: "args_tmpl",
-				Params:   map[string]interface{}{},
+				Params:   map[string]any{},
 			},
 			template: &runnertypes.CommandTemplate{
 				Cmd:  "echo",
@@ -437,7 +437,7 @@ func TestOptionalParameter_InArgs(t *testing.T) {
 			command: &runnertypes.CommandSpec{
 				Name:     "test_cmd",
 				Template: "args_tmpl",
-				Params: map[string]interface{}{
+				Params: map[string]any{
 					"arg1": "value1",
 				},
 			},

--- a/internal/runner/config/template_security_test.go
+++ b/internal/runner/config/template_security_test.go
@@ -136,44 +136,44 @@ func TestValidateTemplateDefinition(t *testing.T) {
 func TestValidateParams(t *testing.T) {
 	tests := []struct {
 		name         string
-		params       map[string]interface{}
+		params       map[string]any
 		templateName string
 		wantErr      bool
 		errType      error
 	}{
 		{
 			name:         "valid string param",
-			params:       map[string]interface{}{"path": "/data"},
+			params:       map[string]any{"path": "/data"},
 			templateName: "test",
 			wantErr:      false,
 		},
 		{
 			name:         "valid string array param",
-			params:       map[string]interface{}{"flags": []string{"-v", "-q"}},
+			params:       map[string]any{"flags": []string{"-v", "-q"}},
 			templateName: "test",
 			wantErr:      false,
 		},
 		{
 			name:         "valid interface array param with strings",
-			params:       map[string]interface{}{"flags": []interface{}{"-v", "-q"}},
+			params:       map[string]any{"flags": []any{"-v", "-q"}},
 			templateName: "test",
 			wantErr:      false,
 		},
 		{
 			name:         "variable reference allowed in params (NF-006)",
-			params:       map[string]interface{}{"path": "%{group_root}/data"},
+			params:       map[string]any{"path": "%{group_root}/data"},
 			templateName: "test",
 			wantErr:      false, // %{} is allowed in params
 		},
 		{
 			name:         "multiple params",
-			params:       map[string]interface{}{"path": "/data", "flags": []string{"-v"}},
+			params:       map[string]any{"path": "/data", "flags": []string{"-v"}},
 			templateName: "test",
 			wantErr:      false,
 		},
 		{
 			name:         "empty params",
-			params:       map[string]interface{}{},
+			params:       map[string]any{},
 			templateName: "test",
 			wantErr:      false,
 		},
@@ -185,42 +185,42 @@ func TestValidateParams(t *testing.T) {
 		},
 		{
 			name:         "invalid param name starting with number",
-			params:       map[string]interface{}{"123invalid": "value"},
+			params:       map[string]any{"123invalid": "value"},
 			templateName: "test",
 			wantErr:      true,
 			errType:      &ErrInvalidParamName{},
 		},
 		{
 			name:         "invalid param name with dash",
-			params:       map[string]interface{}{"my-param": "value"},
+			params:       map[string]any{"my-param": "value"},
 			templateName: "test",
 			wantErr:      true,
 			errType:      &ErrInvalidParamName{},
 		},
 		{
 			name:         "unsupported type int",
-			params:       map[string]interface{}{"number": 123},
+			params:       map[string]any{"number": 123},
 			templateName: "test",
 			wantErr:      true,
 			errType:      &ErrUnsupportedParamType{},
 		},
 		{
 			name:         "unsupported type float",
-			params:       map[string]interface{}{"number": 3.14},
+			params:       map[string]any{"number": 3.14},
 			templateName: "test",
 			wantErr:      true,
 			errType:      &ErrUnsupportedParamType{},
 		},
 		{
 			name:         "unsupported type bool",
-			params:       map[string]interface{}{"flag": true},
+			params:       map[string]any{"flag": true},
 			templateName: "test",
 			wantErr:      true,
 			errType:      &ErrUnsupportedParamType{},
 		},
 		{
 			name:         "array with non-string element",
-			params:       map[string]interface{}{"mixed": []interface{}{"-v", 123}},
+			params:       map[string]any{"mixed": []any{"-v", 123}},
 			templateName: "test",
 			wantErr:      true,
 			errType:      &ErrTemplateInvalidArrayElement{},
@@ -253,7 +253,7 @@ func TestValidateCommandSpecExclusivity(t *testing.T) {
 	}{
 		{
 			name:    "template only (valid)",
-			spec:    runnertypes.CommandSpec{Name: "backup", Template: "restic_backup", Params: map[string]interface{}{"path": "/data"}},
+			spec:    runnertypes.CommandSpec{Name: "backup", Template: "restic_backup", Params: map[string]any{"path": "/data"}},
 			wantErr: false,
 		},
 		{
@@ -314,7 +314,7 @@ func TestValidateCommandSpecExclusivity(t *testing.T) {
 		},
 		{
 			name:    "template with params only (valid)",
-			spec:    runnertypes.CommandSpec{Name: "test", Template: "tmpl", Params: map[string]interface{}{"key": "value"}},
+			spec:    runnertypes.CommandSpec{Name: "test", Template: "tmpl", Params: map[string]any{"key": "value"}},
 			wantErr: false,
 		},
 	}

--- a/internal/runner/config/verify_files_expansion_test.go
+++ b/internal/runner/config/verify_files_expansion_test.go
@@ -13,7 +13,7 @@ import (
 func TestVerifyFilesExpansion_SpecialCharacters(t *testing.T) {
 	t.Run("GlobalVerifyFiles_WithSpaces", func(t *testing.T) {
 		spec := &runnertypes.GlobalSpec{
-			Vars:        map[string]interface{}{"base_dir": "/opt/my app", "file_name": "test-file_v1.0.sh"},
+			Vars:        map[string]any{"base_dir": "/opt/my app", "file_name": "test-file_v1.0.sh"},
 			VerifyFiles: []string{"%{base_dir}/%{file_name}"},
 		}
 
@@ -26,7 +26,7 @@ func TestVerifyFilesExpansion_SpecialCharacters(t *testing.T) {
 
 	t.Run("GlobalVerifyFiles_WithDashes", func(t *testing.T) {
 		spec := &runnertypes.GlobalSpec{
-			Vars:        map[string]interface{}{"base_dir": "/opt/app", "sub_dir": "sub-dir_v2.0"},
+			Vars:        map[string]any{"base_dir": "/opt/app", "sub_dir": "sub-dir_v2.0"},
 			VerifyFiles: []string{"%{base_dir}/%{sub_dir}/script.sh"},
 		}
 
@@ -39,14 +39,14 @@ func TestVerifyFilesExpansion_SpecialCharacters(t *testing.T) {
 
 	t.Run("GroupVerifyFiles_WithSpecialChars", func(t *testing.T) {
 		globalSpec := &runnertypes.GlobalSpec{
-			Vars: map[string]interface{}{"root": "/opt/my-app"},
+			Vars: map[string]any{"root": "/opt/my-app"},
 		}
 		globalRuntime, err := config.ExpandGlobal(globalSpec)
 		require.NoError(t, err)
 
 		groupSpec := &runnertypes.GroupSpec{
 			Name:        "test_group",
-			Vars:        map[string]interface{}{"sub_dir": "test dir v1.0"},
+			Vars:        map[string]any{"sub_dir": "test dir v1.0"},
 			VerifyFiles: []string{"%{root}/%{sub_dir}/verify.sh"},
 		}
 
@@ -62,7 +62,7 @@ func TestVerifyFilesExpansion_SpecialCharacters(t *testing.T) {
 func TestVerifyFilesExpansion_NestedReferences(t *testing.T) {
 	t.Run("GlobalVerifyFiles_NestedReferences", func(t *testing.T) {
 		spec := &runnertypes.GlobalSpec{
-			Vars:        map[string]interface{}{"root": "/opt", "app_name": "myapp", "app_dir": "%{root}/%{app_name}"},
+			Vars:        map[string]any{"root": "/opt", "app_name": "myapp", "app_dir": "%{root}/%{app_name}"},
 			VerifyFiles: []string{"%{app_dir}/verify.sh"},
 		}
 
@@ -75,7 +75,7 @@ func TestVerifyFilesExpansion_NestedReferences(t *testing.T) {
 
 	t.Run("GlobalVerifyFiles_DeeplyNestedReferences", func(t *testing.T) {
 		spec := &runnertypes.GlobalSpec{
-			Vars: map[string]interface{}{
+			Vars: map[string]any{
 				"root":          "/opt",
 				"app_name":      "myapp",
 				"version":       "v1.0",
@@ -94,14 +94,14 @@ func TestVerifyFilesExpansion_NestedReferences(t *testing.T) {
 
 	t.Run("GroupVerifyFiles_DeeplyNestedReferences", func(t *testing.T) {
 		globalSpec := &runnertypes.GlobalSpec{
-			Vars: map[string]interface{}{"root": "/opt", "app_name": "myapp", "app_dir": "%{root}/%{app_name}"},
+			Vars: map[string]any{"root": "/opt", "app_name": "myapp", "app_dir": "%{root}/%{app_name}"},
 		}
 		globalRuntime, err := config.ExpandGlobal(globalSpec)
 		require.NoError(t, err)
 
 		groupSpec := &runnertypes.GroupSpec{
 			Name:        "test_group",
-			Vars:        map[string]interface{}{"subdir": "scripts", "full_path": "%{app_dir}/%{subdir}"},
+			Vars:        map[string]any{"subdir": "scripts", "full_path": "%{app_dir}/%{subdir}"},
 			VerifyFiles: []string{"%{full_path}/check.sh"},
 		}
 
@@ -117,7 +117,7 @@ func TestVerifyFilesExpansion_NestedReferences(t *testing.T) {
 func TestVerifyFilesExpansion_ErrorHandling(t *testing.T) {
 	t.Run("UndefinedVariable", func(t *testing.T) {
 		spec := &runnertypes.GlobalSpec{
-			Vars:        map[string]interface{}{"existing_var": "/opt"},
+			Vars:        map[string]any{"existing_var": "/opt"},
 			VerifyFiles: []string{"%{undefined_var}/script.sh"},
 		}
 
@@ -139,7 +139,7 @@ func TestVerifyFilesExpansion_ErrorHandling(t *testing.T) {
 
 	t.Run("MultipleVerifyFilesWithMixedErrors", func(t *testing.T) {
 		spec := &runnertypes.GlobalSpec{
-			Vars: map[string]interface{}{"valid_dir": "/opt"},
+			Vars: map[string]any{"valid_dir": "/opt"},
 			VerifyFiles: []string{
 				"%{valid_dir}/good.sh",
 				"%{invalid_var}/bad.sh",
@@ -153,7 +153,7 @@ func TestVerifyFilesExpansion_ErrorHandling(t *testing.T) {
 
 	t.Run("GroupVerifyFiles_UndefinedVariable", func(t *testing.T) {
 		globalSpec := &runnertypes.GlobalSpec{
-			Vars: map[string]interface{}{"global_var": "/opt"},
+			Vars: map[string]any{"global_var": "/opt"},
 		}
 		globalRuntime, err := config.ExpandGlobal(globalSpec)
 		require.NoError(t, err)
@@ -173,7 +173,7 @@ func TestVerifyFilesExpansion_ErrorHandling(t *testing.T) {
 func TestVerifyFilesExpansion_EmptyAndNoFiles(t *testing.T) {
 	t.Run("NoVerifyFiles", func(t *testing.T) {
 		spec := &runnertypes.GlobalSpec{
-			Vars:        map[string]interface{}{"var1": "/opt"},
+			Vars:        map[string]any{"var1": "/opt"},
 			VerifyFiles: nil,
 		}
 
@@ -184,7 +184,7 @@ func TestVerifyFilesExpansion_EmptyAndNoFiles(t *testing.T) {
 
 	t.Run("EmptyVerifyFilesList", func(t *testing.T) {
 		spec := &runnertypes.GlobalSpec{
-			Vars:        map[string]interface{}{"var1": "/opt"},
+			Vars:        map[string]any{"var1": "/opt"},
 			VerifyFiles: []string{},
 		}
 
@@ -198,7 +198,7 @@ func TestVerifyFilesExpansion_EmptyAndNoFiles(t *testing.T) {
 func TestVerifyFilesExpansion_MultipleFiles(t *testing.T) {
 	t.Run("GlobalMultipleVerifyFiles", func(t *testing.T) {
 		spec := &runnertypes.GlobalSpec{
-			Vars: map[string]interface{}{"dir1": "/opt/app1", "dir2": "/opt/app2"},
+			Vars: map[string]any{"dir1": "/opt/app1", "dir2": "/opt/app2"},
 			VerifyFiles: []string{
 				"%{dir1}/verify1.sh",
 				"%{dir2}/verify2.sh",
@@ -216,14 +216,14 @@ func TestVerifyFilesExpansion_MultipleFiles(t *testing.T) {
 
 	t.Run("GroupMultipleVerifyFiles", func(t *testing.T) {
 		globalSpec := &runnertypes.GlobalSpec{
-			Vars: map[string]interface{}{"root": "/opt"},
+			Vars: map[string]any{"root": "/opt"},
 		}
 		globalRuntime, err := config.ExpandGlobal(globalSpec)
 		require.NoError(t, err)
 
 		groupSpec := &runnertypes.GroupSpec{
 			Name: "test_group",
-			Vars: map[string]interface{}{"app": "myapp"},
+			Vars: map[string]any{"app": "myapp"},
 			VerifyFiles: []string{
 				"%{root}/%{app}/check1.sh",
 				"%{root}/%{app}/check2.sh",

--- a/internal/runner/e2e_slack_redaction_test.go
+++ b/internal/runner/e2e_slack_redaction_test.go
@@ -43,14 +43,14 @@ func (m *MockSlackHandler) Handle(_ context.Context, record slog.Record) error {
 	var buf bytes.Buffer
 
 	// Format record attributes
-	attrs := make(map[string]interface{})
+	attrs := make(map[string]any)
 	record.Attrs(func(a slog.Attr) bool {
 		attrs[a.Key] = a.Value.Any()
 		return true
 	})
 
 	// Convert to JSON (simulating Slack webhook payload)
-	data, err := json.Marshal(map[string]interface{}{
+	data, err := json.Marshal(map[string]any{
 		"message": record.Message,
 		"level":   record.Level.String(),
 		"attrs":   attrs,

--- a/internal/runner/group_executor_test.go
+++ b/internal/runner/group_executor_test.go
@@ -1456,7 +1456,7 @@ func TestExecuteGroup_DryRunVariableExpansion(t *testing.T) {
 
 	group := &runnertypes.GroupSpec{
 		Name: "test-group",
-		Vars: map[string]interface{}{"TEST_VAR": "test_value"},
+		Vars: map[string]any{"TEST_VAR": "test_value"},
 		Commands: []runnertypes.CommandSpec{
 			{Name: "test-cmd", Cmd: "/bin/echo"},
 		},
@@ -2298,7 +2298,7 @@ func TestCreateCommandContext_UnlimitedTimeout_SecurityLogging(t *testing.T) {
 		commandName      string
 		currentUser      string
 		expectLog        bool
-		expectedFields   map[string]interface{}
+		expectedFields   map[string]any
 	}{
 		{
 			name:             "zero timeout logs unlimited execution",
@@ -2306,7 +2306,7 @@ func TestCreateCommandContext_UnlimitedTimeout_SecurityLogging(t *testing.T) {
 			commandName:      "unlimited-cmd",
 			currentUser:      "testuser",
 			expectLog:        true,
-			expectedFields: map[string]interface{}{
+			expectedFields: map[string]any{
 				"command":        "unlimited-cmd",
 				"user":           "testuser",
 				"timeout":        "unlimited",
@@ -2319,7 +2319,7 @@ func TestCreateCommandContext_UnlimitedTimeout_SecurityLogging(t *testing.T) {
 			commandName:      "test-cmd",
 			currentUser:      "unknown",
 			expectLog:        true,
-			expectedFields: map[string]interface{}{
+			expectedFields: map[string]any{
 				"command":        "test-cmd",
 				"user":           "unknown",
 				"timeout":        "unlimited",
@@ -2836,7 +2836,7 @@ func TestPreExpandCommands_Success(t *testing.T) {
 				Commands: []runnertypes.CommandSpec{
 					{
 						Name: "cmd1",
-						Vars: map[string]interface{}{"cmd_var": "/custom/path"},
+						Vars: map[string]any{"cmd_var": "/custom/path"},
 						Cmd:  "%{cmd_var}/tool",
 					},
 				},

--- a/internal/runner/resource/types.go
+++ b/internal/runner/resource/types.go
@@ -321,14 +321,14 @@ type EnvironmentInfo struct {
 
 // DryRunError represents an error that occurred during dry-run
 type DryRunError struct {
-	Type        ErrorType   `json:"type"`
-	Code        string      `json:"code"`
-	Message     string      `json:"message"`
-	Component   string      `json:"component"`
-	Group       string      `json:"group,omitempty"`
-	Command     string      `json:"command,omitempty"`
-	Details     interface{} `json:"details,omitempty"`
-	Recoverable bool        `json:"recoverable"`
+	Type        ErrorType `json:"type"`
+	Code        string    `json:"code"`
+	Message     string    `json:"message"`
+	Component   string    `json:"component"`
+	Group       string    `json:"group,omitempty"`
+	Command     string    `json:"command,omitempty"`
+	Details     any       `json:"details,omitempty"`
+	Recoverable bool      `json:"recoverable"`
 }
 
 // ErrorType represents the type of error

--- a/internal/runner/runnertypes/runtime_test.go
+++ b/internal/runner/runnertypes/runtime_test.go
@@ -262,7 +262,7 @@ func TestRuntimeGlobal_Structure(t *testing.T) {
 	spec := &GlobalSpec{
 		Timeout: commontesting.Int32Ptr(300),
 		EnvVars: []string{"PATH=/usr/bin"},
-		Vars:    map[string]interface{}{"VAR1": "value1"},
+		Vars:    map[string]any{"VAR1": "value1"},
 	}
 
 	runtime, err := NewRuntimeGlobal(spec)
@@ -290,7 +290,7 @@ func TestRuntimeGroup_Structure(t *testing.T) {
 		Name:    "test-group",
 		WorkDir: "/tmp/test",
 		EnvVars: []string{"CC=gcc"},
-		Vars:    map[string]interface{}{"BUILD_TYPE": "release"},
+		Vars:    map[string]any{"BUILD_TYPE": "release"},
 	}
 
 	runtime := &RuntimeGroup{

--- a/internal/runner/runnertypes/spec.go
+++ b/internal/runner/runnertypes/spec.go
@@ -111,7 +111,7 @@ type GlobalSpec struct {
 	//   config_files = ["config.yml", "secrets.yml"]
 	//
 	// Changed from: Vars []string `toml:"vars"` (array-based format)
-	Vars map[string]interface{} `toml:"vars"`
+	Vars map[string]any `toml:"vars"`
 }
 
 // GroupSpec represents a command group configuration loaded from TOML file.
@@ -158,7 +158,7 @@ type GroupSpec struct {
 	//   deploy_target = "production"
 	//
 	// Changed from: Vars []string `toml:"vars"` (array-based format)
-	Vars map[string]interface{} `toml:"vars"`
+	Vars map[string]any `toml:"vars"`
 }
 
 // CommandSpec represents a single command configuration loaded from TOML file.
@@ -190,7 +190,7 @@ type CommandSpec struct {
 	//   template = "restic_backup"
 	//   params.verbose_flags = ["-q"]
 	//   params.path = "%{backup_dir}/data"  # %{} is allowed in params
-	Params map[string]interface{} `toml:"params"`
+	Params map[string]any `toml:"params"`
 
 	// Command definition (raw values, not yet expanded)
 	// These fields are MUTUALLY EXCLUSIVE with Template:
@@ -226,7 +226,7 @@ type CommandSpec struct {
 	//   backup_suffix = ".bak"
 	//
 	// Changed from: Vars []string `toml:"vars"` (array-based format)
-	Vars map[string]interface{} `toml:"vars"`
+	Vars map[string]any `toml:"vars"`
 }
 
 // GetRiskLevel parses and returns the maximum risk level for this command.

--- a/internal/runner/runnertypes/spec_test.go
+++ b/internal/runner/runnertypes/spec_test.go
@@ -250,7 +250,7 @@ cmd = "/bin/echo"
 					EnvAllowed:          []string{"PATH", "HOME"},
 					EnvVars:             []string{"PATH=/usr/bin:/bin", "HOME=/root"},
 					EnvImport:           []string{"user=USER", "shell=SHELL"},
-					Vars:                map[string]interface{}{"PREFIX": "/opt", "VERSION": "1.0"},
+					Vars:                map[string]any{"PREFIX": "/opt", "VERSION": "1.0"},
 				},
 				Groups: []GroupSpec{
 					{
@@ -304,7 +304,7 @@ cmd = "/usr/bin/make"
 						EnvAllowed:  []string{"PATH", "CC"},
 						EnvVars:     []string{"CC=gcc"},
 						EnvImport:   []string{"home=HOME"},
-						Vars:        map[string]interface{}{"BUILD_TYPE": "release"},
+						Vars:        map[string]any{"BUILD_TYPE": "release"},
 						Commands: []CommandSpec{
 							{
 								Name: "compile",
@@ -366,7 +366,7 @@ TEST_VAR = "value"
 								OutputFile:  "/tmp/output.log",
 								EnvVars:     []string{"PYTHONPATH=/opt/lib"},
 								EnvImport:   []string{"path=PATH"},
-								Vars:        map[string]interface{}{"TEST_VAR": "value"},
+								Vars:        map[string]any{"TEST_VAR": "value"},
 							},
 						},
 					},

--- a/internal/runner/test_helpers.go
+++ b/internal/runner/test_helpers.go
@@ -110,7 +110,7 @@ func createRuntimeCommand(spec *runnertypes.CommandSpec) *runnertypes.RuntimeCom
 // Usage:
 //
 //	mockVerificationManager.On("VerifyGroupFiles", matchRuntimeGroupWithName("test-group")).Return(...)
-func matchRuntimeGroupWithName(expectedName string) interface{} {
+func matchRuntimeGroupWithName(expectedName string) any {
 	return mock.MatchedBy(func(rg *runnertypes.RuntimeGroup) bool {
 		return rg != nil && rg.Spec != nil && rg.Spec.Name == expectedName
 	})

--- a/internal/safefileio/safe_file_cleanup_test.go
+++ b/internal/safefileio/safe_file_cleanup_test.go
@@ -85,7 +85,7 @@ func (m *mockFileInfo) Size() int64        { return m.size }
 func (m *mockFileInfo) Mode() os.FileMode  { return m.mode }
 func (m *mockFileInfo) ModTime() time.Time { return time.Time{} }
 func (m *mockFileInfo) IsDir() bool        { return false }
-func (m *mockFileInfo) Sys() interface{} {
+func (m *mockFileInfo) Sys() any {
 	// Return a syscall.Stat_t for compatibility with getFileStatInfo
 	return &syscall.Stat_t{
 		Uid: m.uid,

--- a/internal/verification/testing/helpers.go
+++ b/internal/verification/testing/helpers.go
@@ -13,7 +13,7 @@ import (
 // Usage:
 //
 //	mockVerificationManager.On("VerifyGroupFiles", verificationtesting.MatchRuntimeGroupWithName("test-group")).Return(...)
-func MatchRuntimeGroupWithName(expectedName string) interface{} {
+func MatchRuntimeGroupWithName(expectedName string) any {
 	return mock.MatchedBy(func(rg *runnertypes.RuntimeGroup) bool {
 		return rg != nil && rg.Spec != nil && rg.Spec.Name == expectedName
 	})


### PR DESCRIPTION
This pull request standardizes the use of the Go 1.18+ `any` type alias in place of the older `interface{}` type throughout the codebase. The change affects variable declarations, function signatures, struct fields, and test cases, improving code clarity and aligning with modern Go best practices. The update is applied consistently across configuration expansion logic, tests, and benchmarks.

**Type alias migration to `any`:**

* All instances of `interface{}` have been replaced with `any` in variable declarations, function signatures, and struct fields, including in configuration expansion logic, variable processing, and validation functions (`internal/runner/config/expansion.go`). [[1]](diffhunk://#diff-6e5ae76d30918d3292205ee6bb8a8b30cb221db08d7c74e1eca21e07eb6aa30bL322-R322) [[2]](diffhunk://#diff-6e5ae76d30918d3292205ee6bb8a8b30cb221db08d7c74e1eca21e07eb6aa30bL332-R332) [[3]](diffhunk://#diff-6e5ae76d30918d3292205ee6bb8a8b30cb221db08d7c74e1eca21e07eb6aa30bL444-R444) [[4]](diffhunk://#diff-6e5ae76d30918d3292205ee6bb8a8b30cb221db08d7c74e1eca21e07eb6aa30bL467-R467) [[5]](diffhunk://#diff-6e5ae76d30918d3292205ee6bb8a8b30cb221db08d7c74e1eca21e07eb6aa30bL484-R484) [[6]](diffhunk://#diff-6e5ae76d30918d3292205ee6bb8a8b30cb221db08d7c74e1eca21e07eb6aa30bL496-R496) [[7]](diffhunk://#diff-6e5ae76d30918d3292205ee6bb8a8b30cb221db08d7c74e1eca21e07eb6aa30bL545-R552) [[8]](diffhunk://#diff-6e5ae76d30918d3292205ee6bb8a8b30cb221db08d7c74e1eca21e07eb6aa30bL580-R580) [[9]](diffhunk://#diff-6e5ae76d30918d3292205ee6bb8a8b30cb221db08d7c74e1eca21e07eb6aa30bL631-R631) [[10]](diffhunk://#diff-6e5ae76d30918d3292205ee6bb8a8b30cb221db08d7c74e1eca21e07eb6aa30bL683-R685)

**Test updates for type consistency:**

* Test files now use `any` instead of `interface{}` for JSON unmarshaling, slice declarations, and map types in assertions and test data (`internal/redaction/redactor_test.go`, `internal/runner/command_output_capture_test.go`, `internal/runner/bootstrap/logger_test.go`, `cmd/runner/dry_run_integration_test.go`). [[1]](diffhunk://#diff-c99b7a031102f0664020a5007919865eb05db7b584e5688da2779671423252fdL1391-R1391) [[2]](diffhunk://#diff-c99b7a031102f0664020a5007919865eb05db7b584e5688da2779671423252fdL1533-R1540) [[3]](diffhunk://#diff-c99b7a031102f0664020a5007919865eb05db7b584e5688da2779671423252fdL1599-R1599) [[4]](diffhunk://#diff-c99b7a031102f0664020a5007919865eb05db7b584e5688da2779671423252fdL1611-R1613) [[5]](diffhunk://#diff-79cba01a90ca71db27779f12a020e2f8c8f0b4e17d5344da2cef6f13880f17e4L132-R139) [[6]](diffhunk://#diff-5cf52c1a11d8197aceef710fee4adf0e9d68274d39dcde99d58c723a085d54a8L299-R301) [[7]](diffhunk://#diff-de802620d09fb8c6887601a7de51c9383d670fb38cca6403d4a9dc8cfbae48c1L469-R469)

**Configuration and benchmark struct updates:**

* All `Vars` fields in configuration specs (`GlobalSpec`, `GroupSpec`, `CommandSpec`) and related test and benchmark files now use `map[string]any` instead of `map[string]interface{}` (`internal/runner/config/auto_vars_test.go`, `internal/runner/config/expansion_bench_test.go`, `internal/runner/config/expansion_cmd_allowed_test.go`). [[1]](diffhunk://#diff-b04ec70d5e8bc752452faa6a91874d3340176c9cde90c977e1a2de3d9cd7f3b5L56-R56) [[2]](diffhunk://#diff-b04ec70d5e8bc752452faa6a91874d3340176c9cde90c977e1a2de3d9cd7f3b5L73-R73) [[3]](diffhunk://#diff-b04ec70d5e8bc752452faa6a91874d3340176c9cde90c977e1a2de3d9cd7f3b5L112-R112) [[4]](diffhunk://#diff-b04ec70d5e8bc752452faa6a91874d3340176c9cde90c977e1a2de3d9cd7f3b5L159-R159) [[5]](diffhunk://#diff-7651734e418efe4426119c0d38d3b2d786f4bdc7e43dec4584a7fd009c60dc1bL14-R14) [[6]](diffhunk://#diff-7651734e418efe4426119c0d38d3b2d786f4bdc7e43dec4584a7fd009c60dc1bL28-R28) [[7]](diffhunk://#diff-7651734e418efe4426119c0d38d3b2d786f4bdc7e43dec4584a7fd009c60dc1bL47-R47) [[8]](diffhunk://#diff-7651734e418efe4426119c0d38d3b2d786f4bdc7e43dec4584a7fd009c60dc1bL74-R74) [[9]](diffhunk://#diff-7651734e418efe4426119c0d38d3b2d786f4bdc7e43dec4584a7fd009c60dc1bL97-R97) [[10]](diffhunk://#diff-7651734e418efe4426119c0d38d3b2d786f4bdc7e43dec4584a7fd009c60dc1bL134-R134) [[11]](diffhunk://#diff-7651734e418efe4426119c0d38d3b2d786f4bdc7e43dec4584a7fd009c60dc1bL151-R151) [[12]](diffhunk://#diff-7651734e418efe4426119c0d38d3b2d786f4bdc7e43dec4584a7fd009c60dc1bL164-R164) [[13]](diffhunk://#diff-7651734e418efe4426119c0d38d3b2d786f4bdc7e43dec4584a7fd009c60dc1bL183-R183) [[14]](diffhunk://#diff-7651734e418efe4426119c0d38d3b2d786f4bdc7e43dec4584a7fd009c60dc1bL201-R201) [[15]](diffhunk://#diff-7651734e418efe4426119c0d38d3b2d786f4bdc7e43dec4584a7fd009c60dc1bL216-R216) [[16]](diffhunk://#diff-1df78ebb3739c804c6b16d1d6cea32b83fc9e51c79a00e64c3f796b378c05324L193-R193)

**Error handling and logging improvements:**

* Error handling and logging-related code updated to use `any` in error wrapping and logging interfaces (`internal/logging/pre_execution_error.go`).

These changes modernize the codebase, making it more idiomatic and future-proof for Go development.

Close #453 