### PR TITLE
Remove deprecated GSCR_SLACK_WEBHOOK_URL support

### DIFF
--- a/docs/tasks/0086_remove_deprecated_slack_webhook_url/01_requirements.md
+++ b/docs/tasks/0086_remove_deprecated_slack_webhook_url/01_requirements.md
@@ -1,0 +1,140 @@
+# GSCR_SLACK_WEBHOOK_URL 廃止環境変数の完全削除 要件定義書
+
+## 1. 概要
+
+### 1.1 背景
+
+task 0068（Slack Webhook 分離機能）において、旧環境変数 `GSCR_SLACK_WEBHOOK_URL` は廃止（deprecated）とされた。廃止時の実装では、この変数が設定されている場合にエラーメッセージを出力してアプリケーションを即時終了させる「Fail Fast」アプローチが採用された。
+
+移行猶予期間が経過したため、この廃止チェックコード自体と、それに関連するすべてのコード・ドキュメントを完全に削除する。
+
+### 1.2 目的
+
+- 廃止された環境変数 `GSCR_SLACK_WEBHOOK_URL` に関連するコードを完全に削除する
+- 移行ガイドセクションをドキュメントから削除する
+- コードベースをシンプルに保つ（YAGNI 原則）
+
+### 1.3 スコープ外
+
+- task 0068 で作成されたドキュメント（`docs/tasks/0068_separate_slack_webhooks/`）は歴史的記録として保持する
+- `GSCR_SLACK_WEBHOOK_URL_SUCCESS`、`GSCR_SLACK_WEBHOOK_URL_ERROR` に関する変更は行わない
+
+## 2. 用語定義
+
+| 用語 | 定義 |
+|------|------|
+| 旧環境変数 | `GSCR_SLACK_WEBHOOK_URL`（task 0068 で廃止された変数） |
+| Fail Fast チェック | 起動時に旧環境変数が設定されているかを確認し、設定されている場合にエラーで終了する処理 |
+
+## 3. 機能要件
+
+### 3.1 ソースコードの削除
+
+#### FR-3.1.1: `SlackWebhookURLEnvVar` 定数の削除
+
+`internal/logging/pre_execution_error.go` から以下の定数を削除する：
+
+```go
+// SlackWebhookURLEnvVar is deprecated - kept for migration detection
+SlackWebhookURLEnvVar = "GSCR_SLACK_WEBHOOK_URL"
+```
+
+#### FR-3.1.2: `DeprecatedSlackWebhookError` 型の削除
+
+`internal/runner/bootstrap/environment.go` から以下を削除する：
+
+- `ErrDeprecatedSlackWebhook` 変数
+- `DeprecatedSlackWebhookError` 型定義
+- `DeprecatedSlackWebhookError.Error()` メソッド
+- `DeprecatedSlackWebhookError.Is()` メソッド
+
+#### FR-3.1.3: `ValidateSlackWebhookEnv` 関数から deprecated チェックの削除
+
+`internal/runner/bootstrap/environment.go` の `ValidateSlackWebhookEnv` 関数から、旧環境変数チェック部分を削除する：
+
+```go
+// 削除対象
+if os.Getenv(logging.SlackWebhookURLEnvVar) != "" {
+    return nil, &DeprecatedSlackWebhookError{}
+}
+```
+
+### 3.2 テストコードの削除
+
+#### FR-3.2.1: deprecated 変数テストケースの削除
+
+`internal/runner/bootstrap/environment_test.go` から以下のテストケースを削除する：
+
+- `"deprecated env var set - error"` テストケース
+- `"deprecated env var with new vars - error"` テストケース
+- テスト構造体の `oldURL` フィールド
+- `t.Setenv(logging.SlackWebhookURLEnvVar, tt.oldURL)` の呼び出し
+
+### 3.3 ドキュメントの更新
+
+#### FR-3.3.1: 日本語ドキュメントの更新
+
+`docs/user/runner_command.ja.md` から以下のセクションを削除する：
+
+- 「`GSCR_SLACK_WEBHOOK_URL` からの移行」セクション（移行手順のコードブロックを含む）
+
+#### FR-3.3.2: 英語ドキュメントの更新
+
+`docs/user/runner_command.md` から以下のセクションを削除する：
+
+- 「Migration from `GSCR_SLACK_WEBHOOK_URL`」セクション（Migration Steps のコードブロックを含む）
+
+## 4. 非機能要件
+
+### 4.1 後方互換性
+
+旧環境変数 `GSCR_SLACK_WEBHOOK_URL` が設定されている状態でrunnerを実行しても、エラーにならず無視されること（削除後は単に未使用の環境変数として扱われる）。
+
+### 4.2 既存機能への影響なし
+
+`GSCR_SLACK_WEBHOOK_URL_SUCCESS` および `GSCR_SLACK_WEBHOOK_URL_ERROR` の動作は変更しない。
+
+## 5. 受け入れ基準
+
+### AC-1: `SlackWebhookURLEnvVar` 定数の削除
+
+- [ ] `internal/logging/pre_execution_error.go` に `SlackWebhookURLEnvVar` が存在しないこと
+- [ ] `SlackWebhookURLEnvVar` を参照するコードが存在しないこと
+
+### AC-2: `DeprecatedSlackWebhookError` 型の削除
+
+- [ ] `internal/runner/bootstrap/environment.go` に `ErrDeprecatedSlackWebhook` が存在しないこと
+- [ ] `internal/runner/bootstrap/environment.go` に `DeprecatedSlackWebhookError` が存在しないこと
+
+### AC-3: `ValidateSlackWebhookEnv` からの deprecated チェック削除
+
+- [ ] `ValidateSlackWebhookEnv` 関数が `GSCR_SLACK_WEBHOOK_URL` を参照しないこと
+- [ ] `GSCR_SLACK_WEBHOOK_URL` を設定してrunnerを起動してもエラーにならないこと
+
+### AC-4: テストコードの削除
+
+- [ ] deprecated 変数に関するテストケースが削除されていること
+- [ ] `logging.SlackWebhookURLEnvVar` への参照がテストコードに存在しないこと
+- [ ] 残存テストがすべてパスすること
+
+### AC-5: ドキュメントの更新
+
+- [ ] `docs/user/runner_command.ja.md` に「`GSCR_SLACK_WEBHOOK_URL` からの移行」セクションが存在しないこと
+- [ ] `docs/user/runner_command.md` に「Migration from `GSCR_SLACK_WEBHOOK_URL`」セクションが存在しないこと
+
+### AC-6: ビルドとテストの成功
+
+- [ ] `make build` が成功すること
+- [ ] `make test` がすべてパスすること
+- [ ] `make lint` がエラーなく完了すること
+
+## 6. 削除対象ファイル・コード箇所一覧
+
+| ファイル | 対象 | 種別 |
+|---------|------|------|
+| `internal/logging/pre_execution_error.go` | `SlackWebhookURLEnvVar` 定数 | ソースコード |
+| `internal/runner/bootstrap/environment.go` | `ErrDeprecatedSlackWebhook`、`DeprecatedSlackWebhookError` 型・メソッド | ソースコード |
+| `internal/runner/bootstrap/environment.go` | `ValidateSlackWebhookEnv` 内 deprecated チェック | ソースコード |
+| `internal/runner/bootstrap/environment_test.go` | deprecated 変数のテストケース・フィールド | テストコード |
+| `docs/user/runner_command.ja.md` | 「`GSCR_SLACK_WEBHOOK_URL` からの移行」セクション | ドキュメント |
+| `docs/user/runner_command.md` | 「Migration from `GSCR_SLACK_WEBHOOK_URL`」セクション | ドキュメント |

