### PR TITLE
docs: add architecture design for ELF syscall analysis on Linux/arm64

### DIFF
--- a/docs/tasks/0072_elf_syscall_analysis_linux_arm64/02_architecture.md
+++ b/docs/tasks/0072_elf_syscall_analysis_linux_arm64/02_architecture.md
@@ -566,8 +566,8 @@ sequenceDiagram
     "summary": {
       "has_network_syscalls": true,
       "is_high_risk": false,
-      "total_detected_events": 15,
-      "network_syscall_count": 3
+      "total_detected_events": 2,
+      "network_syscall_count": 2
     }
   }
 }


### PR DESCRIPTION
- Define multi-architecture interface generalization strategy:
  - Rename MachineCodeDecoder methods to architecture-neutral names
  - Generalize DecodedInstruction with arch any field (decoder-internal only)
  - GoWrapperResolver accesses decoded data via concrete decoder methods (GetCallTarget, IsImmediateToFirstArgRegister), not via arch field directly
- Document ARM64Decoder design with arm64asm behavior notes:
  - MOVZ instructions decoded as Op == arm64asm.MOV (not MOVZ)
  - W8/X8 and W0/X0 are distinct constants; both must be accepted
  - Imm vs Imm64 type difference between 32-bit and 64-bit register variants
- Document architecture dispatch via archConfigs registry pattern
- Document performance characteristics: interface generalization adds no overhead since findSyscallInstructions already loops via decoder.Decode()