### PR TITLE
Migrate filevalidator tests to in-memory ELF generation

### DIFF
--- a/docs/tasks/0093_filevalidator_elf_inmemory/01_requirements.md
+++ b/docs/tasks/0093_filevalidator_elf_inmemory/01_requirements.md
@@ -30,11 +30,11 @@ if _, err := os.Stat(elfPath); err != nil {
 
 ### 1.3 対象テスト
 
-| テスト名 | 行 | 説明 |
-|---|---|---|
-| `TestRecord_LibcCache_Error_CausesRecordFailure` | 1385 | libc キャッシュエラーが `analyzeSyscalls` を失敗させることを検証 |
-| `TestRecord_Force_ELFToNonELF_ClearsSyscallAnalysis` | 1426 | ELF → 非 ELF の force 再記録で `SyscallAnalysis` が nil になることを検証 |
-| `TestRecord_Force_SyscallsToNone_ClearsSyscallAnalysis` | 1488 | ELF の force 再記録で syscall 数が 0 になると `SyscallAnalysis` が nil になることを検証 |
+| テスト名 | 説明 |
+|---|---|
+| `TestRecord_LibcCache_Error_CausesRecordFailure` | libc キャッシュエラーが `analyzeSyscalls` を失敗させることを検証 |
+| `TestRecord_Force_ELFToNonELF_ClearsSyscallAnalysis` | ELF → 非 ELF の force 再記録で `SyscallAnalysis` が nil になることを検証 |
+| `TestRecord_Force_SyscallsToNone_ClearsSyscallAnalysis` | ELF の force 再記録で syscall 数が 0 になると `SyscallAnalysis` が nil になることを検証 |
 
 ### 1.4 スコープ外
 

--- a/docs/tasks/0093_filevalidator_elf_inmemory/01_requirements.md
+++ b/docs/tasks/0093_filevalidator_elf_inmemory/01_requirements.md
@@ -1,0 +1,128 @@
+# 0093: filevalidator テストのインメモリ ELF 生成への移行
+
+## 1. 概要
+
+### 1.1 背景
+
+`internal/filevalidator/validator_test.go` には、実システムの ELF バイナリ（`/usr/bin/ls`）を参照する 3 つのテストが存在する。
+
+これらのテストは、テスト実行時に `/usr/bin/ls` が利用可能であることを条件としており、ファイルが存在しない場合は `t.Skipf` によってスキップされる。
+
+```go
+const elfPath = "/usr/bin/ls"
+if _, err := os.Stat(elfPath); err != nil {
+    t.Skipf("skipping: %s not available: %v", elfPath, err)
+}
+```
+
+この設計には以下の問題がある。
+
+1. **環境依存**: Alpine Linux コンテナや GNU coreutils を持たない Docker イメージなど、`/usr/bin/ls` が存在しない環境でテストがスキップされる。
+2. **テストカバレッジの欠落**: `analyzeSyscalls` のエラー伝播テスト・`SyscallAnalysis` の nil 遷移テストが実行されない場合がある。
+3. **外部ファイルへの依存**: テストの正確性が OS 環境のファイル配置に依存している。
+4. **テストデータの不確定性**: システムの `/usr/bin/ls` の ELF フォーマットはディストリビューションによって異なる可能性がある。
+
+同パッケージの関連テスト（`internal/runner/security/elfanalyzer/testing/helpers.go`）には、テスト用のインメモリ ELF を生成する `CreateDynamicELFFile(t, path)` ヘルパーがすでに整備されている。これを活用することで、外部ファイルへの依存を解消できる。
+
+### 1.2 目的
+
+`internal/filevalidator/validator_test.go` 内の `/usr/bin/ls` に依存する 3 つのテストを、`elfanalyzertesting.CreateDynamicELFFile` を用いたインメモリ ELF 生成方式に書き換え、任意の環境で安定してテストが実行できるようにする。
+
+### 1.3 対象テスト
+
+| テスト名 | 行 | 説明 |
+|---|---|---|
+| `TestRecord_LibcCache_Error_CausesRecordFailure` | 1385 | libc キャッシュエラーが `analyzeSyscalls` を失敗させることを検証 |
+| `TestRecord_Force_ELFToNonELF_ClearsSyscallAnalysis` | 1426 | ELF → 非 ELF の force 再記録で `SyscallAnalysis` が nil になることを検証 |
+| `TestRecord_Force_SyscallsToNone_ClearsSyscallAnalysis` | 1488 | ELF の force 再記録で syscall 数が 0 になると `SyscallAnalysis` が nil になることを検証 |
+
+### 1.4 スコープ外
+
+- 上記 3 テスト以外の変更
+- `elfanalyzertesting.CreateDynamicELFFile` 自体の変更
+- `internal/runner/security/elfanalyzer/testdata/*.elf` ファイルの変更
+
+---
+
+## 2. 用語定義
+
+| 用語 | 定義 |
+|------|------|
+| インメモリ ELF | Go の `debug/elf` パッケージで解析可能な最小限の ELF バイナリをテスト実行時にバイト列として構築したもの。外部ファイルや GCC に依存しない |
+| `CreateDynamicELFFile` | `internal/runner/security/elfanalyzer/testing/helpers.go` で定義されるテストヘルパー。`.dynsym` セクションを持つ動的 ELF64 LE ファイルをディスクに生成する |
+| `SyscallAnalysis` | `fileanalysis.Record` のフィールド。ELF バイナリから検出されたシステムコール情報を格納する。非 ELF または検出ゼロの場合は `nil` |
+
+---
+
+## 3. 機能要件
+
+### FR-1: `TestRecord_LibcCache_Error_CausesRecordFailure` の外部ファイル依存の解消
+
+`TestRecord_LibcCache_Error_CausesRecordFailure` は、外部 ELF ファイル依存なしに動作すること。
+
+- `/usr/bin/ls` の存在確認および `t.Skipf` を除去する
+- `elfanalyzertesting.CreateDynamicELFFile(t, elfPath)` でインメモリ ELF ファイルを生成し、それを `analyzeSyscalls` に渡す
+- 生成した ELF は `debug/elf.Open` で解析可能であること（`CreateDynamicELFFile` が保証）
+- libc stub はエラーを返し、`analyzeSyscalls` がそのエラーを伝播することを検証する動作を維持する
+
+**変更対象**: `internal/filevalidator/validator_test.go`
+
+### FR-2: `TestRecord_Force_ELFToNonELF_ClearsSyscallAnalysis` の外部ファイル依存の解消
+
+`TestRecord_Force_ELFToNonELF_ClearsSyscallAnalysis` は、外部 ELF ファイル依存なしに動作すること。
+
+- `/usr/bin/ls` の存在確認および `t.Skipf` を除去する
+- `os.ReadFile(elfPath)` + `os.WriteFile(targetFile, elfBytes, ...)` のパターンを `elfanalyzertesting.CreateDynamicELFFile(t, targetFile)` の直接呼び出しに置き換える
+- 以降の「非 ELF への上書き → force 再記録 → `SyscallAnalysis` が nil」という検証ロジックは変更しない
+
+**変更対象**: `internal/filevalidator/validator_test.go`
+
+### FR-3: `TestRecord_Force_SyscallsToNone_ClearsSyscallAnalysis` の外部ファイル依存の解消
+
+`TestRecord_Force_SyscallsToNone_ClearsSyscallAnalysis` は、外部 ELF ファイル依存なしに動作すること。
+
+- `/usr/bin/ls` の存在確認および `t.Skipf` を除去する
+- FR-2 と同様に `os.ReadFile(elfPath)` + `os.WriteFile(targetFile, elfBytes, ...)` を `elfanalyzertesting.CreateDynamicELFFile(t, targetFile)` に置き換える
+- 「force 再記録 → syscall 数 0 → `SyscallAnalysis` が nil」という検証ロジックは変更しない
+
+**変更対象**: `internal/filevalidator/validator_test.go`
+
+---
+
+## 4. 非機能要件
+
+### 4.1 テスト実行環境
+
+変更後、3 つのテストはすべて `/usr/bin/ls` の存在に依存せず実行できること。
+
+### 4.2 テストのスキップ廃止
+
+変更前は `/usr/bin/ls` 不在時にテストをスキップしていた。変更後はスキップ処理を含まず、常にテストが実行されること。
+
+### 4.3 既存の検証ロジックの維持
+
+各テストの「何を検証しているか」（`analyzeSyscalls` のエラー伝播、`SyscallAnalysis` の nil 遷移）はそのまま維持すること。ELF ファイルの調達方法のみを置き換える。
+
+---
+
+## 5. 受け入れ基準
+
+### AC-1: `/usr/bin/ls` 参照の除去
+
+- [ ] `TestRecord_LibcCache_Error_CausesRecordFailure` 内に `elfPath = "/usr/bin/ls"` の参照が存在しないこと
+- [ ] `TestRecord_Force_ELFToNonELF_ClearsSyscallAnalysis` 内に `elfPath = "/usr/bin/ls"` の参照が存在しないこと
+- [ ] `TestRecord_Force_SyscallsToNone_ClearsSyscallAnalysis` 内に `elfPath = "/usr/bin/ls"` の参照が存在しないこと
+- [ ] ファイル存在確認に基づくスキップ処理（`t.Skip` / `t.Skipf`）がこれら 3 テストから除去されていること
+
+### AC-2: インメモリ ELF による検証
+
+- [ ] 3 つのテストがそれぞれ `elfanalyzertesting.CreateDynamicELFFile` を呼び出してインメモリ ELF ファイルを生成すること
+- [ ] `TestRecord_LibcCache_Error_CausesRecordFailure` が libc キャッシュエラーの伝播を検証していること
+- [ ] `TestRecord_Force_ELFToNonELF_ClearsSyscallAnalysis` が ELF → 非 ELF 遷移後に `SyscallAnalysis` が nil になることを検証していること
+- [ ] `TestRecord_Force_SyscallsToNone_ClearsSyscallAnalysis` が syscall 数 0 の再記録後に `SyscallAnalysis` が nil になることを検証していること
+
+### AC-3: テストの安定実行
+
+- [ ] `go test -tags test -v ./internal/filevalidator/...` を `/usr/bin/ls` なしの環境でも実行したとき 3 テストが PASS すること
+- [ ] `make test` がすべてパスすること
+- [ ] `make lint` がエラーなく完了すること

--- a/docs/tasks/0093_filevalidator_elf_inmemory/04_implementation_plan.md
+++ b/docs/tasks/0093_filevalidator_elf_inmemory/04_implementation_plan.md
@@ -4,8 +4,8 @@
   - [x] `elfanalyzertesting` パッケージのインポートを追加する
   - [x] `TestRecord_LibcCache_Error_CausesRecordFailure` を修正する (FR-1)
     - `const elfPath = "/usr/bin/ls"` および `os.Stat` + `t.Skipf` ブロックを削除
-    - `tmpELFPath := filepath.Join(t.TempDir(), "test.elf")` + `elfanalyzertesting.CreateDynamicELFFile(t, tmpELFPath)` に置き換える
-    - `analyzeSyscalls(record, elfPath)` の `elfPath` を新しいパスに変更する
+    - `safeTempDir(t)` で一時ディレクトリを作成し、必要に応じて `filepath.EvalSymlinks` で解決したパス配下の `test.elf` を `elfanalyzertesting.CreateDynamicELFFile(t, ...)` で生成する形に置き換える
+    - `analyzeSyscalls(record, elfPath)` の `elfPath` を生成した ELF のパスに変更する
   - [x] `TestRecord_Force_ELFToNonELF_ClearsSyscallAnalysis` を修正する (FR-2)
     - `const elfPath = "/usr/bin/ls"` および `os.Stat` + `t.Skipf` ブロックを削除
     - `elfBytes, err := os.ReadFile(elfPath)` + `os.WriteFile(targetFile, elfBytes, ...)` を `elfanalyzertesting.CreateDynamicELFFile(t, targetFile)` に置き換える

--- a/docs/tasks/0093_filevalidator_elf_inmemory/04_implementation_plan.md
+++ b/docs/tasks/0093_filevalidator_elf_inmemory/04_implementation_plan.md
@@ -1,0 +1,18 @@
+# 実装計画: filevalidator テストのインメモリ ELF 生成への移行
+
+- [x] 1. `internal/filevalidator/validator_test.go` の修正 (AC-1, AC-2)
+  - [x] `elfanalyzertesting` パッケージのインポートを追加する
+  - [x] `TestRecord_LibcCache_Error_CausesRecordFailure` を修正する (FR-1)
+    - `const elfPath = "/usr/bin/ls"` および `os.Stat` + `t.Skipf` ブロックを削除
+    - `tmpELFPath := filepath.Join(t.TempDir(), "test.elf")` + `elfanalyzertesting.CreateDynamicELFFile(t, tmpELFPath)` に置き換える
+    - `analyzeSyscalls(record, elfPath)` の `elfPath` を新しいパスに変更する
+  - [x] `TestRecord_Force_ELFToNonELF_ClearsSyscallAnalysis` を修正する (FR-2)
+    - `const elfPath = "/usr/bin/ls"` および `os.Stat` + `t.Skipf` ブロックを削除
+    - `elfBytes, err := os.ReadFile(elfPath)` + `os.WriteFile(targetFile, elfBytes, ...)` を `elfanalyzertesting.CreateDynamicELFFile(t, targetFile)` に置き換える
+  - [x] `TestRecord_Force_SyscallsToNone_ClearsSyscallAnalysis` を修正する (FR-3)
+    - `const elfPath = "/usr/bin/ls"` および `os.Stat` + `t.Skipf` ブロックを削除
+    - FR-2 と同様に `elfBytes, err := os.ReadFile(elfPath)` + `os.WriteFile(targetFile, elfBytes, ...)` を `elfanalyzertesting.CreateDynamicELFFile(t, targetFile)` に置き換える
+
+- [x] 2. テストの実行確認 (AC-3)
+  - [x] `make test` を実行してすべてのテストがパスすることを確認する
+  - [x] `make lint` を実行してエラーがないことを確認する

--- a/internal/filevalidator/validator_test.go
+++ b/internal/filevalidator/validator_test.go
@@ -1386,10 +1386,10 @@ func TestRecord_LibcCache_NonELFFile(t *testing.T) {
 func TestRecord_LibcCache_Error_CausesRecordFailure(t *testing.T) {
 	// Use an in-memory dynamic ELF so that openELFFile succeeds and reaches the
 	// libc cache path without depending on any system binary.
-	tmpELFPath := filepath.Join(t.TempDir(), "test.elf")
-	elfanalyzertesting.CreateDynamicELFFile(t, tmpELFPath)
-
 	tempDir := safeTempDir(t)
+	elfPath := filepath.Join(tempDir, "test.elf")
+	elfanalyzertesting.CreateDynamicELFFile(t, elfPath)
+
 	stub := &stubLibcCache{err: errors.New("libc file not accessible")}
 	v, err := New(&SHA256{}, tempDir)
 	require.NoError(t, err)
@@ -1401,7 +1401,7 @@ func TestRecord_LibcCache_Error_CausesRecordFailure(t *testing.T) {
 			{SOName: "libc.so.6", Path: "/lib/x86_64-linux-gnu/libc.so.6", Hash: "sha256:aabb"},
 		},
 	}
-	analyzeErr := v.analyzeSyscalls(record, tmpELFPath)
+	analyzeErr := v.analyzeSyscalls(record, elfPath)
 	require.Error(t, analyzeErr, "fatal libc cache error must propagate")
 	require.Contains(t, analyzeErr.Error(), "libc cache error")
 }

--- a/internal/filevalidator/validator_test.go
+++ b/internal/filevalidator/validator_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/isseis/go-safe-cmd-runner/internal/fileanalysis"
 	privtesting "github.com/isseis/go-safe-cmd-runner/internal/runner/privilege/testutil"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/security/binaryanalyzer"
+	elfanalyzertesting "github.com/isseis/go-safe-cmd-runner/internal/runner/security/elfanalyzer/testing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -1383,12 +1384,10 @@ func TestRecord_LibcCache_NonELFFile(t *testing.T) {
 // TestRecord_LibcCache_Error_CausesRecordFailure verifies that a fatal libc
 // cache error causes analyzeSyscalls to return an error.
 func TestRecord_LibcCache_Error_CausesRecordFailure(t *testing.T) {
-	// Use a real ELF binary so that openELFFile succeeds and reaches the
-	// libc cache path. /usr/bin/ls is a standard ELF available on all Linux systems.
-	const elfPath = "/usr/bin/ls"
-	if _, err := os.Stat(elfPath); err != nil {
-		t.Skipf("skipping: %s not available: %v", elfPath, err)
-	}
+	// Use an in-memory dynamic ELF so that openELFFile succeeds and reaches the
+	// libc cache path without depending on any system binary.
+	tmpELFPath := filepath.Join(t.TempDir(), "test.elf")
+	elfanalyzertesting.CreateDynamicELFFile(t, tmpELFPath)
 
 	tempDir := safeTempDir(t)
 	stub := &stubLibcCache{err: errors.New("libc file not accessible")}
@@ -1402,7 +1401,7 @@ func TestRecord_LibcCache_Error_CausesRecordFailure(t *testing.T) {
 			{SOName: "libc.so.6", Path: "/lib/x86_64-linux-gnu/libc.so.6", Hash: "sha256:aabb"},
 		},
 	}
-	analyzeErr := v.analyzeSyscalls(record, elfPath)
+	analyzeErr := v.analyzeSyscalls(record, tmpELFPath)
 	require.Error(t, analyzeErr, "fatal libc cache error must propagate")
 	require.Contains(t, analyzeErr.Error(), "libc cache error")
 }
