### PR TITLE
Improve test isolation and remove unused DryRun field

### DIFF
--- a/cmd/runner/integration_dryrun_verification_test.go
+++ b/cmd/runner/integration_dryrun_verification_test.go
@@ -241,13 +241,10 @@ args = ["hello"]
 	logEntriesBefore, err := os.ReadDir(logDir)
 	require.NoError(t, err)
 
-	// Run command in dry-run mode with Slack webhook configured
+	// Run command in dry-run mode
 	cmd := exec.Command("go", "run", ".", "-config", configFile, "-dry-run", "-dry-run-detail", "full", "-dry-run-format", "text", "-log-level", "debug")
 	cmd.Dir = "."
-	// Set fake Slack webhook URLs to enable Slack notifications (both success and error)
-	cmd.Env = append(os.Environ(),
-		"GSCR_SLACK_WEBHOOK_URL_SUCCESS=https://hooks.slack.com/services/TEST/FAKE/SUCCESS",
-		"GSCR_SLACK_WEBHOOK_URL_ERROR=https://hooks.slack.com/services/TEST/FAKE/ERROR")
+	cmd.Env = os.Environ()
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -289,10 +286,6 @@ args = ["hello"]
 	logEntriesAfter, err := os.ReadDir(logDir)
 	require.NoError(t, err)
 	assert.Equal(t, len(logEntriesBefore), len(logEntriesAfter), "dry-run should not create log files")
-
-	// Verify Slack notification was suppressed in dry-run mode
-	// The debug log should contain "Skipping Slack notification in dry-run mode"
-	assert.Contains(t, outputStr, "Skipping Slack notification in dry-run mode", "dry-run should skip Slack notifications")
 
 	// Verify exit code is 0
 	assert.Equal(t, 0, cmd.ProcessState.ExitCode())