--- a/docs/tasks/0086_remove_deprecated_slack_webhook_url/04_implementation_plan.md
+++ b/docs/tasks/0086_remove_deprecated_slack_webhook_url/04_implementation_plan.md
@@ -1,0 +1,40 @@
+# GSCR_SLACK_WEBHOOK_URL 廃止環境変数の完全削除 実装計画書
+
+## 実装ステップ
+
+- [ ] **1. `SlackWebhookURLEnvVar` 定数の削除**
+  - ファイル: `internal/logging/pre_execution_error.go`
+  - 内容: `SlackWebhookURLEnvVar = "GSCR_SLACK_WEBHOOK_URL"` 定数とそのコメントを削除
+
+- [ ] **2. `DeprecatedSlackWebhookError` 型と `ErrDeprecatedSlackWebhook` の削除**
+  - ファイル: `internal/runner/bootstrap/environment.go`
+  - 内容: 以下を削除
+    - `ErrDeprecatedSlackWebhook` 変数
+    - `DeprecatedSlackWebhookError` 型定義
+    - `Error()` メソッド
+    - `Is()` メソッド
+
+- [ ] **3. `ValidateSlackWebhookEnv` から deprecated チェックの削除**
+  - ファイル: `internal/runner/bootstrap/environment.go`
+  - 内容: `os.Getenv(logging.SlackWebhookURLEnvVar)` を使った if ブロックを削除
+
+- [ ] **4. テストコードの更新**
+  - ファイル: `internal/runner/bootstrap/environment_test.go`
+  - 内容: 以下を削除・更新
+    - テスト構造体の `oldURL` フィールド
+    - `t.Setenv(logging.SlackWebhookURLEnvVar, tt.oldURL)` の呼び出し
+    - `"deprecated env var set - error"` テストケース
+    - `"deprecated env var with new vars - error"` テストケース
+
+- [ ] **5. 日本語ドキュメントの更新**
+  - ファイル: `docs/user/runner_command.ja.md`
+  - 内容: 「`GSCR_SLACK_WEBHOOK_URL` からの移行」セクションを削除
+
+- [ ] **6. 英語ドキュメントの更新**
+  - ファイル: `docs/user/runner_command.md`
+  - 内容: 「Migration from `GSCR_SLACK_WEBHOOK_URL`」セクションを削除
+
+- [ ] **7. ビルド・テスト・Lint の確認**
+  - `make build` の成功を確認
+  - `make test` の全テストパスを確認
+  - `make lint` のエラーなし完了を確認

