### PR TITLE
docs(0092): Add documents for dynlib analysis static ELF in-memory development

### DIFF
--- a/docs/tasks/0092_dynlibanalysis_static_elf_inmemory/01_requirements.md
+++ b/docs/tasks/0092_dynlibanalysis_static_elf_inmemory/01_requirements.md
@@ -1,0 +1,107 @@
+# 0092: TestAnalyze_StaticELF のインメモリ ELF 生成への移行
+
+## 1. 概要
+
+### 1.1 背景
+
+`internal/dynlibanalysis/analyzer_test.go` の `TestAnalyze_StaticELF` は、ELF バイナリに動的依存ライブラリ（DT_NEEDED）が存在しない場合に `Analyze()` が nil を返すことを検証するテストである。
+
+現在、このテストは `internal/runner/security/elfanalyzer/testdata/static.elf` を外部ファイルとして参照している。このファイルは以下の性質を持つ。
+
+- `internal/runner/security/elfanalyzer/testdata/.gitignore` により Git 管理外（`*.elf` で除外）
+- `make elfanalyzer-testdata` により `gcc -x c -static` で生成される
+- `dynlibanalysis` パッケージとは別パッケージ（`elfanalyzer`）のテストデータディレクトリに存在する
+
+この設計には以下の問題がある。
+
+1. **クロスパッケージのテストデータ依存**：`dynlibanalysis` テストが `elfanalyzer` パッケージのテストデータ生成に依存している。パッケージ間の責務境界を侵害する。
+2. **外部ツール依存**：GCC がインストールされていない環境や、`make elfanalyzer-testdata` を実行していない環境でテストが実行された場合、ファイルが存在せずテストがスキップされる（テストカバレッジが欠落する）。
+3. **パスの脆弱性**：外部ファイルへの相対パス参照は、リポジトリ構造の変更やビルドアーティファクトの配置によって誤動作を起こしやすい（本タスクの起因となった障害はこれによって発生した）。
+
+同じファイル内の他のテスト（`TestAnalyze_TransitiveDeps`、`TestAnalyze_CircularDeps` 等）は `buildTestELFWithDeps` ヘルパーを使ってインメモリで ELF を構築しており、外部ファイルに依存しない。`TestAnalyze_StaticELF` も同様の手法に統一する。
+
+### 1.2 目的
+
+`TestAnalyze_StaticELF` を、外部ファイルに依存しないインメモリ ELF 生成方式に書き換え、GCC や `make` ターゲットへの依存なしに任意の環境で安定してテストが実行できるようにする。
+
+### 1.3 スコープ外
+
+- `elfanalyzer/testdata/static.elf` 自体の削除・変更（`elfanalyzer` パッケージのテストは引き続き使用する）
+- `buildTestELFWithDeps` の動作変更
+- `dynlibanalysis` パッケージの他テストへの変更
+
+---
+
+## 2. 用語定義
+
+| 用語 | 定義 |
+|------|------|
+| 静的 ELF | PT_DYNAMIC セグメントを持たない、または DT_NEEDED エントリを持たない ELF バイナリ。`Analyze()` は nil を返す |
+| `buildTestELFWithDeps` | `analyzer_test.go` に定義済みのインメモリ ELF 生成ヘルパー。動的依存ライブラリを指定して ELF を構築する |
+| DT_NEEDED | ELF の DYNAMIC セクションに記録される動的リンク依存ライブラリのエントリ |
+
+---
+
+## 3. 機能要件
+
+### FR-1: `buildTestELFWithDeps` を利用した静的 ELF の生成
+
+`buildTestELFWithDeps` に `sonames=nil`、`runpath=""` を渡すと、DT_NEEDED エントリを持たない ELF が生成される。`elf.DynString(elf.DT_NEEDED)` は空スライスを返し、`Analyze()` は nil を返す。この挙動を利用して `TestAnalyze_StaticELF` を書き換える。
+
+**変更対象**：`internal/dynlibanalysis/analyzer_test.go`
+
+**変更内容**：
+
+1. `TestAnalyze_StaticELF` 関数本体を以下の構造に書き換える：
+   - `t.TempDir()` で一時ディレクトリを用意する
+   - `buildTestELFWithDeps(t, tmpDir, "no_deps.elf", nil, "")` で DT_NEEDED なし ELF を生成する
+   - `a.Analyze(path)` を呼び出す
+   - 結果が nil であることを `assert.Nil` で検証する
+2. 外部ファイルパス（`../runner/security/elfanalyzer/testdata/static.elf`）への参照を削除する
+3. `os.Stat` によるファイル存在確認とスキップ処理を削除する
+
+### FR-2: `os` パッケージのインポート整理
+
+`os.Stat` の削除により `os` パッケージが不要になる場合は、インポートから除去する。ただし、他のテスト関数（例：`TestAnalyze_NonELF` の `os.WriteFile`）で使用されている場合は除去しない。
+
+---
+
+## 4. 非機能要件
+
+### 4.1 テスト実行環境
+
+変更後、`TestAnalyze_StaticELF` は GCC、`make`、外部バイナリファイルへの依存なしに実行できること。
+
+### 4.2 テストのスキップ廃止
+
+変更前は `os.Stat` 失敗時にテストをスキップしていた。変更後はスキップ処理を持たず、常にテストが実行されること。
+
+---
+
+## 5. 受け入れ基準
+
+### AC-1: 外部ファイル参照の除去
+
+- [ ] `TestAnalyze_StaticELF` 内に `elfanalyzer/testdata` へのパス参照が存在しないこと
+- [ ] `os.Stat` によるファイル存在確認コードが除去されていること
+- [ ] `t.Skip` / `t.Skipf` 呼び出しが除去されていること
+
+### AC-2: インメモリ ELF による検証
+
+- [ ] `buildTestELFWithDeps` を `sonames=nil`、`runpath=""` で呼び出して ELF を生成していること
+- [ ] `a.Analyze(path)` の返り値が nil であることを `assert.Nil` で検証していること
+- [ ] `require.NoError` でエラーがないことを検証していること
+
+### AC-3: テストの安定実行
+
+- [ ] `go test -tags test -v ./internal/dynlibanalysis/...` を `make elfanalyzer-testdata` なしで実行したとき `TestAnalyze_StaticELF` が PASS すること
+- [ ] `make test` がすべてパスすること
+- [ ] `make lint` がエラーなく完了すること
+
+---
+
+## 6. 実装ノート
+
+`buildTestELFWithDeps(t, tmpDir, "no_deps.elf", nil, "")` が生成する ELF は、DT_STRTAB・DT_STRSZ・DT_NULL のみを含む `.dynamic` セクションを持つ。これは `gcc -static` で生成される「PT_DYNAMIC セグメントを持たない」ELF とは構造が異なるが、`Analyze()` の戻り値（DT_NEEDED が空のとき nil）の検証という観点では同等である。
+
+テストの目的が「DT_NEEDED なし ELF に対して Analyze() が nil を返すこと」の確認であるため、本変更は機能的に等価な置き換えである。

