### PR TITLE
Convert ResolvedPath to struct with type-safe path handling

### DIFF
--- a/internal/filevalidator/sha256_path_hash_getter_test.go
+++ b/internal/filevalidator/sha256_path_hash_getter_test.go
@@ -123,7 +123,7 @@ func TestSHA256PathHashGetter_GetHashFilePath_DifferentHashDirs(t *testing.T) {
 		results[i] = result
 
 		// Verify the result uses the correct hash directory
-		assert.True(t, strings.HasPrefix(result, hashDir.String()))
+assert.Equal(t, hashDir.String(), filepath.Dir(result))
 	}
 
 	// All results should have different prefixes but same filename

--- a/internal/filevalidator/sha256_path_hash_getter_test.go
+++ b/internal/filevalidator/sha256_path_hash_getter_test.go
@@ -123,7 +123,7 @@ func TestSHA256PathHashGetter_GetHashFilePath_DifferentHashDirs(t *testing.T) {
 		results[i] = result
 
 		// Verify the result uses the correct hash directory
-		assert.True(t, strings.HasPrefix(result, rawDir))
+		assert.True(t, strings.HasPrefix(result, hashDir.String()))
 	}
 
 	// All results should have different prefixes but same filename


### PR DESCRIPTION
## Summary

- Convert `ResolvedPath` from a string alias to a struct, enforcing type safety at compile time across path resolution, storage, and validation
- Migrate all storage path consumers (`filevalidator`, `fileanalysis`, `runner/security`) to use the new struct API
- Fix several bugs uncovered during migration: symlink-resolution in `GetHashFilePath` prefix checks, `%s` format verbs for the new struct, and unguarded `nil` groupMembership

## Test plan

- [ ] `make test` passes — all unit and integration tests green
- [ ] `make lint` passes — no new lint errors
- [ ] Verify `GetHashFilePath` handles symlinked hash directories correctly (symlink-resolution fix)
- [ ] Confirm cross-platform prefix checks in `GetHashFilePath` test pass on Linux
- [ ] Confirm `newResolvedPathForNew` is test-only and not exported (YAGNI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)