### PR TITLE
docs: add requirements for ELF syscall analysis on Linux/arm64

### DIFF
--- a/docs/tasks/0072_elf_syscall_analysis_linux_arm64/01_requirements.md
+++ b/docs/tasks/0072_elf_syscall_analysis_linux_arm64/01_requirements.md
@@ -120,6 +120,7 @@ arm64 Linux の syscall 番号でネットワーク関連 syscall を判定す�
 | syscall | 番号 (arm64 Linux) | 意味 |
 |---------|---------------------|------|
 | `socket` | 198 | ソケット作成 |
+| `socketpair` | 199 | ソケットペア作成 |
 | `bind` | 200 | アドレスにバインド |
 | `listen` | 201 | 接続待ち受け |
 | `accept` | 202 | 接続受け入れ |
@@ -129,6 +130,8 @@ arm64 Linux の syscall 番号でネットワーク関連 syscall を判定す�
 | `sendmsg` | 211 | メッセージ送信 |
 | `recvmsg` | 212 | メッセージ受信 |
 | `accept4` | 242 | 接続受け入れ（フラグ付き） |
+| `recvmmsg` | 243 | 複数メッセージ受信 |
+| `sendmmsg` | 269 | 複数メッセージ送信 |
 
 #### FR-3.1.6: Go syscall ラッパーの解析（arm64）
 


### PR DESCRIPTION
This pull request adds a comprehensive requirements definition for static syscall analysis of ELF binaries on Linux/arm64. It extends the existing x86_64 implementation to support arm64 architecture, detailing the differences in syscall invocation, machine code decoding, and Go binary analysis. The document also specifies functional and non-functional requirements, acceptance criteria, and testing strategies for the new arm64 support.

Requirements and architecture extension:

* Added a detailed background and rationale for supporting Linux/arm64 ELF binaries, including differences in syscall invocation and register usage compared to x86_64.
* Defined the scope, terminology, and purpose for extending the static syscall analyzer to arm64, including Go binary analysis and network syscall detection.

Functional requirements for arm64 support:

* Specified the implementation of an arm64 machine code decoder using the `arm64asm` package, detection of `svc #0` instructions, and extraction of syscall numbers from `w8`/`x8` registers.
* Outlined integration with existing interfaces (`MachineCodeDecoder`, `SyscallNumberTable`, `SyscallAnalyzer`, and Go wrapper resolver), including necessary refactoring for architecture-agnostic support.

Testing and acceptance criteria:

* Defined unit and integration test strategies for arm64 binaries, including detection of network-related syscalls and handling of high-risk cases. (Fabf76dd