--- a/docs/tasks/0092_dynlibanalysis_static_elf_inmemory/01_requirements.md
+++ b/docs/tasks/0092_dynlibanalysis_static_elf_inmemory/01_requirements.md
@@ -18,7 +18,7 @@
 2. **外部ツール依存**：GCC がインストールされていない環境や、`make elfanalyzer-testdata` を実行していない環境でテストが実行された場合、ファイルが存在せずテストがスキップされる（テストカバレッジが欠落する）。
 3. **パスの脆弱性**：外部ファイルへの相対パス参照は、リポジトリ構造の変更やビルドアーティファクトの配置によって誤動作を起こしやすい（本タスクの起因となった障害はこれによって発生した）。
 
-同じファイル内の他のテスト（`TestAnalyze_TransitiveDeps`、`TestAnalyze_CircularDeps` 等）は `buildTestELFWithDeps` ヘルパーを使ってインメモリで ELF を構築しており、外部ファイルに依存しない。`TestAnalyze_StaticELF` も同様の手法に統一する。
+同じファイル内の他のテスト（`TestAnalyze_TransitiveDeps`、`TestAnalyze_CircularDeps` 等）はインメモリで ELF を構築しており、外部ファイルに依存しない。`TestAnalyze_StaticELF` も同様の手法に統一する。
 
 ### 1.2 目的
 