--- a/docs/tasks/0086_remove_deprecated_slack_webhook_url/04_implementation_plan.md
+++ b/docs/tasks/0086_remove_deprecated_slack_webhook_url/04_implementation_plan.md
@@ -2,11 +2,11 @@
 
 ## 実装ステップ
 
-- [ ] **1. `SlackWebhookURLEnvVar` 定数の削除**
+- [x] **1. `SlackWebhookURLEnvVar` 定数の削除**
   - ファイル: `internal/logging/pre_execution_error.go`
   - 内容: `SlackWebhookURLEnvVar = "GSCR_SLACK_WEBHOOK_URL"` 定数とそのコメントを削除
 
-- [ ] **2. `DeprecatedSlackWebhookError` 型と `ErrDeprecatedSlackWebhook` の削除**
+- [x] **2. `DeprecatedSlackWebhookError` 型と `ErrDeprecatedSlackWebhook` の削除**
   - ファイル: `internal/runner/bootstrap/environment.go`
   - 内容: 以下を削除
     - `ErrDeprecatedSlackWebhook` 変数
@@ -14,11 +14,11 @@
     - `Error()` メソッド
     - `Is()` メソッド
 
-- [ ] **3. `ValidateSlackWebhookEnv` から deprecated チェックの削除**
+- [x] **3. `ValidateSlackWebhookEnv` から deprecated チェックの削除**
   - ファイル: `internal/runner/bootstrap/environment.go`
   - 内容: `os.Getenv(logging.SlackWebhookURLEnvVar)` を使った if ブロックを削除
 