@@ -1424,22 +1423,15 @@ func TestRecord_LibcCache_UnsupportedArch_SkipsAndContinues(t *testing.T) {
 // a file that was previously recorded as ELF (with SyscallAnalysis set) and is now
 // treated as non-ELF clears SyscallAnalysis (schema contract: nil for non-ELF).
 func TestRecord_Force_ELFToNonELF_ClearsSyscallAnalysis(t *testing.T) {
-	// Use a real ELF for the first record so SyscallAnalysis gets populated,
-	// then replace the file with non-ELF bytes and force re-record.
-	const elfPath = "/usr/bin/ls"
-	if _, err := os.Stat(elfPath); err != nil {
-		t.Skipf("skipping: %s not available: %v", elfPath, err)
-	}
-
+	// Use an in-memory dynamic ELF for the first record so SyscallAnalysis gets
+	// populated, then replace the file with non-ELF bytes and force re-record.
 	tempDir := safeTempDir(t)
 	hashDir := filepath.Join(tempDir, "hashes")
 	require.NoError(t, os.MkdirAll(hashDir, 0o700))
 
-	// Copy the ELF to a writable location so we can replace it.
-	elfBytes, err := os.ReadFile(elfPath)
-	require.NoError(t, err)
+	// Create an in-memory ELF at the target path.
 	targetFile := filepath.Join(tempDir, "target.bin")
-	require.NoError(t, os.WriteFile(targetFile, elfBytes, 0o755))
+	elfanalyzertesting.CreateDynamicELFFile(t, targetFile)
 
 	v, err := New(&SHA256{}, hashDir)
 	require.NoError(t, err)
@@ -1486,19 +1478,13 @@ func (s *stubSyscallAnalyzerReturnsOne) GetSyscallTable(_ elf.Machine) (SyscallN
 // an ELF that previously had syscalls detected now clears SyscallAnalysis when the
 // analyzer returns zero results (schema contract: nil when no syscalls detected).
 func TestRecord_Force_SyscallsToNone_ClearsSyscallAnalysis(t *testing.T) {
-	const elfPath = "/usr/bin/ls"
-	if _, err := os.Stat(elfPath); err != nil {
-		t.Skipf("skipping: %s not available: %v", elfPath, err)
-	}
-
 	tempDir := safeTempDir(t)
 	hashDir := filepath.Join(tempDir, "hashes")
 	require.NoError(t, os.MkdirAll(hashDir, 0o700))
 
-	elfBytes, err := os.ReadFile(elfPath)
-	require.NoError(t, err)
+	// Create an in-memory ELF at the target path.
 	targetFile := filepath.Join(tempDir, "target.bin")
-	require.NoError(t, os.WriteFile(targetFile, elfBytes, 0o755))
+	elfanalyzertesting.CreateDynamicELFFile(t, targetFile)
 
 	v, err := New(&SHA256{}, hashDir)
 	require.NoError(t, err)


### PR DESCRIPTION
This pull request migrates three tests in `internal/filevalidator/validator_test.go` from relying on the system `/usr/bin/ls` ELF binary to using an in-memory ELF file generated by `elfanalyzertesting.CreateDynamicELFFile`. This eliminates environment dependencies, ensures the tests always run regardless of system binaries, and improves test reliability and coverage.

**Test modernization and reliability improvements:**

* Replaced all references to `/usr/bin/ls` and associated skip logic (`t.Skipf`) in the following tests with in-memory ELF generation using `elfanalyzertesting.CreateDynamicELFFile`:
  - `TestRecord_LibcCache_Error_CausesRecordFailure`
  - `TestRecord_Force_ELFToNonELF_ClearsSyscallAnalysis`
  - `TestRecord_Force_SyscallsToNone_ClearsSyscallAnalysis` [[1]](diffhunk://#diff-bb57ec3f326dbfc2ea1ed8fd23e6d783b02a55ae6ba8b620e71329f708debc67L1386-R1390) [[2]](diffhunk://#diff-bb57ec3f326dbfc2ea1ed8fd23e6d783b02a55ae6ba8b620e71329f708debc67L1405-R1404) [[3]](diffhunk://#diff-bb57ec3f326dbfc2ea1ed8fd23e6d783b02a55ae6ba8b620e71329f708debc67L1427-R1434) [[4]](diffhunk://#diff-bb57ec3f326dbfc2ea1ed8fd23e6d783b02a55ae6ba8b620e71329f708debc67L1489-R1487)

* Added the import for the `elfanalyzertesting` package to enable in-memory ELF file generation.

**Documentation and planning:**

* Added a requirements document outlining the motivation, scope, requirements, and acceptance criteria for migrating filevalidator tests to in-memory ELF generation.
* Added an implementation plan documenting concrete steps taken to migrate the tests and verify the migration.

With these changes, the three tests no longer depend on the host environment and will always execute, improving both reliability and coverage.