@@ -27,7 +27,6 @@
 ### 1.3 スコープ外
 
 - `elfanalyzer/testdata/static.elf` 自体の削除・変更（`elfanalyzer` パッケージのテストは引き続き使用する）
-- `buildTestELFWithDeps` の動作変更
 - `dynlibanalysis` パッケージの他テストへの変更
 
 ---
@@ -37,32 +36,19 @@
 | 用語 | 定義 |
 |------|------|
 | 静的 ELF | PT_DYNAMIC セグメントを持たない、または DT_NEEDED エントリを持たない ELF バイナリ。`Analyze()` は nil を返す |
-| `buildTestELFWithDeps` | `analyzer_test.go` に定義済みのインメモリ ELF 生成ヘルパー。動的依存ライブラリを指定して ELF を構築する |
 | DT_NEEDED | ELF の DYNAMIC セクションに記録される動的リンク依存ライブラリのエントリ |
 
 ---
 
 ## 3. 機能要件
 
-### FR-1: `buildTestELFWithDeps` を利用した静的 ELF の生成
+### FR-1: `TestAnalyze_StaticELF` の外部ファイル依存の解消
 
-`buildTestELFWithDeps` に `sonames=nil`、`runpath=""` を渡すと、DT_NEEDED エントリを持たない ELF が生成される。`elf.DynString(elf.DT_NEEDED)` は空スライスを返し、`Analyze()` は nil を返す。この挙動を利用して `TestAnalyze_StaticELF` を書き換える。
+`TestAnalyze_StaticELF` は、外部ファイルに依存せず、テスト実行時にインメモリで ELF バイナリを生成して検証を行うこと。
+
+生成する ELF は DT_NEEDED エントリを持たないものとし、`Analyze()` が nil を返すことを検証する。
 
 **変更対象**：`internal/dynlibanalysis/analyzer_test.go`
-
-**変更内容**：
-
-1. `TestAnalyze_StaticELF` 関数本体を以下の構造に書き換える：
-   - `t.TempDir()` で一時ディレクトリを用意する
-   - `buildTestELFWithDeps(t, tmpDir, "no_deps.elf", nil, "")` で DT_NEEDED なし ELF を生成する
-   - `a.Analyze(path)` を呼び出す
-   - 結果が nil であることを `assert.Nil` で検証する
-2. 外部ファイルパス（`../runner/security/elfanalyzer/testdata/static.elf`）への参照を削除する
-3. `os.Stat` によるファイル存在確認とスキップ処理を削除する
-
-### FR-2: `os` パッケージのインポート整理
-
-`os.Stat` の削除により `os` パッケージが不要になる場合は、インポートから除去する。ただし、他のテスト関数（例：`TestAnalyze_NonELF` の `os.WriteFile`）で使用されている場合は除去しない。
 
 ---
 
@@ -74,7 +60,7 @@
 
 ### 4.2 テストのスキップ廃止
 
-変更前は `os.Stat` 失敗時にテストをスキップしていた。変更後はスキップ処理を持たず、常にテストが実行されること。
+変更前は外部ファイルの不在時にテストをスキップしていた。変更後はスキップ処理を持たず、常にテストが実行されること。
 
 ---
 
@@ -83,25 +69,15 @@
 ### AC-1: 外部ファイル参照の除去
 
 - [ ] `TestAnalyze_StaticELF` 内に `elfanalyzer/testdata` へのパス参照が存在しないこと
-- [ ] `os.Stat` によるファイル存在確認コードが除去されていること
-- [ ] `t.Skip` / `t.Skipf` 呼び出しが除去されていること
+- [ ] ファイル存在確認に基づくスキップ処理（`t.Skip` / `t.Skipf`）が除去されていること
 
 ### AC-2: インメモリ ELF による検証
 
-- [ ] `buildTestELFWithDeps` を `sonames=nil`、`runpath=""` で呼び出して ELF を生成していること
-- [ ] `a.Analyze(path)` の返り値が nil であることを `assert.Nil` で検証していること
-- [ ] `require.NoError` でエラーがないことを検証していること
+- [ ] `TestAnalyze_StaticELF` がインメモリで生成した ELF を使用して検証を行うこと
+- [ ] DT_NEEDED エントリを持たない ELF に対して `Analyze()` が nil を返すことを検証していること
 
 ### AC-3: テストの安定実行
 
 - [ ] `go test -tags test -v ./internal/dynlibanalysis/...` を `make elfanalyzer-testdata` なしで実行したとき `TestAnalyze_StaticELF` が PASS すること
 - [ ] `make test` がすべてパスすること
 - [ ] `make lint` がエラーなく完了すること