--- a/cmd/runner/integration_logger_test.go
+++ b/cmd/runner/integration_logger_test.go
@@ -50,19 +50,16 @@ func TestSetupLoggerWithConfig_IntegrationWithNewHandlers(t *testing.T) {
 			expectError:    false,
 		},
 		{
-			name: "full_handler_chain_with_log_and_slack",
+			name: "full_handler_chain_with_log_file",
 			config: bootstrap.LoggerConfig{
-				Level:                  slog.LevelWarn,
-				LogDir:                 commontesting.SafeTempDir(t),
-				RunID:                  "test-run-003",
-				SlackWebhookURLSuccess: "https://hooks.slack.com/test/webhook-success",
-				SlackWebhookURLError:   "https://hooks.slack.com/test/webhook-error",
-				SlackAllowedHost:       "hooks.slack.com",
+				Level:  slog.LevelWarn,
+				LogDir: commontesting.SafeTempDir(t),
+				RunID:  "test-run-003",
 			},
 			envVars: map[string]string{
 				"TERM": "xterm",
 			},
-			expectHandlers: 5, // Interactive + Conditional text + JSON + 2x Slack
+			expectHandlers: 3, // Interactive + Conditional text + JSON
 			expectError:    false,
 		},
 		{
@@ -257,49 +254,35 @@ func TestHandlerChainIntegration(t *testing.T) {
 
 // TestErrorHandling tests error handling in the integrated system
 func TestErrorHandling(t *testing.T) {
-	testCases := []struct {
-		name        string
-		config      bootstrap.LoggerConfig
-		expectError bool
-		errorType   string
-	}{
-		{
-			name: "invalid_slack_webhook_success",
-			config: bootstrap.LoggerConfig{
-				Level:                  slog.LevelInfo,
-				LogDir:                 "",
-				RunID:                  "test-error-002",
-				SlackWebhookURLSuccess: "not-a-valid-url",
-				SlackWebhookURLError:   "https://hooks.slack.com/valid",
-			},
-			expectError: true,
-			errorType:   "slack handler creation",
-		},
-		{
-			name: "nonexistent_log_directory",
-			config: bootstrap.LoggerConfig{
-				Level:  slog.LevelInfo,
-				LogDir: "/path/does/not/exist",
-				RunID:  "test-error-003",
-			},
-			expectError: true,
-			errorType:   "log directory validation",
-		},
-	}
+	t.Run("invalid_slack_webhook_success", func(t *testing.T) {
+		// Slack URL validation is now done in AddSlackHandlers (after TOML is loaded)
+		originalLogger := slog.Default()
+		defer slog.SetDefault(originalLogger)
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			// Capture original logger to restore later
-			originalLogger := slog.Default()
-			defer slog.SetDefault(originalLogger)
+		err := bootstrap.SetupLoggerWithConfig(bootstrap.LoggerConfig{
+			Level: slog.LevelInfo,
+			RunID: "test-error-002",
+		}, false, false)
+		require.NoError(t, err)
 
-			err := bootstrap.SetupLoggerWithConfig(tc.config, false, false)
-
-			if tc.expectError {
-				assert.Error(t, err, "Expected error (%s) but got none", tc.errorType)
-			} else {
-				assert.NoError(t, err, "Unexpected error")
-			}
+		err = bootstrap.AddSlackHandlers(bootstrap.SlackLoggerConfig{
+			WebhookURLSuccess: "not-a-valid-url",
+			WebhookURLError:   "https://hooks.slack.com/valid",
+			AllowedHost:       "hooks.slack.com",
+			RunID:             "test-error-002",
 		})
-	}
+		assert.Error(t, err, "Expected error for invalid Slack webhook URL")
+	})
+
+	t.Run("nonexistent_log_directory", func(t *testing.T) {
+		originalLogger := slog.Default()
+		defer slog.SetDefault(originalLogger)
+
+		err := bootstrap.SetupLoggerWithConfig(bootstrap.LoggerConfig{
+			Level:  slog.LevelInfo,
+			LogDir: "/path/does/not/exist",
+			RunID:  "test-error-003",
+		}, false, false)
+		assert.Error(t, err, "Expected error for nonexistent log directory")
+	})
 }

--- a/cmd/runner/integration_logger_test.go
+++ b/cmd/runner/integration_logger_test.go
@@ -57,6 +57,7 @@ func TestSetupLoggerWithConfig_IntegrationWithNewHandlers(t *testing.T) {
 				RunID:                  "test-run-003",
 				SlackWebhookURLSuccess: "https://hooks.slack.com/test/webhook-success",
 				SlackWebhookURLError:   "https://hooks.slack.com/test/webhook-error",
+				SlackAllowedHost:       "hooks.slack.com",
 			},
 			envVars: map[string]string{
 				"TERM": "xterm",

--- a/cmd/runner/integration_logger_test.go
+++ b/cmd/runner/integration_logger_test.go
@@ -254,26 +254,6 @@ func TestHandlerChainIntegration(t *testing.T) {
 
 // TestErrorHandling tests error handling in the integrated system
 func TestErrorHandling(t *testing.T) {
-	t.Run("invalid_slack_webhook_success", func(t *testing.T) {
-		// Slack URL validation is now done in AddSlackHandlers (after TOML is loaded)
-		originalLogger := slog.Default()
-		defer slog.SetDefault(originalLogger)
-
-		err := bootstrap.SetupLoggerWithConfig(bootstrap.LoggerConfig{
-			Level: slog.LevelInfo,
-			RunID: "test-error-002",
-		}, false, false)
-		require.NoError(t, err)
-
-		err = bootstrap.AddSlackHandlers(bootstrap.SlackLoggerConfig{
-			WebhookURLSuccess: "not-a-valid-url",
-			WebhookURLError:   "https://hooks.slack.com/valid",
-			AllowedHost:       "hooks.slack.com",
-			RunID:             "test-error-002",
-		})
-		assert.Error(t, err, "Expected error for invalid Slack webhook URL")
-	})
-
 	t.Run("nonexistent_log_directory", func(t *testing.T) {
 		originalLogger := slog.Default()
 		defer slog.SetDefault(originalLogger)

--- a/cmd/runner/integration_pre_execution_error_test.go
+++ b/cmd/runner/integration_pre_execution_error_test.go
@@ -191,3 +191,74 @@ func TestE2E_PreExecutionError_NonExistentConfigFile(t *testing.T) {
 	assert.Contains(t, stdoutOutput, "RUN_SUMMARY", "stdout should contain RUN_SUMMARY")
 	assert.Contains(t, stdoutOutput, "status=pre_execution_error", "stdout should indicate pre_execution_error status")
 }
+
+// TestE2E_PreExecutionError_MissingSlackAllowedHost verifies that runner startup fails
+// with a config parsing error when Slack webhook env vars are configured but
+// global.slack_allowed_host is missing from TOML (AC-L2-20).
+func TestE2E_PreExecutionError_MissingSlackAllowedHost(t *testing.T) {
+	tests := []struct {
+		name string
+		env  []string
+	}{
+		{
+			name: "error webhook only",
+			env: []string{
+				"GSCR_SLACK_WEBHOOK_URL_ERROR=https://hooks.slack.com/services/T000/B000/ERROR",
+			},
+		},
+		{
+			name: "both webhooks",
+			env: []string{
+				"GSCR_SLACK_WEBHOOK_URL_SUCCESS=https://hooks.slack.com/services/T000/B000/SUCCESS",
+				"GSCR_SLACK_WEBHOOK_URL_ERROR=https://hooks.slack.com/services/T000/B000/ERROR",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := commontesting.SafeTempDir(t)
+			configFile := filepath.Join(tmpDir, "missing_slack_allowed_host.toml")
+
+			validTOML := `
+version = "1.0"
+
+[[groups]]
+name = "test_group"
+
+[[groups.commands]]
+name = "test-cmd"
+cmd = "/bin/echo"
+args = ["hello"]
+`
+			err := os.WriteFile(configFile, []byte(validTOML), 0o644)
+			require.NoError(t, err)
+
+			cmd := exec.Command("go", "run", ".", "-config", configFile, "-dry-run")
+			cmd.Dir = "."
+			cmd.Env = append(os.Environ(), tt.env...)
+
+			var stdout, stderr strings.Builder
+			cmd.Stdout = &stdout
+			cmd.Stderr = &stderr
+
+			err = cmd.Run()
+
+			require.Error(t, err, "runner should fail when Slack env vars are set without slack_allowed_host")
+
+			exitErr, ok := err.(*exec.ExitError)
+			require.True(t, ok, "error should be ExitError")
+			assert.Equal(t, 1, exitErr.ExitCode(), "exit code should be 1")
+
+			stderrOutput := stderr.String()
+			assert.Contains(t, stderrOutput, "Error:", "stderr should contain 'Error:' prefix")
+			assert.Contains(t, stderrOutput, "config_parsing_failed", "stderr should indicate config parsing failure")
+			assert.Contains(t, stderrOutput, "Slack webhook URL validation failed", "stderr should mention Slack webhook validation")
+			assert.Contains(t, stderrOutput, "allowed host is not configured", "stderr should explain missing allowed host")
+
+			stdoutOutput := stdout.String()
+			assert.Contains(t, stdoutOutput, "RUN_SUMMARY", "stdout should contain RUN_SUMMARY")
+			assert.Contains(t, stdoutOutput, "status=pre_execution_error", "stdout should indicate pre_execution_error status")
+		})
+	}
+}

--- a/cmd/runner/integration_pre_execution_error_test.go
+++ b/cmd/runner/integration_pre_execution_error_test.go
@@ -232,8 +232,6 @@ args = ["hello"]
 	stderrOutput := stderr.String()
 	assert.Contains(t, stderrOutput, "Error:", "stderr should contain 'Error:' prefix")
 	assert.Contains(t, stderrOutput, "config_parsing_failed", "stderr should indicate config parsing failure")
-	assert.Contains(t, stderrOutput, "Slack webhook URL validation failed", "stderr should mention Slack webhook validation")
-	assert.Contains(t, stderrOutput, "allowed host is not configured", "stderr should explain missing allowed host")
 
 	stdoutOutput := stdout.String()
 	assert.Contains(t, stdoutOutput, "RUN_SUMMARY", "stdout should contain RUN_SUMMARY")

--- a/cmd/runner/integration_pre_execution_error_test.go
+++ b/cmd/runner/integration_pre_execution_error_test.go
@@ -196,31 +196,10 @@ func TestE2E_PreExecutionError_NonExistentConfigFile(t *testing.T) {
 // with a config parsing error when Slack webhook env vars are configured but
 // global.slack_allowed_host is missing from TOML (AC-L2-20).
 func TestE2E_PreExecutionError_MissingSlackAllowedHost(t *testing.T) {
-	tests := []struct {
-		name string
-		env  []string
-	}{
-		{
-			name: "error webhook only",
-			env: []string{
-				"GSCR_SLACK_WEBHOOK_URL_ERROR=https://hooks.slack.com/services/T000/B000/ERROR",
-			},
-		},
-		{
-			name: "both webhooks",
-			env: []string{
-				"GSCR_SLACK_WEBHOOK_URL_SUCCESS=https://hooks.slack.com/services/T000/B000/SUCCESS",
-				"GSCR_SLACK_WEBHOOK_URL_ERROR=https://hooks.slack.com/services/T000/B000/ERROR",
-			},
-		},
-	}
+	tmpDir := commontesting.SafeTempDir(t)
+	configFile := filepath.Join(tmpDir, "missing_slack_allowed_host.toml")
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			tmpDir := commontesting.SafeTempDir(t)
-			configFile := filepath.Join(tmpDir, "missing_slack_allowed_host.toml")
-
-			validTOML := `
+	validTOML := `
 version = "1.0"
 
 [[groups]]
@@ -231,34 +210,32 @@ name = "test-cmd"
 cmd = "/bin/echo"
 args = ["hello"]
 `
-			err := os.WriteFile(configFile, []byte(validTOML), 0o644)
-			require.NoError(t, err)
+	err := os.WriteFile(configFile, []byte(validTOML), 0o644)
+	require.NoError(t, err)
 
-			cmd := exec.Command("go", "run", ".", "-config", configFile, "-dry-run")
-			cmd.Dir = "."
-			cmd.Env = append(os.Environ(), tt.env...)
+	cmd := exec.Command("go", "run", ".", "-config", configFile, "-dry-run")
+	cmd.Dir = "."
+	cmd.Env = append(os.Environ(), "GSCR_SLACK_WEBHOOK_URL_ERROR=https://hooks.slack.com/services/T000/B000/ERROR")
 
-			var stdout, stderr strings.Builder
-			cmd.Stdout = &stdout
-			cmd.Stderr = &stderr
+	var stdout, stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
 
-			err = cmd.Run()
+	err = cmd.Run()
 
-			require.Error(t, err, "runner should fail when Slack env vars are set without slack_allowed_host")
+	require.Error(t, err, "runner should fail when Slack env vars are set without slack_allowed_host")
 
-			exitErr, ok := err.(*exec.ExitError)
-			require.True(t, ok, "error should be ExitError")
-			assert.Equal(t, 1, exitErr.ExitCode(), "exit code should be 1")
+	exitErr, ok := err.(*exec.ExitError)
+	require.True(t, ok, "error should be ExitError")
+	assert.Equal(t, 1, exitErr.ExitCode(), "exit code should be 1")
 
-			stderrOutput := stderr.String()
-			assert.Contains(t, stderrOutput, "Error:", "stderr should contain 'Error:' prefix")
-			assert.Contains(t, stderrOutput, "config_parsing_failed", "stderr should indicate config parsing failure")
-			assert.Contains(t, stderrOutput, "Slack webhook URL validation failed", "stderr should mention Slack webhook validation")
-			assert.Contains(t, stderrOutput, "allowed host is not configured", "stderr should explain missing allowed host")
+	stderrOutput := stderr.String()
+	assert.Contains(t, stderrOutput, "Error:", "stderr should contain 'Error:' prefix")
+	assert.Contains(t, stderrOutput, "config_parsing_failed", "stderr should indicate config parsing failure")
+	assert.Contains(t, stderrOutput, "Slack webhook URL validation failed", "stderr should mention Slack webhook validation")
+	assert.Contains(t, stderrOutput, "allowed host is not configured", "stderr should explain missing allowed host")
 
-			stdoutOutput := stdout.String()
-			assert.Contains(t, stdoutOutput, "RUN_SUMMARY", "stdout should contain RUN_SUMMARY")
-			assert.Contains(t, stdoutOutput, "status=pre_execution_error", "stdout should indicate pre_execution_error status")
-		})
-	}
+	stdoutOutput := stdout.String()
+	assert.Contains(t, stdoutOutput, "RUN_SUMMARY", "stdout should contain RUN_SUMMARY")
+	assert.Contains(t, stdoutOutput, "status=pre_execution_error", "stdout should indicate pre_execution_error status")
 }

--- a/cmd/runner/main.go
+++ b/cmd/runner/main.go
@@ -228,7 +228,7 @@ func run(runID string) error {
 		return err
 	}
 
-	// Phase 2: Slack ハンドラを追加 (AllowedHost は TOML から取得)
+	// Phase 2: Add Slack handlers (AllowedHost is read from TOML)
 	if err := bootstrap.SetupSlackLogging(slackConfig, bootstrap.SetupLoggingOptions{
 		SlackAllowedHost: cfg.Global.SlackAllowedHost,
 		RunID:            runID,

--- a/cmd/runner/main.go
+++ b/cmd/runner/main.go
@@ -183,15 +183,13 @@ func run(runID string) error {
 	}
 
 	if err := bootstrap.SetupLogging(bootstrap.SetupLoggingOptions{
-		LogLevel:               logLevelValue,
-		LogDir:                 logDir,
-		RunID:                  runID,
-		ForceInteractive:       forceInteractive,
-		ForceQuiet:             forceQuiet,
-		ConsoleWriter:          consoleWriter,
-		SlackWebhookURLSuccess: slackConfig.SuccessURL,
-		SlackWebhookURLError:   slackConfig.ErrorURL,
-		DryRun:                 dryRun,
+		LogLevel:         logLevelValue,
+		LogDir:           logDir,
+		RunID:            runID,
+		ForceInteractive: forceInteractive,
+		ForceQuiet:       forceQuiet,
+		ConsoleWriter:    consoleWriter,
+		DryRun:           dryRun,
 	}); err != nil {
 		return err
 	}
@@ -227,6 +225,15 @@ func run(runID string) error {
 	// Load and prepare configuration (verify, parse, and expand variables)
 	cfg, err := bootstrap.LoadAndPrepareConfig(verificationManager, configPath, runID)
 	if err != nil {
+		return err
+	}
+
+	// Phase 2: Slack ハンドラを追加 (AllowedHost は TOML から取得)
+	if err := bootstrap.SetupSlackLogging(slackConfig, bootstrap.SetupLoggingOptions{
+		SlackAllowedHost: cfg.Global.SlackAllowedHost,
+		RunID:            runID,
+		DryRun:           dryRun,
+	}); err != nil {
 		return err
 	}
 

--- a/docs/tasks/0091_slack_webhook_allowlist/04_implementation_plan.md
+++ b/docs/tasks/0091_slack_webhook_allowlist/04_implementation_plan.md
@@ -23,13 +23,13 @@
     - 正常系テスト: `allowedHost` に適切なホスト名 (例: `hooks.slack.com`) を設定
     - 異常系テスト (HTTPS チェック等): `allowedHost` に任意のホストを設定 (HTTPS チェックが先行するため到達しない)
 
-- [ ] 4. ホスト検証テストの追加 (AC-L2-13〜AC-L2-17)
-  - [ ] AC-L2-13: `allowedHost=""` の場合に `ErrInvalidWebhookURL` が返ることを確認
-  - [ ] AC-L2-14: ホスト不一致 (`evil.example.com` vs `hooks.slack.com`) でエラーになることを確認
-  - [ ] AC-L2-15: ホスト一致 (`hooks.slack.com`) で `nil` が返ることを確認
-  - [ ] AC-L2-16: 大文字ホスト (`HOOKS.SLACK.COM`) が `hooks.slack.com` の許可設定で通過することを確認
-  - [ ] AC-L2-17: ポート番号付き URL (`https://hooks.slack.com:443/...`) が正しく処理されることを確認
-  - [ ] 各テストは `errors.Is(err, ErrInvalidWebhookURL)` で検証する
+- [x] 4. ホスト検証テストの追加 (AC-L2-13〜AC-L2-17)
+  - [x] AC-L2-13: `allowedHost=""` の場合に `ErrInvalidWebhookURL` が返ることを確認
+  - [x] AC-L2-14: ホスト不一致 (`evil.example.com` vs `hooks.slack.com`) でエラーになることを確認
+  - [x] AC-L2-15: ホスト一致 (`hooks.slack.com`) で `nil` が返ることを確認
+  - [x] AC-L2-16: 大文字ホスト (`HOOKS.SLACK.COM`) が `hooks.slack.com` の許可設定で通過することを確認
+  - [x] AC-L2-17: ポート番号付き URL (`https://hooks.slack.com:443/...`) が正しく処理されることを確認
+  - [x] 各テストは `errors.Is(err, ErrInvalidWebhookURL)` で検証する
 
 - [ ] 5. Phase 1 ハンドラ状態の保持機構を追加 (AC-L2-11 の前提)
   - **背景**: 現行の `SetupLoggerWithConfig` はすべてのハンドラをローカル変数で組み立て `slog.SetDefault` まで完結させる。Phase 2 (`AddSlackHandlers`) が Slack ハンドラを追加するには、Phase 1 で作成したコンソール・ファイルハンドラ群と `failureLogger` を後から参照できる必要がある。

--- a/docs/tasks/0091_slack_webhook_allowlist/04_implementation_plan.md
+++ b/docs/tasks/0091_slack_webhook_allowlist/04_implementation_plan.md
@@ -31,12 +31,12 @@
   - [x] AC-L2-17: ポート番号付き URL (`https://hooks.slack.com:443/...`) が正しく処理されることを確認
   - [x] 各テストは `errors.Is(err, ErrInvalidWebhookURL)` で検証する
 
-- [ ] 5. Phase 1 ハンドラ状態の保持機構を追加 (AC-L2-11 の前提)
+- [x] 5. Phase 1 ハンドラ状態の保持機構を追加 (AC-L2-11 の前提)
   - **背景**: 現行の `SetupLoggerWithConfig` はすべてのハンドラをローカル変数で組み立て `slog.SetDefault` まで完結させる。Phase 2 (`AddSlackHandlers`) が Slack ハンドラを追加するには、Phase 1 で作成したコンソール・ファイルハンドラ群と `failureLogger` を後から参照できる必要がある。
-  - [ ] `internal/runner/bootstrap/logger.go` にパッケージレベルの変数を追加する
+  - [x] `internal/runner/bootstrap/logger.go` にパッケージレベルの変数を追加する
     - `phase1BaseHandlers []slog.Handler`: `SetupLoggerWithConfig` の末尾で Slack ハンドラを除いたハンドラ群 (= 既存の `failureHandlers` と同一集合) を保存する。`AddSlackHandlers` のみが読み取り専用で参照する
     - `phase1FailureLogger *slog.Logger`: Phase 1 で作成した `failureLogger` を保存する。`AddSlackHandlers` が `RedactingHandler` 再構築時に継続使用する
-  - [ ] `phase1BaseHandlers` が nil のとき `AddSlackHandlers` を呼び出したらエラーを返すガードを追加する
+  - [x] `phase1BaseHandlers` が nil のとき `AddSlackHandlers` を呼び出したらエラーを返すガードを追加する
 
 - [ ] 6. 段階的ロギング初期化の実装 (AC-L2-10, AC-L2-11, AC-L2-12)
   - [ ] `internal/runner/bootstrap/logger.go` の `SetupLoggerWithConfig` から Slack ハンドラ生成ブロック (現行 :133-164) を**削除**する

--- a/docs/tasks/0091_slack_webhook_allowlist/04_implementation_plan.md
+++ b/docs/tasks/0091_slack_webhook_allowlist/04_implementation_plan.md
@@ -38,38 +38,24 @@
     - `phase1FailureLogger *slog.Logger`: Phase 1 で作成した `failureLogger` を保存する。`AddSlackHandlers` が `RedactingHandler` 再構築時に継続使用する
   - [x] `phase1BaseHandlers` が nil のとき `AddSlackHandlers` を呼び出したらエラーを返すガードを追加する
 
-- [ ] 6. 段階的ロギング初期化の実装 (AC-L2-10, AC-L2-11, AC-L2-12)
-  - [ ] `internal/runner/bootstrap/logger.go` の `SetupLoggerWithConfig` から Slack ハンドラ生成ブロック (現行 :133-164) を**削除**する
-    - `LoggerConfig` から `SlackWebhookURLSuccess/Error` フィールドも**削除**する (`LoggerConfig` は Phase 1 専用とし Slack フィールドを一切持たない)
-  - [ ] `internal/runner/bootstrap/logger.go` に Phase 2 専用の `SlackLoggerConfig` 構造体を新規追加する (AC-L2-4)
-    - フィールド: `WebhookURLSuccess string`、`WebhookURLError string`、`AllowedHost string`、`RunID string`、`DryRun bool`
-  - [ ] `internal/runner/bootstrap/environment.go` の `SetupLoggingOptions` から `SlackWebhookURLSuccess/Error` フィールドを削除し、`SetupLogging` の `LoggerConfig` 生成からも除去する
-    - これにより `SetupLogging` は Phase 1 専用となりコンパイルレベルで Slack URL を受け付けなくなる
-  - [ ] `internal/runner/bootstrap/logger.go` に `AddSlackHandlers(config SlackLoggerConfig) error` を追加する
+- [x] 6. 段階的ロギング初期化の実装 (AC-L2-10, AC-L2-11, AC-L2-12)
+  - [x] `internal/runner/bootstrap/logger.go` の `SetupLoggerWithConfig` から Slack ハンドラ生成ブロックを**削除**する
+    - `LoggerConfig` から `SlackWebhookURLSuccess/Error/AllowedHost` フィールドも**削除**する (`LoggerConfig` は Phase 1 専用)
+  - [x] `internal/runner/bootstrap/logger.go` に `AddSlackHandlers(config SlackLoggerConfig) error` を完全実装する
     - `phase1BaseHandlers` が nil の場合はエラーを返す
-    - `config.WebhookURLSuccess` が設定されている場合: `newSlackHandlerFunc` (後述タスク 7 で追加する factory 変数) で成功ハンドラを生成し、エラーがあれば即座に返す
-    - `config.WebhookURLError` が設定されている場合: 同様に処理
-    - `phase1BaseHandlers` + Slack ハンドラを結合した `allHandlers` で `MultiHandler` を再構築し、Phase 1 で作成済みの `redactionErrorCollector` と `phase1FailureLogger` を使って `RedactingHandler` を再構築し `slog.SetDefault` を更新する
-    - `failureHandlers` は Slack を除外したハンドラ群であり Phase 1 と内容が変わらないため、`phase1BaseHandlers` から再構築せず `phase1FailureLogger` をそのまま継続使用する
-    - `redactionErrorCollector` および `redactionReporter` は Phase 1 で生成済みのものを継続使用し、再初期化しない (Phase 1 中に蓄積されたエラー記録を保持するため)
-  - [ ] `internal/runner/bootstrap/environment.go` に `SetupSlackLogging(slackConfig *SlackWebhookConfig, opts SetupLoggingOptions) error` を追加する
-    - `slackConfig` の両 URL が空の場合は何もせず `nil` を返す
-    - `SlackLoggerConfig{WebhookURLSuccess: slackConfig.SuccessURL, WebhookURLError: slackConfig.ErrorURL, AllowedHost: opts.SlackAllowedHost, RunID: opts.RunID, DryRun: opts.DryRun}` を組み立てて `AddSlackHandlers` を呼ぶ
-    - `AddSlackHandlers` が返したエラーを `PreExecutionError{Type: ErrorTypeConfigParsing}` にラップして返す (AC-L2-10)
+    - `newSlackHandlerFunc` factory 経由でハンドラを生成し `slog.SetDefault` を更新する
+    - `phase1FailureLogger` と `redactionErrorCollector` を継続使用する
+  - [x] `internal/runner/bootstrap/environment.go` の `SetupLoggingOptions` から `SlackWebhookURLSuccess/Error` フィールドを削除する
+  - [x] `internal/runner/bootstrap/environment.go` に `SetupSlackLogging(slackConfig *SlackWebhookConfig, opts SetupLoggingOptions) error` を追加する
 
-- [ ] 7. Slack handler factory の差し替え機構を追加 (AC-L2-19 のテスト前提)
-  - **背景**: 現行の `logger.go:137-158` は `logging.NewSlackHandler` を直接呼び出しており、テストから受け取った `SlackHandlerOptions` を検査できない
-  - [ ] `internal/runner/bootstrap/logger.go` にパッケージレベルの factory 変数を追加する
-    ```go
-    var newSlackHandlerFunc = logging.NewSlackHandler
-    ```
-  - [ ] `AddSlackHandlers` 内の `logging.NewSlackHandler` 直接呼び出しをすべて `newSlackHandlerFunc` 経由に変更する
-  - [ ] テストファイル内で `newSlackHandlerFunc` を差し替えてキャプチャするヘルパーを用意し、テスト終了後に元の値に戻す
+- [x] 7. Slack handler factory の差し替え機構を追加 (AC-L2-19 のテスト前提)
+  - [x] `internal/runner/bootstrap/logger.go` に `newSlackHandlerFunc` factory 変数を追加する
+  - [x] `AddSlackHandlers` 内で `newSlackHandlerFunc` 経由で Slack ハンドラを生成する
 
-- [ ] 8. 起動フローの Phase 1/2 分割 (AC-L2-11, AC-L2-12)
-  - [ ] `cmd/runner/main.go` の `SetupLogging` 呼び出しを確認し、削除済みの `SlackWebhookURLSuccess/Error` フィールドへの代入を除去する (タスク 6 の変更に伴うコンパイルエラー修正)
-  - [ ] `LoadAndPrepareConfig` の直後に `SetupSlackLogging(slackConfig, SetupLoggingOptions{SlackAllowedHost: cfg.Global.SlackAllowedHost, RunID: runID, DryRun: dryRun})` を呼び出す
-  - [ ] `SetupSlackLogging` のエラーを既存の設定エラー処理と同様にハンドルする
+- [x] 8. 起動フローの Phase 1/2 分割 (AC-L2-11, AC-L2-12)
+  - [x] `cmd/runner/main.go` の `SetupLogging` から `SlackWebhookURLSuccess/Error` フィールドを削除する
+  - [x] `LoadAndPrepareConfig` の直後に `SetupSlackLogging` を呼び出す
+  - [x] `SetupSlackLogging` のエラーを既存の設定エラー処理と同様にハンドルする
 
 - [ ] 9. 伝播テストの追加 (AC-L2-19, AC-L2-20)
   - [ ] AC-L2-19: `SlackHandlerOptions.AllowedHost` への伝播確認

--- a/docs/tasks/0091_slack_webhook_allowlist/04_implementation_plan.md
+++ b/docs/tasks/0091_slack_webhook_allowlist/04_implementation_plan.md
@@ -10,16 +10,16 @@
     - 正規化済みの値を `cfg.Global.SlackAllowedHost` に書き戻すことで以降の全層が正規化値を参照する
     - 違反した場合は `ErrorTypeConfigParsing` にラップして返す (詳細仕様 §2.9)
 
-- [ ] 2. Slack ホスト検証ロジックの実装 (AC-L2-2, AC-L2-5〜AC-L2-9)
-  - [ ] `internal/logging/slack_handler.go` の `SlackHandlerOptions` に `AllowedHost string` フィールドを追加
-  - [ ] `validateWebhookURL(webhookURL string)` → `validateWebhookURL(webhookURL, allowedHost string)` にシグネチャ変更
+- [x] 2. Slack ホスト検証ロジックの実装 (AC-L2-2, AC-L2-5〜AC-L2-9)
+  - [x] `internal/logging/slack_handler.go` の `SlackHandlerOptions` に `AllowedHost string` フィールドを追加
+  - [x] `validateWebhookURL(webhookURL string)` → `validateWebhookURL(webhookURL, allowedHost string)` にシグネチャ変更
     - `allowedHost` が空の場合は `ErrInvalidWebhookURL` を返す (AC-L2-7)
     - `strings.ToLower(parsedURL.Hostname()) != strings.ToLower(allowedHost)` の場合は `ErrInvalidWebhookURL` を返す (AC-L2-5, AC-L2-6, AC-L2-8)
     - 既存の HTTPS スキーム・ホスト名存在チェックは維持する (AC-L2-9)
-  - [ ] `NewSlackHandler` 内の `validateWebhookURL` 呼び出しに `opts.AllowedHost` を追加
+  - [x] `NewSlackHandler` 内の `validateWebhookURL` 呼び出しに `opts.AllowedHost` を追加
 
-- [ ] 3. 既存テストの修正 (AC-L2-18)
-  - [ ] `internal/logging/slack_handler_test.go` の既存 `validateWebhookURL` テストに `allowedHost` 引数を追加
+- [x] 3. 既存テストの修正 (AC-L2-18)
+  - [x] `internal/logging/slack_handler_test.go` の既存 `validateWebhookURL` テストに `allowedHost` 引数を追加
     - 正常系テスト: `allowedHost` に適切なホスト名 (例: `hooks.slack.com`) を設定
     - 異常系テスト (HTTPS チェック等): `allowedHost` に任意のホストを設定 (HTTPS チェックが先行するため到達しない)
 

--- a/docs/tasks/0091_slack_webhook_allowlist/04_implementation_plan.md
+++ b/docs/tasks/0091_slack_webhook_allowlist/04_implementation_plan.md
@@ -1,10 +1,10 @@
 # 実装計画: Slack webhook URL ホスト allowlist
 
-- [ ] 1. TOML・設定構造体の拡張 (AC-L2-1, AC-L2-3, AC-L2-4)
-  - [ ] `internal/runner/runnertypes/spec.go` の `GlobalSpec` に `SlackAllowedHost string` フィールドを追加 (AC-L2-1)
-  - [ ] `internal/runner/bootstrap/environment.go` の `SetupLoggingOptions` に `SlackAllowedHost string` フィールドを追加 (AC-L2-3)
-  - [ ] `internal/runner/bootstrap/logger.go` に Phase 2 専用の `SlackLoggerConfig` 構造体を新規追加し `AllowedHost string` フィールドを持たせる (AC-L2-4、タスク 6 でも再掲)
-  - [ ] `internal/runner/bootstrap/config.go` の `LoadAndPrepareConfig` に `normalizeSlackAllowedHost` 呼び出しを追加する
+- [x] 1. TOML・設定構造体の拡張 (AC-L2-1, AC-L2-3, AC-L2-4)
+  - [x] `internal/runner/runnertypes/spec.go` の `GlobalSpec` に `SlackAllowedHost string` フィールドを追加 (AC-L2-1)
+  - [x] `internal/runner/bootstrap/environment.go` の `SetupLoggingOptions` に `SlackAllowedHost string` フィールドを追加 (AC-L2-3)
+  - [x] `internal/runner/bootstrap/logger.go` に Phase 2 専用の `SlackLoggerConfig` 構造体を新規追加し `AllowedHost string` フィールドを持たせる (AC-L2-4、タスク 6 でも再掲)
+  - [x] `internal/runner/bootstrap/config.go` の `LoadAndPrepareConfig` に `normalizeSlackAllowedHost` 呼び出しを追加する
     - 検証と正規化を兼ねる: `url.Parse("https://" + host + "/")` でパースし、`u.Hostname()` が空でなく `u.Port()` が空であることを確認する
     - IPv6 ブラケット記法 (`[::1]`) は `u.Hostname()` が `::1` を返すことで自動的に正規化される
     - 正規化済みの値を `cfg.Global.SlackAllowedHost` に書き戻すことで以降の全層が正規化値を参照する

--- a/docs/tasks/0091_slack_webhook_allowlist/04_implementation_plan.md
+++ b/docs/tasks/0091_slack_webhook_allowlist/04_implementation_plan.md
@@ -57,9 +57,9 @@
   - [x] `LoadAndPrepareConfig` の直後に `SetupSlackLogging` を呼び出す
   - [x] `SetupSlackLogging` のエラーを既存の設定エラー処理と同様にハンドルする
 
-- [ ] 9. 伝播テストの追加 (AC-L2-19, AC-L2-20)
-  - [ ] AC-L2-19: `SlackHandlerOptions.AllowedHost` への伝播確認
+- [x] 9. 伝播テストの追加 (AC-L2-19, AC-L2-20)
+  - [x] AC-L2-19: `SlackHandlerOptions.AllowedHost` への伝播確認
     - タスク 7 で追加した `newSlackHandlerFunc` をテスト内で差し替え、受け取った `SlackHandlerOptions.AllowedHost` が期待値と一致することを確認する
-  - [ ] AC-L2-20: 起動フロー統合テスト
+  - [x] AC-L2-20: 起動フロー統合テスト
     - 前提: `slackConfig.ErrorURL` = 有効 HTTPS URL、`SetupLoggingOptions.SlackAllowedHost` = `""` (未設定)
     - `SetupSlackLogging` が返すエラーを `errors.As(err, &preExecErr)` で検査し `preExecErr.Type == ErrorTypeConfigParsing` であることを確認する

--- a/internal/logging/slack_handler.go
+++ b/internal/logging/slack_handler.go
@@ -128,8 +128,8 @@ type SlackHandlerOptions struct {
 	IsDryRun      bool                  // If true, suppresses actual Slack notifications (used for dry-run mode)
 	LevelMode     SlackHandlerLevelMode // Level filtering mode (optional, defaults to LevelModeDefault)
 
-	// AllowedHost は webhook URL のホスト名を検証する許可ホスト。
-	// 空文字列の場合、すべての URL がエラーを返す。
+	// AllowedHost is the permitted hostname used to validate the webhook URL.
+	// An empty string causes all URLs to be rejected.
 	AllowedHost string
 }
 

--- a/internal/logging/slack_handler.go
+++ b/internal/logging/slack_handler.go
@@ -127,10 +127,15 @@ type SlackHandlerOptions struct {
 	BackoffConfig BackoffConfig         // Retry backoff configuration (optional, defaults to DefaultBackoffConfig)
 	IsDryRun      bool                  // If true, suppresses actual Slack notifications (used for dry-run mode)
 	LevelMode     SlackHandlerLevelMode // Level filtering mode (optional, defaults to LevelModeDefault)
+
+	// AllowedHost は webhook URL のホスト名を検証する許可ホスト。
+	// 空文字列の場合、すべての URL がエラーを返す。
+	AllowedHost string
 }
 
-// validateWebhookURL validates that the webhook URL is a valid HTTPS URL
-func validateWebhookURL(webhookURL string) error {
+// validateWebhookURL validates that the webhook URL is a valid HTTPS URL with allowed host.
+// allowedHost must be a pure hostname without port (pre-validated by normalizeSlackAllowedHost).
+func validateWebhookURL(webhookURL string, allowedHost string) error {
 	if webhookURL == "" {
 		return fmt.Errorf("%w: empty URL", ErrInvalidWebhookURL)
 	}
@@ -148,13 +153,23 @@ func validateWebhookURL(webhookURL string) error {
 		return fmt.Errorf("%w: URL must have a host", ErrInvalidWebhookURL)
 	}
 
+	if allowedHost == "" {
+		return fmt.Errorf("%w: allowed host is not configured", ErrInvalidWebhookURL)
+	}
+
+	hostname := strings.ToLower(parsedURL.Hostname())
+	normalizedAllowedHost := strings.ToLower(allowedHost)
+	if hostname != normalizedAllowedHost {
+		return fmt.Errorf("%w: host not allowed: %s (allowed: %s)", ErrInvalidWebhookURL, hostname, normalizedAllowedHost)
+	}
+
 	return nil
 }
 
 // NewSlackHandler creates a new SlackHandler with the provided options
 // This is the preferred way to create a SlackHandler as it allows for easy addition of new configuration options
 func NewSlackHandler(opts SlackHandlerOptions) (*SlackHandler, error) {
-	if err := validateWebhookURL(opts.WebhookURL); err != nil {
+	if err := validateWebhookURL(opts.WebhookURL, opts.AllowedHost); err != nil {
 		return nil, fmt.Errorf("invalid webhook URL: %w", err)
 	}
 

--- a/internal/logging/slack_handler_test.go
+++ b/internal/logging/slack_handler_test.go
@@ -216,71 +216,82 @@ func TestValidateWebhookURL(t *testing.T) {
 	tests := []struct {
 		name        string
 		url         string
+		allowedHost string
 		expectError bool
 		errorType   error
 	}{
 		{
 			name:        "valid HTTPS URL",
 			url:         "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX",
+			allowedHost: "hooks.slack.com",
 			expectError: false,
 		},
 		{
 			name:        "empty URL",
 			url:         "",
+			allowedHost: "hooks.slack.com",
 			expectError: true,
 			errorType:   ErrInvalidWebhookURL,
 		},
 		{
 			name:        "HTTP URL (should be rejected)",
 			url:         "http://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX",
+			allowedHost: "hooks.slack.com",
 			expectError: true,
 			errorType:   ErrInvalidWebhookURL,
 		},
 		{
 			name:        "URL without scheme",
 			url:         "hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX",
+			allowedHost: "hooks.slack.com",
 			expectError: true,
 			errorType:   ErrInvalidWebhookURL,
 		},
 		{
 			name:        "URL without host",
 			url:         "https:///services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX",
+			allowedHost: "hooks.slack.com",
 			expectError: true,
 			errorType:   ErrInvalidWebhookURL,
 		},
 		{
 			name:        "malformed URL with invalid characters",
 			url:         "https://hooks.slack.com/services/T00000000/B00000000/XXXX\x00XX",
+			allowedHost: "hooks.slack.com",
 			expectError: true,
 			errorType:   ErrInvalidWebhookURL,
 		},
 		{
 			name:        "URL with only protocol",
 			url:         "https://",
+			allowedHost: "hooks.slack.com",
 			expectError: true,
 			errorType:   ErrInvalidWebhookURL,
 		},
 		{
 			name:        "FTP protocol (should be rejected)",
 			url:         "ftp://example.com/webhook",
+			allowedHost: "hooks.slack.com",
 			expectError: true,
 			errorType:   ErrInvalidWebhookURL,
 		},
 		{
 			name:        "localhost HTTPS URL (valid for testing)",
 			url:         "https://localhost:8080/webhook",
+			allowedHost: "localhost",
 			expectError: false,
 		},
 		{
 			name:        "URL with special characters in path (valid)",
 			url:         "https://hooks.slack.com/services/T00000000/B00000000/XXXX%20XX",
+			allowedHost: "hooks.slack.com",
 			expectError: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateWebhookURL(tt.url)
+			err := validateWebhookURL(tt.url, tt.allowedHost)
 
 			if tt.expectError {
 				require.Error(t, err, "Expected error for URL: %s", tt.url)
@@ -304,8 +315,9 @@ func TestNewSlackHandlerWithOptions(t *testing.T) {
 		{
 			name: "minimal options with defaults",
 			opts: SlackHandlerOptions{
-				WebhookURL: "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX",
-				RunID:      "test-run-123",
+				WebhookURL:  "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX",
+				RunID:       "test-run-123",
+				AllowedHost: "hooks.slack.com",
 			},
 			expectError: false,
 			validate: func(t *testing.T, handler *SlackHandler) {
@@ -318,9 +330,10 @@ func TestNewSlackHandlerWithOptions(t *testing.T) {
 		{
 			name: "all options specified",
 			opts: SlackHandlerOptions{
-				WebhookURL: "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX",
-				RunID:      "test-run-456",
-				HTTPClient: &http.Client{Timeout: 10 * time.Second},
+				WebhookURL:  "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX",
+				RunID:       "test-run-456",
+				AllowedHost: "hooks.slack.com",
+				HTTPClient:  &http.Client{Timeout: 10 * time.Second},
 				BackoffConfig: BackoffConfig{
 					Base:       3 * time.Second,
 					RetryCount: 5,
@@ -338,9 +351,10 @@ func TestNewSlackHandlerWithOptions(t *testing.T) {
 		{
 			name: "with LevelModeExactInfo",
 			opts: SlackHandlerOptions{
-				WebhookURL: "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX",
-				RunID:      "test-run-exact-info",
-				LevelMode:  LevelModeExactInfo,
+				WebhookURL:  "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX",
+				RunID:       "test-run-exact-info",
+				AllowedHost: "hooks.slack.com",
+				LevelMode:   LevelModeExactInfo,
 			},
 			expectError: false,
 			validate: func(t *testing.T, handler *SlackHandler) {
@@ -350,9 +364,10 @@ func TestNewSlackHandlerWithOptions(t *testing.T) {
 		{
 			name: "with LevelModeWarnAndAbove",
 			opts: SlackHandlerOptions{
-				WebhookURL: "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX",
-				RunID:      "test-run-warn-above",
-				LevelMode:  LevelModeWarnAndAbove,
+				WebhookURL:  "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX",
+				RunID:       "test-run-warn-above",
+				AllowedHost: "hooks.slack.com",
+				LevelMode:   LevelModeWarnAndAbove,
 			},
 			expectError: false,
 			validate: func(t *testing.T, handler *SlackHandler) {

--- a/internal/logging/slack_handler_test.go
+++ b/internal/logging/slack_handler_test.go
@@ -305,7 +305,7 @@ func TestValidateWebhookURL(t *testing.T) {
 	}
 }
 
-// TestValidateWebhookURL_AllowedHostChecks tests allowedHost validation (AC-L2-13〜AC-L2-17)
+// TestValidateWebhookURL_AllowedHostChecks tests allowedHost validation (AC-L2-13 to AC-L2-17)
 func TestValidateWebhookURL_AllowedHostChecks(t *testing.T) {
 	const validURL = "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
 
@@ -316,35 +316,35 @@ func TestValidateWebhookURL_AllowedHostChecks(t *testing.T) {
 		expectError bool
 	}{
 		{
-			// AC-L2-13: allowedHost が空の場合は ErrInvalidWebhookURL
+			// AC-L2-13: empty allowedHost returns ErrInvalidWebhookURL
 			name:        "empty allowedHost",
 			url:         validURL,
 			allowedHost: "",
 			expectError: true,
 		},
 		{
-			// AC-L2-14: ホスト不一致でエラー
+			// AC-L2-14: host mismatch returns an error
 			name:        "host mismatch",
 			url:         "https://evil.example.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX",
 			allowedHost: "hooks.slack.com",
 			expectError: true,
 		},
 		{
-			// AC-L2-15: ホスト一致で nil
+			// AC-L2-15: matching host returns nil
 			name:        "host match",
 			url:         validURL,
 			allowedHost: "hooks.slack.com",
 			expectError: false,
 		},
 		{
-			// AC-L2-16: URL の大文字ホストが allowedHost (小文字) で通過する
+			// AC-L2-16: uppercase host in URL passes with lowercase allowedHost
 			name:        "uppercase host in URL matches lowercase allowedHost",
 			url:         "https://HOOKS.SLACK.COM/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX",
 			allowedHost: "hooks.slack.com",
 			expectError: false,
 		},
 		{
-			// AC-L2-17: ポート番号付き URL が正しく処理される (Hostname() がポートを除去)
+			// AC-L2-17: URL with port is handled correctly (Hostname() strips the port)
 			name:        "URL with port number",
 			url:         "https://hooks.slack.com:443/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX",
 			allowedHost: "hooks.slack.com",

--- a/internal/logging/slack_handler_test.go
+++ b/internal/logging/slack_handler_test.go
@@ -305,6 +305,66 @@ func TestValidateWebhookURL(t *testing.T) {
 	}
 }
 
+// TestValidateWebhookURL_AllowedHostChecks tests allowedHost validation (AC-L2-13〜AC-L2-17)
+func TestValidateWebhookURL_AllowedHostChecks(t *testing.T) {
+	const validURL = "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
+
+	tests := []struct {
+		name        string
+		url         string
+		allowedHost string
+		expectError bool
+	}{
+		{
+			// AC-L2-13: allowedHost が空の場合は ErrInvalidWebhookURL
+			name:        "empty allowedHost",
+			url:         validURL,
+			allowedHost: "",
+			expectError: true,
+		},
+		{
+			// AC-L2-14: ホスト不一致でエラー
+			name:        "host mismatch",
+			url:         "https://evil.example.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX",
+			allowedHost: "hooks.slack.com",
+			expectError: true,
+		},
+		{
+			// AC-L2-15: ホスト一致で nil
+			name:        "host match",
+			url:         validURL,
+			allowedHost: "hooks.slack.com",
+			expectError: false,
+		},
+		{
+			// AC-L2-16: URL の大文字ホストが allowedHost (小文字) で通過する
+			name:        "uppercase host in URL matches lowercase allowedHost",
+			url:         "https://HOOKS.SLACK.COM/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX",
+			allowedHost: "hooks.slack.com",
+			expectError: false,
+		},
+		{
+			// AC-L2-17: ポート番号付き URL が正しく処理される (Hostname() がポートを除去)
+			name:        "URL with port number",
+			url:         "https://hooks.slack.com:443/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX",
+			allowedHost: "hooks.slack.com",
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateWebhookURL(tt.url, tt.allowedHost)
+			if tt.expectError {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, ErrInvalidWebhookURL)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestNewSlackHandlerWithOptions(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/internal/runner/bootstrap/config.go
+++ b/internal/runner/bootstrap/config.go
@@ -25,7 +25,9 @@ func normalizeSlackAllowedHost(host string) (string, error) {
 		return "", nil
 	}
 	u, err := url.Parse("https://" + host + "/")
-	if err != nil || u.Hostname() == "" || u.Port() != "" {
+	// u.Path is always "/" for a valid bare hostname since we append "/" in the URL.
+	// A non-"/" path means the input contained a path or scheme component (e.g. "host/path" or "https://host").
+	if err != nil || u.Hostname() == "" || u.Port() != "" || u.Path != "/" {
 		return "", fmt.Errorf("%w (got %q)", ErrInvalidSlackAllowedHost, host)
 	}
 	return u.Hostname(), nil

--- a/internal/runner/bootstrap/config.go
+++ b/internal/runner/bootstrap/config.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"regexp"
+	"strings"
 
 	"github.com/isseis/go-safe-cmd-runner/internal/common"
 	"github.com/isseis/go-safe-cmd-runner/internal/logging"
@@ -17,20 +19,34 @@ import (
 // ErrInvalidSlackAllowedHost is a sentinel error returned when the slack_allowed_host value is invalid.
 var ErrInvalidSlackAllowedHost = errors.New("slack_allowed_host must be a valid hostname without port or whitespace")
 
+// rfc1123LabelRE matches a single DNS label per RFC 1123 §2.1:
+// starts and ends with a letter or digit; interior may contain hyphens.
+var rfc1123LabelRE = regexp.MustCompile(`^[A-Za-z0-9]([A-Za-z0-9\-]*[A-Za-z0-9])?$`)
+
 // normalizeSlackAllowedHost converts host to a normalized allowed hostname.
 // Returns ("", nil) when host is empty (Slack disabled).
-// Returns an error for invalid values such as port numbers, schemes, paths, or whitespace.
+// Accepts RFC 1123 hostnames (dot-separated labels) and IPv6 literals in brackets.
+// Returns an error for any other value (port, scheme, path, query, fragment, whitespace, etc.).
 func normalizeSlackAllowedHost(host string) (string, error) {
 	if host == "" {
 		return "", nil
 	}
-	u, err := url.Parse("https://" + host + "/")
-	// u.Path is always "/" for a valid bare hostname since we append "/" in the URL.
-	// A non-"/" path means the input contained a path or scheme component (e.g. "host/path" or "https://host").
-	if err != nil || u.Hostname() == "" || u.User != nil || u.Port() != "" || u.Path != "/" {
-		return "", fmt.Errorf("%w (got %q)", ErrInvalidSlackAllowedHost, host)
+	// IPv6 literal: "[<addr>]" — delegate bracket-stripping to url.Parse.
+	if strings.HasPrefix(host, "[") {
+		u, err := url.Parse("https://" + host + "/")
+		if err != nil || u.Hostname() == "" || u.Port() != "" {
+			return "", fmt.Errorf("%w (got %q)", ErrInvalidSlackAllowedHost, host)
+		}
+		return u.Hostname(), nil // bare address e.g. "::1"
 	}
-	return u.Hostname(), nil
+
+	// Plain hostname: validate each dot-separated label against RFC 1123.
+	for label := range strings.SplitSeq(host, ".") {
+		if !rfc1123LabelRE.MatchString(label) {
+			return "", fmt.Errorf("%w (got %q)", ErrInvalidSlackAllowedHost, host)
+		}
+	}
+	return strings.ToLower(host), nil
 }
 
 // LoadAndPrepareConfig loads and verifies a configuration file.

--- a/internal/runner/bootstrap/config.go
+++ b/internal/runner/bootstrap/config.go
@@ -14,12 +14,12 @@ import (
 	"github.com/isseis/go-safe-cmd-runner/internal/verification"
 )
 
-// ErrInvalidSlackAllowedHost は slack_allowed_host の値が不正な場合に返される静的エラー。
+// ErrInvalidSlackAllowedHost is a sentinel error returned when the slack_allowed_host value is invalid.
 var ErrInvalidSlackAllowedHost = errors.New("slack_allowed_host must be a valid hostname without port or whitespace")
 
-// normalizeSlackAllowedHost は host を正規化された許可ホスト名に変換する。
-// host が空文字列の場合は ("", nil) を返す (Slack 無効)。
-// ポート番号・スキーム・パス・空白など不正な値は error を返す。
+// normalizeSlackAllowedHost converts host to a normalized allowed hostname.
+// Returns ("", nil) when host is empty (Slack disabled).
+// Returns an error for invalid values such as port numbers, schemes, paths, or whitespace.
 func normalizeSlackAllowedHost(host string) (string, error) {
 	if host == "" {
 		return "", nil

--- a/internal/runner/bootstrap/config.go
+++ b/internal/runner/bootstrap/config.go
@@ -27,7 +27,7 @@ func normalizeSlackAllowedHost(host string) (string, error) {
 	u, err := url.Parse("https://" + host + "/")
 	// u.Path is always "/" for a valid bare hostname since we append "/" in the URL.
 	// A non-"/" path means the input contained a path or scheme component (e.g. "host/path" or "https://host").
-	if err != nil || u.Hostname() == "" || u.Port() != "" || u.Path != "/" {
+	if err != nil || u.Hostname() == "" || u.User != nil || u.Port() != "" || u.Path != "/" {
 		return "", fmt.Errorf("%w (got %q)", ErrInvalidSlackAllowedHost, host)
 	}
 	return u.Hostname(), nil

--- a/internal/runner/bootstrap/config.go
+++ b/internal/runner/bootstrap/config.go
@@ -2,6 +2,10 @@
 package bootstrap
 
 import (
+	"errors"
+	"fmt"
+	"net/url"
+
 	"github.com/isseis/go-safe-cmd-runner/internal/common"
 	"github.com/isseis/go-safe-cmd-runner/internal/logging"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/config"
@@ -9,6 +13,23 @@ import (
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/runnertypes"
 	"github.com/isseis/go-safe-cmd-runner/internal/verification"
 )
+
+// ErrInvalidSlackAllowedHost は slack_allowed_host の値が不正な場合に返される静的エラー。
+var ErrInvalidSlackAllowedHost = errors.New("slack_allowed_host must be a valid hostname without port or whitespace")
+
+// normalizeSlackAllowedHost は host を正規化された許可ホスト名に変換する。
+// host が空文字列の場合は ("", nil) を返す (Slack 無効)。
+// ポート番号・スキーム・パス・空白など不正な値は error を返す。
+func normalizeSlackAllowedHost(host string) (string, error) {
+	if host == "" {
+		return "", nil
+	}
+	u, err := url.Parse("https://" + host + "/")
+	if err != nil || u.Hostname() == "" || u.Port() != "" {
+		return "", fmt.Errorf("%w (got %q)", ErrInvalidSlackAllowedHost, host)
+	}
+	return u.Hostname(), nil
+}
 
 // LoadAndPrepareConfig loads and verifies a configuration file.
 //
@@ -71,6 +92,17 @@ func LoadAndPrepareConfig(verificationManager *verification.Manager, configPath,
 			RunID:     runID,
 		}
 	}
+
+	normalizedHost, err := normalizeSlackAllowedHost(cfg.Global.SlackAllowedHost)
+	if err != nil {
+		return nil, &logging.PreExecutionError{
+			Type:      logging.ErrorTypeConfigParsing,
+			Message:   err.Error(),
+			Component: string(resource.ComponentConfig),
+			RunID:     runID,
+		}
+	}
+	cfg.Global.SlackAllowedHost = normalizedHost
 
 	return cfg, nil
 }

--- a/internal/runner/bootstrap/config.go
+++ b/internal/runner/bootstrap/config.go
@@ -19,14 +19,17 @@ import (
 // ErrInvalidSlackAllowedHost is a sentinel error returned when the slack_allowed_host value is invalid.
 var ErrInvalidSlackAllowedHost = errors.New("slack_allowed_host must be a valid hostname or IP address without port or whitespace")
 
-// rfc1123LabelRE matches a single DNS label per RFC 1123 §2.1:
+// rfc1123LabelRE matches the RFC 1123 §2.1 character pattern for a single DNS label:
 // starts and ends with a letter or digit; interior may contain hyphens.
+// Note: the 63-character per-label and 253-character total-hostname length limits
+// defined by RFC 1123 are not enforced here.
 var rfc1123LabelRE = regexp.MustCompile(`^[A-Za-z0-9]([A-Za-z0-9\-]*[A-Za-z0-9])?$`)
 
 // normalizeSlackAllowedHost converts host to a normalized allowed host value.
 // Returns ("", nil) when host is empty (Slack disabled).
-// Accepts RFC 1123 hostnames (dot-separated labels), IPv4 literals (e.g. "192.0.2.1"),
-// and IPv6 literals in brackets (e.g. "[::1]").
+// Accepts hostnames and IPv4 literals whose dot-separated labels match the RFC 1123
+// character pattern, and IPv6 literals in brackets (e.g. "[::1]").
+// Length limits (63 chars per label, 253 chars total) are not enforced.
 // Returns an error for any other value (port, scheme, path, query, fragment, whitespace, etc.).
 func normalizeSlackAllowedHost(host string) (string, error) {
 	if host == "" {
@@ -41,7 +44,7 @@ func normalizeSlackAllowedHost(host string) (string, error) {
 		return u.Hostname(), nil // bare address e.g. "::1"
 	}
 
-	// Plain hostname or IPv4 literal: validate each dot-separated label against RFC 1123.
+	// Plain hostname or IPv4 literal: validate the character pattern of each dot-separated label.
 	// IPv4 addresses (e.g. "192.0.2.1") pass because each octet matches the label regex.
 	for label := range strings.SplitSeq(host, ".") {
 		if !rfc1123LabelRE.MatchString(label) {

--- a/internal/runner/bootstrap/config.go
+++ b/internal/runner/bootstrap/config.go
@@ -17,15 +17,16 @@ import (
 )
 
 // ErrInvalidSlackAllowedHost is a sentinel error returned when the slack_allowed_host value is invalid.
-var ErrInvalidSlackAllowedHost = errors.New("slack_allowed_host must be a valid hostname without port or whitespace")
+var ErrInvalidSlackAllowedHost = errors.New("slack_allowed_host must be a valid hostname or IP address without port or whitespace")
 
 // rfc1123LabelRE matches a single DNS label per RFC 1123 §2.1:
 // starts and ends with a letter or digit; interior may contain hyphens.
 var rfc1123LabelRE = regexp.MustCompile(`^[A-Za-z0-9]([A-Za-z0-9\-]*[A-Za-z0-9])?$`)
 
-// normalizeSlackAllowedHost converts host to a normalized allowed hostname.
+// normalizeSlackAllowedHost converts host to a normalized allowed host value.
 // Returns ("", nil) when host is empty (Slack disabled).
-// Accepts RFC 1123 hostnames (dot-separated labels) and IPv6 literals in brackets.
+// Accepts RFC 1123 hostnames (dot-separated labels), IPv4 literals (e.g. "192.0.2.1"),
+// and IPv6 literals in brackets (e.g. "[::1]").
 // Returns an error for any other value (port, scheme, path, query, fragment, whitespace, etc.).
 func normalizeSlackAllowedHost(host string) (string, error) {
 	if host == "" {
@@ -40,7 +41,8 @@ func normalizeSlackAllowedHost(host string) (string, error) {
 		return u.Hostname(), nil // bare address e.g. "::1"
 	}
 
-	// Plain hostname: validate each dot-separated label against RFC 1123.
+	// Plain hostname or IPv4 literal: validate each dot-separated label against RFC 1123.
+	// IPv4 addresses (e.g. "192.0.2.1") pass because each octet matches the label regex.
 	for label := range strings.SplitSeq(host, ".") {
 		if !rfc1123LabelRE.MatchString(label) {
 			return "", fmt.Errorf("%w (got %q)", ErrInvalidSlackAllowedHost, host)

--- a/internal/runner/bootstrap/config_test.go
+++ b/internal/runner/bootstrap/config_test.go
@@ -66,6 +66,16 @@ func TestNormalizeSlackAllowedHost(t *testing.T) {
 			input:   "hooks.slack.com ",
 			wantErr: true,
 		},
+		{
+			name:    "userinfo prefix rejected",
+			input:   "user@hooks.slack.com",
+			wantErr: true,
+		},
+		{
+			name:    "userinfo used as host spoofing rejected",
+			input:   "hooks.slack.com@evil.com",
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/runner/bootstrap/config_test.go
+++ b/internal/runner/bootstrap/config_test.go
@@ -15,6 +15,63 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestNormalizeSlackAllowedHost tests normalizeSlackAllowedHost input validation and normalization.
+func TestNormalizeSlackAllowedHost(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantHost string
+		wantErr  bool
+	}{
+		{
+			name:     "empty string disables Slack",
+			input:    "",
+			wantHost: "",
+			wantErr:  false,
+		},
+		{
+			name:     "valid plain hostname",
+			input:    "hooks.slack.com",
+			wantHost: "hooks.slack.com",
+			wantErr:  false,
+		},
+		{
+			name:     "IPv6 bracket notation normalized",
+			input:    "[::1]",
+			wantHost: "::1",
+			wantErr:  false,
+		},
+		{
+			name:    "port number rejected",
+			input:   "hooks.slack.com:443",
+			wantErr: true,
+		},
+		{
+			name:    "path component rejected",
+			input:   "hooks.slack.com/path",
+			wantErr: true,
+		},
+		{
+			name:    "scheme-included value rejected",
+			input:   "https://hooks.slack.com",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := normalizeSlackAllowedHost(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, ErrInvalidSlackAllowedHost)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantHost, got)
+			}
+		})
+	}
+}
+
 // TestBootstrapCommandEnvExpansionIntegration verifies the complete expansion pipeline
 // from Global.EnvVars -> Group.EnvVars -> Command.EnvVars/Cmd/Args during bootstrap process.
 // This test ensures that:

--- a/internal/runner/bootstrap/config_test.go
+++ b/internal/runner/bootstrap/config_test.go
@@ -102,6 +102,12 @@ func TestNormalizeSlackAllowedHost(t *testing.T) {
 			wantHost: "hooks.slack.com",
 			wantErr:  false,
 		},
+		{
+			name:     "IPv4 literal accepted",
+			input:    "192.0.2.1",
+			wantHost: "192.0.2.1",
+			wantErr:  false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/runner/bootstrap/config_test.go
+++ b/internal/runner/bootstrap/config_test.go
@@ -56,6 +56,16 @@ func TestNormalizeSlackAllowedHost(t *testing.T) {
 			input:   "https://hooks.slack.com",
 			wantErr: true,
 		},
+		{
+			name:    "leading whitespace rejected",
+			input:   " hooks.slack.com",
+			wantErr: true,
+		},
+		{
+			name:    "trailing whitespace rejected",
+			input:   "hooks.slack.com ",
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/runner/bootstrap/config_test.go
+++ b/internal/runner/bootstrap/config_test.go
@@ -76,6 +76,32 @@ func TestNormalizeSlackAllowedHost(t *testing.T) {
 			input:   "hooks.slack.com@evil.com",
 			wantErr: true,
 		},
+		{
+			name:    "query string after path separator rejected",
+			input:   "hooks.slack.com/?q=1",
+			wantErr: true,
+		},
+		{
+			name:    "fragment after path separator rejected",
+			input:   "hooks.slack.com/#frag",
+			wantErr: true,
+		},
+		{
+			name:    "label with leading hyphen rejected",
+			input:   "-hooks.slack.com",
+			wantErr: true,
+		},
+		{
+			name:    "label with trailing hyphen rejected",
+			input:   "hooks-.slack.com",
+			wantErr: true,
+		},
+		{
+			name:     "uppercase hostname normalized to lowercase",
+			input:    "Hooks.Slack.Com",
+			wantHost: "hooks.slack.com",
+			wantErr:  false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/runner/bootstrap/environment.go
+++ b/internal/runner/bootstrap/environment.go
@@ -75,8 +75,8 @@ type SetupLoggingOptions struct {
 	ConsoleWriter    io.Writer // If nil, defaults to stdout for backward compatibility
 	DryRun           bool      // If true, Slack notifications are not sent
 
-	// SlackAllowedHost は TOML から読んだ許可ホスト名。
-	// SetupSlackLogging が SlackLoggerConfig.AllowedHost に転送する。
+	// SlackAllowedHost is the permitted hostname read from TOML.
+	// SetupSlackLogging forwards it to SlackLoggerConfig.AllowedHost.
 	SlackAllowedHost string
 }
 
@@ -102,8 +102,8 @@ func SetupLogging(opts SetupLoggingOptions) error {
 	return nil
 }
 
-// SetupSlackLogging は TOML 設定読み込み後に呼び出し、Slack ハンドラを追加する。
-// ホスト検証に失敗した場合は ErrorTypeConfigParsing エラーを返す (AC-L2-10)。
+// SetupSlackLogging is called after TOML config is loaded and adds Slack handlers.
+// Returns an ErrorTypeConfigParsing error if host validation fails (AC-L2-10).
 func SetupSlackLogging(slackConfig *SlackWebhookConfig, opts SetupLoggingOptions) error {
 	if slackConfig.SuccessURL == "" && slackConfig.ErrorURL == "" {
 		return nil

--- a/internal/runner/bootstrap/environment.go
+++ b/internal/runner/bootstrap/environment.go
@@ -90,6 +90,7 @@ func SetupLogging(opts SetupLoggingOptions) error {
 		RunID:                  opts.RunID,
 		SlackWebhookURLSuccess: opts.SlackWebhookURLSuccess,
 		SlackWebhookURLError:   opts.SlackWebhookURLError,
+		SlackAllowedHost:       opts.SlackAllowedHost,
 		ConsoleWriter:          opts.ConsoleWriter,
 		DryRun:                 opts.DryRun,
 	}

--- a/internal/runner/bootstrap/environment.go
+++ b/internal/runner/bootstrap/environment.go
@@ -121,11 +121,15 @@ func SetupSlackLogging(slackConfig *SlackWebhookConfig, opts SetupLoggingOptions
 	}
 
 	if err := AddSlackHandlers(slackLoggerConfig); err != nil {
+		// Use a constant Message and store the raw error in Err rather than formatting it
+		// into Message, because url.Parse errors embed the webhook URL verbatim and Message
+		// is written to stderr/slog by HandlePreExecutionError.
 		return &logging.PreExecutionError{
 			Type:      logging.ErrorTypeConfigParsing,
-			Message:   fmt.Sprintf("Slack webhook URL validation failed: %v", err),
+			Message:   "Slack webhook URL validation failed",
 			Component: string(resource.ComponentLogging),
 			RunID:     opts.RunID,
+			Err:       err,
 		}
 	}
 

--- a/internal/runner/bootstrap/environment.go
+++ b/internal/runner/bootstrap/environment.go
@@ -88,7 +88,6 @@ func SetupLogging(opts SetupLoggingOptions) error {
 		LogDir:        opts.LogDir,
 		RunID:         opts.RunID,
 		ConsoleWriter: opts.ConsoleWriter,
-		DryRun:        opts.DryRun,
 	}
 
 	if err := SetupLoggerWithConfig(loggerConfig, opts.ForceInteractive, opts.ForceQuiet); err != nil {

--- a/internal/runner/bootstrap/environment.go
+++ b/internal/runner/bootstrap/environment.go
@@ -75,6 +75,10 @@ type SetupLoggingOptions struct {
 	SlackWebhookURLSuccess string    // Slack webhook URL for success (INFO) notifications. Empty string disables.
 	SlackWebhookURLError   string    // Slack webhook URL for error (WARN/ERROR) notifications. Empty string disables.
 	DryRun                 bool      // If true, Slack notifications are not sent
+
+	// SlackAllowedHost は TOML から読んだ許可ホスト名。
+	// SetupSlackLogging が SlackLoggerConfig.AllowedHost に転送する。
+	SlackAllowedHost string
 }
 
 // SetupLogging sets up logging system without environment file handling

--- a/internal/runner/bootstrap/environment.go
+++ b/internal/runner/bootstrap/environment.go
@@ -105,6 +105,9 @@ func SetupLogging(opts SetupLoggingOptions) error {
 // SetupSlackLogging is called after TOML config is loaded and adds Slack handlers.
 // Returns an ErrorTypeConfigParsing error if host validation fails (AC-L2-10).
 func SetupSlackLogging(slackConfig *SlackWebhookConfig, opts SetupLoggingOptions) error {
+	if slackConfig == nil {
+		return nil
+	}
 	if slackConfig.SuccessURL == "" && slackConfig.ErrorURL == "" {
 		return nil
 	}

--- a/internal/runner/bootstrap/environment.go
+++ b/internal/runner/bootstrap/environment.go
@@ -64,41 +64,64 @@ func ValidateSlackWebhookEnv() (*SlackWebhookConfig, error) {
 	}, nil
 }
 
-// SetupLoggingOptions holds configuration for SetupLogging
+// SetupLoggingOptions holds configuration for SetupLogging (Phase 1: console and file handlers).
+// Slack handlers are configured separately via SetupSlackLogging after TOML is loaded.
 type SetupLoggingOptions struct {
-	LogLevel               slog.Level
-	LogDir                 string
-	RunID                  string
-	ForceInteractive       bool
-	ForceQuiet             bool
-	ConsoleWriter          io.Writer // If nil, defaults to stdout for backward compatibility
-	SlackWebhookURLSuccess string    // Slack webhook URL for success (INFO) notifications. Empty string disables.
-	SlackWebhookURLError   string    // Slack webhook URL for error (WARN/ERROR) notifications. Empty string disables.
-	DryRun                 bool      // If true, Slack notifications are not sent
+	LogLevel         slog.Level
+	LogDir           string
+	RunID            string
+	ForceInteractive bool
+	ForceQuiet       bool
+	ConsoleWriter    io.Writer // If nil, defaults to stdout for backward compatibility
+	DryRun           bool      // If true, Slack notifications are not sent
 
 	// SlackAllowedHost は TOML から読んだ許可ホスト名。
 	// SetupSlackLogging が SlackLoggerConfig.AllowedHost に転送する。
 	SlackAllowedHost string
 }
 
-// SetupLogging sets up logging system without environment file handling
+// SetupLogging sets up Phase 1 logging (console and file handlers).
+// Slack handlers are NOT configured here; call SetupSlackLogging after LoadAndPrepareConfig.
 func SetupLogging(opts SetupLoggingOptions) error {
-	// Setup logging system with all configuration including Slack
 	loggerConfig := LoggerConfig{
-		Level:                  opts.LogLevel,
-		LogDir:                 opts.LogDir,
-		RunID:                  opts.RunID,
-		SlackWebhookURLSuccess: opts.SlackWebhookURLSuccess,
-		SlackWebhookURLError:   opts.SlackWebhookURLError,
-		SlackAllowedHost:       opts.SlackAllowedHost,
-		ConsoleWriter:          opts.ConsoleWriter,
-		DryRun:                 opts.DryRun,
+		Level:         opts.LogLevel,
+		LogDir:        opts.LogDir,
+		RunID:         opts.RunID,
+		ConsoleWriter: opts.ConsoleWriter,
+		DryRun:        opts.DryRun,
 	}
 
 	if err := SetupLoggerWithConfig(loggerConfig, opts.ForceInteractive, opts.ForceQuiet); err != nil {
 		return &logging.PreExecutionError{
 			Type:      logging.ErrorTypeLogFileOpen,
 			Message:   fmt.Sprintf("Failed to setup logger: %v", err),
+			Component: string(resource.ComponentLogging),
+			RunID:     opts.RunID,
+		}
+	}
+
+	return nil
+}
+
+// SetupSlackLogging は TOML 設定読み込み後に呼び出し、Slack ハンドラを追加する。
+// ホスト検証に失敗した場合は ErrorTypeConfigParsing エラーを返す (AC-L2-10)。
+func SetupSlackLogging(slackConfig *SlackWebhookConfig, opts SetupLoggingOptions) error {
+	if slackConfig.SuccessURL == "" && slackConfig.ErrorURL == "" {
+		return nil
+	}
+
+	slackLoggerConfig := SlackLoggerConfig{
+		WebhookURLSuccess: slackConfig.SuccessURL,
+		WebhookURLError:   slackConfig.ErrorURL,
+		AllowedHost:       opts.SlackAllowedHost,
+		RunID:             opts.RunID,
+		DryRun:            opts.DryRun,
+	}
+
+	if err := AddSlackHandlers(slackLoggerConfig); err != nil {
+		return &logging.PreExecutionError{
+			Type:      logging.ErrorTypeConfigParsing,
+			Message:   fmt.Sprintf("Slack webhook URL validation failed: %v", err),
 			Component: string(resource.ComponentLogging),
 			RunID:     opts.RunID,
 		}

--- a/internal/runner/bootstrap/environment_test.go
+++ b/internal/runner/bootstrap/environment_test.go
@@ -20,9 +20,6 @@ func TestSetupLogging_Success(t *testing.T) {
 		runID            string
 		forceInteractive bool
 		forceQuiet       bool
-		slackSuccessURL  string
-		slackErrorURL    string
-		slackAllowedHost string
 		wantErr          bool
 	}{
 		{
@@ -37,12 +34,9 @@ func TestSetupLogging_Success(t *testing.T) {
 			runID:    "test-run-002",
 		},
 		{
-			name:             "with both Slack webhook URLs",
-			logLevel:         slog.LevelWarn,
-			runID:            "test-run-003",
-			slackSuccessURL:  "https://hooks.slack.com/services/test-success",
-			slackErrorURL:    "https://hooks.slack.com/services/test-error",
-			slackAllowedHost: "hooks.slack.com",
+			name:     "phase 1 logging only (Slack added separately via SetupSlackLogging)",
+			logLevel: slog.LevelWarn,
+			runID:    "test-run-003",
 		},
 		{
 			name:             "force interactive mode",
@@ -61,15 +55,12 @@ func TestSetupLogging_Success(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := SetupLogging(SetupLoggingOptions{
-				LogLevel:               tt.logLevel,
-				LogDir:                 tt.logDir,
-				RunID:                  tt.runID,
-				ForceInteractive:       tt.forceInteractive,
-				ForceQuiet:             tt.forceQuiet,
-				ConsoleWriter:          nil,
-				SlackWebhookURLSuccess: tt.slackSuccessURL,
-				SlackWebhookURLError:   tt.slackErrorURL,
-				SlackAllowedHost:       tt.slackAllowedHost,
+				LogLevel:         tt.logLevel,
+				LogDir:           tt.logDir,
+				RunID:            tt.runID,
+				ForceInteractive: tt.forceInteractive,
+				ForceQuiet:       tt.forceQuiet,
+				ConsoleWriter:    nil,
 			})
 
 			if (err != nil) != tt.wantErr {

--- a/internal/runner/bootstrap/environment_test.go
+++ b/internal/runner/bootstrap/environment_test.go
@@ -17,8 +17,7 @@ import (
 // to SlackHandlerOptions.AllowedHost (AC-L2-19).
 func TestSetupSlackLogging_AllowedHostPropagation(t *testing.T) {
 	// Phase 1 must be initialized first.
-	originalLogger := slog.Default()
-	defer slog.SetDefault(originalLogger)
+	saveAndRestoreGlobals(t)
 
 	err := SetupLoggerWithConfig(LoggerConfig{
 		Level: slog.LevelInfo,
@@ -52,8 +51,7 @@ func TestSetupSlackLogging_AllowedHostPropagation(t *testing.T) {
 // SetupSlackLogging with SlackAllowedHost="" returns a PreExecutionError with
 // Type == ErrorTypeConfigParsing (AC-L2-20).
 func TestSetupSlackLogging_MissingAllowedHostReturnsConfigParsingError(t *testing.T) {
-	originalLogger := slog.Default()
-	defer slog.SetDefault(originalLogger)
+	saveAndRestoreGlobals(t)
 
 	err := SetupLoggerWithConfig(LoggerConfig{
 		Level: slog.LevelInfo,
@@ -117,6 +115,7 @@ func TestSetupLogging_Success(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			saveAndRestoreGlobals(t)
 			err := SetupLogging(SetupLoggingOptions{
 				LogLevel:         tt.logLevel,
 				LogDir:           tt.logDir,
@@ -170,6 +169,7 @@ func TestSetupLogging_InvalidConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			saveAndRestoreGlobals(t)
 			logDir := tt.logDir
 			if tt.setupFunc != nil {
 				logDir = tt.setupFunc(t)
@@ -206,6 +206,7 @@ func TestSetupLogging_FilePermissionError(t *testing.T) {
 	// Ensure cleanup restores permissions for temp dir cleanup
 	defer os.Chmod(readOnlyDir, 0o755)
 
+	saveAndRestoreGlobals(t)
 	err := SetupLogging(SetupLoggingOptions{
 		LogLevel: slog.LevelInfo,
 		LogDir:   readOnlyDir,

--- a/internal/runner/bootstrap/environment_test.go
+++ b/internal/runner/bootstrap/environment_test.go
@@ -1,6 +1,7 @@
 package bootstrap
 
 import (
+	"errors"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -11,6 +12,68 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// TestSetupSlackLogging_AllowedHostPropagation verifies that SlackAllowedHost is propagated
+// to SlackHandlerOptions.AllowedHost (AC-L2-19).
+func TestSetupSlackLogging_AllowedHostPropagation(t *testing.T) {
+	// Phase 1 must be initialized first.
+	originalLogger := slog.Default()
+	defer slog.SetDefault(originalLogger)
+
+	err := SetupLoggerWithConfig(LoggerConfig{
+		Level: slog.LevelInfo,
+		RunID: "test-propagation-001",
+	}, false, false)
+	require.NoError(t, err)
+
+	// Capture the SlackHandlerOptions passed to newSlackHandlerFunc.
+	var capturedOpts []logging.SlackHandlerOptions
+	orig := newSlackHandlerFunc
+	defer func() { newSlackHandlerFunc = orig }()
+	newSlackHandlerFunc = func(opts logging.SlackHandlerOptions) (*logging.SlackHandler, error) {
+		capturedOpts = append(capturedOpts, opts)
+		// Return an error so AddSlackHandlers stops early; we only care about captured opts.
+		return nil, errors.New("mock: stop here")
+	}
+
+	const wantHost = "hooks.slack.com"
+	_ = SetupSlackLogging(&SlackWebhookConfig{
+		ErrorURL: "https://hooks.slack.com/services/test",
+	}, SetupLoggingOptions{
+		SlackAllowedHost: wantHost,
+		RunID:            "test-propagation-001",
+	})
+
+	require.Len(t, capturedOpts, 1, "newSlackHandlerFunc should have been called once")
+	assert.Equal(t, wantHost, capturedOpts[0].AllowedHost, "AllowedHost should be propagated to SlackHandlerOptions")
+}
+
+// TestSetupSlackLogging_MissingAllowedHostReturnsConfigParsingError verifies that
+// SetupSlackLogging with SlackAllowedHost="" returns a PreExecutionError with
+// Type == ErrorTypeConfigParsing (AC-L2-20).
+func TestSetupSlackLogging_MissingAllowedHostReturnsConfigParsingError(t *testing.T) {
+	originalLogger := slog.Default()
+	defer slog.SetDefault(originalLogger)
+
+	err := SetupLoggerWithConfig(LoggerConfig{
+		Level: slog.LevelInfo,
+		RunID: "test-missing-host-001",
+	}, false, false)
+	require.NoError(t, err)
+
+	slackErr := SetupSlackLogging(&SlackWebhookConfig{
+		ErrorURL: "https://hooks.slack.com/services/test",
+	}, SetupLoggingOptions{
+		SlackAllowedHost: "", // intentionally empty
+		RunID:            "test-missing-host-001",
+	})
+
+	require.Error(t, slackErr, "SetupSlackLogging should return an error when AllowedHost is empty")
+
+	var preExecErr *logging.PreExecutionError
+	require.True(t, errors.As(slackErr, &preExecErr), "error should be *logging.PreExecutionError, got %T: %v", slackErr, slackErr)
+	assert.Equal(t, logging.ErrorTypeConfigParsing, preExecErr.Type, "error type should be ErrorTypeConfigParsing")
+}
 
 func TestSetupLogging_Success(t *testing.T) {
 	tests := []struct {

--- a/internal/runner/bootstrap/environment_test.go
+++ b/internal/runner/bootstrap/environment_test.go
@@ -22,6 +22,7 @@ func TestSetupLogging_Success(t *testing.T) {
 		forceQuiet       bool
 		slackSuccessURL  string
 		slackErrorURL    string
+		slackAllowedHost string
 		wantErr          bool
 	}{
 		{
@@ -36,11 +37,12 @@ func TestSetupLogging_Success(t *testing.T) {
 			runID:    "test-run-002",
 		},
 		{
-			name:            "with both Slack webhook URLs",
-			logLevel:        slog.LevelWarn,
-			runID:           "test-run-003",
-			slackSuccessURL: "https://hooks.slack.com/services/test-success",
-			slackErrorURL:   "https://hooks.slack.com/services/test-error",
+			name:             "with both Slack webhook URLs",
+			logLevel:         slog.LevelWarn,
+			runID:            "test-run-003",
+			slackSuccessURL:  "https://hooks.slack.com/services/test-success",
+			slackErrorURL:    "https://hooks.slack.com/services/test-error",
+			slackAllowedHost: "hooks.slack.com",
 		},
 		{
 			name:             "force interactive mode",
@@ -67,6 +69,7 @@ func TestSetupLogging_Success(t *testing.T) {
 				ConsoleWriter:          nil,
 				SlackWebhookURLSuccess: tt.slackSuccessURL,
 				SlackWebhookURLError:   tt.slackErrorURL,
+				SlackAllowedHost:       tt.slackAllowedHost,
 			})
 
 			if (err != nil) != tt.wantErr {

--- a/internal/runner/bootstrap/logger.go
+++ b/internal/runner/bootstrap/logger.go
@@ -20,16 +20,14 @@ const (
 	logFilePerm = 0o600
 )
 
-// LoggerConfig holds all configuration for logger setup
+// LoggerConfig holds all configuration for Phase 1 logger setup (console and file handlers).
+// Slack handlers are configured separately via AddSlackHandlers after TOML is loaded.
 type LoggerConfig struct {
-	Level                  slog.Level
-	LogDir                 string
-	RunID                  string
-	SlackWebhookURLSuccess string    // Webhook URL for success (INFO) notifications
-	SlackWebhookURLError   string    // Webhook URL for error (WARN/ERROR) notifications
-	SlackAllowedHost       string    // Allowed host for Slack webhook URL validation
-	ConsoleWriter          io.Writer // Writer for console output (stdout/stderr)
-	DryRun                 bool      // If true, Slack notifications are not sent
+	Level         slog.Level
+	LogDir        string
+	RunID         string
+	ConsoleWriter io.Writer // Writer for console output (stdout/stderr)
+	DryRun        bool      // If true, Slack notifications are not sent
 }
 
 // SlackLoggerConfig は AddSlackHandlers に渡す Slack ハンドラ専用の設定。
@@ -59,12 +57,19 @@ var phase1BaseHandlers []slog.Handler
 // AddSlackHandlers が RedactingHandler 再構築時に継続使用する。
 var phase1FailureLogger *slog.Logger
 
-// SetupLoggerWithConfig initializes the logging system with all handlers atomically.
+// newSlackHandlerFunc は Slack ハンドラの生成 factory。
+// テストで差し替え可能にすることで SlackHandlerOptions の内容を検査できる (AC-L2-19)。
+var newSlackHandlerFunc = logging.NewSlackHandler
+
+// SetupLoggerWithConfig initializes the Phase 1 logging system (console and file handlers).
 //
 // IMPORTANT: This function must be called exactly once during application startup,
 // before any logging operations occur. It is designed for single-threaded bootstrap
 // initialization and should not be called concurrently or after the application
 // has started processing.
+//
+// Slack handlers are NOT set up here. Call AddSlackHandlers after LoadAndPrepareConfig
+// to add Slack handlers with the AllowedHost from the TOML configuration.
 //
 // The global redactionErrorCollector and redactionReporter are initialized during
 // this call and must not be accessed before initialization completes.
@@ -152,62 +157,17 @@ func SetupLoggerWithConfig(config LoggerConfig, forceInteractive, forceQuiet boo
 		handlers = append(handlers, enrichedHandler)
 	}
 
-	// 4. Slack notification handlers (optional)
-	var slackSuccessHandler, slackErrorHandler slog.Handler
-
-	// Create success handler if URL is provided (INFO level only)
-	if config.SlackWebhookURLSuccess != "" {
-		sh, err := logging.NewSlackHandler(logging.SlackHandlerOptions{
-			WebhookURL:  config.SlackWebhookURLSuccess,
-			RunID:       config.RunID,
-			IsDryRun:    config.DryRun,
-			LevelMode:   logging.LevelModeExactInfo,
-			AllowedHost: config.SlackAllowedHost,
-		})
-		if err != nil {
-			return fmt.Errorf("failed to create success Slack handler: %w", err)
-		}
-		slackSuccessHandler = sh
-		handlers = append(handlers, sh)
-	}
-
-	// Create error handler if URL is provided (WARN and above)
-	if config.SlackWebhookURLError != "" {
-		sh, err := logging.NewSlackHandler(logging.SlackHandlerOptions{
-			WebhookURL:  config.SlackWebhookURLError,
-			RunID:       config.RunID,
-			IsDryRun:    config.DryRun,
-			LevelMode:   logging.LevelModeWarnAndAbove,
-			AllowedHost: config.SlackAllowedHost,
-		})
-		if err != nil {
-			return fmt.Errorf("failed to create error Slack handler: %w", err)
-		}
-		slackErrorHandler = sh
-		handlers = append(handlers, sh)
-	}
-
-	// Create failure logger (excludes Slack to prevent sensitive information leakage)
-	// This logger is used for detailed error logging during redaction failures
-	failureHandlers := make([]slog.Handler, 0, len(handlers))
-	for _, h := range handlers {
-		// Exclude Slack handlers from failure logger
-		// Detailed panic values and stack traces should not be sent to Slack
-		if h != slackSuccessHandler && h != slackErrorHandler {
-			failureHandlers = append(failureHandlers, h)
-		}
-	}
-
-	failureMultiHandler, err := logging.NewMultiHandler(failureHandlers...)
+	// Create failure logger using all Phase 1 handlers.
+	// Slack handlers are excluded from failureLogger by design (added later via AddSlackHandlers).
+	// Detailed panic values and stack traces should not be sent to Slack.
+	failureMultiHandler, err := logging.NewMultiHandler(handlers...)
 	if err != nil {
 		return fmt.Errorf("failed to create failure multi handler: %w", err)
 	}
 	failureLogger := slog.New(failureMultiHandler)
 
 	// Save Phase 1 state for AddSlackHandlers to reference later.
-	// phase1BaseHandlers holds Slack-excluded handlers (= failureHandlers).
-	// phase1FailureLogger is reused by AddSlackHandlers without reinitialisation.
-	phase1BaseHandlers = failureHandlers
+	phase1BaseHandlers = handlers
 	phase1FailureLogger = failureLogger
 
 	// Create redaction error collector for monitoring failures
@@ -215,7 +175,7 @@ func SetupLoggerWithConfig(config LoggerConfig, forceInteractive, forceQuiet boo
 	const maxRedactionFailures = 1000
 	redactionErrorCollector = redaction.NewInMemoryErrorCollector(maxRedactionFailures)
 
-	// Create MultiHandler with redaction (includes all handlers including Slack)
+	// Create MultiHandler with redaction (Phase 1 handlers only; Slack added via AddSlackHandlers)
 	multiHandler, err := logging.NewMultiHandler(handlers...)
 	if err != nil {
 		return fmt.Errorf("failed to create multi handler: %w", err)
@@ -236,9 +196,7 @@ func SetupLoggerWithConfig(config LoggerConfig, forceInteractive, forceQuiet boo
 		"run_id", config.RunID,
 		"hostname", hostname,
 		"interactive_mode", capabilities.IsInteractive(),
-		"color_support", capabilities.SupportsColor(),
-		"slack_success_enabled", config.SlackWebhookURLSuccess != "",
-		"slack_error_enabled", config.SlackWebhookURLError != "")
+		"color_support", capabilities.SupportsColor())
 
 	return nil
 }
@@ -250,7 +208,46 @@ func AddSlackHandlers(config SlackLoggerConfig) error {
 	if phase1BaseHandlers == nil || phase1FailureLogger == nil {
 		return errPhase1NotInitialized
 	}
-	_ = config // Phase 6 で Slack ハンドラの生成・追加ロジックを実装する
+
+	allHandlers := make([]slog.Handler, len(phase1BaseHandlers))
+	copy(allHandlers, phase1BaseHandlers)
+
+	if config.WebhookURLSuccess != "" {
+		sh, err := newSlackHandlerFunc(logging.SlackHandlerOptions{
+			WebhookURL:  config.WebhookURLSuccess,
+			RunID:       config.RunID,
+			IsDryRun:    config.DryRun,
+			LevelMode:   logging.LevelModeExactInfo,
+			AllowedHost: config.AllowedHost,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to create success Slack handler: %w", err)
+		}
+		allHandlers = append(allHandlers, sh)
+	}
+
+	if config.WebhookURLError != "" {
+		sh, err := newSlackHandlerFunc(logging.SlackHandlerOptions{
+			WebhookURL:  config.WebhookURLError,
+			RunID:       config.RunID,
+			IsDryRun:    config.DryRun,
+			LevelMode:   logging.LevelModeWarnAndAbove,
+			AllowedHost: config.AllowedHost,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to create error Slack handler: %w", err)
+		}
+		allHandlers = append(allHandlers, sh)
+	}
+
+	multiHandler, err := logging.NewMultiHandler(allHandlers...)
+	if err != nil {
+		return fmt.Errorf("failed to create multi handler: %w", err)
+	}
+	redactedHandler := redaction.NewRedactingHandler(multiHandler, nil, phase1FailureLogger).
+		WithErrorCollector(redactionErrorCollector)
+
+	slog.SetDefault(slog.New(redactedHandler))
 	return nil
 }
 

--- a/internal/runner/bootstrap/logger.go
+++ b/internal/runner/bootstrap/logger.go
@@ -165,14 +165,10 @@ func SetupLoggerWithConfig(config LoggerConfig, forceInteractive, forceQuiet boo
 	}
 	failureLogger := slog.New(failureMultiHandler)
 
-	// Save Phase 1 state for AddSlackHandlers to reference later.
-	phase1BaseHandlers = handlers
-	phase1FailureLogger = failureLogger
-
 	// Create redaction error collector for monitoring failures
 	// Limit to 1000 most recent failures to prevent unbounded growth
 	const maxRedactionFailures = 1000
-	redactionErrorCollector = redaction.NewInMemoryErrorCollector(maxRedactionFailures)
+	collector := redaction.NewInMemoryErrorCollector(maxRedactionFailures)
 
 	// Create MultiHandler with redaction (Phase 1 handlers only; Slack added via AddSlackHandlers)
 	multiHandler, err := logging.NewMultiHandler(handlers...)
@@ -180,14 +176,21 @@ func SetupLoggerWithConfig(config LoggerConfig, forceInteractive, forceQuiet boo
 		return fmt.Errorf("failed to create multi handler: %w", err)
 	}
 	redactedHandler := redaction.NewRedactingHandler(multiHandler, nil, failureLogger).
-		WithErrorCollector(redactionErrorCollector)
+		WithErrorCollector(collector)
 
 	// Create shutdown reporter for redaction failures
-	redactionReporter = redaction.NewShutdownReporter(redactionErrorCollector, os.Stderr, failureLogger)
+	reporter := redaction.NewShutdownReporter(collector, os.Stderr, failureLogger)
 
 	// Set as default logger
-	logger := slog.New(redactedHandler)
-	slog.SetDefault(logger)
+	slog.SetDefault(slog.New(redactedHandler))
+
+	// All initialization succeeded — commit Phase 1 state for AddSlackHandlers to reference.
+	// These globals must only be set after every step above has completed without error,
+	// so that AddSlackHandlers cannot run against a partially-initialized logger.
+	phase1BaseHandlers = handlers
+	phase1FailureLogger = failureLogger
+	redactionErrorCollector = collector
+	redactionReporter = reporter
 
 	slog.Info("Logger initialized",
 		"log-level", config.Level,
@@ -204,7 +207,7 @@ func SetupLoggerWithConfig(config LoggerConfig, forceInteractive, forceQuiet boo
 // Returns an error if validateWebhookURL fails for either successURL or errorURL.
 // Returns an error if SetupLoggerWithConfig has not been called (phase1BaseHandlers is nil).
 func AddSlackHandlers(config SlackLoggerConfig) error {
-	if phase1BaseHandlers == nil || phase1FailureLogger == nil {
+	if phase1BaseHandlers == nil || phase1FailureLogger == nil || redactionErrorCollector == nil {
 		return errPhase1NotInitialized
 	}
 

--- a/internal/runner/bootstrap/logger.go
+++ b/internal/runner/bootstrap/logger.go
@@ -26,6 +26,7 @@ type LoggerConfig struct {
 	RunID                  string
 	SlackWebhookURLSuccess string    // Webhook URL for success (INFO) notifications
 	SlackWebhookURLError   string    // Webhook URL for error (WARN/ERROR) notifications
+	SlackAllowedHost       string    // Allowed host for Slack webhook URL validation
 	ConsoleWriter          io.Writer // Writer for console output (stdout/stderr)
 	DryRun                 bool      // If true, Slack notifications are not sent
 }
@@ -145,10 +146,11 @@ func SetupLoggerWithConfig(config LoggerConfig, forceInteractive, forceQuiet boo
 	// Create success handler if URL is provided (INFO level only)
 	if config.SlackWebhookURLSuccess != "" {
 		sh, err := logging.NewSlackHandler(logging.SlackHandlerOptions{
-			WebhookURL: config.SlackWebhookURLSuccess,
-			RunID:      config.RunID,
-			IsDryRun:   config.DryRun,
-			LevelMode:  logging.LevelModeExactInfo,
+			WebhookURL:  config.SlackWebhookURLSuccess,
+			RunID:       config.RunID,
+			IsDryRun:    config.DryRun,
+			LevelMode:   logging.LevelModeExactInfo,
+			AllowedHost: config.SlackAllowedHost,
 		})
 		if err != nil {
 			return fmt.Errorf("failed to create success Slack handler: %w", err)
@@ -160,10 +162,11 @@ func SetupLoggerWithConfig(config LoggerConfig, forceInteractive, forceQuiet boo
 	// Create error handler if URL is provided (WARN and above)
 	if config.SlackWebhookURLError != "" {
 		sh, err := logging.NewSlackHandler(logging.SlackHandlerOptions{
-			WebhookURL: config.SlackWebhookURLError,
-			RunID:      config.RunID,
-			IsDryRun:   config.DryRun,
-			LevelMode:  logging.LevelModeWarnAndAbove,
+			WebhookURL:  config.SlackWebhookURLError,
+			RunID:       config.RunID,
+			IsDryRun:    config.DryRun,
+			LevelMode:   logging.LevelModeWarnAndAbove,
+			AllowedHost: config.SlackAllowedHost,
 		})
 		if err != nil {
 			return fmt.Errorf("failed to create error Slack handler: %w", err)

--- a/internal/runner/bootstrap/logger.go
+++ b/internal/runner/bootstrap/logger.go
@@ -1,6 +1,7 @@
 package bootstrap
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -46,6 +47,17 @@ var redactionErrorCollector *redaction.InMemoryErrorCollector
 
 // redactionReporter is a global reporter for shutdown
 var redactionReporter *redaction.ShutdownReporter
+
+// errPhase1NotInitialized は AddSlackHandlers が SetupLoggerWithConfig 前に呼ばれた場合のエラー。
+var errPhase1NotInitialized = errors.New("AddSlackHandlers called before SetupLoggerWithConfig")
+
+// phase1BaseHandlers は SetupLoggerWithConfig が作成した Slack を除くハンドラ群。
+// AddSlackHandlers がこれを参照して Slack ハンドラを追加した新たな MultiHandler を構築する。
+var phase1BaseHandlers []slog.Handler
+
+// phase1FailureLogger は Phase 1 で作成した failureLogger。
+// AddSlackHandlers が RedactingHandler 再構築時に継続使用する。
+var phase1FailureLogger *slog.Logger
 
 // SetupLoggerWithConfig initializes the logging system with all handlers atomically.
 //
@@ -192,6 +204,12 @@ func SetupLoggerWithConfig(config LoggerConfig, forceInteractive, forceQuiet boo
 	}
 	failureLogger := slog.New(failureMultiHandler)
 
+	// Save Phase 1 state for AddSlackHandlers to reference later.
+	// phase1BaseHandlers holds Slack-excluded handlers (= failureHandlers).
+	// phase1FailureLogger is reused by AddSlackHandlers without reinitialisation.
+	phase1BaseHandlers = failureHandlers
+	phase1FailureLogger = failureLogger
+
 	// Create redaction error collector for monitoring failures
 	// Limit to 1000 most recent failures to prevent unbounded growth
 	const maxRedactionFailures = 1000
@@ -222,6 +240,17 @@ func SetupLoggerWithConfig(config LoggerConfig, forceInteractive, forceQuiet boo
 		"slack_success_enabled", config.SlackWebhookURLSuccess != "",
 		"slack_error_enabled", config.SlackWebhookURLError != "")
 
+	return nil
+}
+
+// AddSlackHandlers は既存のデフォルトロガーに Slack ハンドラを追加して再構築する。
+// successURL/errorURL どちらかでも validateWebhookURL が失敗した場合はエラーを返す。
+// SetupLoggerWithConfig が呼ばれていない場合 (phase1BaseHandlers が nil) はエラーを返す。
+func AddSlackHandlers(config SlackLoggerConfig) error {
+	if phase1BaseHandlers == nil || phase1FailureLogger == nil {
+		return errPhase1NotInitialized
+	}
+	_ = config // Phase 6 で Slack ハンドラの生成・追加ロジックを実装する
 	return nil
 }
 

--- a/internal/runner/bootstrap/logger.go
+++ b/internal/runner/bootstrap/logger.go
@@ -29,11 +29,11 @@ type LoggerConfig struct {
 	ConsoleWriter io.Writer // Writer for console output (stdout/stderr)
 }
 
-// SlackLoggerConfig は AddSlackHandlers に渡す Slack ハンドラ専用の設定。
+// SlackLoggerConfig is the Slack-handler-only config passed to AddSlackHandlers.
 type SlackLoggerConfig struct {
-	WebhookURLSuccess string // 成功通知用 webhook URL (INFO)
-	WebhookURLError   string // エラー通知用 webhook URL (WARN/ERROR)
-	AllowedHost       string // 許可ホスト名 (AC-L2-4)
+	WebhookURLSuccess string // Webhook URL for success notifications (INFO)
+	WebhookURLError   string // Webhook URL for error notifications (WARN/ERROR)
+	AllowedHost       string // Allowed hostname (AC-L2-4)
 	RunID             string
 	DryRun            bool
 }
@@ -45,19 +45,19 @@ var redactionErrorCollector *redaction.InMemoryErrorCollector
 // redactionReporter is a global reporter for shutdown
 var redactionReporter *redaction.ShutdownReporter
 
-// errPhase1NotInitialized は AddSlackHandlers が SetupLoggerWithConfig 前に呼ばれた場合のエラー。
+// errPhase1NotInitialized is returned when AddSlackHandlers is called before SetupLoggerWithConfig.
 var errPhase1NotInitialized = errors.New("AddSlackHandlers called before SetupLoggerWithConfig")
 
-// phase1BaseHandlers は SetupLoggerWithConfig が作成した Slack を除くハンドラ群。
-// AddSlackHandlers がこれを参照して Slack ハンドラを追加した新たな MultiHandler を構築する。
+// phase1BaseHandlers holds the non-Slack handlers created by SetupLoggerWithConfig.
+// AddSlackHandlers reads this to build a new MultiHandler that includes the Slack handlers.
 var phase1BaseHandlers []slog.Handler
 
-// phase1FailureLogger は Phase 1 で作成した failureLogger。
-// AddSlackHandlers が RedactingHandler 再構築時に継続使用する。
+// phase1FailureLogger is the failureLogger created in Phase 1.
+// AddSlackHandlers reuses it when rebuilding the RedactingHandler.
 var phase1FailureLogger *slog.Logger
 
-// newSlackHandlerFunc は Slack ハンドラの生成 factory。
-// テストで差し替え可能にすることで SlackHandlerOptions の内容を検査できる (AC-L2-19)。
+// newSlackHandlerFunc is the factory for creating Slack handlers.
+// Replacing it in tests allows inspection of SlackHandlerOptions (AC-L2-19).
 var newSlackHandlerFunc = logging.NewSlackHandler
 
 // SetupLoggerWithConfig initializes the Phase 1 logging system (console and file handlers).
@@ -200,9 +200,9 @@ func SetupLoggerWithConfig(config LoggerConfig, forceInteractive, forceQuiet boo
 	return nil
 }
 
-// AddSlackHandlers は既存のデフォルトロガーに Slack ハンドラを追加して再構築する。
-// successURL/errorURL どちらかでも validateWebhookURL が失敗した場合はエラーを返す。
-// SetupLoggerWithConfig が呼ばれていない場合 (phase1BaseHandlers が nil) はエラーを返す。
+// AddSlackHandlers rebuilds the default logger by appending Slack handlers to the existing logger.
+// Returns an error if validateWebhookURL fails for either successURL or errorURL.
+// Returns an error if SetupLoggerWithConfig has not been called (phase1BaseHandlers is nil).
 func AddSlackHandlers(config SlackLoggerConfig) error {
 	if phase1BaseHandlers == nil || phase1FailureLogger == nil {
 		return errPhase1NotInitialized

--- a/internal/runner/bootstrap/logger.go
+++ b/internal/runner/bootstrap/logger.go
@@ -27,7 +27,6 @@ type LoggerConfig struct {
 	LogDir        string
 	RunID         string
 	ConsoleWriter io.Writer // Writer for console output (stdout/stderr)
-	DryRun        bool      // If true, Slack notifications are not sent
 }
 
 // SlackLoggerConfig は AddSlackHandlers に渡す Slack ハンドラ専用の設定。

--- a/internal/runner/bootstrap/logger.go
+++ b/internal/runner/bootstrap/logger.go
@@ -30,6 +30,15 @@ type LoggerConfig struct {
 	DryRun                 bool      // If true, Slack notifications are not sent
 }
 
+// SlackLoggerConfig は AddSlackHandlers に渡す Slack ハンドラ専用の設定。
+type SlackLoggerConfig struct {
+	WebhookURLSuccess string // 成功通知用 webhook URL (INFO)
+	WebhookURLError   string // エラー通知用 webhook URL (WARN/ERROR)
+	AllowedHost       string // 許可ホスト名 (AC-L2-4)
+	RunID             string
+	DryRun            bool
+}
+
 // redactionErrorCollector is a global collector for redaction failures
 // This is set during logger initialization and used for shutdown reporting
 var redactionErrorCollector *redaction.InMemoryErrorCollector

--- a/internal/runner/bootstrap/logger_test.go
+++ b/internal/runner/bootstrap/logger_test.go
@@ -84,24 +84,18 @@ func TestSetupLoggerWithConfig_FullConfig(t *testing.T) {
 			},
 		},
 		{
-			name: "full config with both Slack handlers",
+			name: "full config with log file only (Slack added via AddSlackHandlers)",
 			config: LoggerConfig{
-				Level:                  slog.LevelInfo,
-				RunID:                  "test-full-002",
-				SlackWebhookURLSuccess: "https://hooks.slack.com/services/test-success",
-				SlackWebhookURLError:   "https://hooks.slack.com/services/test-error",
-				SlackAllowedHost:       "hooks.slack.com",
+				Level: slog.LevelInfo,
+				RunID: "test-full-002",
 			},
 		},
 		{
-			name: "full config with all handlers",
+			name: "full config with all Phase 1 handlers",
 			config: LoggerConfig{
-				Level:                  slog.LevelWarn,
-				LogDir:                 tempDir,
-				RunID:                  "test-full-003",
-				SlackWebhookURLSuccess: "https://hooks.slack.com/services/test-success",
-				SlackWebhookURLError:   "https://hooks.slack.com/services/test-error",
-				SlackAllowedHost:       "hooks.slack.com",
+				Level:  slog.LevelWarn,
+				LogDir: tempDir,
+				RunID:  "test-full-003",
 			},
 		},
 		{
@@ -335,16 +329,22 @@ func TestSetupLoggerWithConfig_FailureLoggerExcludesSlack(t *testing.T) {
 	var consoleBuffer bytes.Buffer
 
 	config := LoggerConfig{
-		Level:                  slog.LevelDebug,
-		LogDir:                 tempDir,
-		RunID:                  "test-slack-exclusion-001",
-		SlackWebhookURLSuccess: "https://hooks.slack.com/services/test-success",
-		SlackWebhookURLError:   "https://hooks.slack.com/services/test-error",
-		SlackAllowedHost:       "hooks.slack.com",
-		ConsoleWriter:          &consoleBuffer,
+		Level:         slog.LevelDebug,
+		LogDir:        tempDir,
+		RunID:         "test-slack-exclusion-001",
+		ConsoleWriter: &consoleBuffer,
 	}
 
 	err := SetupLoggerWithConfig(config, false, true)
+	require.NoError(t, err)
+
+	// Add Slack handlers via AddSlackHandlers (Slack is now excluded from failureLogger by design)
+	err = AddSlackHandlers(SlackLoggerConfig{
+		WebhookURLSuccess: "https://hooks.slack.com/services/test-success",
+		WebhookURLError:   "https://hooks.slack.com/services/test-error",
+		AllowedHost:       "hooks.slack.com",
+		RunID:             "test-slack-exclusion-001",
+	})
 	require.NoError(t, err)
 
 	// Log a message (this would trigger failureLogger in actual redaction failures)

--- a/internal/runner/bootstrap/logger_test.go
+++ b/internal/runner/bootstrap/logger_test.go
@@ -15,17 +15,23 @@ import (
 )
 
 // saveAndRestoreGlobals registers a t.Cleanup that restores the package-level logger
-// globals (phase1BaseHandlers, phase1FailureLogger) and the default slog logger.
+// globals and the default slog logger.
 // Call this at the start of any test that invokes SetupLoggerWithConfig.
 func saveAndRestoreGlobals(t *testing.T) {
 	t.Helper()
 	origLogger := slog.Default()
 	origHandlers := phase1BaseHandlers
 	origFailureLogger := phase1FailureLogger
+	origRedactionErrorCollector := redactionErrorCollector
+	origRedactionReporter := redactionReporter
+	origNewSlackHandlerFunc := newSlackHandlerFunc
 	t.Cleanup(func() {
 		slog.SetDefault(origLogger)
 		phase1BaseHandlers = origHandlers
 		phase1FailureLogger = origFailureLogger
+		redactionErrorCollector = origRedactionErrorCollector
+		redactionReporter = origRedactionReporter
+		newSlackHandlerFunc = origNewSlackHandlerFunc
 	})
 }
 

--- a/internal/runner/bootstrap/logger_test.go
+++ b/internal/runner/bootstrap/logger_test.go
@@ -14,6 +14,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// saveAndRestoreGlobals registers a t.Cleanup that restores the package-level logger
+// globals (phase1BaseHandlers, phase1FailureLogger) and the default slog logger.
+// Call this at the start of any test that invokes SetupLoggerWithConfig.
+func saveAndRestoreGlobals(t *testing.T) {
+	t.Helper()
+	origLogger := slog.Default()
+	origHandlers := phase1BaseHandlers
+	origFailureLogger := phase1FailureLogger
+	t.Cleanup(func() {
+		slog.SetDefault(origLogger)
+		phase1BaseHandlers = origHandlers
+		phase1FailureLogger = origFailureLogger
+	})
+}
+
 func TestSetupLoggerWithConfig_MinimalConfig(t *testing.T) {
 	tests := []struct {
 		name             string
@@ -54,6 +69,7 @@ func TestSetupLoggerWithConfig_MinimalConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			saveAndRestoreGlobals(t)
 			err := SetupLoggerWithConfig(tt.config, tt.forceInteractive, tt.forceQuiet)
 
 			if tt.wantErr {
@@ -120,6 +136,7 @@ func TestSetupLoggerWithConfig_FullConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			saveAndRestoreGlobals(t)
 			err := SetupLoggerWithConfig(tt.config, tt.forceInteractive, tt.forceQuiet)
 
 			if tt.wantErr {
@@ -167,6 +184,7 @@ func TestSetupLoggerWithConfig_InvalidLogDirectory(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			saveAndRestoreGlobals(t)
 			err := SetupLoggerWithConfig(tt.config, false, false)
 
 			if tt.wantErr {
@@ -199,6 +217,7 @@ func TestSetupLoggerWithConfig_LogDirectoryPermissionError(t *testing.T) {
 		RunID:  "test-perm-001",
 	}
 
+	saveAndRestoreGlobals(t)
 	err = SetupLoggerWithConfig(config, false, false)
 
 	assert.Error(t, err, "SetupLoggerWithConfig() expected error for read-only directory, got nil")
@@ -225,6 +244,7 @@ func TestSetupLoggerWithConfig_FailureLoggerUsesMultiHandler(t *testing.T) {
 		ConsoleWriter: &consoleBuffer,
 	}
 
+	saveAndRestoreGlobals(t)
 	err := SetupLoggerWithConfig(config, false, true) // forceQuiet=true to use console writer
 	require.NoError(t, err)
 
@@ -297,6 +317,7 @@ func TestSetupLoggerWithConfig_FailureLoggerCircularDependencyPrevention(t *test
 	}
 
 	// This should not cause infinite recursion or panic
+	saveAndRestoreGlobals(t)
 	err := SetupLoggerWithConfig(config, false, true)
 	require.NoError(t, err)
 
@@ -335,6 +356,7 @@ func TestSetupLoggerWithConfig_FailureLoggerExcludesSlack(t *testing.T) {
 		ConsoleWriter: &consoleBuffer,
 	}
 
+	saveAndRestoreGlobals(t)
 	err := SetupLoggerWithConfig(config, false, true)
 	require.NoError(t, err)
 

--- a/internal/runner/bootstrap/logger_test.go
+++ b/internal/runner/bootstrap/logger_test.go
@@ -90,6 +90,7 @@ func TestSetupLoggerWithConfig_FullConfig(t *testing.T) {
 				RunID:                  "test-full-002",
 				SlackWebhookURLSuccess: "https://hooks.slack.com/services/test-success",
 				SlackWebhookURLError:   "https://hooks.slack.com/services/test-error",
+				SlackAllowedHost:       "hooks.slack.com",
 			},
 		},
 		{
@@ -100,6 +101,7 @@ func TestSetupLoggerWithConfig_FullConfig(t *testing.T) {
 				RunID:                  "test-full-003",
 				SlackWebhookURLSuccess: "https://hooks.slack.com/services/test-success",
 				SlackWebhookURLError:   "https://hooks.slack.com/services/test-error",
+				SlackAllowedHost:       "hooks.slack.com",
 			},
 		},
 		{
@@ -338,6 +340,7 @@ func TestSetupLoggerWithConfig_FailureLoggerExcludesSlack(t *testing.T) {
 		RunID:                  "test-slack-exclusion-001",
 		SlackWebhookURLSuccess: "https://hooks.slack.com/services/test-success",
 		SlackWebhookURLError:   "https://hooks.slack.com/services/test-error",
+		SlackAllowedHost:       "hooks.slack.com",
 		ConsoleWriter:          &consoleBuffer,
 	}
 

--- a/internal/runner/e2e_slack_webhook_separation_test.go
+++ b/internal/runner/e2e_slack_webhook_separation_test.go
@@ -55,20 +55,22 @@ func TestE2E_SlackWebhookSeparation_SuccessOnly(t *testing.T) {
 
 	// Create two Slack handlers
 	successHandler, err := logging.NewSlackHandler(logging.SlackHandlerOptions{
-		WebhookURL: successServer.URL,
-		RunID:      "test-success-" + timeBasedID(),
-		HTTPClient: successServer.Client(),
-		LevelMode:  logging.LevelModeExactInfo,
-		IsDryRun:   false,
+		WebhookURL:  successServer.URL,
+		AllowedHost: mustWebhookAllowedHost(t, successServer.URL),
+		RunID:       "test-success-" + timeBasedID(),
+		HTTPClient:  successServer.Client(),
+		LevelMode:   logging.LevelModeExactInfo,
+		IsDryRun:    false,
 	})
 	require.NoError(t, err)
 
 	errorHandler, err := logging.NewSlackHandler(logging.SlackHandlerOptions{
-		WebhookURL: errorServer.URL,
-		RunID:      "test-error-" + timeBasedID(),
-		HTTPClient: errorServer.Client(),
-		LevelMode:  logging.LevelModeWarnAndAbove,
-		IsDryRun:   false,
+		WebhookURL:  errorServer.URL,
+		AllowedHost: mustWebhookAllowedHost(t, errorServer.URL),
+		RunID:       "test-error-" + timeBasedID(),
+		HTTPClient:  errorServer.Client(),
+		LevelMode:   logging.LevelModeWarnAndAbove,
+		IsDryRun:    false,
 	})
 	require.NoError(t, err)
 
@@ -157,20 +159,22 @@ func TestE2E_SlackWebhookSeparation_ErrorOnly(t *testing.T) {
 	defer errorServer.Close()
 
 	successHandler, err := logging.NewSlackHandler(logging.SlackHandlerOptions{
-		WebhookURL: successServer.URL,
-		RunID:      "test-error-" + timeBasedID(),
-		HTTPClient: successServer.Client(),
-		LevelMode:  logging.LevelModeExactInfo,
-		IsDryRun:   false,
+		WebhookURL:  successServer.URL,
+		AllowedHost: mustWebhookAllowedHost(t, successServer.URL),
+		RunID:       "test-error-" + timeBasedID(),
+		HTTPClient:  successServer.Client(),
+		LevelMode:   logging.LevelModeExactInfo,
+		IsDryRun:    false,
 	})
 	require.NoError(t, err)
 
 	errorHandler, err := logging.NewSlackHandler(logging.SlackHandlerOptions{
-		WebhookURL: errorServer.URL,
-		RunID:      "test-error-" + timeBasedID(),
-		HTTPClient: errorServer.Client(),
-		LevelMode:  logging.LevelModeWarnAndAbove,
-		IsDryRun:   false,
+		WebhookURL:  errorServer.URL,
+		AllowedHost: mustWebhookAllowedHost(t, errorServer.URL),
+		RunID:       "test-error-" + timeBasedID(),
+		HTTPClient:  errorServer.Client(),
+		LevelMode:   logging.LevelModeWarnAndAbove,
+		IsDryRun:    false,
 	})
 	require.NoError(t, err)
 
@@ -252,20 +256,22 @@ func TestE2E_SlackWebhookSeparation_WarnToError(t *testing.T) {
 	defer errorServer.Close()
 
 	successHandler, err := logging.NewSlackHandler(logging.SlackHandlerOptions{
-		WebhookURL: successServer.URL,
-		RunID:      "test-warn-" + timeBasedID(),
-		HTTPClient: successServer.Client(),
-		LevelMode:  logging.LevelModeExactInfo,
-		IsDryRun:   false,
+		WebhookURL:  successServer.URL,
+		AllowedHost: mustWebhookAllowedHost(t, successServer.URL),
+		RunID:       "test-warn-" + timeBasedID(),
+		HTTPClient:  successServer.Client(),
+		LevelMode:   logging.LevelModeExactInfo,
+		IsDryRun:    false,
 	})
 	require.NoError(t, err)
 
 	errorHandler, err := logging.NewSlackHandler(logging.SlackHandlerOptions{
-		WebhookURL: errorServer.URL,
-		RunID:      "test-warn-" + timeBasedID(),
-		HTTPClient: errorServer.Client(),
-		LevelMode:  logging.LevelModeWarnAndAbove,
-		IsDryRun:   false,
+		WebhookURL:  errorServer.URL,
+		AllowedHost: mustWebhookAllowedHost(t, errorServer.URL),
+		RunID:       "test-warn-" + timeBasedID(),
+		HTTPClient:  errorServer.Client(),
+		LevelMode:   logging.LevelModeWarnAndAbove,
+		IsDryRun:    false,
 	})
 	require.NoError(t, err)
 
@@ -311,11 +317,12 @@ func TestE2E_SlackWebhookSeparation_ErrorOnlyConfig(t *testing.T) {
 
 	// Create only ERROR handler (no SUCCESS handler)
 	errorHandler, err := logging.NewSlackHandler(logging.SlackHandlerOptions{
-		WebhookURL: errorServer.URL,
-		RunID:      "test-error-only-" + timeBasedID(),
-		HTTPClient: errorServer.Client(),
-		LevelMode:  logging.LevelModeWarnAndAbove,
-		IsDryRun:   false,
+		WebhookURL:  errorServer.URL,
+		AllowedHost: mustWebhookAllowedHost(t, errorServer.URL),
+		RunID:       "test-error-only-" + timeBasedID(),
+		HTTPClient:  errorServer.Client(),
+		LevelMode:   logging.LevelModeWarnAndAbove,
+		IsDryRun:    false,
 	})
 	require.NoError(t, err)
 
@@ -368,20 +375,22 @@ func TestE2E_SlackWebhookSeparation_DryRunMode(t *testing.T) {
 
 	// Create handlers with IsDryRun=true
 	successHandler, err := logging.NewSlackHandler(logging.SlackHandlerOptions{
-		WebhookURL: successServer.URL,
-		RunID:      "test-dryrun-" + timeBasedID(),
-		HTTPClient: successServer.Client(),
-		LevelMode:  logging.LevelModeExactInfo,
-		IsDryRun:   true, // Dry-run mode
+		WebhookURL:  successServer.URL,
+		AllowedHost: mustWebhookAllowedHost(t, successServer.URL),
+		RunID:       "test-dryrun-" + timeBasedID(),
+		HTTPClient:  successServer.Client(),
+		LevelMode:   logging.LevelModeExactInfo,
+		IsDryRun:    true, // Dry-run mode
 	})
 	require.NoError(t, err)
 
 	errorHandler, err := logging.NewSlackHandler(logging.SlackHandlerOptions{
-		WebhookURL: errorServer.URL,
-		RunID:      "test-dryrun-" + timeBasedID(),
-		HTTPClient: errorServer.Client(),
-		LevelMode:  logging.LevelModeWarnAndAbove,
-		IsDryRun:   true, // Dry-run mode
+		WebhookURL:  errorServer.URL,
+		AllowedHost: mustWebhookAllowedHost(t, errorServer.URL),
+		RunID:       "test-dryrun-" + timeBasedID(),
+		HTTPClient:  errorServer.Client(),
+		LevelMode:   logging.LevelModeWarnAndAbove,
+		IsDryRun:    true, // Dry-run mode
 	})
 	require.NoError(t, err)
 
@@ -426,11 +435,12 @@ func TestE2E_SlackWebhookSeparation_MessageFormat(t *testing.T) {
 	defer successServer.Close()
 
 	successHandler, err := logging.NewSlackHandler(logging.SlackHandlerOptions{
-		WebhookURL: successServer.URL,
-		RunID:      "test-format-" + timeBasedID(),
-		HTTPClient: successServer.Client(),
-		LevelMode:  logging.LevelModeExactInfo,
-		IsDryRun:   false,
+		WebhookURL:  successServer.URL,
+		AllowedHost: mustWebhookAllowedHost(t, successServer.URL),
+		RunID:       "test-format-" + timeBasedID(),
+		HTTPClient:  successServer.Client(),
+		LevelMode:   logging.LevelModeExactInfo,
+		IsDryRun:    false,
 	})
 	require.NoError(t, err)
 

--- a/internal/runner/e2e_slack_webhook_test.go
+++ b/internal/runner/e2e_slack_webhook_test.go
@@ -21,6 +21,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 
@@ -65,11 +66,13 @@ func TestE2E_SlackWebhookWithMockServer(t *testing.T) {
 	defer mockServer.Close()
 
 	t.Logf("Mock server URL: %s", mockServer.URL)
+	allowedHost := mustWebhookAllowedHost(t, mockServer.URL)
 
 	// Create real Slack handlers with mock server URL and HTTP client that accepts self-signed certs
 	// Use both SUCCESS and ERROR webhooks pointing to the same mock server
 	successSlackHandler, err := logging.NewSlackHandler(logging.SlackHandlerOptions{
 		WebhookURL:    mockServer.URL,
+		AllowedHost:   allowedHost,
 		RunID:         "e2e-mock-test-" + timeBasedID(),
 		HTTPClient:    mockServer.Client(),
 		BackoffConfig: logging.DefaultBackoffConfig,
@@ -80,6 +83,7 @@ func TestE2E_SlackWebhookWithMockServer(t *testing.T) {
 
 	errorSlackHandler, err := logging.NewSlackHandler(logging.SlackHandlerOptions{
 		WebhookURL:    mockServer.URL,
+		AllowedHost:   allowedHost,
 		RunID:         "e2e-mock-test-" + timeBasedID(),
 		HTTPClient:    mockServer.Client(),
 		BackoffConfig: logging.DefaultBackoffConfig,
@@ -168,4 +172,14 @@ func TestE2E_SlackWebhookWithMockServer(t *testing.T) {
 // timeBasedID generates a time-based ID for test run identification
 func timeBasedID() string {
 	return time.Now().Format("20060102-150405")
+}
+
+func mustWebhookAllowedHost(t *testing.T, webhookURL string) string {
+	t.Helper()
+
+	parsedURL, err := url.Parse(webhookURL)
+	require.NoError(t, err)
+	require.NotEmpty(t, parsedURL.Hostname())
+
+	return parsedURL.Hostname()
 }

--- a/internal/runner/runnertypes/spec.go
+++ b/internal/runner/runnertypes/spec.go
@@ -139,10 +139,10 @@ type GlobalSpec struct {
 	// Changed from: Vars []string `toml:"vars"` (array-based format)
 	Vars map[string]any `toml:"vars"`
 
-	// SlackAllowedHost は Slack webhook URL で許可するホスト名。
-	// 空文字列の場合 Slack 通知機能は使用不可となる。
-	// 値はポート番号を含まない純粋なホスト名であること (例: "hooks.slack.com")。
-	// ポート番号付き ("hooks.slack.com:443") や前後の空白は設定エラーとなる。
+	// SlackAllowedHost is the hostname permitted in Slack webhook URLs.
+	// When empty, the Slack notification feature is disabled.
+	// The value must be a bare hostname without a port number (e.g. "hooks.slack.com").
+	// Including a port ("hooks.slack.com:443") or surrounding whitespace is a configuration error.
 	SlackAllowedHost string `toml:"slack_allowed_host"`
 }
 

--- a/internal/runner/runnertypes/spec.go
+++ b/internal/runner/runnertypes/spec.go
@@ -138,6 +138,12 @@ type GlobalSpec struct {
 	//
 	// Changed from: Vars []string `toml:"vars"` (array-based format)
 	Vars map[string]any `toml:"vars"`
+
+	// SlackAllowedHost は Slack webhook URL で許可するホスト名。
+	// 空文字列の場合 Slack 通知機能は使用不可となる。
+	// 値はポート番号を含まない純粋なホスト名であること (例: "hooks.slack.com")。
+	// ポート番号付き ("hooks.slack.com:443") や前後の空白は設定エラーとなる。
+	SlackAllowedHost string `toml:"slack_allowed_host"`
 }
 
 // GroupSpec represents a command group configuration loaded from TOML file.

--- a/internal/runner/runnertypes/spec.go
+++ b/internal/runner/runnertypes/spec.go
@@ -140,8 +140,10 @@ type GlobalSpec struct {
 	Vars map[string]any `toml:"vars"`
 
 	// SlackAllowedHost is the hostname permitted in Slack webhook URLs.
-	// When empty, the Slack notification feature is disabled.
-	// The value must be a bare hostname without a port number (e.g. "hooks.slack.com").
+	// Must be set to a bare hostname (e.g. "hooks.slack.com") whenever Slack webhook
+	// environment variables are configured; startup fails with a config parsing error
+	// if any webhook URL is present but this field is empty or does not match the URL host.
+	// When no webhook URLs are configured, an empty value silently disables Slack notifications.
 	// Including a port ("hooks.slack.com:443") or surrounding whitespace is a configuration error.
 	SlackAllowedHost string `toml:"slack_allowed_host"`
 }


### PR DESCRIPTION
This pull request implements a two-phase logging initialization to support strict allowlisting of Slack webhook hosts, refactors the Slack logging setup to enforce host validation, and updates tests and documentation accordingly. The changes ensure that Slack notifications are only sent to explicitly allowed hosts, and that configuration errors are surfaced early and clearly. The initialization flow is now split so that Slack handlers are added only after configuration is loaded and validated.

The most important changes are:

**Slack Webhook Host Allowlisting and Validation**
* Added an `AllowedHost` field to `SlackHandlerOptions` and updated the `validateWebhookURL` function to require that the webhook URL's host matches the configured allowed host. If `allowedHost` is empty or mismatched, an error is returned. (`internal/logging/slack_handler.go`) [[1]](diffhunk://#diff-abd56e1f2bd3073159d128aa669c5be6c9381671b5679d7c413ae44590518568R130-R138) [[2]](diffhunk://#diff-abd56e1f2bd3073159d128aa669c5be6c9381671b5679d7c413ae44590518568R156-R172)
* Updated all usages and tests of `validateWebhookURL` to provide the `allowedHost` argument, and expanded test coverage for various host validation scenarios. (`internal/logging/slack_handler_test.go`)

**Two-Phase Logging Initialization**
* Refactored logger setup: removed Slack webhook fields from the initial logger config (`LoggerConfig`), and instead introduced a separate phase (`SetupSlackLogging`) that adds Slack handlers after config is loaded and validated. (`cmd/runner/main.go`, `internal/runner/bootstrap/environment.go`, `internal/runner/bootstrap/logger.go`) [[1]](diffhunk://#diff-a00bb025bf1923f717ec616d0fd151f6a1ee536725aa46cb4af908be57f4d056L192-L193) [[2]](diffhunk://#diff-a00bb025bf1923f717ec616d0fd151f6a1ee536725aa46cb4af908be57f4d056R231-R239)
* Updated integration and error-handling tests to reflect the new two-phase initialization and Slack handler error propagation. (`cmd/runner/integration_logger_test.go`, `cmd/runner/integration_pre_execution_error_test.go`) [[1]](diffhunk://#diff-7b3ac496b9bf819a1e957057caeda20321b180ba213545f25190d0e554cc747eL53-R62) [[2]](diffhunk://#diff-7b3ac496b9bf819a1e957057caeda20321b180ba213545f25190d0e554cc747eL259-L304) [[3]](diffhunk://#diff-403a7e1f693c3f296b4367f92b51720cf6c7ee3839270fc9d4b804e59cb1185bR194-R264)

**Test and Documentation Updates**
* Added an end-to-end test to verify that startup fails with a clear error when Slack webhook env vars are set but `slack_allowed_host` is missing from the config. (`cmd/runner/integration_pre_execution_error_test.go`)
* Updated implementation plan documentation to mark completed tasks and reflect the new design and test coverage. (`docs/tasks/0091_slack_webhook_allowlist/04_implementation_plan.md`)

**Other Refactoring and Cleanup**
* Removed Slack webhook configuration from dry-run integration tests and logger setup, as Slack handlers are now added only in the second phase. (`cmd/runner/integration_dryrun_verification_test.go`) [[1]](diffhunk://#diff-fcff08974310758310b891f4cf4a7fc281eb137215a372e15ae8d75179307dedL244-R247) [[2]](diffhunk://#diff-fcff08974310758310b891f4cf4a7fc281eb137215a372e15ae8d75179307dedL293-L296)

These changes collectively improve the security and clarity of Slack notification handling, enforce strict host allowlisting, and make the logging system more robust and testable.