### PR TITLE
Send Slack notification on group file verification failure

### DIFF
--- a/internal/logging/pre_execution_error.go
+++ b/internal/logging/pre_execution_error.go
@@ -35,6 +35,8 @@ const (
 	ErrorTypeBuildConfig ErrorType = "build_config_error"
 	// ErrorTypeSystemError represents system errors
 	ErrorTypeSystemError ErrorType = "system_error"
+	// ErrorTypeGroupFileVerification represents group file verification failures
+	ErrorTypeGroupFileVerification ErrorType = "group_file_verification_failed"
 )
 
 // PreExecutionError represents an error that occurs before command execution


### PR DESCRIPTION
Group file verification failures were only logged with slog.Warn, which did not trigger Slack notifications. Changed to use HandlePreExecutionError with a new ErrorTypeGroupFileVerification error type, which sends Slack notifications via the pre_execution_error message type.

The group is still skipped and execution continues with the next group.