-
----
-
-## 6. 実装ノート
-
-`buildTestELFWithDeps(t, tmpDir, "no_deps.elf", nil, "")` が生成する ELF は、DT_STRTAB・DT_STRSZ・DT_NULL のみを含む `.dynamic` セクションを持つ。これは `gcc -static` で生成される「PT_DYNAMIC セグメントを持たない」ELF とは構造が異なるが、`Analyze()` の戻り値（DT_NEEDED が空のとき nil）の検証という観点では同等である。
-
-テストの目的が「DT_NEEDED なし ELF に対して Analyze() が nil を返すこと」の確認であるため、本変更は機能的に等価な置き換えである。

--- a/docs/tasks/0092_dynlibanalysis_static_elf_inmemory/02_architecture.md
+++ b/docs/tasks/0092_dynlibanalysis_static_elf_inmemory/02_architecture.md
@@ -1,0 +1,189 @@
+# アーキテクチャ設計書: TestAnalyze_StaticELF のインメモリ ELF 生成への移行
+
+## 1. システム概要
+
+### 1.1 アーキテクチャ目標
+
+- 外部ファイル依存の解消
+- 既存のインメモリ ELF ビルダー（`buildTestELFWithDeps`）の再利用
+- テストの安定実行（GCC・`make` 不要）
+
+### 1.2 設計原則
+
+- **既存活用**: 同テストファイル内に存在する `buildTestELFWithDeps` ヘルパーを再利用する
+- **YAGNI**: 新たなヘルパー関数は追加しない。`buildTestELFWithDeps` に `sonames=nil` を渡すことで静的 ELF を表現する
+- **最小変更**: 変更対象は `TestAnalyze_StaticELF` 関数本体のみ
+
+## 2. 変更前後の構成比較
+
+### 2.1 変更前: 外部ファイル依存
+
+```mermaid
+flowchart TD
+    classDef data fill:#e6f7ff,stroke:#1f77b4,stroke-width:1px,color:#0b3d91;
+    classDef process fill:#fff1e6,stroke:#ff7f0e,stroke-width:1px,color:#8a3e00;
+    classDef problem fill:#ffe6e6,stroke:#d62728,stroke-width:2px,color:#7b0000;
+
+    A[("elfanalyzer/testdata/static.elf")] -->|"ファイル存在確認"| B{"ファイルあり?"}
+    B -->|"なし"| C["t.Skipf → テストスキップ"]
+    B -->|"あり"| D["Analyze(path)"]
+    D --> E["assert.Nil(result)"]
+
+    F[("make elfanalyzer-testdata<br>GCC 依存")] -->|"生成"| A
+
+    class A,F data;
+    class D,E process;
+    class B,C problem;
+```
+
+**問題点**
+
+- `make elfanalyzer-testdata` 未実行時はテストがスキップされる（カバレッジ欠落）
+- `dynlibanalysis` パッケージが `elfanalyzer` パッケージのテストデータに依存（責務境界違反）
+
+### 2.2 変更後: インメモリ ELF 生成
+
+```mermaid
+flowchart TD
+    classDef data fill:#e6f7ff,stroke:#1f77b4,stroke-width:1px,color:#0b3d91;
+    classDef process fill:#fff1e6,stroke:#ff7f0e,stroke-width:1px,color:#8a3e00;
+    classDef enhanced fill:#e8f5e8,stroke:#2e8b57,stroke-width:2px,color:#006400;
+
+    A[("t.TempDir()")] --> B["buildTestELFWithDeps<br>sonames=nil, runpath=&quot;&quot;"]
+    B -->|"インメモリ ELF バイト列"| C[("静的 ELF (DT_NEEDED なし)")]
+    C --> D["Analyze(path)"]
+    D --> E["assert.Nil(result)"]
+
+    class A data;
+    class B enhanced;
+    class C data;
+    class D,E process;
+```
+
+**凡例（Legend）**
+
+```mermaid
+flowchart LR
+    classDef data fill:#e6f7ff,stroke:#1f77b4,stroke-width:1px,color:#0b3d91;
+    classDef process fill:#fff1e6,stroke:#ff7f0e,stroke-width:1px,color:#8a3e00;
+    classDef enhanced fill:#e8f5e8,stroke:#2e8b57,stroke-width:2px,color:#006400;
+    classDef problem fill:#ffe6e6,stroke:#d62728,stroke-width:2px,color:#7b0000;
+
+    D1[("設定・環境データ")] --> P1["既存コンポーネント"] --> E1["変更・追加コンポーネント"] --> X1["問題箇所"]
+    class D1 data
+    class P1 process
+    class E1 enhanced
+    class X1 problem
+```
+
+## 3. コンポーネント設計
+
+### 3.1 対象ファイルと変更範囲
+
+```mermaid
+graph TB
+    classDef data fill:#e6f7ff,stroke:#1f77b4,stroke-width:1px,color:#0b3d91;
+    classDef process fill:#fff1e6,stroke:#ff7f0e,stroke-width:1px,color:#8a3e00;
+    classDef enhanced fill:#e8f5e8,stroke:#2e8b57,stroke-width:2px,color:#006400;
+
+    subgraph "internal/dynlibanalysis/analyzer_test.go"
+        H["buildTestELFWithDeps<br>（既存ヘルパー・変更なし）"]
+        T["TestAnalyze_StaticELF<br>（変更対象）"]
+    end
+
+    subgraph "internal/runner/security/elfanalyzer/testdata/"
+        F[("static.elf<br>（参照除去・ファイル自体は残す）")]
+    end
+
+    H -->|"再利用"| T
+    F -. "参照を除去" .-> T
+
+    class H process;
+    class T enhanced;
+    class F data;
+```
+
+### 3.2 `buildTestELFWithDeps` による静的 ELF の表現
+
+`buildTestELFWithDeps` の引数に `sonames=nil`、`runpath=""` を渡すことで、DT_NEEDED エントリを持たない ELF バイナリが生成される。
+
+生成される ELF の構造:
+
+| セクション/セグメント | 内容 |
+|---|---|
+| ELF Header | ELF64 LE, ET_DYN, EM_X86_64 |
+| PT_LOAD | ファイル全体をカバーするロードセグメント |
+| PT_DYNAMIC | .dynamic セクションを指す動的セグメント |
+| .dynamic | DT_STRTAB, DT_STRSZ, DT_NULL のみ（DT_NEEDED なし） |
+| .dynstr | 空文字列のみ（`\x00`） |
+| .shstrtab | セクション名テーブル |
+
+### 3.3 変更前後のコード比較
+
+**変更前**:
+
+```go
+func TestAnalyze_StaticELF(t *testing.T) {
+    staticELF := "../runner/security/elfanalyzer/testdata/static.elf"
+    if _, err := os.Stat(staticELF); err != nil {
+        t.Skipf("static.elf testdata not accessible: %v", err)
+    }
+
+    a := newTestAnalyzer(t)
+    result, err := a.Analyze(staticELF)
+    require.NoError(t, err)
+    assert.Nil(t, result, "static ELF with no DT_NEEDED should return nil")
+}
+```
+
+**変更後**:
+
+```go
+func TestAnalyze_StaticELF(t *testing.T) {
+    tmpDir := t.TempDir()
+    // sonames=nil produces an ELF with no DT_NEEDED entries.
+    staticELF := buildTestELFWithDeps(t, tmpDir, "static.elf", nil, "")
+
+    a := newTestAnalyzer(t)
+    result, err := a.Analyze(staticELF)
+    require.NoError(t, err)
+    assert.Nil(t, result, "static ELF with no DT_NEEDED should return nil")
+}
+```
+
+## 4. データフロー
+
+```mermaid
+sequenceDiagram
+    participant T as "TestAnalyze_StaticELF"
+    participant B as "buildTestELFWithDeps"
+    participant FS as "t.TempDir()"
+    participant A as "DynLibAnalyzer.Analyze()"
+
+    T->>FS: "一時ディレクトリ作成"
+    T->>B: "buildTestELFWithDeps(t, tmpDir, 'static.elf', nil, '')"
+    B->>B: "ELF バイト列をメモリ上で構築"
+    B->>FS: "ELF ファイルを書き込む"
+    B-->>T: "ファイルパスを返す"
+    T->>A: "Analyze(path)"
+    A->>A: "ELF を解析: DT_NEEDED なし"
+    A-->>T: "nil, nil"
+    T->>T: "assert.Nil(result) → PASS"
+```
+
+## 5. 影響範囲
+
+| 対象 | 変更内容 |
+|---|---|
+| `internal/dynlibanalysis/analyzer_test.go` | `TestAnalyze_StaticELF` のみ書き換え |
+| `internal/runner/security/elfanalyzer/testdata/static.elf` | 変更なし（`elfanalyzer` パッケージのテストが引き続き使用） |
+| `Makefile` の `elfanalyzer-testdata` ターゲット | 変更なし |
+| その他テスト | 変更なし |
+
+## 6. 削除対象の依存関係
+
+| 依存 | 削除理由 |
+|---|---|
+| `os.Stat` によるファイル存在確認 | インメモリ生成により不要 |
+| `t.Skipf` によるスキップ処理 | インメモリ生成により不要 |
+| `"../runner/security/elfanalyzer/testdata/static.elf"` パス参照 | パッケージ間依存の解消 |

