### PR TITLE
Migrate TestAnalyze_StaticELF to in-memory ELF generation

### DIFF
--- a/docs/tasks/0092_dynlibanalysis_static_elf_inmemory/04_implementation_plan.md
+++ b/docs/tasks/0092_dynlibanalysis_static_elf_inmemory/04_implementation_plan.md
@@ -1,7 +1,7 @@
 # 実装計画: TestAnalyze_StaticELF のインメモリ ELF 生成への移行
 
-- [ ] 1. `TestAnalyze_StaticELF` をインメモリ ELF 生成方式に書き換え (AC-1, AC-2, AC-3)
-  - [ ] `internal/dynlibanalysis/analyzer_test.go` の `TestAnalyze_StaticELF` 関数を変更する
+- [x] 1. `TestAnalyze_StaticELF` をインメモリ ELF 生成方式に書き換え (AC-1, AC-2, AC-3)
+  - [x] `internal/dynlibanalysis/analyzer_test.go` の `TestAnalyze_StaticELF` 関数を変更する
     - `staticELF := "../runner/security/elfanalyzer/testdata/static.elf"` を削除 (AC-1)
     - `os.Stat(staticELF)` によるファイル存在確認を削除 (AC-1)
     - `t.Skipf(...)` によるスキップ処理を削除 (AC-1)
@@ -9,6 +9,6 @@
     - `staticELF := buildTestELFWithDeps(t, tmpDir, "static.elf", nil, "")` を追加 (AC-2)
   - `os` パッケージは `TestAnalyze_NonELF` で引き続き使用されるためインポート変更は不要 (AC-3)
 
-- [ ] 2. テストの実行確認 (AC-3)
-  - [ ] `make test` を実行してすべてのテストがパスすることを確認する
-  - [ ] `make lint` を実行してエラーがないことを確認する
+- [x] 2. テストの実行確認 (AC-3)
+  - [x] `make test` を実行してすべてのテストがパスすることを確認する
+  - [x] `make lint` を実行してエラーがないことを確認する

--- a/internal/dynlibanalysis/analyzer_test.go
+++ b/internal/dynlibanalysis/analyzer_test.go
@@ -246,10 +246,9 @@ func TestAnalyze_NonELF(t *testing.T) {
 // TestAnalyze_StaticELF verifies that Analyze returns nil for a static ELF
 // (no DT_NEEDED entries).
 func TestAnalyze_StaticELF(t *testing.T) {
-	staticELF := "../runner/security/elfanalyzer/testdata/static.elf"
-	if _, err := os.Stat(staticELF); err != nil {
-		t.Skipf("static.elf testdata not accessible: %v", err)
-	}
+	tmpDir := t.TempDir()
+	// sonames=nil produces an ELF with no DT_NEEDED entries.
+	staticELF := buildTestELFWithDeps(t, tmpDir, "static.elf", nil, "")
 
 	a := newTestAnalyzer(t)
 	result, err := a.Analyze(staticELF)


### PR DESCRIPTION
- Remove dependency on external testdata file static.elf
- Remove os.Stat check and t.Skipf fallback logic
- Use buildTestELFWithDeps helper to generate a static ELF (no DT_NEEDED entries) in a temp directory
- Update implementation plan checkboxes to mark all tasks done