-- [ ] **4. テストコードの更新**
+- [x] **4. テストコードの更新**
   - ファイル: `internal/runner/bootstrap/environment_test.go`
   - 内容: 以下を削除・更新
     - テスト構造体の `oldURL` フィールド

--- a/docs/tasks/0086_remove_deprecated_slack_webhook_url/04_implementation_plan.md
+++ b/docs/tasks/0086_remove_deprecated_slack_webhook_url/04_implementation_plan.md
@@ -26,15 +26,15 @@
     - `"deprecated env var set - error"` テストケース
     - `"deprecated env var with new vars - error"` テストケース
 
-- [ ] **5. 日本語ドキュメントの更新**
+- [x] **5. 日本語ドキュメントの更新**
   - ファイル: `docs/user/runner_command.ja.md`
   - 内容: 「`GSCR_SLACK_WEBHOOK_URL` からの移行」セクションを削除
 
-- [ ] **6. 英語ドキュメントの更新**
+- [x] **6. 英語ドキュメントの更新**
   - ファイル: `docs/user/runner_command.md`
   - 内容: 「Migration from `GSCR_SLACK_WEBHOOK_URL`」セクションを削除
 
-- [ ] **7. ビルド・テスト・Lint の確認**
+- [x] **7. ビルド・テスト・Lint の確認**
   - `make build` の成功を確認
   - `make test` の全テストパスを確認
   - `make lint` のエラーなし完了を確認

--- a/docs/user/runner_command.ja.md
+++ b/docs/user/runner_command.ja.md
@@ -1375,26 +1375,6 @@ Run ID: 01K2YK812JA735M4TWZ6BK0JH9
 - ログやエラーメッセージには含まれません
 - dry-runモードでは、どちらのWebhookにも通知は送信されません
 
-#### `GSCR_SLACK_WEBHOOK_URL` からの移行
-
-旧 `GSCR_SLACK_WEBHOOK_URL` 環境変数は廃止されました。設定されている場合、runnerは移行方法を説明するエラーメッセージを出力して失敗します。
-
-**移行手順**
-
-```bash
-# 以前（廃止）
-export GSCR_SLACK_WEBHOOK_URL="https://hooks.slack.com/services/..."
-
-# 以後（推奨：エラー通知のみ）
-unset GSCR_SLACK_WEBHOOK_URL
-export GSCR_SLACK_WEBHOOK_URL_ERROR="https://hooks.slack.com/services/..."
-
-# 以後（成功とエラー両方の通知が必要な場合）
-unset GSCR_SLACK_WEBHOOK_URL
-export GSCR_SLACK_WEBHOOK_URL_SUCCESS="https://hooks.slack.com/services/..."
-export GSCR_SLACK_WEBHOOK_URL_ERROR="https://hooks.slack.com/services/..."
-```
-
 ### 4.3 CI環境の自動検出
 
 以下の環境変数が設定されている場合、自動的にCI環境として認識され、非インタラクティブモードで動作します。

--- a/docs/user/runner_command.md
+++ b/docs/user/runner_command.md
@@ -1405,26 +1405,6 @@ Run ID: 01K2YK812JA735M4TWZ6BK0JH9
 - Not included in logs or error messages
 - In dry-run mode, no notifications are sent to either webhook
 