--- a/docs/tasks/0092_dynlibanalysis_static_elf_inmemory/03_detailed_specification.md
+++ b/docs/tasks/0092_dynlibanalysis_static_elf_inmemory/03_detailed_specification.md
@@ -1,0 +1,92 @@
+# 詳細仕様書: TestAnalyze_StaticELF のインメモリ ELF 生成への移行
+
+## 0. 変更方針
+
+変更対象は `internal/dynlibanalysis/analyzer_test.go` の `TestAnalyze_StaticELF` 関数の本体のみ。
+既存の `buildTestELFWithDeps` ヘルパーを再利用し、新たなヘルパー追加や他テスト関数への影響はない。
+
+---
+
+## 1. 変更対象ファイル一覧
+
+| ファイル | 変更種別 | 概要 |
+|---------|---------|------|
+| `internal/dynlibanalysis/analyzer_test.go` | 変更 | `TestAnalyze_StaticELF` の本体をインメモリ生成方式に書き換え |
+
+---
+
+## 2. 変更詳細
+
+### 2.1 `TestAnalyze_StaticELF` (`internal/dynlibanalysis/analyzer_test.go`)
+
+**変更前**:
+
+```go
+// TestAnalyze_StaticELF verifies that Analyze returns nil for a static ELF
+// (no DT_NEEDED entries).
+func TestAnalyze_StaticELF(t *testing.T) {
+	staticELF := "../runner/security/elfanalyzer/testdata/static.elf"
+	if _, err := os.Stat(staticELF); err != nil {
+		t.Skipf("static.elf testdata not accessible: %v", err)
+	}
+
+	a := newTestAnalyzer(t)
+	result, err := a.Analyze(staticELF)
+	require.NoError(t, err)
+	assert.Nil(t, result, "static ELF with no DT_NEEDED should return nil")
+}
+```
+
+**変更後**:
+
+```go
+// TestAnalyze_StaticELF verifies that Analyze returns nil for a static ELF
+// (no DT_NEEDED entries).
+func TestAnalyze_StaticELF(t *testing.T) {
+	tmpDir := t.TempDir()
+	// sonames=nil produces an ELF with no DT_NEEDED entries.
+	staticELF := buildTestELFWithDeps(t, tmpDir, "static.elf", nil, "")
+
+	a := newTestAnalyzer(t)
+	result, err := a.Analyze(staticELF)
+	require.NoError(t, err)
+	assert.Nil(t, result, "static ELF with no DT_NEEDED should return nil")
+}
+```
+
+### 2.2 削除する要素
+
+| 要素 | 削除理由 |
+|------|---------|
+| `staticELF := "../runner/security/elfanalyzer/testdata/static.elf"` | インメモリ生成へ移行するため不要 |
+| `os.Stat(staticELF)` によるファイル存在確認 | インメモリ生成ではファイルの事前存在が不要 |
+| `t.Skipf(...)` によるスキップ処理 | 外部ファイル依存がなくなりスキップ条件が消滅 |
+
+### 2.3 `os` パッケージのインポート
+
+`os` パッケージは同ファイル内の `TestAnalyze_NonELF` で引き続き使用されるため、インポート宣言の変更は不要。
+
+---
+
+## 3. `buildTestELFWithDeps` の動作仕様（静的 ELF 生成に関する部分）
+
+`buildTestELFWithDeps(t, dir, fileName, nil, "")` を呼び出したとき:
+
+- `sonames` が `nil`（または空スライス）の場合、DT_NEEDED エントリは生成されない
+- `runpath` が空文字列の場合、DT_RUNPATH エントリは生成されない
+- `.dynamic` セクションには `DT_STRTAB`、`DT_STRSZ`、`DT_NULL` の 3 エントリのみが書き込まれる
+- `DynLibAnalyzer.Analyze()` はこの ELF を解析し、DT_NEEDED が存在しないため `nil` を返す
+
+---
+
+## 4. テストと受け入れ基準の対応
+
+| 受け入れ基準 | 対応箇所 |
+|------------|---------|
+| AC-1: `elfanalyzer/testdata` パス参照の除去 | `staticELF := "../runner/security/elfanalyzer/testdata/static.elf"` を削除 |
+| AC-1: `t.Skip` / `t.Skipf` の除去 | `t.Skipf(...)` を削除 |
+| AC-2: インメモリ ELF による検証 | `buildTestELFWithDeps(t, tmpDir, "static.elf", nil, "")` を使用 |
+| AC-2: `Analyze()` が nil を返すことの検証 | `assert.Nil(t, result, ...)` で検証（変更なし） |
+| AC-3: `make elfanalyzer-testdata` 不要での PASS | 外部ファイル依存が解消されるため達成 |
+| AC-3: `make test` がすべてパス | テストロジックの変更は最小限であり影響なし |
+| AC-3: `make lint` がエラーなし | 削除した変数 `err` はスコープが消えるため、未使用変数エラーは発生しない |

--- a/docs/tasks/0092_dynlibanalysis_static_elf_inmemory/03_detailed_specification.md
+++ b/docs/tasks/0092_dynlibanalysis_static_elf_inmemory/03_detailed_specification.md
@@ -87,6 +87,6 @@ func TestAnalyze_StaticELF(t *testing.T) {
 | AC-1: `t.Skip` / `t.Skipf` の除去 | `t.Skipf(...)` を削除 |
 | AC-2: インメモリ ELF による検証 | `buildTestELFWithDeps(t, tmpDir, "static.elf", nil, "")` を使用 |
 | AC-2: `Analyze()` が nil を返すことの検証 | `assert.Nil(t, result, ...)` で検証（変更なし） |
-| AC-3: `make elfanalyzer-testdata` 不要での PASS | 外部ファイル依存が解消されるため達成 |
-| AC-3: `make test` がすべてパス | テストロジックの変更は最小限であり影響なし |
-| AC-3: `make lint` がエラーなし | 削除した変数 `err` はスコープが消えるため、未使用変数エラーは発生しない |
+| AC-3: `make elfanalyzer-testdata` 不要での PASS | 外部ファイル依存が解消されるため、実装後に達成予定 |
+| AC-3: `make test` がすべてパス | テストロジックの変更は最小限であり、実装後に確認 |
+| AC-3: `make lint` がエラーなし | 削除した変数 `err` はスコープが消えるため未使用変数エラーは発生しない想定。実装後に確認 |

--- a/docs/tasks/0092_dynlibanalysis_static_elf_inmemory/04_implementation_plan.md
+++ b/docs/tasks/0092_dynlibanalysis_static_elf_inmemory/04_implementation_plan.md
@@ -1,0 +1,14 @@
+# 実装計画: TestAnalyze_StaticELF のインメモリ ELF 生成への移行
+
+- [ ] 1. `TestAnalyze_StaticELF` をインメモリ ELF 生成方式に書き換え (AC-1, AC-2, AC-3)
+  - [ ] `internal/dynlibanalysis/analyzer_test.go` の `TestAnalyze_StaticELF` 関数を変更する
+    - `staticELF := "../runner/security/elfanalyzer/testdata/static.elf"` を削除 (AC-1)
+    - `os.Stat(staticELF)` によるファイル存在確認を削除 (AC-1)
+    - `t.Skipf(...)` によるスキップ処理を削除 (AC-1)
+    - `tmpDir := t.TempDir()` を追加 (AC-2)
+    - `staticELF := buildTestELFWithDeps(t, tmpDir, "static.elf", nil, "")` を追加 (AC-2)
+  - `os` パッケージは `TestAnalyze_NonELF` で引き続き使用されるためインポート変更は不要 (AC-3)
+
+- [ ] 2. テストの実行確認 (AC-3)
+  - [ ] `make test` を実行してすべてのテストがパスすることを確認する
+  - [ ] `make lint` を実行してエラーがないことを確認する


### PR DESCRIPTION
This pull request introduces a comprehensive plan and specification for refactoring the `TestAnalyze_StaticELF` test in `internal/dynlibanalysis/analyzer_test.go` to generate ELF test binaries in-memory, instead of relying on an external file. The main objective is to eliminate cross-package test data dependencies and external tool requirements (like GCC and `make`), ensuring that the test can always run reliably in any environment. The change leverages an existing helper (`buildTestELFWithDeps`) and only modifies the test function itself, minimizing the impact on the rest of the codebase.

Key changes and themes:

**Requirements and Rationale:**
- Clearly documents the motivation for removing the external file dependency, including issues with cross-package coupling, reliance on external tools, and brittle path references.

**Architecture and Design:**
- Specifies that the existing `buildTestELFWithDeps` helper will be reused to generate a static ELF (with no DT_NEEDED entries) in-memory by passing `sonames=nil`. No new helpers are introduced, and only the test function body is changed.
- Provides before/after diagrams and code samples to illustrate the new approach and its benefits.

**Detailed Specification:**
- Details the exact code changes to be made, including the removal of file existence checks and test skipping logic, and the use of in-memory ELF generation.
- Explains that the `os` package import remains for other tests, and documents the unchanged behavior of the analyzer under test.

**Implementation Plan:**
- Outlines a step-by-step checklist for implementing and verifying the change, including code modifications and validation via `make test` and `make lint`.

These changes ensure that `TestAnalyze_StaticELF` is robust, portable, and decoupled from external artifacts and tools.

Most important changes:

**Test Refactoring and Decoupling:**
- Replaces the external file dependency in `TestAnalyze_StaticELF` with in-memory ELF generation using `buildTestELFWithDeps`, removing the need for GCC, `make`, or test data in another package. [[1]](diffhunk://#diff-7cb2fff11220e5e0658f1016abb24e0610229c8544e90c2f8be79b22ce5b737aR1-R83) [[2]](diffhunk://#diff-fdf556c6ae5f9ba44b9ecbf55000b3aba28ffb01d80d29e80b3322329e2a9afeR1-R189) [[3]](diffhunk://#diff-d1085c7c049d59e6ed455dc6f14b865df8041582c369a30fc8695769f1fe0182R1-R92)

**Test Stability and Coverage:**
- Eliminates file existence checks and test skipping logic, ensuring the test always runs and contributes to coverage regardless of environment or prior setup. [[1]](diffhunk://#diff-7cb2fff11220e5e0658f1016abb24e0610229c8544e90c2f8be79b22ce5b737aR1-R83) [[2]](diffhunk://#diff-d1085c7c049d59e6ed455dc6f14b865df8041582c369a30fc8695769f1fe0182R1-R92)

**Documentation and Planning:**
- Provides thorough requirements, architecture, detailed specifications, and an implementation plan to guide and justify the change, supporting maintainability and review. [[1]](diffhunk://#diff-7cb2fff11220e5e0658f1016abb24e0610229c8544e90c2f8be79b22ce5b737aR1-R83) [[2]](diffhunk://#diff-fdf556c6ae5f9ba44b9ecbf55000b3aba28ffb01d80d29e80b3322329e2a9afeR1-R189) [[3]](diffhunk://#diff-d1085c7c049d59e6ed455dc6f14b865df8041582c369a30fc8695769f1fe0182R1-R92) [[4]](diffhunk://#diff-53ca33dda257455c6623ea1215b07bde39d828f928e3b6d2e60e1618bcc59681R1-R14)