-#### Migration from `GSCR_SLACK_WEBHOOK_URL`
-
-The old `GSCR_SLACK_WEBHOOK_URL` environment variable is deprecated. If set, the runner will fail with an error message explaining how to migrate.
-
-**Migration Steps**
-
-```bash
-# Before (deprecated)
-export GSCR_SLACK_WEBHOOK_URL="https://hooks.slack.com/services/..."
-
-# After (recommended: error notifications only)
-unset GSCR_SLACK_WEBHOOK_URL
-export GSCR_SLACK_WEBHOOK_URL_ERROR="https://hooks.slack.com/services/..."
-
-# After (if you want both success and error notifications)
-unset GSCR_SLACK_WEBHOOK_URL
-export GSCR_SLACK_WEBHOOK_URL_SUCCESS="https://hooks.slack.com/services/..."
-export GSCR_SLACK_WEBHOOK_URL_ERROR="https://hooks.slack.com/services/..."
-```
-
 ### 4.3 CI Environment Auto-Detection
 
 When the following environment variables are set, they are automatically recognized as CI environment and operate in non-interactive mode.

--- a/internal/logging/pre_execution_error.go
+++ b/internal/logging/pre_execution_error.go
@@ -11,9 +11,6 @@ import (
 
 // Environment variable names
 const (
-	// SlackWebhookURLEnvVar is deprecated - kept for migration detection
-	SlackWebhookURLEnvVar = "GSCR_SLACK_WEBHOOK_URL"
-
 	// SlackWebhookURLSuccessEnvVar is the environment variable for success webhook
 	SlackWebhookURLSuccessEnvVar = "GSCR_SLACK_WEBHOOK_URL_SUCCESS"
 

--- a/internal/runner/bootstrap/environment.go
+++ b/internal/runner/bootstrap/environment.go
@@ -16,30 +16,6 @@ type SlackWebhookConfig struct {
 	ErrorURL   string
 }
 
-// ErrDeprecatedSlackWebhook is returned when the deprecated env var is set.
-// Use errors.Is(err, ErrDeprecatedSlackWebhook) to check for this error type.
-var ErrDeprecatedSlackWebhook = &DeprecatedSlackWebhookError{}
-
-// DeprecatedSlackWebhookError indicates that the deprecated GSCR_SLACK_WEBHOOK_URL is set.
-type DeprecatedSlackWebhookError struct{}
-
-func (e *DeprecatedSlackWebhookError) Error() string {
-	return `Error: GSCR_SLACK_WEBHOOK_URL is deprecated.
-
-Please migrate to the new webhook configuration:
-  export GSCR_SLACK_WEBHOOK_URL_SUCCESS="<your_webhook_url>"
-  export GSCR_SLACK_WEBHOOK_URL_ERROR="<your_webhook_url>"
-
-For more information, see the migration guide at:
-  https://github.com/isseis/go-safe-cmd-runner/docs/user/runner_command.md#slack-webhook-configuration`
-}
-
-// Is implements errors.Is support.
-func (e *DeprecatedSlackWebhookError) Is(target error) bool {
-	_, ok := target.(*DeprecatedSlackWebhookError)
-	return ok
-}
-
 // ErrSuccessWithoutError is returned when SUCCESS is set but ERROR is not.
 // Use errors.Is(err, ErrSuccessWithoutError) to check for this error type.
 var ErrSuccessWithoutError = &SuccessWithoutErrorError{}
@@ -70,11 +46,6 @@ func (e *SuccessWithoutErrorError) Is(target error) bool {
 
 // ValidateSlackWebhookEnv validates Slack webhook environment variables
 func ValidateSlackWebhookEnv() (*SlackWebhookConfig, error) {
-	// Check for deprecated environment variable
-	if os.Getenv(logging.SlackWebhookURLEnvVar) != "" {
-		return nil, &DeprecatedSlackWebhookError{}
-	}
-
 	successURL := os.Getenv(logging.SlackWebhookURLSuccessEnvVar)
 	errorURL := os.Getenv(logging.SlackWebhookURLErrorEnvVar)
 

--- a/internal/runner/bootstrap/environment_test.go
+++ b/internal/runner/bootstrap/environment_test.go
@@ -164,7 +164,6 @@ func TestValidateSlackWebhookEnv(t *testing.T) {
 		name        string
 		successURL  string
 		errorURL    string
-		oldURL      string
 		wantErr     error
 		wantSuccess string
 		wantError   string
@@ -173,7 +172,6 @@ func TestValidateSlackWebhookEnv(t *testing.T) {
 			name:        "both SUCCESS and ERROR set",
 			successURL:  "https://hooks.slack.com/success",
 			errorURL:    "https://hooks.slack.com/error",
-			oldURL:      "",
 			wantErr:     nil,
 			wantSuccess: "https://hooks.slack.com/success",
 			wantError:   "https://hooks.slack.com/error",
@@ -182,7 +180,6 @@ func TestValidateSlackWebhookEnv(t *testing.T) {
 			name:        "only ERROR set",
 			successURL:  "",
 			errorURL:    "https://hooks.slack.com/error",
-			oldURL:      "",
 			wantErr:     nil,
 			wantSuccess: "",
 			wantError:   "https://hooks.slack.com/error",
@@ -191,7 +188,6 @@ func TestValidateSlackWebhookEnv(t *testing.T) {
 			name:        "only SUCCESS set - error because ERROR is required",
 			successURL:  "https://hooks.slack.com/success",
 			errorURL:    "",
-			oldURL:      "",
 			wantErr:     ErrSuccessWithoutError,
 			wantSuccess: "",
 			wantError:   "",
@@ -200,26 +196,7 @@ func TestValidateSlackWebhookEnv(t *testing.T) {
 			name:        "neither set - Slack disabled",
 			successURL:  "",
 			errorURL:    "",
-			oldURL:      "",
 			wantErr:     nil,
-			wantSuccess: "",
-			wantError:   "",
-		},
-		{
-			name:        "deprecated env var set - error",
-			successURL:  "",
-			errorURL:    "",
-			oldURL:      "https://hooks.slack.com/old",
-			wantErr:     ErrDeprecatedSlackWebhook,
-			wantSuccess: "",
-			wantError:   "",
-		},
-		{
-			name:        "deprecated env var with new vars - error",
-			successURL:  "https://hooks.slack.com/success",
-			errorURL:    "https://hooks.slack.com/error",
-			oldURL:      "https://hooks.slack.com/old",
-			wantErr:     ErrDeprecatedSlackWebhook,
 			wantSuccess: "",
 			wantError:   "",
 		},
@@ -227,7 +204,6 @@ func TestValidateSlackWebhookEnv(t *testing.T) {
 			name:        "same URL for both SUCCESS and ERROR",
 			successURL:  "https://hooks.slack.com/same",
 			errorURL:    "https://hooks.slack.com/same",
-			oldURL:      "",
 			wantErr:     nil,
 			wantSuccess: "https://hooks.slack.com/same",
 			wantError:   "https://hooks.slack.com/same",
@@ -237,7 +213,6 @@ func TestValidateSlackWebhookEnv(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Set environment variables for this test (t.Setenv automatically restores on cleanup)
-			t.Setenv(logging.SlackWebhookURLEnvVar, tt.oldURL)
 			t.Setenv(logging.SlackWebhookURLSuccessEnvVar, tt.successURL)
 			t.Setenv(logging.SlackWebhookURLErrorEnvVar, tt.errorURL)
 


### PR DESCRIPTION
## Summary

Remove all code and documentation related to the deprecated
`GSCR_SLACK_WEBHOOK_URL` environment variable.

## Changes

- Remove `SlackWebhookURLEnvVar` constant from
  `internal/logging/pre_execution_error.go`
- Remove `DeprecatedSlackWebhookError` type and `ErrDeprecatedSlackWebhook`
  variable from `internal/runner/bootstrap/environment.go`
- Remove deprecated env var check block from `ValidateSlackWebhookEnv`
- Update `environment_test.go`: remove `oldURL` field and deprecated
  test cases
- Remove Migration section from `docs/user/runner_command.ja.md`
- Remove Migration section from `docs/user/runner_command.md`

## Testing

- All tests pass (`make test`)
- No lint issues (`make lint`)
- Build succeeds (`make build`)