### PR TITLE
feat(security): add Mach-O arm64 svc #0x80 syscall analysis

### DIFF
--- a/docs/tasks/0097_macho_arm64_syscall_analysis/04_implementation_plan.md
+++ b/docs/tasks/0097_macho_arm64_syscall_analysis/04_implementation_plan.md
@@ -81,33 +81,33 @@ go test -tags test -v ./internal/runner/security/machoanalyzer/
 
 ### 4.1 実装チェックリスト
 
-- [ ] `machoanalyzer` パッケージのインポートを追加する:
+- [x] `machoanalyzer` パッケージのインポートを追加する:
   `"github.com/isseis/go-safe-cmd-runner/internal/runner/security/machoanalyzer"`
-- [ ] `buildSVCSyscallAnalysis(addrs []uint64) *fileanalysis.SyscallAnalysisData` を実装する
-  - [ ] `Architecture: "arm64"` を設定する
-  - [ ] `AnalysisWarnings: []string{"svc #0x80 detected: direct syscall bypassing libSystem.dylib"}` を設定する
-  - [ ] `DetectedSyscalls` に各アドレスを `Number=-1, DeterminationMethod="direct_svc_0x80", Source="direct_svc_0x80"` で記録する
-  - [ ] `ArgEvalResults` は設定しない（nil のまま）
-- [ ] `updateAnalysisRecord` のコールバック内、`analyzeSyscalls()` 呼び出し直後に Mach-O svc スキャンを追加する
-  - [ ] `v.binaryAnalyzer != nil` の条件分岐を追加する（binaryAnalyzer が nil の場合はスキップ）
-  - [ ] `machoanalyzer.CollectSVCAddressesFromFile(filePath.String(), v.fileSystem)` を呼ぶ
-  - [ ] エラー時はラップして返す
-  - [ ] `len(addrs) > 0` の場合のみ `record.SyscallAnalysis = buildSVCSyscallAnalysis(addrs)` を設定する
-  - [ ] `SymbolAnalysis = NetworkDetected` の場合も svc スキャンを実行すること（`runner` 側で参照可否を制御する）
+- [x] `buildSVCSyscallAnalysis(addrs []uint64) *fileanalysis.SyscallAnalysisData` を実装する
+  - [x] `Architecture: "arm64"` を設定する
+  - [x] `AnalysisWarnings: []string{"svc #0x80 detected: direct syscall bypassing libSystem.dylib"}` を設定する
+  - [x] `DetectedSyscalls` に各アドレスを `Number=-1, DeterminationMethod="direct_svc_0x80", Source="direct_svc_0x80"` で記録する
+  - [x] `ArgEvalResults` は設定しない（nil のまま）
+- [x] `updateAnalysisRecord` のコールバック内、`analyzeSyscalls()` 呼び出し直後に Mach-O svc スキャンを追加する
+  - [x] `v.binaryAnalyzer != nil` の条件分岐を追加する（binaryAnalyzer が nil の場合はスキップ）
+  - [x] `machoanalyzer.CollectSVCAddressesFromFile(filePath.String(), v.fileSystem)` を呼ぶ
+  - [x] エラー時はラップして返す
+  - [x] `len(addrs) > 0` の場合のみ `record.SyscallAnalysis = buildSVCSyscallAnalysis(addrs)` を設定する
+  - [x] `SymbolAnalysis = NetworkDetected` の場合も svc スキャンを実行すること（`runner` 側で参照可否を制御する）
 
 ### 4.2 テストチェックリスト
 
 **ファイル**: `internal/filevalidator/validator_macho_test.go`（新規推奨）
 
-- [ ] `TestBuildSVCSyscallAnalysis`: 単体テスト
-  - [ ] `Architecture == "arm64"` を確認
-  - [ ] `AnalysisWarnings` に検出メッセージが含まれる
-  - [ ] `DetectedSyscalls` に正しいフィールドが設定される
-- [ ] `TestUpdateAnalysisRecord_MachoSVCDetected`: svc ありの Mach-O (NoNetworkSymbols) で SyscallAnalysis が設定される
-- [ ] `TestUpdateAnalysisRecord_MachoNoSVC`: svc なしの Mach-O で SyscallAnalysis が nil
-- [ ] `TestUpdateAnalysisRecord_MachoNetworkDetected_SVCDetected`: NetworkDetected + svc あり → SyscallAnalysis が保存される
-- [ ] `TestUpdateAnalysisRecord_MachoNetworkDetected_NoSVC`: NetworkDetected + svc なし → SyscallAnalysis が nil
-- [ ] `TestUpdateAnalysisRecord_ELFNotAffected`: ELF バイナリのフロー変更なし（linux のみ、またはモック）
+- [x] `TestBuildSVCSyscallAnalysis`: 単体テスト
+  - [x] `Architecture == "arm64"` を確認
+  - [x] `AnalysisWarnings` に検出メッセージが含まれる
+  - [x] `DetectedSyscalls` に正しいフィールドが設定される
+- [x] `TestUpdateAnalysisRecord_MachoSVCDetected`: svc ありの Mach-O (NoNetworkSymbols) で SyscallAnalysis が設定される
+- [x] `TestUpdateAnalysisRecord_MachoNoSVC`: svc なしの Mach-O で SyscallAnalysis が nil
+- [x] `TestUpdateAnalysisRecord_MachoNetworkDetected_SVCDetected`: NetworkDetected + svc あり → SyscallAnalysis が保存される
+- [x] `TestUpdateAnalysisRecord_MachoNetworkDetected_NoSVC`: NetworkDetected + svc なし → SyscallAnalysis が nil
+- [x] `TestUpdateAnalysisRecord_ELFNotAffected`: ELF バイナリのフロー変更なし（linux のみ、またはモック）
 
 **注意**:
 - `debug/macho` はクロスプラットフォームで利用できるため、darwin ビルドタグは不要

--- a/docs/tasks/0097_macho_arm64_syscall_analysis/04_implementation_plan.md
+++ b/docs/tasks/0097_macho_arm64_syscall_analysis/04_implementation_plan.md
@@ -17,9 +17,9 @@
 
 ### 2.1 インポートサイクル確認
 
-- [ ] `internal/runner/security/machoanalyzer` が `internal/filevalidator` を import していないこと
+- [x] `internal/runner/security/machoanalyzer` が `internal/filevalidator` を import していないこと
   - 確認コマンド: `grep -r "filevalidator" internal/runner/security/machoanalyzer/`
-- [ ] `internal/filevalidator` が `internal/runner/security/machoanalyzer` を import 可能なこと
+- [x] `internal/filevalidator` が `internal/runner/security/machoanalyzer` を import 可能なこと
   - 確認コマンド: `go build ./internal/filevalidator/...` が通ること
 
 ### 2.2 `safefileio.FileSystem.SafeOpenFile` の返り値型確認
@@ -30,7 +30,7 @@
 
 ### 2.3 `fileanalysis.SyscallAnalysisData` の型確認
 
-- [ ] `fileanalysis.SyscallAnalysisData` が `common.SyscallAnalysisResultCore` を embed していること
+- [x] `fileanalysis.SyscallAnalysisData` が `common.SyscallAnalysisResultCore` を embed していること
   - ファイル: `internal/fileanalysis/schema.go`
 
 ## 3. Step 1: `machoanalyzer` パッケージの拡張
@@ -39,36 +39,36 @@
 
 ### 3.1 実装チェックリスト
 
-- [ ] `svc_scanner.go` に `safefileio` パッケージのインポートを追加する:
+- [x] `svc_scanner.go` に `safefileio` パッケージのインポートを追加する:
   `"github.com/isseis/go-safe-cmd-runner/internal/safefileio"`
-- [ ] `svc_scanner.go` に `"os"` パッケージのインポートを追加する
-- [ ] `collectSVCAddresses(f *macho.File) ([]uint64, error)` を実装する
-  - [ ] `f.Cpu != macho.CpuArm64` の場合は `nil, nil` を返す
-  - [ ] `__TEXT,__text` セクションが存在しない場合は `nil, nil` を返す
-  - [ ] セクションデータ読み出しエラー時はエラーを返す
-  - [ ] 4 バイトアラインで走査し、`svcInstruction` にマッチした仮想アドレスを収集する
-  - [ ] `section.Addr + uint64(i)` で仮想アドレスを算出する
-  - [ ] 検出なしの場合は `nil, nil` を返す
-- [ ] `containsSVCInstruction` を `collectSVCAddresses` に委譲するよう変更する
-  - [ ] 変更後も既存の動作（bool 返し）を維持する
-- [ ] `CollectSVCAddressesFromFile(filePath string, fs safefileio.FileSystem) ([]uint64, error)` を実装する
-  - [ ] `fs.SafeOpenFile` でファイルを開く
-  - [ ] 先頭 4 バイトでマジック確認を行い、非 Mach-O には `nil, nil` を返す
-  - [ ] Fat バイナリ: arm64 スライスのみ `collectSVCAddresses` を呼び結果を連結する
-  - [ ] 単一アーキテクチャ: `collectSVCAddresses` を呼ぶ
-  - [ ] パースエラー時はエラーを返す
+- [x] `svc_scanner.go` に `"os"` パッケージのインポートを追加する
+- [x] `collectSVCAddresses(f *macho.File) ([]uint64, error)` を実装する
+  - [x] `f.Cpu != macho.CpuArm64` の場合は `nil, nil` を返す
+  - [x] `__TEXT,__text` セクションが存在しない場合は `nil, nil` を返す
+  - [x] セクションデータ読み出しエラー時はエラーを返す
+  - [x] 4 バイトアラインで走査し、`svcInstruction` にマッチした仮想アドレスを収集する
+  - [x] `section.Addr + uint64(i)` で仮想アドレスを算出する
+  - [x] 検出なしの場合は `nil, nil` を返す
+- [x] `containsSVCInstruction` を `collectSVCAddresses` に委譲するよう変更する
+  - [x] 変更後も既存の動作（bool 返し）を維持する
+- [x] `CollectSVCAddressesFromFile(filePath string, fs safefileio.FileSystem) ([]uint64, error)` を実装する
+  - [x] `fs.SafeOpenFile` でファイルを開く
+  - [x] 先頭 4 バイトでマジック確認を行い、非 Mach-O には `nil, nil` を返す
+  - [x] Fat バイナリ: arm64 スライスのみ `collectSVCAddresses` を呼び結果を連結する
+  - [x] 単一アーキテクチャ: `collectSVCAddresses` を呼ぶ
+  - [x] パースエラー時はエラーを返す
 
 ### 3.2 テストチェックリスト
 
 **ファイル**: `internal/runner/security/machoanalyzer/svc_scanner_test.go`（追加分）
 
-- [ ] `TestCollectSVCAddresses_Arm64WithSVC`: arm64 + svc #0x80 → アドレスを返す
-- [ ] `TestCollectSVCAddresses_Arm64NoSVC`: arm64 + svc なし → `nil, nil`
-- [ ] `TestCollectSVCAddresses_NonArm64`: x86_64 → `nil, nil`
-- [ ] `TestCollectSVCAddresses_MultipleSVC`: 複数 svc #0x80 → 全アドレスを返す
-- [ ] `TestCollectSVCAddressesFromFile_NotMacho`: ELF ファイル → `nil, nil`
-- [ ] `TestCollectSVCAddressesFromFile_FatBinary`: Fat バイナリ → arm64 スライスのみ走査
-- [ ] `TestContainsSVCInstruction_DelegatesToCollect`: リファクタリング後も正常動作
+- [x] `TestCollectSVCAddresses_Arm64WithSVC`: arm64 + svc #0x80 → アドレスを返す
+- [x] `TestCollectSVCAddresses_Arm64NoSVC`: arm64 + svc なし → `nil, nil`
+- [x] `TestCollectSVCAddresses_NonArm64`: x86_64 → `nil, nil`
+- [x] `TestCollectSVCAddresses_MultipleSVC`: 複数 svc #0x80 → 全アドレスを返す
+- [x] `TestCollectSVCAddressesFromFile_NotMacho`: ELF ファイル → `nil, nil`
+- [x] `TestCollectSVCAddressesFromFile_FatBinary`: Fat バイナリ → arm64 スライスのみ走査
+- [x] `TestContainsSVCInstruction_DelegatesToCollect`: リファクタリング後も正常動作
 
 **実行コマンド**:
 ```

--- a/docs/tasks/0097_macho_arm64_syscall_analysis/04_implementation_plan.md
+++ b/docs/tasks/0097_macho_arm64_syscall_analysis/04_implementation_plan.md
@@ -124,45 +124,45 @@ go test -tags test -v ./internal/filevalidator/
 
 ### 5.1 実装チェックリスト
 
-- [ ] `NetworkAnalyzer` 構造体に `syscallStore fileanalysis.SyscallAnalysisStore` フィールドを追加する
-- [ ] `NewNetworkAnalyzerWithStores` コンストラクタを実装する
-  - [ ] `symStore` と `svcStore` を受け取り `NetworkAnalyzer` を返す
-  - [ ] `binaryAnalyzer: NewBinaryAnalyzer()` を設定する
-- [ ] `syscallAnalysisHasSVCSignal(result *fileanalysis.SyscallAnalysisResult) bool` を実装する
-  - [ ] nil の場合は `false` を返す
-  - [ ] `DetectedSyscalls` に `DeterminationMethod == "direct_svc_0x80"` のエントリがある場合のみ `true` を返す
-  - [ ] `AnalysisWarnings` は判定条件に含めない（ELF 側の警告による誤検知を防ぐ）
-- [ ] `isNetworkViaBinaryAnalysis` の cache-backed path を書き直し、SVC 判定の live 解析フォールバックを削除する
-  - [ ] `a.store == nil` / `contentHash == ""` の互換ガード（legacy live 解析経路）を削除する（実装計画書 Section 8 参照）
-  - [ ] SymbolAnalysis ロードエラー → `return true, true`（AnalysisError、live 解析なし）
-  - [ ] `a.binaryAnalyzer.AnalyzeNetworkSymbols()` の呼び出しを cache-backed path から削除する
-  - [ ] SymbolAnalysis ロード成功後、`SymbolAnalysis` の結果に関わらず `a.syscallStore.LoadSyscallAnalysis(cmdPath, contentHash)` を呼ぶ（FR-3.3.1）
-  - [ ] `svcErr == nil` かつ `syscallAnalysisHasSVCSignal(svcResult)` → `true, true` を返す（`SymbolAnalysis` の結果に関わらず高リスク確定）
-  - [ ] `svcErr == nil` かつ svc signal なし → `SymbolAnalysis` 結果に基づいて判定を続ける（fall through）
-  - [ ] `ErrNoSyscallAnalysis` → `SymbolAnalysis` 結果に基づいて判定を続ける（fall through、v15 保証：スキャン済み・svc 未検出）
-  - [ ] `ErrHashMismatch` → `return true, true`
-  - [ ] `SchemaVersionMismatchError` → `return true, true`（再 `record` 要求）
-  - [ ] `ErrRecordNotFound` / その他エラー → `return true, true`（整合性エラー）
-  - [ ] svc signal なし時の `SymbolAnalysis` 結果判定: `NetworkDetected` → `true, false`、`NoNetworkSymbols` → `false, false`
+- [x] `NetworkAnalyzer` 構造体に `syscallStore fileanalysis.SyscallAnalysisStore` フィールドを追加する
+- [x] `NewNetworkAnalyzerWithStores` コンストラクタを実装する
+  - [x] `symStore` と `svcStore` を受け取り `NetworkAnalyzer` を返す
+  - [x] `binaryAnalyzer: NewBinaryAnalyzer()` を設定する
+- [x] `syscallAnalysisHasSVCSignal(result *fileanalysis.SyscallAnalysisResult) bool` を実装する
+  - [x] nil の場合は `false` を返す
+  - [x] `DetectedSyscalls` に `DeterminationMethod == "direct_svc_0x80"` のエントリがある場合のみ `true` を返す
+  - [x] `AnalysisWarnings` は判定条件に含めない（ELF 側の警告による誤検知を防ぐ）
+- [x] `isNetworkViaBinaryAnalysis` の cache-backed path を書き直し、SVC 判定の live 解析フォールバックを削除する
+  - [-] `a.store == nil` / `contentHash == ""` の互換ガード（legacy live 解析経路）を削除する（実装計画書 Section 8 参照）
+  - [x] SymbolAnalysis ロードエラー → `return true, true`（AnalysisError、live 解析なし）
+  - [x] `a.binaryAnalyzer.AnalyzeNetworkSymbols()` の呼び出しを cache-backed path から削除する
+  - [x] SymbolAnalysis ロード成功後、`SymbolAnalysis` の結果に関わらず `a.syscallStore.LoadSyscallAnalysis(cmdPath, contentHash)` を呼ぶ（FR-3.3.1）
+  - [x] `svcErr == nil` かつ `syscallAnalysisHasSVCSignal(svcResult)` → `true, true` を返す（`SymbolAnalysis` の結果に関わらず高リスク確定）
+  - [x] `svcErr == nil` かつ svc signal なし → `SymbolAnalysis` 結果に基づいて判定を続ける（fall through）
+  - [x] `ErrNoSyscallAnalysis` → `SymbolAnalysis` 結果に基づいて判定を続ける（fall through、v15 保証：スキャン済み・svc 未検出）
+  - [x] `ErrHashMismatch` → `return true, true`
+  - [x] `SchemaVersionMismatchError` → `return true, true`（再 `record` 要求）
+  - [x] `ErrRecordNotFound` / その他エラー → `return true, true`（整合性エラー）
+  - [x] svc signal なし時の `SymbolAnalysis` 結果判定: `NetworkDetected` → `true, false`、`NoNetworkSymbols` → `false, false`
 
 ### 5.2 テストチェックリスト
 
 **ファイル**: `internal/runner/security/network_analyzer_test.go`（追加分）
 
-- [ ] `TestSyscallAnalysisHasSVCSignal_Nil`: nil → false
-- [ ] `TestSyscallAnalysisHasSVCSignal_Empty`: 空の result → false
-- [ ] `TestSyscallAnalysisHasSVCSignal_WithWarningsOnly`: AnalysisWarnings のみ（DeterminationMethod なし）→ false
-- [ ] `TestSyscallAnalysisHasSVCSignal_WithDeterminationMethod`: DeterminationMethod == "direct_svc_0x80" → true
-- [ ] `TestIsNetworkViaBinaryAnalysis_SymbolAnalysisCacheMiss`: SymbolAnalysis ロードエラー → AnalysisError（live 解析なし）
-- [ ] `TestIsNetworkViaBinaryAnalysis_NoNetworkSymbols_SVCCacheHit`: NoNetworkSymbols + svc あり → true, true
-- [ ] `TestIsNetworkViaBinaryAnalysis_NoNetworkSymbols_SVCCacheNil`: ロード成功・svc なし → false, false
-- [ ] `TestIsNetworkViaBinaryAnalysis_NoNetworkSymbols_SVCHashMismatch`: ErrHashMismatch → AnalysisError
-- [ ] `TestIsNetworkViaBinaryAnalysis_NoNetworkSymbols_SVCNoSyscallAnalysis`: ErrNoSyscallAnalysis → false, false（フォールバックなし）
-- [ ] `TestIsNetworkViaBinaryAnalysis_NoNetworkSymbols_SVCSchemaMismatch`: SchemaVersionMismatchError → AnalysisError
-- [ ] `TestIsNetworkViaBinaryAnalysis_NoNetworkSymbols_SVCRecordNotFound`: ErrRecordNotFound → AnalysisError（live 解析なし）
-- [ ] `TestIsNetworkViaBinaryAnalysis_NetworkDetected_SVCCacheHit`: NetworkDetected + svc あり → true, true（isHighRisk 格上げ）
-- [ ] `TestIsNetworkViaBinaryAnalysis_NetworkDetected_SVCNoSyscallAnalysis`: NetworkDetected + ErrNoSyscallAnalysis → true, false（格上げなし）
-- [ ] `TestIsNetworkViaBinaryAnalysis_NetworkDetected_NoSVC`: NetworkDetected + svc なし（ロード成功）→ true, false（格上げなし）
+- [x] `TestSyscallAnalysisHasSVCSignal_Nil`: nil → false
+- [x] `TestSyscallAnalysisHasSVCSignal_Empty`: 空の result → false
+- [x] `TestSyscallAnalysisHasSVCSignal_WithWarningsOnly`: AnalysisWarnings のみ（DeterminationMethod なし）→ false
+- [x] `TestSyscallAnalysisHasSVCSignal_WithDeterminationMethod`: DeterminationMethod == "direct_svc_0x80" → true
+- [x] `TestIsNetworkViaBinaryAnalysis_SymbolAnalysisCacheMiss`: SymbolAnalysis ロードエラー → AnalysisError（live 解析なし）
+- [x] `TestIsNetworkViaBinaryAnalysis_NoNetworkSymbols_SVCCacheHit`: NoNetworkSymbols + svc あり → true, true
+- [x] `TestIsNetworkViaBinaryAnalysis_NoNetworkSymbols_SVCCacheNil`: ロード成功・svc なし → false, false
+- [x] `TestIsNetworkViaBinaryAnalysis_NoNetworkSymbols_SVCHashMismatch`: ErrHashMismatch → AnalysisError
+- [x] `TestIsNetworkViaBinaryAnalysis_NoNetworkSymbols_SVCNoSyscallAnalysis`: ErrNoSyscallAnalysis → false, false（フォールバックなし）
+- [x] `TestIsNetworkViaBinaryAnalysis_NoNetworkSymbols_SVCSchemaMismatch`: SchemaVersionMismatchError → AnalysisError
+- [x] `TestIsNetworkViaBinaryAnalysis_NoNetworkSymbols_SVCRecordNotFound`: ErrRecordNotFound → AnalysisError（live 解析なし）
+- [x] `TestIsNetworkViaBinaryAnalysis_NetworkDetected_SVCCacheHit`: NetworkDetected + svc あり → true, true（isHighRisk 格上げ）
+- [x] `TestIsNetworkViaBinaryAnalysis_NetworkDetected_SVCNoSyscallAnalysis`: NetworkDetected + ErrNoSyscallAnalysis → true, false（格上げなし）
+- [x] `TestIsNetworkViaBinaryAnalysis_NetworkDetected_NoSVC`: NetworkDetected + svc なし（ロード成功）→ true, false（格上げなし）
 
 **実行コマンド**:
 ```

--- a/internal/fileanalysis/schema.go
+++ b/internal/fileanalysis/schema.go
@@ -21,11 +21,14 @@ const (
 	// Version 13 removes UpdatedAt field (was unused by verify; caused noisy diffs).
 	// Version 14 adds AnalysisWarnings to Record for dynlib analysis warnings.
 	// Mach-O binaries also record DynLibDeps starting with version 14.
-	// Load returns SchemaVersionMismatchError for records with schema_version != 14.
+	// Version 15 adds Mach-O arm64 svc #0x80 scanning: records written at v15 or later
+	// guarantee that the svc scan was performed, so ErrNoSyscallAnalysis means the scan
+	// ran and found nothing (safe to fall through to SymbolAnalysis-based decision).
+	// Load returns SchemaVersionMismatchError for records with schema_version != 15.
 	// Store.Update treats older schemas (Actual < Expected) as overwritable;
 	// re-running `record` migrates old-schema records automatically (--force not required).
 	// Store.Update rejects newer schemas (Actual > Expected) to preserve forward compatibility.
-	CurrentSchemaVersion = 14
+	CurrentSchemaVersion = 15
 )
 
 // Record represents a unified file analysis record containing both

--- a/internal/filevalidator/validator.go
+++ b/internal/filevalidator/validator.go
@@ -333,7 +333,7 @@ func (v *Validator) updateAnalysisRecord(filePath common.ResolvedPath, hash stri
 		// on SymbolAnalysis outcome (FR-3.2.2).
 		// CollectSVCAddressesFromFile checks magic bytes and returns nil for non-Mach-O
 		// files, so this is safe to call on all platforms and binary formats.
-		if v.binaryAnalyzer != nil {
+		{
 			addrs, svcErr := machoanalyzer.CollectSVCAddressesFromFile(filePath.String(), v.fileSystem)
 			if svcErr != nil {
 				return fmt.Errorf("mach-o svc scan failed: %w", svcErr)

--- a/internal/filevalidator/validator.go
+++ b/internal/filevalidator/validator.go
@@ -16,6 +16,7 @@ import (
 	"github.com/isseis/go-safe-cmd-runner/internal/machodylib"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/runnertypes"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/security/binaryanalyzer"
+	"github.com/isseis/go-safe-cmd-runner/internal/runner/security/machoanalyzer"
 	"github.com/isseis/go-safe-cmd-runner/internal/safefileio"
 	"github.com/isseis/go-safe-cmd-runner/internal/shebang"
 )
@@ -323,6 +324,23 @@ func (v *Validator) updateAnalysisRecord(filePath common.ResolvedPath, hash stri
 		// Steps A-D: ELF syscall analysis (libc import + direct instruction).
 		if err := v.analyzeSyscalls(record, filePath.String()); err != nil {
 			return err
+		}
+
+		// Mach-O arm64 svc #0x80 scan.
+		// Run after analyzeSyscalls() to overwrite the nil it sets for non-ELF files.
+		// record's responsibility is to faithfully capture binary state regardless of
+		// SymbolAnalysis result. runner decides whether to consult SyscallAnalysis based
+		// on SymbolAnalysis outcome (FR-3.2.2).
+		// CollectSVCAddressesFromFile checks magic bytes and returns nil for non-Mach-O
+		// files, so this is safe to call on all platforms and binary formats.
+		if v.binaryAnalyzer != nil {
+			addrs, svcErr := machoanalyzer.CollectSVCAddressesFromFile(filePath.String(), v.fileSystem)
+			if svcErr != nil {
+				return fmt.Errorf("mach-o svc scan failed: %w", svcErr)
+			}
+			if len(addrs) > 0 {
+				record.SyscallAnalysis = buildSVCSyscallAnalysis(addrs)
+			}
 		}
 
 		// Record shebang interpreter info.
@@ -705,6 +723,32 @@ func convertDetectedSymbols(syms []binaryanalyzer.DetectedSymbol) []fileanalysis
 		entries[i] = fileanalysis.DetectedSymbolEntry{Name: s.Name, Category: s.Category}
 	}
 	return entries
+}
+
+// buildSVCSyscallAnalysis constructs a SyscallAnalysisData record for a Mach-O
+// binary where svc #0x80 instructions were detected at the given virtual addresses.
+// Each address is recorded as a DetectedSyscall with Number=-1 (undetermined) and
+// DeterminationMethod="direct_svc_0x80".
+func buildSVCSyscallAnalysis(addrs []uint64) *fileanalysis.SyscallAnalysisData {
+	syscalls := make([]common.SyscallInfo, len(addrs))
+	for i, addr := range addrs {
+		syscalls[i] = common.SyscallInfo{
+			Number:              -1,
+			IsNetwork:           false,
+			Location:            addr,
+			DeterminationMethod: "direct_svc_0x80",
+			Source:              "direct_svc_0x80",
+		}
+	}
+	return &fileanalysis.SyscallAnalysisData{
+		SyscallAnalysisResultCore: common.SyscallAnalysisResultCore{
+			Architecture: "arm64",
+			AnalysisWarnings: []string{
+				"svc #0x80 detected: direct syscall bypassing libSystem.dylib",
+			},
+			DetectedSyscalls: syscalls,
+		},
+	}
 }
 
 // analyzeSyscalls performs ELF syscall analysis on the given file path and sets

--- a/internal/filevalidator/validator_macho_test.go
+++ b/internal/filevalidator/validator_macho_test.go
@@ -189,6 +189,28 @@ func TestUpdateAnalysisRecord_MachoNoSVC(t *testing.T) {
 	assert.Nil(t, record.SyscallAnalysis, "SyscallAnalysis must be nil when no svc #0x80 found")
 }
 
+// TestUpdateAnalysisRecord_MachoSVCDetected_BinaryAnalyzerNil verifies that the
+// Mach-O svc scan does not depend on SymbolAnalysis being enabled.
+func TestUpdateAnalysisRecord_MachoSVCDetected_BinaryAnalyzerNil(t *testing.T) {
+	tempDir := safeTempDir(t)
+	hashDir := filepath.Join(tempDir, "hashes")
+	require.NoError(t, os.MkdirAll(hashDir, 0o700))
+
+	binPath := writeTempBinary(t, tempDir, "target.bin", buildArm64MachOBinary(t, []uint32{svcEncodingU32}))
+
+	v, err := New(&SHA256{}, hashDir)
+	require.NoError(t, err)
+
+	_, _, recErr := v.SaveRecord(binPath, false)
+	require.NoError(t, recErr)
+
+	record, loadErr := v.LoadRecord(binPath)
+	require.NoError(t, loadErr)
+	require.NotNil(t, record.SyscallAnalysis, "SyscallAnalysis must be set when svc #0x80 is found")
+	require.Len(t, record.SyscallAnalysis.DetectedSyscalls, 1)
+	assert.Equal(t, "direct_svc_0x80", record.SyscallAnalysis.DetectedSyscalls[0].DeterminationMethod)
+}
+
 // TestUpdateAnalysisRecord_MachoNetworkDetected_SVCDetected verifies that SaveRecord
 // saves SyscallAnalysis even when the Mach-O also has network symbols (NetworkDetected).
 // The runner controls whether to consult SyscallAnalysis; record captures it unconditionally.

--- a/internal/filevalidator/validator_macho_test.go
+++ b/internal/filevalidator/validator_macho_test.go
@@ -1,0 +1,276 @@
+//go:build test
+
+package filevalidator
+
+import (
+	"bytes"
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/isseis/go-safe-cmd-runner/internal/common"
+	"github.com/isseis/go-safe-cmd-runner/internal/fileanalysis"
+	"github.com/isseis/go-safe-cmd-runner/internal/runner/security/binaryanalyzer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// svcEncodingU32 is the uint32 encoding of arm64 "svc #0x80" (little-endian).
+const svcEncodingU32 = uint32(0xD4001001)
+
+// nopEncodingU32 is a common arm64 NOP instruction.
+const nopEncodingU32 = uint32(0xD503201F)
+
+// buildArm64MachOBinary builds a minimal arm64 Mach-O binary in memory.
+// The given 32-bit instruction words are placed in __TEXT,__text at virtual
+// address 0x100000000. Returns the binary as a byte slice.
+func buildArm64MachOBinary(t *testing.T, instructions []uint32) []byte {
+	t.Helper()
+
+	const (
+		headerSize    = 32                                 // mach_header_64
+		segCmdSize    = 72                                 // segment_command_64
+		sectSize      = 80                                 // section_64
+		textOffset    = headerSize + segCmdSize + sectSize // 184 = 0xB8
+		lcSegment64   = uint32(0x19)
+		mhExecute     = uint32(0x2)
+		cpuArm64      = uint32(0x0100000C)
+		vmBase        = uint64(0x100000000)
+		sAttrPureInst = uint32(0x80000000)
+	)
+
+	instBytes := make([]byte, len(instructions)*4)
+	for i, inst := range instructions {
+		binary.LittleEndian.PutUint32(instBytes[i*4:], inst)
+	}
+	sectDataSize := uint32(len(instBytes))
+
+	var buf bytes.Buffer
+	pu32 := func(v uint32) {
+		b := [4]byte{}
+		binary.LittleEndian.PutUint32(b[:], v)
+		buf.Write(b[:])
+	}
+	pu64 := func(v uint64) {
+		b := [8]byte{}
+		binary.LittleEndian.PutUint64(b[:], v)
+		buf.Write(b[:])
+	}
+	pad16 := func(s string) {
+		b := [16]byte{}
+		copy(b[:], s)
+		buf.Write(b[:])
+	}
+
+	// mach_header_64 (32 bytes)
+	pu32(0xFEEDFACF)                    // magic
+	pu32(cpuArm64)                      // cputype
+	pu32(0)                             // cpusubtype
+	pu32(mhExecute)                     // filetype
+	pu32(1)                             // ncmds
+	pu32(uint32(segCmdSize + sectSize)) // sizeofcmds
+	pu32(0)                             // flags
+	pu32(0)                             // reserved
+
+	// segment_command_64 (72 bytes)
+	pu32(lcSegment64)                   // cmd
+	pu32(uint32(segCmdSize + sectSize)) // cmdsize
+	pad16("__TEXT")                     // segname
+	pu64(vmBase)                        // vmaddr
+	pu64(0x1000)                        // vmsize
+	pu64(uint64(textOffset))            // fileoff
+	pu64(uint64(sectDataSize))          // filesize
+	pu32(7)                             // maxprot
+	pu32(5)                             // initprot
+	pu32(1)                             // nsects
+	pu32(0)                             // flags
+
+	// section_64 (80 bytes)
+	pad16("__text")            // sectname
+	pad16("__TEXT")            // segname
+	pu64(vmBase)               // addr
+	pu64(uint64(sectDataSize)) // size
+	pu32(uint32(textOffset))   // offset
+	pu32(2)                    // align
+	pu32(0)                    // reloff
+	pu32(0)                    // nreloc
+	pu32(sAttrPureInst)        // flags
+	pu32(0)                    // reserved1
+	pu32(0)                    // reserved2
+	pu32(0)                    // reserved3
+
+	// section data
+	buf.Write(instBytes)
+
+	require.Equal(t, textOffset+int(sectDataSize), buf.Len())
+	return buf.Bytes()
+}
+
+// writeTempBinary writes data to a file in the given directory and returns its path.
+func writeTempBinary(t *testing.T, dir string, name string, data []byte) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, data, 0o644))
+	return path
+}
+
+// recordMachO records a synthetic binary and returns the analysis record.
+// stub controls the SymbolAnalysis result; the svc scan runs independently.
+func recordMachO(t *testing.T, binData []byte, stub *stubBinaryAnalyzer) *fileanalysis.Record {
+	t.Helper()
+	tempDir := safeTempDir(t)
+	hashDir := filepath.Join(tempDir, "hashes")
+	require.NoError(t, os.MkdirAll(hashDir, 0o700))
+
+	binPath := writeTempBinary(t, tempDir, "target.bin", binData)
+
+	v, err := New(&SHA256{}, hashDir)
+	require.NoError(t, err)
+	v.SetBinaryAnalyzer(stub)
+
+	_, _, recErr := v.SaveRecord(binPath, false)
+	require.NoError(t, recErr)
+
+	record, loadErr := v.LoadRecord(binPath)
+	require.NoError(t, loadErr)
+	return record
+}
+
+// TestBuildSVCSyscallAnalysis is a unit test for the buildSVCSyscallAnalysis helper.
+// It verifies that the returned SyscallAnalysisData has the correct fields.
+func TestBuildSVCSyscallAnalysis(t *testing.T) {
+	addrs := []uint64{0x100000004, 0x10000000C}
+	result := buildSVCSyscallAnalysis(addrs)
+
+	require.NotNil(t, result)
+	assert.Equal(t, "arm64", result.Architecture)
+	require.Len(t, result.AnalysisWarnings, 1)
+	assert.Contains(t, result.AnalysisWarnings[0], "svc #0x80")
+	require.Len(t, result.DetectedSyscalls, 2)
+
+	for i, addr := range addrs {
+		sc := result.DetectedSyscalls[i]
+		assert.Equal(t, -1, sc.Number)
+		assert.Equal(t, addr, sc.Location)
+		assert.Equal(t, "direct_svc_0x80", sc.DeterminationMethod)
+		assert.Equal(t, "direct_svc_0x80", sc.Source)
+		assert.False(t, sc.IsNetwork)
+	}
+	assert.Nil(t, result.ArgEvalResults)
+}
+
+// TestUpdateAnalysisRecord_MachoSVCDetected verifies that SaveRecord sets
+// SyscallAnalysis when a svc #0x80 instruction is found in an arm64 Mach-O
+// that has no network symbols (NoNetworkSymbols case).
+func TestUpdateAnalysisRecord_MachoSVCDetected(t *testing.T) {
+	// Build a minimal arm64 Mach-O with one svc #0x80 instruction.
+	binData := buildArm64MachOBinary(t, []uint32{svcEncodingU32})
+	stub := &stubBinaryAnalyzer{result: binaryanalyzer.NoNetworkSymbols}
+
+	record := recordMachO(t, binData, stub)
+
+	require.NotNil(t, record.SyscallAnalysis, "SyscallAnalysis must be set when svc #0x80 is found")
+	assert.Equal(t, "arm64", record.SyscallAnalysis.Architecture)
+	require.Len(t, record.SyscallAnalysis.DetectedSyscalls, 1)
+	assert.Equal(t, "direct_svc_0x80", record.SyscallAnalysis.DetectedSyscalls[0].DeterminationMethod)
+	assert.Equal(t, uint64(0x100000000), record.SyscallAnalysis.DetectedSyscalls[0].Location)
+}
+
+// TestUpdateAnalysisRecord_MachoNoSVC verifies that SaveRecord leaves
+// SyscallAnalysis nil when the arm64 Mach-O contains no svc #0x80.
+func TestUpdateAnalysisRecord_MachoNoSVC(t *testing.T) {
+	// Build a minimal arm64 Mach-O with only NOP instructions (no svc).
+	binData := buildArm64MachOBinary(t, []uint32{nopEncodingU32, nopEncodingU32})
+	stub := &stubBinaryAnalyzer{result: binaryanalyzer.NoNetworkSymbols}
+
+	record := recordMachO(t, binData, stub)
+
+	assert.Nil(t, record.SyscallAnalysis, "SyscallAnalysis must be nil when no svc #0x80 found")
+}
+
+// TestUpdateAnalysisRecord_MachoNetworkDetected_SVCDetected verifies that SaveRecord
+// saves SyscallAnalysis even when the Mach-O also has network symbols (NetworkDetected).
+// The runner controls whether to consult SyscallAnalysis; record captures it unconditionally.
+func TestUpdateAnalysisRecord_MachoNetworkDetected_SVCDetected(t *testing.T) {
+	// Build a minimal arm64 Mach-O with one svc #0x80 instruction.
+	binData := buildArm64MachOBinary(t, []uint32{svcEncodingU32})
+	stub := &stubBinaryAnalyzer{
+		result: binaryanalyzer.NetworkDetected,
+		detectedSymbols: []binaryanalyzer.DetectedSymbol{
+			{Name: "socket", Category: "network"},
+		},
+	}
+
+	record := recordMachO(t, binData, stub)
+
+	// SymbolAnalysis must be set (NetworkDetected).
+	require.NotNil(t, record.SymbolAnalysis, "SymbolAnalysis must be set for NetworkDetected")
+	// SyscallAnalysis must also be set (svc found regardless of SymbolAnalysis result).
+	require.NotNil(t, record.SyscallAnalysis, "SyscallAnalysis must be set when svc #0x80 is found")
+	assert.Equal(t, "arm64", record.SyscallAnalysis.Architecture)
+}
+
+// TestUpdateAnalysisRecord_MachoNetworkDetected_NoSVC verifies that SaveRecord
+// leaves SyscallAnalysis nil when the Mach-O has network symbols but no svc #0x80.
+func TestUpdateAnalysisRecord_MachoNetworkDetected_NoSVC(t *testing.T) {
+	// Build a minimal arm64 Mach-O with only NOP instructions (no svc).
+	binData := buildArm64MachOBinary(t, []uint32{nopEncodingU32})
+	stub := &stubBinaryAnalyzer{
+		result: binaryanalyzer.NetworkDetected,
+		detectedSymbols: []binaryanalyzer.DetectedSymbol{
+			{Name: "socket", Category: "network"},
+		},
+	}
+
+	record := recordMachO(t, binData, stub)
+
+	require.NotNil(t, record.SymbolAnalysis, "SymbolAnalysis must be set for NetworkDetected")
+	assert.Nil(t, record.SyscallAnalysis, "SyscallAnalysis must be nil when no svc #0x80 found")
+}
+
+// TestUpdateAnalysisRecord_ELFNotAffected verifies that the Mach-O svc scan path
+// does not affect non-Mach-O files. A plain text file (neither ELF nor Mach-O)
+// should result in nil SyscallAnalysis after the svc scan code runs.
+func TestUpdateAnalysisRecord_ELFNotAffected(t *testing.T) {
+	tempDir := safeTempDir(t)
+	hashDir := filepath.Join(tempDir, "hashes")
+	require.NoError(t, os.MkdirAll(hashDir, 0o700))
+
+	// Plain text file: neither ELF nor Mach-O. analyzeSyscalls sets nil.
+	// The Mach-O svc scan must also return nil (magic mismatch).
+	textPath := writeTempBinary(t, tempDir, "not_binary.txt", []byte("hello world"))
+
+	v, err := New(&SHA256{}, hashDir)
+	require.NoError(t, err)
+	// Set a non-nil BinaryAnalyzer so the svc scan path is exercised.
+	v.SetBinaryAnalyzer(&stubBinaryAnalyzer{result: binaryanalyzer.NotSupportedBinary})
+
+	_, _, recErr := v.SaveRecord(textPath, false)
+	require.NoError(t, recErr)
+
+	record, loadErr := v.LoadRecord(textPath)
+	require.NoError(t, loadErr)
+
+	assert.Nil(t, record.SyscallAnalysis,
+		"SyscallAnalysis must remain nil for a non-Mach-O, non-ELF file")
+}
+
+// TestBuildSVCSyscallAnalysis_CommonSyscallInfo verifies that DetectedSyscalls use
+// common.SyscallInfo and the fields match the expected values from the spec.
+func TestBuildSVCSyscallAnalysis_CommonSyscallInfo(t *testing.T) {
+	addrs := []uint64{0x100000000}
+	result := buildSVCSyscallAnalysis(addrs)
+
+	require.NotNil(t, result)
+	require.Len(t, result.DetectedSyscalls, 1)
+
+	sc := result.DetectedSyscalls[0]
+	// Verify the type is common.SyscallInfo (zero-value assignment as type check).
+	_ = common.SyscallInfo{}
+	assert.Equal(t, -1, sc.Number, "Number must be -1 (undetermined)")
+	assert.Equal(t, "direct_svc_0x80", sc.DeterminationMethod)
+	assert.Equal(t, "direct_svc_0x80", sc.Source)
+	assert.False(t, sc.IsNetwork)
+	assert.Empty(t, sc.Name)
+}

--- a/internal/runner/command_output_capture_test.go
+++ b/internal/runner/command_output_capture_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/executor"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/output"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/resource"
+	resourcetestutil "github.com/isseis/go-safe-cmd-runner/internal/runner/resource/testutil"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/runnertypes"
 	securitytesting "github.com/isseis/go-safe-cmd-runner/internal/runner/security/testing"
 	"github.com/isseis/go-safe-cmd-runner/internal/verification"
@@ -87,7 +88,7 @@ func TestIntegration_CommandOutputCapture(t *testing.T) {
 	var outputMgr output.CaptureManager
 
 	// Create resource manager
-	rm, err := resource.NewDefaultResourceManager(
+	rm, err := resourcetestutil.NewDefaultResourceManager(
 		exec,
 		fs,
 		nil, // privilege manager not needed for this test
@@ -263,7 +264,7 @@ func TestIntegration_SensitiveDataRedaction(t *testing.T) {
 			// Output manager will be created by NewDefaultResourceManager
 			var outputMgr output.CaptureManager
 
-			rm, err := resource.NewDefaultResourceManager(
+			rm, err := resourcetestutil.NewDefaultResourceManager(
 				exec,
 				fs,
 				nil,

--- a/internal/runner/e2e_slack_redaction_test.go
+++ b/internal/runner/e2e_slack_redaction_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/executor"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/output"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/resource"
+	resourcetestutil "github.com/isseis/go-safe-cmd-runner/internal/runner/resource/testutil"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/runnertypes"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/security"
 	"github.com/isseis/go-safe-cmd-runner/internal/verification"
@@ -136,7 +137,7 @@ func TestIntegration_SlackRedaction(t *testing.T) {
 	// Output manager will be created by NewDefaultResourceManager
 	var outputMgr output.CaptureManager
 
-	rm, err := resource.NewDefaultResourceManager(
+	rm, err := resourcetestutil.NewDefaultResourceManager(
 		exec,
 		fs,
 		nil,
@@ -259,7 +260,7 @@ func TestE2E_MultiHandlerLogging(t *testing.T) {
 
 	var outputMgr output.CaptureManager
 
-	rm, err := resource.NewDefaultResourceManager(
+	rm, err := resourcetestutil.NewDefaultResourceManager(
 		exec,
 		fs,
 		nil,

--- a/internal/runner/integration_dual_defense_test.go
+++ b/internal/runner/integration_dual_defense_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/executor"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/output"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/resource"
+	resourcetestutil "github.com/isseis/go-safe-cmd-runner/internal/runner/resource/testutil"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/runnertypes"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/security"
 	securitytesting "github.com/isseis/go-safe-cmd-runner/internal/runner/security/testing"
@@ -86,7 +87,7 @@ func TestIntegration_DualDefense(t *testing.T) {
 	// Output manager will be created by NewDefaultResourceManager
 	var outputMgr output.CaptureManager
 
-	rm, err := resource.NewDefaultResourceManager(
+	rm, err := resourcetestutil.NewDefaultResourceManager(
 		exec,
 		fs,
 		nil,
@@ -197,7 +198,7 @@ func TestIntegration_Case1Only(t *testing.T) {
 	// Output manager will be created by NewDefaultResourceManager
 	var outputMgr output.CaptureManager
 
-	rm, err := resource.NewDefaultResourceManager(
+	rm, err := resourcetestutil.NewDefaultResourceManager(
 		exec,
 		fs,
 		nil,
@@ -299,7 +300,7 @@ func TestIntegration_Case2Only(t *testing.T) {
 	// Output manager will be created by NewDefaultResourceManager
 	var outputMgr output.CaptureManager
 
-	rm, err := resource.NewDefaultResourceManager(
+	rm, err := resourcetestutil.NewDefaultResourceManager(
 		exec,
 		fs,
 		nil,
@@ -406,7 +407,7 @@ func TestIntegration_Case2Only_DebugLeakage(t *testing.T) {
 	// Output manager will be created by NewDefaultResourceManager
 	var outputMgr output.CaptureManager
 
-	rm, err := resource.NewDefaultResourceManager(
+	rm, err := resourcetestutil.NewDefaultResourceManager(
 		exec,
 		fs,
 		nil,

--- a/internal/runner/resource/default_manager.go
+++ b/internal/runner/resource/default_manager.go
@@ -22,15 +22,9 @@ type DefaultResourceManager struct {
 	dryrun *DryRunResourceManager
 }
 
-// NewDefaultResourceManager creates a new DefaultResourceManager with output capture support.
-// If mode is ExecutionModeDryRun, opts may be used to configure the dry-run behavior.
-func NewDefaultResourceManager(exec executor.CommandExecutor, fs executor.FileSystem, privMgr runnertypes.PrivilegeManager, pathResolver PathResolver, logger *slog.Logger, mode ExecutionMode, dryRunOpts *DryRunOptions, outputMgr output.CaptureManager, maxOutputSize int64, store fileanalysis.NetworkSymbolStore) (*DefaultResourceManager, error) {
-	return NewDefaultResourceManagerWithStores(exec, fs, privMgr, pathResolver, logger, mode, dryRunOpts, outputMgr, maxOutputSize, store, nil)
-}
-
-// NewDefaultResourceManagerWithStores creates a new DefaultResourceManager with
-// output capture support and both binary-analysis caches.
-func NewDefaultResourceManagerWithStores(exec executor.CommandExecutor, fs executor.FileSystem, privMgr runnertypes.PrivilegeManager, pathResolver PathResolver, logger *slog.Logger, mode ExecutionMode, dryRunOpts *DryRunOptions, outputMgr output.CaptureManager, maxOutputSize int64, symStore fileanalysis.NetworkSymbolStore, syscallStore fileanalysis.SyscallAnalysisStore) (*DefaultResourceManager, error) {
+// NewDefaultResourceManager creates a new DefaultResourceManager with output capture support
+// and both binary-analysis caches.
+func NewDefaultResourceManager(exec executor.CommandExecutor, fs executor.FileSystem, privMgr runnertypes.PrivilegeManager, pathResolver PathResolver, logger *slog.Logger, mode ExecutionMode, dryRunOpts *DryRunOptions, outputMgr output.CaptureManager, maxOutputSize int64, symStore fileanalysis.NetworkSymbolStore, syscallStore fileanalysis.SyscallAnalysisStore) (*DefaultResourceManager, error) {
 	// Create output manager if not provided
 	if outputMgr == nil {
 		// Create a security validator for output validation

--- a/internal/runner/resource/default_manager.go
+++ b/internal/runner/resource/default_manager.go
@@ -25,6 +25,12 @@ type DefaultResourceManager struct {
 // NewDefaultResourceManager creates a new DefaultResourceManager with output capture support.
 // If mode is ExecutionModeDryRun, opts may be used to configure the dry-run behavior.
 func NewDefaultResourceManager(exec executor.CommandExecutor, fs executor.FileSystem, privMgr runnertypes.PrivilegeManager, pathResolver PathResolver, logger *slog.Logger, mode ExecutionMode, dryRunOpts *DryRunOptions, outputMgr output.CaptureManager, maxOutputSize int64, store fileanalysis.NetworkSymbolStore) (*DefaultResourceManager, error) {
+	return NewDefaultResourceManagerWithStores(exec, fs, privMgr, pathResolver, logger, mode, dryRunOpts, outputMgr, maxOutputSize, store, nil)
+}
+
+// NewDefaultResourceManagerWithStores creates a new DefaultResourceManager with
+// output capture support and both binary-analysis caches.
+func NewDefaultResourceManagerWithStores(exec executor.CommandExecutor, fs executor.FileSystem, privMgr runnertypes.PrivilegeManager, pathResolver PathResolver, logger *slog.Logger, mode ExecutionMode, dryRunOpts *DryRunOptions, outputMgr output.CaptureManager, maxOutputSize int64, symStore fileanalysis.NetworkSymbolStore, syscallStore fileanalysis.SyscallAnalysisStore) (*DefaultResourceManager, error) {
 	// Create output manager if not provided
 	if outputMgr == nil {
 		// Create a security validator for output validation
@@ -37,7 +43,7 @@ func NewDefaultResourceManager(exec executor.CommandExecutor, fs executor.FileSy
 
 	mgr := &DefaultResourceManager{
 		mode:   mode,
-		normal: NewNormalResourceManagerWithOutput(exec, fs, privMgr, outputMgr, maxOutputSize, logger, store),
+		normal: NewNormalResourceManagerWithStores(exec, fs, privMgr, outputMgr, maxOutputSize, logger, symStore, syscallStore),
 	}
 	// Create dry-run manager eagerly to keep state like analyses across mode flips
 	// and to simplify switching without re-wiring dependencies.

--- a/internal/runner/resource/default_manager_test.go
+++ b/internal/runner/resource/default_manager_test.go
@@ -45,7 +45,7 @@ func TestDefaultResourceManager_ModeDelegation(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("Normal Mode", func(t *testing.T) {
-		mgr, err := NewDefaultResourceManager(mocks.exec, mocks.fs, mocks.priv, mocks.pathResolver, slog.Default(), ExecutionModeNormal, &DryRunOptions{}, nil, 0, nil)
+		mgr, err := NewDefaultResourceManagerForTest(mocks.exec, mocks.fs, mocks.priv, mocks.pathResolver, slog.Default(), ExecutionModeNormal, &DryRunOptions{}, nil, 0, nil)
 		require.NoError(t, err)
 
 		expected := &executor.Result{ExitCode: 0, Stdout: "ok"}
@@ -59,7 +59,7 @@ func TestDefaultResourceManager_ModeDelegation(t *testing.T) {
 	})
 
 	t.Run("Dry Run Mode", func(t *testing.T) {
-		mgr, err := NewDefaultResourceManager(mocks.exec, mocks.fs, mocks.priv, mocks.pathResolver, slog.Default(), ExecutionModeDryRun, &DryRunOptions{DetailLevel: DetailLevelDetailed}, nil, 0, nil)
+		mgr, err := NewDefaultResourceManagerForTest(mocks.exec, mocks.fs, mocks.priv, mocks.pathResolver, slog.Default(), ExecutionModeDryRun, &DryRunOptions{DetailLevel: DetailLevelDetailed}, nil, 0, nil)
 		require.NoError(t, err)
 
 		_, res2, err := mgr.ExecuteCommand(ctx, cmd, createTestCommandGroup(), env)
@@ -74,7 +74,7 @@ func TestDefaultResourceManager_TempDirDelegation(t *testing.T) {
 	mocks := setupTestMocks()
 
 	t.Run("CreateTempDir Normal", func(t *testing.T) {
-		mgr, err := NewDefaultResourceManager(mocks.exec, mocks.fs, mocks.priv, mocks.pathResolver, slog.Default(), ExecutionModeNormal, &DryRunOptions{}, nil, 0, nil)
+		mgr, err := NewDefaultResourceManagerForTest(mocks.exec, mocks.fs, mocks.priv, mocks.pathResolver, slog.Default(), ExecutionModeNormal, &DryRunOptions{}, nil, 0, nil)
 		require.NoError(t, err)
 		mocks.fs.On("CreateTempDir", "", "scr-group-").Return("/tmp/scr-group-123", nil)
 		path, err := mgr.CreateTempDir("group")
@@ -84,7 +84,7 @@ func TestDefaultResourceManager_TempDirDelegation(t *testing.T) {
 
 	t.Run("CreateTempDir Dry Run", func(t *testing.T) {
 		// Dry-run
-		mgr, err := NewDefaultResourceManager(mocks.exec, mocks.fs, mocks.priv, mocks.pathResolver, slog.Default(), ExecutionModeDryRun, &DryRunOptions{}, nil, 0, nil)
+		mgr, err := NewDefaultResourceManagerForTest(mocks.exec, mocks.fs, mocks.priv, mocks.pathResolver, slog.Default(), ExecutionModeDryRun, &DryRunOptions{}, nil, 0, nil)
 		require.NoError(t, err)
 
 		path2, err := mgr.CreateTempDir("group")
@@ -96,7 +96,7 @@ func TestDefaultResourceManager_TempDirDelegation(t *testing.T) {
 func TestDefaultResourceManager_PrivilegesAndNotifications(t *testing.T) {
 	mocks := setupTestMocks()
 
-	mgr, err := NewDefaultResourceManager(mocks.exec, mocks.fs, mocks.priv, mocks.pathResolver, slog.Default(), ExecutionModeDryRun, &DryRunOptions{}, nil, 0, nil)
+	mgr, err := NewDefaultResourceManagerForTest(mocks.exec, mocks.fs, mocks.priv, mocks.pathResolver, slog.Default(), ExecutionModeDryRun, &DryRunOptions{}, nil, 0, nil)
 	require.NoError(t, err)
 
 	// WithPrivileges should call provided fn in dry-run
@@ -141,7 +141,7 @@ func TestDefaultResourceManager_CleanupTempDir(t *testing.T) {
 	mocks := setupTestMocks()
 
 	t.Run("Dry Run Mode", func(t *testing.T) {
-		mgr, err := NewDefaultResourceManager(mocks.exec, mocks.fs, mocks.priv, mocks.pathResolver, slog.Default(), ExecutionModeDryRun, &DryRunOptions{}, nil, 0, nil)
+		mgr, err := NewDefaultResourceManagerForTest(mocks.exec, mocks.fs, mocks.priv, mocks.pathResolver, slog.Default(), ExecutionModeDryRun, &DryRunOptions{}, nil, 0, nil)
 		require.NoError(t, err)
 
 		// Dry-run should not actually remove but should delegate without error
@@ -154,7 +154,7 @@ func TestDefaultResourceManager_CleanupAllTempDirs(t *testing.T) {
 	mocks := setupTestMocks()
 
 	t.Run("Dry Run Mode", func(t *testing.T) {
-		mgr, err := NewDefaultResourceManager(mocks.exec, mocks.fs, mocks.priv, mocks.pathResolver, slog.Default(), ExecutionModeDryRun, &DryRunOptions{}, nil, 0, nil)
+		mgr, err := NewDefaultResourceManagerForTest(mocks.exec, mocks.fs, mocks.priv, mocks.pathResolver, slog.Default(), ExecutionModeDryRun, &DryRunOptions{}, nil, 0, nil)
 		require.NoError(t, err)
 
 		err = mgr.CleanupAllTempDirs()
@@ -166,7 +166,7 @@ func TestDefaultResourceManager_RecordAnalysis(t *testing.T) {
 	mocks := setupTestMocks()
 
 	t.Run("Normal Mode - No-op", func(t *testing.T) {
-		mgr, err := NewDefaultResourceManager(mocks.exec, mocks.fs, mocks.priv, mocks.pathResolver, slog.Default(), ExecutionModeNormal, &DryRunOptions{}, nil, 0, nil)
+		mgr, err := NewDefaultResourceManagerForTest(mocks.exec, mocks.fs, mocks.priv, mocks.pathResolver, slog.Default(), ExecutionModeNormal, &DryRunOptions{}, nil, 0, nil)
 		require.NoError(t, err)
 
 		analysis := &Analysis{
@@ -183,7 +183,7 @@ func TestDefaultResourceManager_RecordAnalysis(t *testing.T) {
 	})
 
 	t.Run("Dry Run Mode - Records Analysis", func(t *testing.T) {
-		mgr, err := NewDefaultResourceManager(mocks.exec, mocks.fs, mocks.priv, mocks.pathResolver, slog.Default(), ExecutionModeDryRun, &DryRunOptions{}, nil, 0, nil)
+		mgr, err := NewDefaultResourceManagerForTest(mocks.exec, mocks.fs, mocks.priv, mocks.pathResolver, slog.Default(), ExecutionModeDryRun, &DryRunOptions{}, nil, 0, nil)
 		require.NoError(t, err)
 
 		analysis := &Analysis{
@@ -207,7 +207,7 @@ func TestDefaultResourceManager_RecordGroupAnalysis(t *testing.T) {
 	debugInfo := &DebugInfo{}
 
 	t.Run("Normal Mode", func(t *testing.T) {
-		mgr, err := NewDefaultResourceManager(mocks.exec, mocks.fs, mocks.priv, mocks.pathResolver, slog.Default(), ExecutionModeNormal, &DryRunOptions{}, nil, 0, nil)
+		mgr, err := NewDefaultResourceManagerForTest(mocks.exec, mocks.fs, mocks.priv, mocks.pathResolver, slog.Default(), ExecutionModeNormal, &DryRunOptions{}, nil, 0, nil)
 		require.NoError(t, err)
 
 		err = mgr.RecordGroupAnalysis("test-group", debugInfo)
@@ -215,7 +215,7 @@ func TestDefaultResourceManager_RecordGroupAnalysis(t *testing.T) {
 	})
 
 	t.Run("Dry Run Mode", func(t *testing.T) {
-		mgr, err := NewDefaultResourceManager(mocks.exec, mocks.fs, mocks.priv, mocks.pathResolver, slog.Default(), ExecutionModeDryRun, &DryRunOptions{}, nil, 0, nil)
+		mgr, err := NewDefaultResourceManagerForTest(mocks.exec, mocks.fs, mocks.priv, mocks.pathResolver, slog.Default(), ExecutionModeDryRun, &DryRunOptions{}, nil, 0, nil)
 		require.NoError(t, err)
 
 		err = mgr.RecordGroupAnalysis("test-group", debugInfo)
@@ -229,7 +229,7 @@ func TestDefaultResourceManager_UpdateCommandDebugInfo(t *testing.T) {
 	debugInfo := &DebugInfo{}
 
 	t.Run("Normal Mode", func(t *testing.T) {
-		mgr, err := NewDefaultResourceManager(mocks.exec, mocks.fs, mocks.priv, mocks.pathResolver, slog.Default(), ExecutionModeNormal, &DryRunOptions{}, nil, 0, nil)
+		mgr, err := NewDefaultResourceManagerForTest(mocks.exec, mocks.fs, mocks.priv, mocks.pathResolver, slog.Default(), ExecutionModeNormal, &DryRunOptions{}, nil, 0, nil)
 		require.NoError(t, err)
 
 		token := CommandToken("test-token-123")
@@ -239,7 +239,7 @@ func TestDefaultResourceManager_UpdateCommandDebugInfo(t *testing.T) {
 	})
 
 	t.Run("Dry Run Mode - execution creates token", func(t *testing.T) {
-		mgr, err := NewDefaultResourceManager(mocks.exec, mocks.fs, mocks.priv, mocks.pathResolver, slog.Default(), ExecutionModeDryRun, &DryRunOptions{}, nil, 0, nil)
+		mgr, err := NewDefaultResourceManagerForTest(mocks.exec, mocks.fs, mocks.priv, mocks.pathResolver, slog.Default(), ExecutionModeDryRun, &DryRunOptions{}, nil, 0, nil)
 		require.NoError(t, err)
 
 		// Execute a command to get a valid token

--- a/internal/runner/resource/error_scenarios_test.go
+++ b/internal/runner/resource/error_scenarios_test.go
@@ -690,7 +690,7 @@ func TestResourceManagerStateConsistency(t *testing.T) {
 	mockPathResolver := &MockPathResolver{}
 	setupStandardCommandPaths(mockPathResolver)
 	mockPathResolver.On("ResolvePath", mock.Anything).Return("/usr/bin/unknown", nil) // fallback
-	manager, err := NewDefaultResourceManager(nil, nil, nil, mockPathResolver, slog.Default(), ExecutionModeDryRun, dryRunOpts, nil, 0, nil)
+	manager, err := NewDefaultResourceManagerForTest(nil, nil, nil, mockPathResolver, slog.Default(), ExecutionModeDryRun, dryRunOpts, nil, 0, nil)
 	require.NoError(t, err)
 	require.NotNil(t, manager)
 
@@ -744,7 +744,7 @@ func TestResourceManagerStateConsistency(t *testing.T) {
 		mockPathResolver := &MockPathResolver{}
 		setupStandardCommandPaths(mockPathResolver)
 		mockPathResolver.On("ResolvePath", mock.Anything).Return("/usr/bin/unknown", nil) // fallback
-		dryRunManager, err := NewDefaultResourceManager(nil, nil, nil, mockPathResolver, slog.Default(), ExecutionModeDryRun, dryRunOpts, nil, 0, nil)
+		dryRunManager, err := NewDefaultResourceManagerForTest(nil, nil, nil, mockPathResolver, slog.Default(), ExecutionModeDryRun, dryRunOpts, nil, 0, nil)
 		require.NoError(t, err)
 		_, result, err := dryRunManager.ExecuteCommand(ctx, nullCmd, group, nullEnvVars)
 		assert.NoError(t, err, "dry-run mode should handle null bytes in environment")
@@ -754,7 +754,7 @@ func TestResourceManagerStateConsistency(t *testing.T) {
 		// Test with normal mode
 		mockPathResolver2 := &MockPathResolver{}
 		mockPathResolver2.On("ResolvePath", mock.Anything).Return("/usr/bin/unknown", nil)
-		normalManager, err := NewDefaultResourceManager(&mockCommandExecutor{}, &mockFileSystem{}, nil, mockPathResolver2, slog.Default(), ExecutionModeNormal, nil, nil, 0, nil)
+		normalManager, err := NewDefaultResourceManagerForTest(&mockCommandExecutor{}, &mockFileSystem{}, nil, mockPathResolver2, slog.Default(), ExecutionModeNormal, nil, nil, 0, nil)
 		require.NoError(t, err)
 		_, result, err = normalManager.ExecuteCommand(ctx, nullCmd, group, nullEnvVars)
 		assert.NoError(t, err, "normal mode should handle null bytes in environment")

--- a/internal/runner/resource/integration_test.go
+++ b/internal/runner/resource/integration_test.go
@@ -229,7 +229,7 @@ func TestDefaultResourceManagerModeConsistency(t *testing.T) {
 		mockPathResolver := &MockPathResolver{}
 		setupStandardCommandPaths(mockPathResolver)
 		mockPathResolver.On("ResolvePath", mock.Anything).Return("/usr/bin/unknown", nil) // fallback
-		manager, err := NewDefaultResourceManager(nil, nil, nil, mockPathResolver, slog.Default(), ExecutionModeNormal, dryRunOpts, nil, 0, nil)
+		manager, err := NewDefaultResourceManagerForTest(nil, nil, nil, mockPathResolver, slog.Default(), ExecutionModeNormal, dryRunOpts, nil, 0, nil)
 		require.NoError(t, err)
 		require.NotNil(t, manager)
 
@@ -248,7 +248,7 @@ func TestDefaultResourceManagerModeConsistency(t *testing.T) {
 		mockPathResolver := &MockPathResolver{}
 		setupStandardCommandPaths(mockPathResolver)
 		mockPathResolver.On("ResolvePath", mock.Anything).Return("/usr/bin/unknown", nil) // fallback
-		manager, err := NewDefaultResourceManager(nil, nil, nil, mockPathResolver, slog.Default(), ExecutionModeDryRun, dryRunOpts, nil, 0, nil)
+		manager, err := NewDefaultResourceManagerForTest(nil, nil, nil, mockPathResolver, slog.Default(), ExecutionModeDryRun, dryRunOpts, nil, 0, nil)
 		require.NoError(t, err)
 		require.NotNil(t, manager)
 

--- a/internal/runner/resource/normal_manager.go
+++ b/internal/runner/resource/normal_manager.go
@@ -50,11 +50,26 @@ func NewNormalResourceManagerWithOutput(
 	logger *slog.Logger,
 	store fileanalysis.NetworkSymbolStore,
 ) *NormalResourceManager {
+	return NewNormalResourceManagerWithStores(exec, fs, privMgr, outputMgr, maxOutputSize, logger, store, nil)
+}
+
+// NewNormalResourceManagerWithStores creates a new NormalResourceManager with
+// output capture support and both binary-analysis caches.
+func NewNormalResourceManagerWithStores(
+	exec executor.CommandExecutor,
+	fs executor.FileSystem,
+	privMgr runnertypes.PrivilegeManager,
+	outputMgr output.CaptureManager,
+	maxOutputSize int64,
+	logger *slog.Logger,
+	symStore fileanalysis.NetworkSymbolStore,
+	syscallStore fileanalysis.SyscallAnalysisStore,
+) *NormalResourceManager {
 	return &NormalResourceManager{
 		executor:         exec,
 		fileSystem:       fs,
 		privilegeManager: privMgr,
-		riskEvaluator:    risk.NewStandardEvaluator(store),
+		riskEvaluator:    risk.NewStandardEvaluatorWithStores(symStore, syscallStore),
 		outputManager:    outputMgr,
 		maxOutputSize:    maxOutputSize,
 		logger:           logger,

--- a/internal/runner/resource/performance_test.go
+++ b/internal/runner/resource/performance_test.go
@@ -174,7 +174,7 @@ func BenchmarkResourceManagerModeSwitch(b *testing.B) {
 		mockPathResolver := &MockPathResolver{}
 		setupStandardCommandPaths(mockPathResolver)
 		mockPathResolver.On("ResolvePath", mock.Anything).Return("/usr/bin/unknown", nil) // fallback
-		manager, err := NewDefaultResourceManager(nil, nil, nil, mockPathResolver, slog.Default(), ExecutionModeDryRun, dryRunOpts, nil, 0, nil)
+		manager, err := NewDefaultResourceManagerForTest(nil, nil, nil, mockPathResolver, slog.Default(), ExecutionModeDryRun, dryRunOpts, nil, 0, nil)
 		require.NoError(b, err)
 
 		b.ResetTimer()

--- a/internal/runner/resource/test_helpers_test.go
+++ b/internal/runner/resource/test_helpers_test.go
@@ -5,7 +5,9 @@ package resource
 import (
 	"log/slog"
 
+	"github.com/isseis/go-safe-cmd-runner/internal/fileanalysis"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/executor"
+	"github.com/isseis/go-safe-cmd-runner/internal/runner/output"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/runnertypes"
 )
 
@@ -18,4 +20,21 @@ func NewNormalResourceManager(
 ) *NormalResourceManager {
 	// Delegate to NewNormalResourceManagerWithOutput with nil outputManager and 0 maxOutputSize
 	return NewNormalResourceManagerWithOutput(exec, fs, privMgr, nil, 0, logger, nil)
+}
+
+// NewDefaultResourceManagerForTest creates a DefaultResourceManager with nil SyscallAnalysisStore.
+// Use only in tests; production code must supply all stores explicitly via NewDefaultResourceManager.
+func NewDefaultResourceManagerForTest(
+	exec executor.CommandExecutor,
+	fs executor.FileSystem,
+	privMgr runnertypes.PrivilegeManager,
+	pathResolver PathResolver,
+	logger *slog.Logger,
+	mode ExecutionMode,
+	dryRunOpts *DryRunOptions,
+	outputMgr output.CaptureManager,
+	maxOutputSize int64,
+	symStore fileanalysis.NetworkSymbolStore,
+) (*DefaultResourceManager, error) {
+	return NewDefaultResourceManager(exec, fs, privMgr, pathResolver, logger, mode, dryRunOpts, outputMgr, maxOutputSize, symStore, nil)
 }

--- a/internal/runner/resource/testutil/helpers.go
+++ b/internal/runner/resource/testutil/helpers.go
@@ -6,7 +6,9 @@ package testutil
 import (
 	"log/slog"
 
+	"github.com/isseis/go-safe-cmd-runner/internal/fileanalysis"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/executor"
+	"github.com/isseis/go-safe-cmd-runner/internal/runner/output"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/resource"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/runnertypes"
 )
@@ -20,4 +22,21 @@ func NewNormalResourceManager(
 ) *resource.NormalResourceManager {
 	// Delegate to NewNormalResourceManagerWithOutput with nil outputManager and 0 maxOutputSize
 	return resource.NewNormalResourceManagerWithOutput(exec, fs, privMgr, nil, 0, logger, nil)
+}
+
+// NewDefaultResourceManager creates a DefaultResourceManager with nil SyscallAnalysisStore.
+// Use only in tests; production code must supply all stores explicitly via resource.NewDefaultResourceManager.
+func NewDefaultResourceManager(
+	exec executor.CommandExecutor,
+	fs executor.FileSystem,
+	privMgr runnertypes.PrivilegeManager,
+	pathResolver resource.PathResolver,
+	logger *slog.Logger,
+	mode resource.ExecutionMode,
+	dryRunOpts *resource.DryRunOptions,
+	outputMgr output.CaptureManager,
+	maxOutputSize int64,
+	symStore fileanalysis.NetworkSymbolStore,
+) (*resource.DefaultResourceManager, error) {
+	return resource.NewDefaultResourceManager(exec, fs, privMgr, pathResolver, logger, mode, dryRunOpts, outputMgr, maxOutputSize, symStore, nil)
 }

--- a/internal/runner/risk/evaluator.go
+++ b/internal/runner/risk/evaluator.go
@@ -21,7 +21,17 @@ type StandardEvaluator struct {
 // NewStandardEvaluator creates a new standard risk evaluator.
 // Pass a non-nil store to enable cache-based network symbol analysis.
 func NewStandardEvaluator(store fileanalysis.NetworkSymbolStore) Evaluator {
-	return &StandardEvaluator{networkAnalyzer: security.NewNetworkAnalyzerWithStore(store)}
+	return NewStandardEvaluatorWithStores(store, nil)
+}
+
+// NewStandardEvaluatorWithStores creates a new standard risk evaluator with
+// both symbol and syscall analysis caches enabled when the corresponding stores
+// are non-nil.
+func NewStandardEvaluatorWithStores(
+	symStore fileanalysis.NetworkSymbolStore,
+	syscallStore fileanalysis.SyscallAnalysisStore,
+) Evaluator {
+	return &StandardEvaluator{networkAnalyzer: security.NewNetworkAnalyzerWithStores(symStore, syscallStore)}
 }
 
 // EvaluateRisk analyzes a command and returns its risk level

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -250,19 +250,26 @@ func createNormalResourceManager(opts *runnerOptions, _ *runnertypes.ConfigSpec,
 	// Create output manager with the same validator that has group membership support
 	outputMgr := output.NewDefaultOutputCaptureManager(validator)
 
-	// Obtain a NetworkSymbolStore from the path resolver if available.
-	// When the resolver does not implement networkSymbolStoreProvider (e.g., test mocks
-	// without a hash dir), store is nil and cache-based analysis is disabled
-	// (falls back to live binary analysis).
+	// Obtain analysis stores from the path resolver if available.
+	// When the resolver does not implement these provider interfaces (e.g., test mocks
+	// without a hash dir), the corresponding cache is nil and cache-based analysis
+	// is disabled.
 	var networkStore fileanalysis.NetworkSymbolStore
+	var syscallStore fileanalysis.SyscallAnalysisStore
 	type networkSymbolStoreProvider interface {
 		GetNetworkSymbolStore() fileanalysis.NetworkSymbolStore
+	}
+	type syscallAnalysisStoreProvider interface {
+		GetSyscallAnalysisStore() fileanalysis.SyscallAnalysisStore
 	}
 	if p, ok := pathResolver.(networkSymbolStoreProvider); ok {
 		networkStore = p.GetNetworkSymbolStore()
 	}
+	if p, ok := pathResolver.(syscallAnalysisStoreProvider); ok {
+		syscallStore = p.GetSyscallAnalysisStore()
+	}
 
-	resourceManager, err := resource.NewDefaultResourceManager(
+	resourceManager, err := resource.NewDefaultResourceManagerWithStores(
 		opts.executor,
 		fs,
 		opts.privilegeManager,
@@ -273,6 +280,7 @@ func createNormalResourceManager(opts *runnerOptions, _ *runnertypes.ConfigSpec,
 		outputMgr,                 // Pass output manager with validator
 		maxOutputSize,             // Not used anymore (per-command limit is used instead)
 		networkStore,              // NetworkSymbolStore for cache-based analysis (nil disables cache)
+		syscallStore,              // SyscallAnalysisStore for cache-based analysis (nil disables cache)
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create default resource manager: %w", err)

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -269,7 +269,7 @@ func createNormalResourceManager(opts *runnerOptions, _ *runnertypes.ConfigSpec,
 		syscallStore = p.GetSyscallAnalysisStore()
 	}
 
-	resourceManager, err := resource.NewDefaultResourceManagerWithStores(
+	resourceManager, err := resource.NewDefaultResourceManager(
 		opts.executor,
 		fs,
 		opts.privilegeManager,

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -2378,10 +2378,11 @@ func (h *logCaptureHandler) WithGroup(_ string) slog.Handler {
 }
 
 // pathResolverWithStore is a minimal PathResolver that also implements
-// GetNetworkSymbolStore(), allowing tests to verify that createNormalResourceManager
-// picks up the store from the path resolver.
+// GetNetworkSymbolStore() and GetSyscallAnalysisStore(), allowing tests to verify
+// that createNormalResourceManager picks up both stores from the path resolver.
 type pathResolverWithStore struct {
-	storeCalled *bool
+	networkStoreCalled *bool
+	syscallStoreCalled *bool
 }
 
 func (p *pathResolverWithStore) ResolvePath(path string) (string, error) {
@@ -2389,23 +2390,32 @@ func (p *pathResolverWithStore) ResolvePath(path string) (string, error) {
 }
 
 func (p *pathResolverWithStore) GetNetworkSymbolStore() fileanalysis.NetworkSymbolStore {
-	*p.storeCalled = true
+	*p.networkStoreCalled = true
 	return nil // nil store is sufficient; we only verify the method was called
 }
 
-// TestCreateNormalResourceManager_NetworkStoreInjected verifies that when the
-// path resolver implements GetNetworkSymbolStore(), createNormalResourceManager
-// calls it to obtain and inject the store. This ensures the caching path in
-// NetworkAnalyzer is wired up during normal runner initialisation.
-func TestCreateNormalResourceManager_NetworkStoreInjected(t *testing.T) {
-	storeCalled := false
-	resolver := &pathResolverWithStore{storeCalled: &storeCalled}
+func (p *pathResolverWithStore) GetSyscallAnalysisStore() fileanalysis.SyscallAnalysisStore {
+	*p.syscallStoreCalled = true
+	return nil // nil store is sufficient; we only verify the method was called
+}
+
+// TestCreateNormalResourceManager_AnalysisStoresInjected verifies that when the
+// path resolver implements both store getters, createNormalResourceManager calls
+// them to obtain and inject the caches used by NetworkAnalyzer.
+func TestCreateNormalResourceManager_AnalysisStoresInjected(t *testing.T) {
+	networkStoreCalled := false
+	syscallStoreCalled := false
+	resolver := &pathResolverWithStore{
+		networkStoreCalled: &networkStoreCalled,
+		syscallStoreCalled: &syscallStoreCalled,
+	}
 
 	opts := &runnerOptions{}
 	err := createNormalResourceManager(opts, &runnertypes.ConfigSpec{}, resolver, nil)
 	require.NoError(t, err)
 
-	assert.True(t, storeCalled, "GetNetworkSymbolStore must be called when pathResolver implements the interface")
+	assert.True(t, networkStoreCalled, "GetNetworkSymbolStore must be called when pathResolver implements the interface")
+	assert.True(t, syscallStoreCalled, "GetSyscallAnalysisStore must be called when pathResolver implements the interface")
 	assert.NotNil(t, opts.resourceManager)
 }
 

--- a/internal/runner/security/command_analysis_test.go
+++ b/internal/runner/security/command_analysis_test.go
@@ -2711,13 +2711,15 @@ func TestIsNetworkViaBinaryAnalysis_Cache(t *testing.T) {
 		assert.False(t, mock.called, "BinaryAnalyzer must not be called (live fallback removed)")
 	})
 
-	t.Run("SchemaVersionMismatchError → BinaryAnalyzer called as fallback", func(t *testing.T) {
+	t.Run("SchemaVersionMismatchError → high risk, BinaryAnalyzer not called", func(t *testing.T) {
 		schemaErr := &fileanalysis.SchemaVersionMismatchError{Expected: fileanalysis.CurrentSchemaVersion, Actual: fileanalysis.CurrentSchemaVersion - 1}
 		store := &stubNetworkSymbolStore{err: schemaErr}
 		mock := &mockBinaryAnalyzer{result: binaryanalyzer.NetworkDetected}
 		analyzer := newNetworkAnalyzer(mock, store)
-		isNet, _ := analyzer.isNetworkViaBinaryAnalysis(cmdPath, contentHash)
-		assert.True(t, isNet, "expected live binary analysis fallback on schema mismatch")
+		isNet, isHigh := analyzer.isNetworkViaBinaryAnalysis(cmdPath, contentHash)
+		assert.True(t, isNet, "schema mismatch must return isNetwork=true as safety measure")
+		assert.True(t, isHigh, "schema mismatch must return high risk")
+		assert.False(t, mock.called, "BinaryAnalyzer must not be called on schema mismatch")
 	})
 
 	t.Run("nil store → BinaryAnalyzer called directly", func(t *testing.T) {

--- a/internal/runner/security/command_analysis_test.go
+++ b/internal/runner/security/command_analysis_test.go
@@ -2701,12 +2701,14 @@ func TestIsNetworkViaBinaryAnalysis_Cache(t *testing.T) {
 		assert.True(t, isHigh, "expected high risk from dlopen in cache")
 	})
 
-	t.Run("cache miss (ErrNoNetworkSymbolAnalysis) → BinaryAnalyzer called as fallback", func(t *testing.T) {
+	t.Run("ErrNoNetworkSymbolAnalysis (no syscallStore) → false, false (static binary, no live fallback)", func(t *testing.T) {
 		store := &stubNetworkSymbolStore{err: fileanalysis.ErrNoNetworkSymbolAnalysis}
 		mock := &mockBinaryAnalyzer{result: binaryanalyzer.NetworkDetected}
 		analyzer := newNetworkAnalyzer(mock, store)
-		isNet, _ := analyzer.isNetworkViaBinaryAnalysis(cmdPath, contentHash)
-		assert.True(t, isNet, "expected network detected via live binary analysis fallback")
+		isNet, isHigh := analyzer.isNetworkViaBinaryAnalysis(cmdPath, contentHash)
+		assert.False(t, isNet, "static binary with no svc should return false")
+		assert.False(t, isHigh, "static binary with no svc should return false")
+		assert.False(t, mock.called, "BinaryAnalyzer must not be called (live fallback removed)")
 	})
 
 	t.Run("SchemaVersionMismatchError → BinaryAnalyzer called as fallback", func(t *testing.T) {

--- a/internal/runner/security/machoanalyzer/standard_analyzer.go
+++ b/internal/runner/security/machoanalyzer/standard_analyzer.go
@@ -31,6 +31,8 @@ const magicNumberSize = 4
 const (
 	machoMagic64 = 0xFEEDFACF // 64-bit Mach-O (native endian)
 	machoCigam64 = 0xCFFAEDFE // 64-bit Mach-O (byte-swapped)
+	machoMagic32 = 0xFEEDFACE // 32-bit Mach-O (native endian)
+	machoCigam32 = 0xCEFAEDFE // 32-bit Mach-O (byte-swapped)
 	fatMagic     = 0xCAFEBABE // Fat binary
 	fatCigam     = 0xBEBAFECA // Fat binary (byte-swapped)
 )

--- a/internal/runner/security/machoanalyzer/svc_scanner.go
+++ b/internal/runner/security/machoanalyzer/svc_scanner.go
@@ -3,6 +3,7 @@ package machoanalyzer
 import (
 	"debug/macho"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -33,16 +34,19 @@ func collectSVCAddresses(f *macho.File) ([]uint64, error) {
 		return nil, nil
 	}
 
-	data, err := section.Data()
-	if err != nil {
-		return nil, fmt.Errorf("failed to read __TEXT,__text section: %w", err)
-	}
-
+	r := section.Open()
 	target := binary.LittleEndian.Uint32(svcInstruction)
+	buf := make([]byte, len(svcInstruction))
 	var addrs []uint64
-	for i := 0; i+4 <= len(data); i += 4 {
-		if binary.LittleEndian.Uint32(data[i:i+4]) == target {
-			addrs = append(addrs, section.Addr+uint64(i))
+	for offset := uint64(0); ; offset += uint64(len(svcInstruction)) {
+		if _, err := io.ReadFull(r, buf); err != nil {
+			if err == io.EOF || errors.Is(err, io.ErrUnexpectedEOF) {
+				break
+			}
+			return nil, fmt.Errorf("failed to read __TEXT,__text section: %w", err)
+		}
+		if binary.LittleEndian.Uint32(buf) == target {
+			addrs = append(addrs, section.Addr+offset)
 		}
 	}
 	if len(addrs) == 0 {

--- a/internal/runner/security/machoanalyzer/svc_scanner.go
+++ b/internal/runner/security/machoanalyzer/svc_scanner.go
@@ -4,11 +4,52 @@ import (
 	"debug/macho"
 	"encoding/binary"
 	"fmt"
+	"io"
+	"log/slog"
+	"os"
+
+	"github.com/isseis/go-safe-cmd-runner/internal/safefileio"
 )
 
 // svcInstruction is the encoding of "svc #0x80" for arm64 (little-endian).
 // ARM64 encoding: 0xD4001001 → bytes [0x01, 0x10, 0x00, 0xD4]
 var svcInstruction = []byte{0x01, 0x10, 0x00, 0xD4}
+
+// collectSVCAddresses scans the __TEXT,__text section of a Mach-O file
+// for svc #0x80 instructions and returns their virtual addresses.
+//
+// Only processes arm64 binaries (CpuArm64); returns nil, nil for other
+// architectures or when no __TEXT,__text section is present.
+//
+// Returns nil, fmt.Errorf("...") when the section exists but cannot be read —
+// the caller must treat this as a scan failure.
+func collectSVCAddresses(f *macho.File) ([]uint64, error) {
+	if f.Cpu != macho.CpuArm64 {
+		return nil, nil
+	}
+
+	section := f.Section("__text")
+	if section == nil || section.Seg != "__TEXT" {
+		return nil, nil
+	}
+
+	data, err := section.Data()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read __TEXT,__text section: %w", err)
+	}
+
+	target := binary.LittleEndian.Uint32(svcInstruction)
+	var addrs []uint64
+	for i := 0; i+4 <= len(data); i += 4 {
+		if binary.LittleEndian.Uint32(data[i:i+4]) == target {
+			addrs = append(addrs, section.Addr+uint64(i))
+		}
+	}
+	if len(addrs) == 0 {
+		return nil, nil
+	}
+	return addrs, nil
+}
 
 // containsSVCInstruction scans the __TEXT,__text section of a Mach-O file
 // for the svc #0x80 instruction (0xD4001001 in little-endian).
@@ -25,25 +66,91 @@ var svcInstruction = []byte{0x01, 0x10, 0x00, 0xD4}
 // system calls and never contain svc #0x80 directly. Its presence indicates
 // a direct kernel call, bypassing libSystem.dylib.
 func containsSVCInstruction(f *macho.File) (bool, error) {
-	if f.Cpu != macho.CpuArm64 {
-		return false, nil
-	}
+	addrs, err := collectSVCAddresses(f)
+	return len(addrs) > 0, err
+}
 
-	section := f.Section("__text")
-	if section == nil || section.Seg != "__TEXT" {
-		return false, nil
+// isMachOMagicAll reports whether the first 4 bytes match any recognized
+// Mach-O or Fat binary magic number, covering 32-bit, 64-bit, and Fat
+// binaries in both native and byte-swapped byte orders.
+func isMachOMagicAll(b []byte) bool {
+	if len(b) < magicNumberSize {
+		return false
 	}
+	m := binary.LittleEndian.Uint32(b[:magicNumberSize])
+	switch m {
+	case machoMagic64, machoCigam64, fatMagic, fatCigam,
+		machoMagic32, machoCigam32:
+		return true
+	}
+	return false
+}
 
-	data, err := section.Data()
+// CollectSVCAddressesFromFile opens the file at filePath using fs, checks
+// whether it is a Mach-O binary, and collects virtual addresses of svc #0x80
+// instructions from arm64 slices.
+//
+// For Fat binaries only arm64 slices are scanned; other architecture slices
+// are skipped.  Returns nil, nil for non-Mach-O files or when no svc #0x80
+// is detected.  Returns an error on I/O failures or Mach-O parse failures.
+func CollectSVCAddressesFromFile(filePath string, fs safefileio.FileSystem) ([]uint64, error) {
+	f, err := fs.SafeOpenFile(filePath, os.O_RDONLY, 0)
 	if err != nil {
-		return false, fmt.Errorf("failed to read __TEXT,__text section: %w", err)
+		return nil, fmt.Errorf("failed to open file: %w", err)
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+
+	// Read the first 4 bytes to check the Mach-O magic number.
+	// macho.NewFile and macho.NewFatFile accept io.ReaderAt, so they read
+	// from absolute offsets and are not affected by the current read position.
+	magic := make([]byte, magicNumberSize)
+	if _, err := io.ReadFull(f, magic); err != nil {
+		// File is shorter than 4 bytes — cannot be Mach-O.
+		return nil, nil
 	}
 
-	target := binary.LittleEndian.Uint32(svcInstruction)
-	for i := 0; i+4 <= len(data); i += 4 {
-		if binary.LittleEndian.Uint32(data[i:i+4]) == target {
-			return true, nil
-		}
+	if !isMachOMagicAll(magic) {
+		return nil, nil
 	}
-	return false, nil
+
+	m := binary.LittleEndian.Uint32(magic)
+	if m == fatMagic || m == fatCigam {
+		fat, err := macho.NewFatFile(f)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse Fat binary: %w", err)
+		}
+		defer func() {
+			if closeErr := fat.Close(); closeErr != nil {
+				slog.Warn("error closing Fat Mach-O file during svc scan", slog.Any("error", closeErr))
+			}
+		}()
+
+		var all []uint64
+		for i := range fat.Arches {
+			addrs, err := collectSVCAddresses(fat.Arches[i].File)
+			if err != nil {
+				return nil, err
+			}
+			all = append(all, addrs...)
+		}
+		if len(all) == 0 {
+			return nil, nil
+		}
+		return all, nil
+	}
+
+	// Single-architecture Mach-O.
+	machOFile, err := macho.NewFile(f)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse Mach-O: %w", err)
+	}
+	defer func() {
+		if closeErr := machOFile.Close(); closeErr != nil {
+			slog.Warn("error closing Mach-O file during svc scan", slog.Any("error", closeErr))
+		}
+	}()
+
+	return collectSVCAddresses(machOFile)
 }

--- a/internal/runner/security/machoanalyzer/svc_scanner_test.go
+++ b/internal/runner/security/machoanalyzer/svc_scanner_test.go
@@ -1,0 +1,253 @@
+//go:build test
+
+package machoanalyzer
+
+import (
+	"bytes"
+	"debug/macho"
+	"encoding/binary"
+	"os"
+	"testing"
+
+	"github.com/isseis/go-safe-cmd-runner/internal/groupmembership"
+	"github.com/isseis/go-safe-cmd-runner/internal/safefileio"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// svcEncoding is the little-endian encoding of "svc #0x80" for arm64.
+const svcEncoding = uint32(0xD4001001)
+
+// nopEncoding is a common arm64 NOP instruction.
+const nopEncoding = uint32(0xD503201F)
+
+// osWrapFS is a safefileio.FileSystem that opens files using os.Open,
+// used to read testdata fixtures without the security constraints of osFS.
+type osWrapFS struct{}
+
+func (osWrapFS) SafeOpenFile(name string, _ int, _ os.FileMode) (safefileio.File, error) {
+	return os.Open(name)
+}
+func (osWrapFS) AtomicMoveFile(_, _ string, _ os.FileMode) error      { return nil }
+func (osWrapFS) GetGroupMembership() *groupmembership.GroupMembership { return nil }
+func (osWrapFS) Remove(_ string) error                                { return nil }
+
+// buildArm64MachO builds a minimal arm64 Mach-O binary in memory.
+// The given instructions (as 32-bit little-endian words) are placed in
+// the __TEXT,__text section starting at virtual address 0x100000000.
+func buildArm64MachO(t *testing.T, instructions []uint32) []byte {
+	t.Helper()
+
+	const (
+		headerSize    = 32                                 // mach_header_64
+		segCmdSize    = 72                                 // segment_command_64 (without sections)
+		sectSize      = 80                                 // section_64
+		textOffset    = headerSize + segCmdSize + sectSize // 184 = 0xB8
+		lcSegment64   = 0x19
+		mhExecute     = 0x2
+		cpuArm64      = 0x0100000C
+		vmBase        = uint64(0x100000000)
+		sAttrPureInst = uint32(0x80000000)
+	)
+
+	sizeofcmds := uint32(segCmdSize + sectSize)
+	instBytes := make([]byte, len(instructions)*4)
+	for i, inst := range instructions {
+		binary.LittleEndian.PutUint32(instBytes[i*4:], inst)
+	}
+	sectDataSize := uint32(len(instBytes))
+
+	var buf bytes.Buffer
+	writeU32 := func(v uint32) {
+		b := [4]byte{}
+		binary.LittleEndian.PutUint32(b[:], v)
+		buf.Write(b[:])
+	}
+	writeU64 := func(v uint64) {
+		b := [8]byte{}
+		binary.LittleEndian.PutUint64(b[:], v)
+		buf.Write(b[:])
+	}
+	writePad16 := func(s string) {
+		b := [16]byte{}
+		copy(b[:], s)
+		buf.Write(b[:])
+	}
+
+	// mach_header_64 (32 bytes)
+	writeU32(0xFEEDFACF) // magic
+	writeU32(cpuArm64)   // cputype
+	writeU32(0)          // cpusubtype
+	writeU32(mhExecute)  // filetype
+	writeU32(1)          // ncmds
+	writeU32(sizeofcmds) // sizeofcmds
+	writeU32(0)          // flags
+	writeU32(0)          // reserved
+
+	// segment_command_64 (72 bytes)
+	writeU32(lcSegment64)                   // cmd
+	writeU32(uint32(segCmdSize + sectSize)) // cmdsize
+	writePad16("__TEXT")                    // segname
+	writeU64(vmBase)                        // vmaddr
+	writeU64(0x1000)                        // vmsize
+	writeU64(uint64(textOffset))            // fileoff
+	writeU64(uint64(sectDataSize))          // filesize
+	writeU32(7)                             // maxprot
+	writeU32(5)                             // initprot
+	writeU32(1)                             // nsects
+	writeU32(0)                             // flags
+
+	// section_64 (80 bytes)
+	writePad16("__text")           // sectname
+	writePad16("__TEXT")           // segname
+	writeU64(vmBase)               // addr
+	writeU64(uint64(sectDataSize)) // size
+	writeU32(uint32(textOffset))   // offset
+	writeU32(2)                    // align
+	writeU32(0)                    // reloff
+	writeU32(0)                    // nreloc
+	writeU32(sAttrPureInst)        // flags
+	writeU32(0)                    // reserved1
+	writeU32(0)                    // reserved2
+	writeU32(0)                    // reserved3
+
+	// section data
+	buf.Write(instBytes)
+
+	require.Equal(t, textOffset+int(sectDataSize), buf.Len())
+	return buf.Bytes()
+}
+
+// parseMachOFromBytes parses a Mach-O binary from a byte slice using macho.NewFile.
+func parseMachOFromBytes(t *testing.T, data []byte) *macho.File {
+	t.Helper()
+	f, err := macho.NewFile(bytes.NewReader(data))
+	require.NoError(t, err)
+	t.Cleanup(func() { f.Close() })
+	return f
+}
+
+// TestCollectSVCAddresses_Arm64WithSVC verifies that collectSVCAddresses returns
+// the virtual address of a single svc #0x80 instruction in an arm64 Mach-O.
+func TestCollectSVCAddresses_Arm64WithSVC(t *testing.T) {
+	path := testdataPath("svc_only_arm64")
+	skipIfNotExist(t, path)
+
+	f, err := macho.Open(path)
+	require.NoError(t, err)
+	defer f.Close()
+
+	addrs, err := collectSVCAddresses(f)
+	require.NoError(t, err)
+	assert.NotEmpty(t, addrs, "expected at least one svc #0x80 address")
+	for _, addr := range addrs {
+		assert.NotZero(t, addr)
+	}
+}
+
+// TestCollectSVCAddresses_Arm64NoSVC verifies that collectSVCAddresses returns nil
+// for an arm64 Mach-O that contains no svc #0x80 instruction.
+func TestCollectSVCAddresses_Arm64NoSVC(t *testing.T) {
+	path := testdataPath("no_network_macho_arm64")
+	skipIfNotExist(t, path)
+
+	f, err := macho.Open(path)
+	require.NoError(t, err)
+	defer f.Close()
+
+	addrs, err := collectSVCAddresses(f)
+	require.NoError(t, err)
+	assert.Nil(t, addrs, "expected nil for no-svc binary")
+}
+
+// TestCollectSVCAddresses_NonArm64 verifies that collectSVCAddresses returns nil
+// for a non-arm64 Mach-O (x86_64), regardless of instruction content.
+func TestCollectSVCAddresses_NonArm64(t *testing.T) {
+	path := testdataPath("network_macho_x86_64")
+	skipIfNotExist(t, path)
+
+	f, err := macho.Open(path)
+	require.NoError(t, err)
+	defer f.Close()
+
+	addrs, err := collectSVCAddresses(f)
+	require.NoError(t, err)
+	assert.Nil(t, addrs, "expected nil for x86_64 binary")
+}
+
+// TestCollectSVCAddresses_MultipleSVC verifies that collectSVCAddresses returns
+// all virtual addresses when multiple svc #0x80 instructions are present.
+func TestCollectSVCAddresses_MultipleSVC(t *testing.T) {
+	// Build a minimal arm64 Mach-O with 3 instructions: nop, svc, nop, svc, nop, svc
+	instructions := []uint32{
+		nopEncoding, // offset 0  (addr 0x100000000) — no svc
+		svcEncoding, // offset 4  (addr 0x100000004) — svc #1
+		nopEncoding, // offset 8  (addr 0x100000008) — no svc
+		svcEncoding, // offset 12 (addr 0x10000000C) — svc #2
+		nopEncoding, // offset 16 (addr 0x100000010) — no svc
+		svcEncoding, // offset 20 (addr 0x100000014) — svc #3
+	}
+	data := buildArm64MachO(t, instructions)
+	f := parseMachOFromBytes(t, data)
+
+	addrs, err := collectSVCAddresses(f)
+	require.NoError(t, err)
+	require.Len(t, addrs, 3, "expected exactly 3 svc addresses")
+	assert.Equal(t, uint64(0x100000004), addrs[0])
+	assert.Equal(t, uint64(0x10000000C), addrs[1])
+	assert.Equal(t, uint64(0x100000014), addrs[2])
+}
+
+// TestCollectSVCAddressesFromFile_NotMacho verifies that CollectSVCAddressesFromFile
+// returns nil, nil for a non-Mach-O file (e.g., a shell script).
+func TestCollectSVCAddressesFromFile_NotMacho(t *testing.T) {
+	path := testdataPath("script.sh")
+	skipIfNotExist(t, path)
+
+	addrs, err := CollectSVCAddressesFromFile(path, osWrapFS{})
+	require.NoError(t, err)
+	assert.Nil(t, addrs, "expected nil for non-Mach-O file")
+}
+
+// TestCollectSVCAddressesFromFile_FatBinary verifies that CollectSVCAddressesFromFile
+// processes a Fat binary, scanning only arm64 slices for svc #0x80.
+func TestCollectSVCAddressesFromFile_FatBinary(t *testing.T) {
+	path := testdataPath("fat_binary")
+	skipIfNotExist(t, path)
+
+	// fat_binary contains arm64 and x86_64 slices; both lack svc #0x80.
+	// Verify: no error, returns nil (no svc in arm64 slice).
+	addrs, err := CollectSVCAddressesFromFile(path, osWrapFS{})
+	require.NoError(t, err)
+	assert.Nil(t, addrs, "expected nil: arm64 slice in fat_binary has no svc #0x80")
+}
+
+// TestContainsSVCInstruction_DelegatesToCollect verifies that containsSVCInstruction
+// delegates to collectSVCAddresses and returns the correct bool result.
+func TestContainsSVCInstruction_DelegatesToCollect(t *testing.T) {
+	t.Run("with_svc", func(t *testing.T) {
+		path := testdataPath("svc_only_arm64")
+		skipIfNotExist(t, path)
+
+		f, err := macho.Open(path)
+		require.NoError(t, err)
+		defer f.Close()
+
+		hasSVC, err := containsSVCInstruction(f)
+		require.NoError(t, err)
+		assert.True(t, hasSVC, "expected true for svc_only_arm64")
+	})
+
+	t.Run("without_svc", func(t *testing.T) {
+		path := testdataPath("no_network_macho_arm64")
+		skipIfNotExist(t, path)
+
+		f, err := macho.Open(path)
+		require.NoError(t, err)
+		defer f.Close()
+
+		hasSVC, err := containsSVCInstruction(f)
+		require.NoError(t, err)
+		assert.False(t, hasSVC, "expected false for no-svc binary")
+	})
+}

--- a/internal/runner/security/network_analyzer.go
+++ b/internal/runner/security/network_analyzer.go
@@ -2,6 +2,7 @@ package security
 
 import (
 	"errors"
+	"fmt"
 	"log/slog"
 	"path/filepath"
 	"runtime"
@@ -228,13 +229,11 @@ func (a *NetworkAnalyzer) isNetworkViaBinaryAnalysis(cmdPath string, contentHash
 					"actual_schema", svcSchemaMismatch.Actual)
 				return true, true
 			default:
-				// ErrRecordNotFound or unexpected error: treat as integrity error.
-				// (When SymbolAnalysis loaded successfully, a matching SyscallAnalysis record
-				//  must exist. When SymbolAnalysis returned ErrNoNetworkSymbolAnalysis, absence
-				//  of the SyscallAnalysis record is equally unexpected.)
-				slog.Warn("unexpected error loading SyscallAnalysis cache; treating as high risk",
-					"path", cmdPath, "error", svcErr)
-				return true, true
+				// ErrRecordNotFound or unexpected error: this must not occur in production.
+				// The underlying record exists (SymbolAnalysis succeeded or returned
+				// ErrNoNetworkSymbolAnalysis), so a missing SyscallAnalysis record indicates
+				// a consistency bug that must be fixed, not silently absorbed.
+				panic(fmt.Sprintf("SyscallAnalysis cache inconsistency for %q: %v", cmdPath, svcErr))
 			}
 		}
 

--- a/internal/runner/security/network_analyzer.go
+++ b/internal/runner/security/network_analyzer.go
@@ -20,7 +20,8 @@ const gosDarwin = "darwin"
 // NetworkAnalyzer provides network operation detection for commands.
 type NetworkAnalyzer struct {
 	binaryAnalyzer binaryanalyzer.BinaryAnalyzer
-	store          fileanalysis.NetworkSymbolStore // nil means cache disabled
+	store          fileanalysis.NetworkSymbolStore   // nil means cache disabled
+	syscallStore   fileanalysis.SyscallAnalysisStore // nil means svc cache disabled
 }
 
 // NewBinaryAnalyzer creates a BinaryAnalyzer appropriate for the current platform.
@@ -44,6 +45,20 @@ func NewNetworkAnalyzer() *NetworkAnalyzer {
 // If store is nil, falls back to live binary analysis.
 func NewNetworkAnalyzerWithStore(store fileanalysis.NetworkSymbolStore) *NetworkAnalyzer {
 	return &NetworkAnalyzer{binaryAnalyzer: NewBinaryAnalyzer(), store: store}
+}
+
+// NewNetworkAnalyzerWithStores creates a NetworkAnalyzer with both
+// symbol and syscall stores for cache-based analysis.
+// If either store is nil, the corresponding cache lookup is disabled.
+func NewNetworkAnalyzerWithStores(
+	symStore fileanalysis.NetworkSymbolStore,
+	svcStore fileanalysis.SyscallAnalysisStore,
+) *NetworkAnalyzer {
+	return &NetworkAnalyzer{
+		binaryAnalyzer: NewBinaryAnalyzer(),
+		store:          symStore,
+		syscallStore:   svcStore,
+	}
 }
 
 // IsNetworkOperation checks if the command performs network operations.
@@ -156,52 +171,98 @@ func (a *NetworkAnalyzer) isNetworkViaBinaryAnalysis(cmdPath string, contentHash
 	// for a valid record. That would misuse ErrHashMismatch (which signals a genuine
 	// file-content change) for a mere "no hash available" situation.
 	if a.store != nil && contentHash != "" {
+		// Load SymbolAnalysis cache.
+		// ErrNoNetworkSymbolAnalysis is a valid case (static binary): fall through to SyscallAnalysis.
+		// All other errors are treated as AnalysisError because production always has records.
 		data, err := a.store.LoadNetworkSymbolAnalysis(cmdPath, contentHash)
-		var schemaMismatch *fileanalysis.SchemaVersionMismatchError
+		var symSchemaMismatch *fileanalysis.SchemaVersionMismatchError
 		switch {
 		case err == nil:
-			output := binaryanalyzer.AnalysisOutput{
-				DetectedSymbols:    convertNetworkSymbolEntries(data.DetectedSymbols),
-				DynamicLoadSymbols: convertNetworkSymbolEntries(data.DynamicLoadSymbols),
-			}
-			if len(data.DetectedSymbols) > 0 || len(data.KnownNetworkLibDeps) > 0 {
-				output.Result = binaryanalyzer.NetworkDetected
-				// When network capability is inferred only from KnownNetworkLibDeps,
-				// DetectedSymbols remains empty. Log this explicitly so that logs
-				// clearly explain why the binary is treated as network-capable even
-				// if handleAnalysisOutput logs an empty symbol list.
-				if len(data.DetectedSymbols) == 0 && len(data.KnownNetworkLibDeps) > 0 {
-					slog.Info( //nolint:gosec // G706: cmdPath is a configured command path from TOML, not arbitrary user input
-						"treating binary as network-capable based on known network library dependencies",
-						"path", cmdPath,
-						"known_network_lib_deps", data.KnownNetworkLibDeps,
-					)
-				}
-			} else {
-				output.Result = binaryanalyzer.NoNetworkSymbols
-			}
-			return handleAnalysisOutput(output, cmdPath)
-		case errors.Is(err, fileanalysis.ErrNoNetworkSymbolAnalysis) ||
-			errors.Is(err, fileanalysis.ErrHashMismatch) ||
-			errors.Is(err, fileanalysis.ErrRecordNotFound):
-			// Expected cache miss: fall through to live binary analysis.
-		case errors.As(err, &schemaMismatch):
-			// Cache record uses an old schema version. Normally VerifyGroupFiles blocks
-			// execution before reaching this point, but log a warning so that callers
-			// that bypass verification (e.g. tests, future code paths) can diagnose
-			// unexpected schema mismatches.
-			slog.Warn("network symbol analysis cache has outdated schema; falling back to live analysis",
+			// data is valid; continue below.
+		case errors.Is(err, fileanalysis.ErrNoNetworkSymbolAnalysis):
+			// Static binary: no SymbolAnalysis record.
+			// Fall through to SyscallAnalysis check (data remains nil).
+		case errors.Is(err, fileanalysis.ErrHashMismatch):
+			slog.Warn("SymbolAnalysis cache hash mismatch; treating as high risk",
+				"path", cmdPath)
+			return true, true
+		case errors.As(err, &symSchemaMismatch):
+			slog.Warn("SymbolAnalysis cache has outdated schema; treating as high risk",
 				"path", cmdPath,
-				"expected_schema", schemaMismatch.Expected,
-				"actual_schema", schemaMismatch.Actual)
+				"expected_schema", symSchemaMismatch.Expected,
+				"actual_schema", symSchemaMismatch.Actual)
+			return true, true
 		default:
-			// Unexpected error (e.g. I/O failure, corrupted record): log a warning and
-			// fall through to live binary analysis so execution is not silently blocked,
-			// but make the error visible for diagnosis.
-			slog.Warn("unexpected error loading network symbol analysis cache; falling back to live analysis",
-				"path", cmdPath,
-				"error", err)
+			slog.Warn("SymbolAnalysis cache load failed; treating as high risk",
+				"path", cmdPath, "error", err)
+			return true, true
 		}
+
+		// Check SyscallAnalysis cache for svc #0x80 signal (Mach-O arm64).
+		// This check runs regardless of SymbolAnalysis result (NetworkDetected, NoNetworkSymbols,
+		// or ErrNoNetworkSymbolAnalysis for static binaries) so that svc #0x80 always escalates
+		// isHighRisk to true.
+		if a.syscallStore != nil {
+			svcResult, svcErr := a.syscallStore.LoadSyscallAnalysis(cmdPath, contentHash)
+			var svcSchemaMismatch *fileanalysis.SchemaVersionMismatchError
+			switch {
+			case svcErr == nil:
+				if syscallAnalysisHasSVCSignal(svcResult) {
+					slog.Warn("SyscallAnalysis cache indicates svc #0x80; treating as high risk",
+						"path", cmdPath)
+					return true, true
+				}
+				// No svc signal: fall through to SymbolAnalysis-based decision.
+			case errors.Is(svcErr, fileanalysis.ErrNoSyscallAnalysis):
+				// v15 schema guarantee: svc scan was performed and found nothing.
+				// Fall through to SymbolAnalysis-based decision.
+			case errors.Is(svcErr, fileanalysis.ErrHashMismatch):
+				slog.Warn("SyscallAnalysis cache hash mismatch; treating as high risk",
+					"path", cmdPath)
+				return true, true
+			case errors.As(svcErr, &svcSchemaMismatch):
+				slog.Warn("SyscallAnalysis cache has outdated schema; treating as high risk",
+					"path", cmdPath,
+					"expected_schema", svcSchemaMismatch.Expected,
+					"actual_schema", svcSchemaMismatch.Actual)
+				return true, true
+			default:
+				// ErrRecordNotFound or unexpected error: treat as integrity error.
+				// (When SymbolAnalysis loaded successfully, a matching SyscallAnalysis record
+				//  must exist. When SymbolAnalysis returned ErrNoNetworkSymbolAnalysis, absence
+				//  of the SyscallAnalysis record is equally unexpected.)
+				slog.Warn("unexpected error loading SyscallAnalysis cache; treating as high risk",
+					"path", cmdPath, "error", svcErr)
+				return true, true
+			}
+		}
+
+		// No svc #0x80 signal: determine result from SymbolAnalysis.
+		// data == nil when ErrNoNetworkSymbolAnalysis was returned (static binary with no svc).
+		if data == nil {
+			return false, false
+		}
+		output := binaryanalyzer.AnalysisOutput{
+			DetectedSymbols:    convertNetworkSymbolEntries(data.DetectedSymbols),
+			DynamicLoadSymbols: convertNetworkSymbolEntries(data.DynamicLoadSymbols),
+		}
+		if len(data.DetectedSymbols) > 0 || len(data.KnownNetworkLibDeps) > 0 {
+			output.Result = binaryanalyzer.NetworkDetected
+			// When network capability is inferred only from KnownNetworkLibDeps,
+			// DetectedSymbols remains empty. Log this explicitly so that logs
+			// clearly explain why the binary is treated as network-capable even
+			// if handleAnalysisOutput logs an empty symbol list.
+			if len(data.DetectedSymbols) == 0 && len(data.KnownNetworkLibDeps) > 0 {
+				slog.Info( //nolint:gosec // G706: cmdPath is a configured command path from TOML, not arbitrary user input
+					"treating binary as network-capable based on known network library dependencies",
+					"path", cmdPath,
+					"known_network_lib_deps", data.KnownNetworkLibDeps,
+				)
+			}
+		} else {
+			output.Result = binaryanalyzer.NoNetworkSymbols
+		}
+		return handleAnalysisOutput(output, cmdPath)
 	}
 
 	// Fallback: live binary analysis.
@@ -212,6 +273,23 @@ func (a *NetworkAnalyzer) isNetworkViaBinaryAnalysis(cmdPath string, contentHash
 	}
 	output := a.binaryAnalyzer.AnalyzeNetworkSymbols(cmdPath, contentHash)
 	return handleAnalysisOutput(output, cmdPath)
+}
+
+// syscallAnalysisHasSVCSignal reports whether the given SyscallAnalysisResult
+// contains evidence of svc #0x80 direct syscall usage.
+// Returns true only when any DetectedSyscall has DeterminationMethod == "direct_svc_0x80".
+// AnalysisWarnings is not checked here because it may contain warnings from ELF syscall
+// analysis that are unrelated to svc #0x80, which would cause false positives.
+func syscallAnalysisHasSVCSignal(result *fileanalysis.SyscallAnalysisResult) bool {
+	if result == nil {
+		return false
+	}
+	for _, s := range result.DetectedSyscalls {
+		if s.DeterminationMethod == "direct_svc_0x80" {
+			return true
+		}
+	}
+	return false
 }
 
 // handleAnalysisOutput maps a binaryanalyzer.AnalysisOutput to (isNetwork, isHighRisk).

--- a/internal/runner/security/network_analyzer.go
+++ b/internal/runner/security/network_analyzer.go
@@ -214,7 +214,8 @@ func (a *NetworkAnalyzer) isNetworkViaBinaryAnalysis(cmdPath string, contentHash
 				}
 				// No svc signal: fall through to SymbolAnalysis-based decision.
 			case errors.Is(svcErr, fileanalysis.ErrNoSyscallAnalysis):
-				// v15 schema guarantee: svc scan was performed and found nothing.
+				// Schema v15+ guarantee: svc scan was performed and found nothing
+				// (old v14 records are rejected earlier as SchemaVersionMismatchError).
 				// Fall through to SymbolAnalysis-based decision.
 			case errors.Is(svcErr, fileanalysis.ErrHashMismatch):
 				slog.Warn("SyscallAnalysis cache hash mismatch; treating as high risk",

--- a/internal/runner/security/network_analyzer_test.go
+++ b/internal/runner/security/network_analyzer_test.go
@@ -260,18 +260,17 @@ func TestIsNetworkViaBinaryAnalysis_NoNetworkSymbols_SVCSchemaMismatch(t *testin
 }
 
 // TestIsNetworkViaBinaryAnalysis_NoNetworkSymbols_SVCRecordNotFound verifies that
-// ErrRecordNotFound from SyscallAnalysis returns AnalysisError (integrity error, no live analysis).
+// ErrRecordNotFound from SyscallAnalysis panics (consistency bug: SymbolAnalysis record
+// exists but the matching SyscallAnalysis record is missing).
 func TestIsNetworkViaBinaryAnalysis_NoNetworkSymbols_SVCRecordNotFound(t *testing.T) {
 	symStore := &stubNetworkSymbolStore{data: noNetworkSymbolData()}
 	svcStore := &mockFileanalysisSyscallStore{err: fileanalysis.ErrRecordNotFound}
 	mock := &mockBinaryAnalyzer{result: binaryanalyzer.NoNetworkSymbols}
 	analyzer := newNetworkAnalyzerWithStores(mock, symStore, svcStore)
 
-	isNet, isHigh := analyzer.isNetworkViaBinaryAnalysis(testCmdPath, testContentHash)
-
-	assert.True(t, isNet, "ErrRecordNotFound should return AnalysisError (integrity error)")
-	assert.True(t, isHigh, "ErrRecordNotFound should return high risk")
-	assert.False(t, mock.called, "BinaryAnalyzer must not be called")
+	assert.Panics(t, func() {
+		analyzer.isNetworkViaBinaryAnalysis(testCmdPath, testContentHash)
+	}, "ErrRecordNotFound from SyscallAnalysis must panic (consistency bug)")
 }
 
 // TestIsNetworkViaBinaryAnalysis_NetworkDetected_SVCCacheHit verifies that NetworkDetected

--- a/internal/runner/security/network_analyzer_test.go
+++ b/internal/runner/security/network_analyzer_test.go
@@ -1,0 +1,320 @@
+//go:build test
+
+package security
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/isseis/go-safe-cmd-runner/internal/common"
+	"github.com/isseis/go-safe-cmd-runner/internal/fileanalysis"
+	"github.com/isseis/go-safe-cmd-runner/internal/runner/security/binaryanalyzer"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestSyscallAnalysisHasSVCSignal_Nil verifies that a nil result returns false.
+func TestSyscallAnalysisHasSVCSignal_Nil(t *testing.T) {
+	assert.False(t, syscallAnalysisHasSVCSignal(nil))
+}
+
+// TestSyscallAnalysisHasSVCSignal_Empty verifies that an empty result returns false.
+func TestSyscallAnalysisHasSVCSignal_Empty(t *testing.T) {
+	assert.False(t, syscallAnalysisHasSVCSignal(&fileanalysis.SyscallAnalysisResult{}))
+}
+
+// TestSyscallAnalysisHasSVCSignal_WithWarningsOnly verifies that AnalysisWarnings alone
+// do not trigger the svc signal (to avoid false positives from ELF analysis).
+func TestSyscallAnalysisHasSVCSignal_WithWarningsOnly(t *testing.T) {
+	r := &fileanalysis.SyscallAnalysisResult{
+		SyscallAnalysisResultCore: common.SyscallAnalysisResultCore{
+			AnalysisWarnings: []string{"svc #0x80 detected: direct syscall bypassing libSystem.dylib"},
+		},
+	}
+	assert.False(t, syscallAnalysisHasSVCSignal(r))
+}
+
+// TestSyscallAnalysisHasSVCSignal_WithDeterminationMethod verifies that a DetectedSyscall
+// with DeterminationMethod == "direct_svc_0x80" triggers the svc signal.
+func TestSyscallAnalysisHasSVCSignal_WithDeterminationMethod(t *testing.T) {
+	r := &fileanalysis.SyscallAnalysisResult{
+		SyscallAnalysisResultCore: common.SyscallAnalysisResultCore{
+			DetectedSyscalls: []common.SyscallInfo{
+				{Number: -1, DeterminationMethod: "direct_svc_0x80"},
+			},
+		},
+	}
+	assert.True(t, syscallAnalysisHasSVCSignal(r))
+}
+
+const (
+	testCmdPath     = "/usr/bin/curl"
+	testContentHash = "sha256:abc123"
+)
+
+// svcResult builds a SyscallAnalysisResult containing a svc #0x80 signal.
+func svcResult() *fileanalysis.SyscallAnalysisResult {
+	return &fileanalysis.SyscallAnalysisResult{
+		SyscallAnalysisResultCore: common.SyscallAnalysisResultCore{
+			Architecture: "arm64",
+			DetectedSyscalls: []common.SyscallInfo{
+				{Number: -1, DeterminationMethod: "direct_svc_0x80"},
+			},
+		},
+	}
+}
+
+// noSVCResult builds a SyscallAnalysisResult with no svc #0x80 signal.
+func noSVCResult() *fileanalysis.SyscallAnalysisResult {
+	return &fileanalysis.SyscallAnalysisResult{}
+}
+
+// noNetworkSymbolData builds a SymbolAnalysisData with no network symbols.
+func noNetworkSymbolData() *fileanalysis.SymbolAnalysisData {
+	return &fileanalysis.SymbolAnalysisData{
+		DetectedSymbols:     nil,
+		KnownNetworkLibDeps: nil,
+	}
+}
+
+// networkDetectedData builds a SymbolAnalysisData with network symbols detected.
+func networkDetectedData() *fileanalysis.SymbolAnalysisData {
+	return &fileanalysis.SymbolAnalysisData{
+		DetectedSymbols: []fileanalysis.DetectedSymbolEntry{
+			{Name: "socket", Category: "socket"},
+		},
+	}
+}
+
+// TestIsNetworkViaBinaryAnalysis_SymbolAnalysisCacheMiss verifies that an unexpected
+// SymbolAnalysis load error returns AnalysisError (true, true) without calling BinaryAnalyzer.
+func TestIsNetworkViaBinaryAnalysis_SymbolAnalysisCacheMiss(t *testing.T) {
+	symStore := &stubNetworkSymbolStore{err: errors.New("unexpected I/O error")}
+	svcStore := &mockFileanalysisSyscallStore{err: fileanalysis.ErrNoSyscallAnalysis}
+	mock := &mockBinaryAnalyzer{result: binaryanalyzer.NoNetworkSymbols}
+	analyzer := newNetworkAnalyzerWithStores(mock, symStore, svcStore)
+
+	isNet, isHigh := analyzer.isNetworkViaBinaryAnalysis(testCmdPath, testContentHash)
+
+	assert.True(t, isNet, "unexpected SymbolAnalysis error should return true (AnalysisError)")
+	assert.True(t, isHigh, "unexpected SymbolAnalysis error should return high risk")
+	assert.False(t, mock.called, "BinaryAnalyzer must not be called (live fallback removed)")
+}
+
+// TestIsNetworkViaBinaryAnalysis_SymbolAnalysis_HashMismatch verifies that ErrHashMismatch
+// from SymbolAnalysis returns AnalysisError (true, true).
+func TestIsNetworkViaBinaryAnalysis_SymbolAnalysis_HashMismatch(t *testing.T) {
+	symStore := &stubNetworkSymbolStore{err: fileanalysis.ErrHashMismatch}
+	svcStore := &mockFileanalysisSyscallStore{err: fileanalysis.ErrNoSyscallAnalysis}
+	mock := &mockBinaryAnalyzer{result: binaryanalyzer.NoNetworkSymbols}
+	analyzer := newNetworkAnalyzerWithStores(mock, symStore, svcStore)
+
+	isNet, isHigh := analyzer.isNetworkViaBinaryAnalysis(testCmdPath, testContentHash)
+
+	assert.True(t, isNet, "ErrHashMismatch should return true (AnalysisError)")
+	assert.True(t, isHigh, "ErrHashMismatch should return high risk")
+	assert.False(t, mock.called, "BinaryAnalyzer must not be called")
+}
+
+// TestIsNetworkViaBinaryAnalysis_SymbolAnalysis_SchemaMismatch verifies that a
+// SchemaVersionMismatchError from SymbolAnalysis returns AnalysisError (true, true).
+func TestIsNetworkViaBinaryAnalysis_SymbolAnalysis_SchemaMismatch(t *testing.T) {
+	schemaErr := &fileanalysis.SchemaVersionMismatchError{
+		Expected: fileanalysis.CurrentSchemaVersion,
+		Actual:   fileanalysis.CurrentSchemaVersion - 1,
+	}
+	symStore := &stubNetworkSymbolStore{err: schemaErr}
+	svcStore := &mockFileanalysisSyscallStore{err: fileanalysis.ErrNoSyscallAnalysis}
+	mock := &mockBinaryAnalyzer{result: binaryanalyzer.NoNetworkSymbols}
+	analyzer := newNetworkAnalyzerWithStores(mock, symStore, svcStore)
+
+	isNet, isHigh := analyzer.isNetworkViaBinaryAnalysis(testCmdPath, testContentHash)
+
+	assert.True(t, isNet, "SchemaVersionMismatchError should return true (AnalysisError)")
+	assert.True(t, isHigh, "SchemaVersionMismatchError should return high risk")
+	assert.False(t, mock.called, "BinaryAnalyzer must not be called")
+}
+
+// TestIsNetworkViaBinaryAnalysis_StaticBinary_SVCCacheHit verifies that a static binary
+// (ErrNoNetworkSymbolAnalysis) with a svc #0x80 signal returns true, true.
+func TestIsNetworkViaBinaryAnalysis_StaticBinary_SVCCacheHit(t *testing.T) {
+	symStore := &stubNetworkSymbolStore{err: fileanalysis.ErrNoNetworkSymbolAnalysis}
+	svcStore := &mockFileanalysisSyscallStore{result: svcResult()}
+	mock := &mockBinaryAnalyzer{result: binaryanalyzer.NoNetworkSymbols}
+	analyzer := newNetworkAnalyzerWithStores(mock, symStore, svcStore)
+
+	isNet, isHigh := analyzer.isNetworkViaBinaryAnalysis(testCmdPath, testContentHash)
+
+	assert.True(t, isNet, "static binary + svc signal should return true")
+	assert.True(t, isHigh, "static binary + svc signal should return high risk")
+	assert.False(t, mock.called, "BinaryAnalyzer must not be called")
+}
+
+// TestIsNetworkViaBinaryAnalysis_StaticBinary_SVCSignalPresent verifies that a static binary
+// with SyscallAnalysis loaded successfully and a svc signal returns true, true.
+func TestIsNetworkViaBinaryAnalysis_StaticBinary_SVCSignalPresent(t *testing.T) {
+	symStore := &stubNetworkSymbolStore{err: fileanalysis.ErrNoNetworkSymbolAnalysis}
+	svcStore := &mockFileanalysisSyscallStore{result: svcResult()}
+	mock := &mockBinaryAnalyzer{result: binaryanalyzer.NoNetworkSymbols}
+	analyzer := newNetworkAnalyzerWithStores(mock, symStore, svcStore)
+
+	isNet, isHigh := analyzer.isNetworkViaBinaryAnalysis(testCmdPath, testContentHash)
+
+	assert.True(t, isNet)
+	assert.True(t, isHigh)
+}
+
+// TestIsNetworkViaBinaryAnalysis_StaticBinary_NoSVC verifies that a static binary
+// (ErrNoNetworkSymbolAnalysis) with ErrNoSyscallAnalysis returns false, false.
+func TestIsNetworkViaBinaryAnalysis_StaticBinary_NoSVC(t *testing.T) {
+	symStore := &stubNetworkSymbolStore{err: fileanalysis.ErrNoNetworkSymbolAnalysis}
+	svcStore := &mockFileanalysisSyscallStore{err: fileanalysis.ErrNoSyscallAnalysis}
+	mock := &mockBinaryAnalyzer{result: binaryanalyzer.NetworkDetected}
+	analyzer := newNetworkAnalyzerWithStores(mock, symStore, svcStore)
+
+	isNet, isHigh := analyzer.isNetworkViaBinaryAnalysis(testCmdPath, testContentHash)
+
+	assert.False(t, isNet, "static binary + no svc should return false")
+	assert.False(t, isHigh, "static binary + no svc should return false")
+	assert.False(t, mock.called, "BinaryAnalyzer must not be called")
+}
+
+// TestIsNetworkViaBinaryAnalysis_NoNetworkSymbols_SVCCacheHit verifies that a binary with
+// NoNetworkSymbols and a svc signal returns true, true (svc signal escalates to high risk).
+func TestIsNetworkViaBinaryAnalysis_NoNetworkSymbols_SVCCacheHit(t *testing.T) {
+	symStore := &stubNetworkSymbolStore{data: noNetworkSymbolData()}
+	svcStore := &mockFileanalysisSyscallStore{result: svcResult()}
+	mock := &mockBinaryAnalyzer{result: binaryanalyzer.NoNetworkSymbols}
+	analyzer := newNetworkAnalyzerWithStores(mock, symStore, svcStore)
+
+	isNet, isHigh := analyzer.isNetworkViaBinaryAnalysis(testCmdPath, testContentHash)
+
+	assert.True(t, isNet, "svc signal should escalate to true even for NoNetworkSymbols")
+	assert.True(t, isHigh, "svc signal should set high risk")
+	assert.False(t, mock.called, "BinaryAnalyzer must not be called")
+}
+
+// TestIsNetworkViaBinaryAnalysis_NoNetworkSymbols_SVCCacheNil verifies that a binary with
+// NoNetworkSymbols and a nil/empty SyscallAnalysis result (no svc signal) returns false, false.
+func TestIsNetworkViaBinaryAnalysis_NoNetworkSymbols_SVCCacheNil(t *testing.T) {
+	symStore := &stubNetworkSymbolStore{data: noNetworkSymbolData()}
+	// LoadSyscallAnalysis returns nil result (no svc signal).
+	svcStore := &mockFileanalysisSyscallStore{result: nil}
+	mock := &mockBinaryAnalyzer{result: binaryanalyzer.NetworkDetected}
+	analyzer := newNetworkAnalyzerWithStores(mock, symStore, svcStore)
+
+	isNet, isHigh := analyzer.isNetworkViaBinaryAnalysis(testCmdPath, testContentHash)
+
+	assert.False(t, isNet, "NoNetworkSymbols + no svc should return false")
+	assert.False(t, isHigh, "NoNetworkSymbols + no svc should return false")
+	assert.False(t, mock.called, "BinaryAnalyzer must not be called")
+}
+
+// TestIsNetworkViaBinaryAnalysis_NoNetworkSymbols_SVCHashMismatch verifies that
+// ErrHashMismatch from SyscallAnalysis returns AnalysisError (true, true).
+func TestIsNetworkViaBinaryAnalysis_NoNetworkSymbols_SVCHashMismatch(t *testing.T) {
+	symStore := &stubNetworkSymbolStore{data: noNetworkSymbolData()}
+	svcStore := &mockFileanalysisSyscallStore{err: fileanalysis.ErrHashMismatch}
+	mock := &mockBinaryAnalyzer{result: binaryanalyzer.NoNetworkSymbols}
+	analyzer := newNetworkAnalyzerWithStores(mock, symStore, svcStore)
+
+	isNet, isHigh := analyzer.isNetworkViaBinaryAnalysis(testCmdPath, testContentHash)
+
+	assert.True(t, isNet, "SVC ErrHashMismatch should return true (AnalysisError)")
+	assert.True(t, isHigh, "SVC ErrHashMismatch should return high risk")
+	assert.False(t, mock.called, "BinaryAnalyzer must not be called")
+}
+
+// TestIsNetworkViaBinaryAnalysis_NoNetworkSymbols_SVCNoSyscallAnalysis verifies that
+// ErrNoSyscallAnalysis from SyscallAnalysis falls through to SymbolAnalysis decision.
+// NoNetworkSymbols + ErrNoSyscallAnalysis → false, false (v15 guarantee: scan was performed).
+func TestIsNetworkViaBinaryAnalysis_NoNetworkSymbols_SVCNoSyscallAnalysis(t *testing.T) {
+	symStore := &stubNetworkSymbolStore{data: noNetworkSymbolData()}
+	svcStore := &mockFileanalysisSyscallStore{err: fileanalysis.ErrNoSyscallAnalysis}
+	mock := &mockBinaryAnalyzer{result: binaryanalyzer.NetworkDetected}
+	analyzer := newNetworkAnalyzerWithStores(mock, symStore, svcStore)
+
+	isNet, isHigh := analyzer.isNetworkViaBinaryAnalysis(testCmdPath, testContentHash)
+
+	assert.False(t, isNet, "ErrNoSyscallAnalysis should fall through to NoNetworkSymbols result")
+	assert.False(t, isHigh)
+	assert.False(t, mock.called, "BinaryAnalyzer must not be called (no live fallback)")
+}
+
+// TestIsNetworkViaBinaryAnalysis_NoNetworkSymbols_SVCSchemaMismatch verifies that a
+// SchemaVersionMismatchError from SyscallAnalysis returns AnalysisError (true, true).
+func TestIsNetworkViaBinaryAnalysis_NoNetworkSymbols_SVCSchemaMismatch(t *testing.T) {
+	schemaErr := &fileanalysis.SchemaVersionMismatchError{
+		Expected: fileanalysis.CurrentSchemaVersion,
+		Actual:   fileanalysis.CurrentSchemaVersion - 1,
+	}
+	symStore := &stubNetworkSymbolStore{data: noNetworkSymbolData()}
+	svcStore := &mockFileanalysisSyscallStore{err: schemaErr}
+	mock := &mockBinaryAnalyzer{result: binaryanalyzer.NoNetworkSymbols}
+	analyzer := newNetworkAnalyzerWithStores(mock, symStore, svcStore)
+
+	isNet, isHigh := analyzer.isNetworkViaBinaryAnalysis(testCmdPath, testContentHash)
+
+	assert.True(t, isNet, "SVC SchemaVersionMismatchError should return AnalysisError")
+	assert.True(t, isHigh, "SVC SchemaVersionMismatchError should return high risk")
+	assert.False(t, mock.called, "BinaryAnalyzer must not be called")
+}
+
+// TestIsNetworkViaBinaryAnalysis_NoNetworkSymbols_SVCRecordNotFound verifies that
+// ErrRecordNotFound from SyscallAnalysis returns AnalysisError (integrity error, no live analysis).
+func TestIsNetworkViaBinaryAnalysis_NoNetworkSymbols_SVCRecordNotFound(t *testing.T) {
+	symStore := &stubNetworkSymbolStore{data: noNetworkSymbolData()}
+	svcStore := &mockFileanalysisSyscallStore{err: fileanalysis.ErrRecordNotFound}
+	mock := &mockBinaryAnalyzer{result: binaryanalyzer.NoNetworkSymbols}
+	analyzer := newNetworkAnalyzerWithStores(mock, symStore, svcStore)
+
+	isNet, isHigh := analyzer.isNetworkViaBinaryAnalysis(testCmdPath, testContentHash)
+
+	assert.True(t, isNet, "ErrRecordNotFound should return AnalysisError (integrity error)")
+	assert.True(t, isHigh, "ErrRecordNotFound should return high risk")
+	assert.False(t, mock.called, "BinaryAnalyzer must not be called")
+}
+
+// TestIsNetworkViaBinaryAnalysis_NetworkDetected_SVCCacheHit verifies that NetworkDetected
+// with a svc signal returns true, true (isHighRisk escalated).
+func TestIsNetworkViaBinaryAnalysis_NetworkDetected_SVCCacheHit(t *testing.T) {
+	symStore := &stubNetworkSymbolStore{data: networkDetectedData()}
+	svcStore := &mockFileanalysisSyscallStore{result: svcResult()}
+	mock := &mockBinaryAnalyzer{result: binaryanalyzer.NoNetworkSymbols}
+	analyzer := newNetworkAnalyzerWithStores(mock, symStore, svcStore)
+
+	isNet, isHigh := analyzer.isNetworkViaBinaryAnalysis(testCmdPath, testContentHash)
+
+	assert.True(t, isNet, "NetworkDetected + svc should return true")
+	assert.True(t, isHigh, "svc signal should escalate isHighRisk to true")
+	assert.False(t, mock.called, "BinaryAnalyzer must not be called")
+}
+
+// TestIsNetworkViaBinaryAnalysis_NetworkDetected_SVCNoSyscallAnalysis verifies that
+// NetworkDetected with ErrNoSyscallAnalysis returns true, false (no isHighRisk escalation).
+func TestIsNetworkViaBinaryAnalysis_NetworkDetected_SVCNoSyscallAnalysis(t *testing.T) {
+	symStore := &stubNetworkSymbolStore{data: networkDetectedData()}
+	svcStore := &mockFileanalysisSyscallStore{err: fileanalysis.ErrNoSyscallAnalysis}
+	mock := &mockBinaryAnalyzer{result: binaryanalyzer.NoNetworkSymbols}
+	analyzer := newNetworkAnalyzerWithStores(mock, symStore, svcStore)
+
+	isNet, isHigh := analyzer.isNetworkViaBinaryAnalysis(testCmdPath, testContentHash)
+
+	assert.True(t, isNet, "NetworkDetected should return true")
+	assert.False(t, isHigh, "ErrNoSyscallAnalysis should not escalate isHighRisk")
+	assert.False(t, mock.called, "BinaryAnalyzer must not be called")
+}
+
+// TestIsNetworkViaBinaryAnalysis_NetworkDetected_NoSVC verifies that NetworkDetected
+// with no svc signal (successful load, no direct_svc_0x80) returns true, false.
+func TestIsNetworkViaBinaryAnalysis_NetworkDetected_NoSVC(t *testing.T) {
+	symStore := &stubNetworkSymbolStore{data: networkDetectedData()}
+	svcStore := &mockFileanalysisSyscallStore{result: noSVCResult()}
+	mock := &mockBinaryAnalyzer{result: binaryanalyzer.NoNetworkSymbols}
+	analyzer := newNetworkAnalyzerWithStores(mock, symStore, svcStore)
+
+	isNet, isHigh := analyzer.isNetworkViaBinaryAnalysis(testCmdPath, testContentHash)
+
+	assert.True(t, isNet, "NetworkDetected should return true")
+	assert.False(t, isHigh, "no svc signal should not escalate isHighRisk")
+	assert.False(t, mock.called, "BinaryAnalyzer must not be called")
+}

--- a/internal/runner/security/network_analyzer_test_helpers.go
+++ b/internal/runner/security/network_analyzer_test_helpers.go
@@ -16,3 +16,14 @@ func newNetworkAnalyzer(
 ) *NetworkAnalyzer {
 	return &NetworkAnalyzer{binaryAnalyzer: analyzer, store: store}
 }
+
+// newNetworkAnalyzerWithStores creates a NetworkAnalyzer with a custom BinaryAnalyzer,
+// symbol store, and syscall store for testing.
+// This function is only available in test builds.
+func newNetworkAnalyzerWithStores(
+	analyzer binaryanalyzer.BinaryAnalyzer,
+	symStore fileanalysis.NetworkSymbolStore,
+	svcStore fileanalysis.SyscallAnalysisStore,
+) *NetworkAnalyzer {
+	return &NetworkAnalyzer{binaryAnalyzer: analyzer, store: symStore, syscallStore: svcStore}
+}

--- a/internal/verification/manager.go
+++ b/internal/verification/manager.go
@@ -28,7 +28,8 @@ type Manager struct {
 	safeFS                      safefileio.FileSystem // used for secure file I/O (e.g. ELF inspection)
 	fileValidator               filevalidator.FileValidator
 	networkSymbolStore          fileanalysis.NetworkSymbolStore // nil when cache is unavailable
-	dynlibVerifier              *elfdynlib.DynLibVerifier       // initialized once at construction
+	syscallAnalysisStore        fileanalysis.SyscallAnalysisStore
+	dynlibVerifier              *elfdynlib.DynLibVerifier // initialized once at construction
 	security                    *security.Validator
 	pathResolver                *PathResolver
 	isDryRun                    bool
@@ -347,6 +348,13 @@ func (m *Manager) GetNetworkSymbolStore() fileanalysis.NetworkSymbolStore {
 	return m.networkSymbolStore
 }
 
+// GetSyscallAnalysisStore returns a SyscallAnalysisStore backed by the same hash
+// directory, or nil if not available (e.g. when fileValidator is a test mock or
+// hash dir is absent).
+func (m *Manager) GetSyscallAnalysisStore() fileanalysis.SyscallAnalysisStore {
+	return m.syscallAnalysisStore
+}
+
 // verifyFile attempts file verification using the configured fileValidator.
 // In dry-run mode it records the result in the ResultCollector and logs the
 // failure, but still returns the underlying error so callers can track
@@ -501,6 +509,7 @@ func newManagerInternal(hashDir string, options ...InternalOption) (*Manager, er
 			manager.fileValidator = validator
 			if s := validator.GetStore(); s != nil {
 				manager.networkSymbolStore = fileanalysis.NewNetworkSymbolStore(s)
+				manager.syscallAnalysisStore = fileanalysis.NewSyscallAnalysisStore(s)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

- Mach-O arm64バイナリの `svc #0x80` 命令（macOSシステムコール）を静的解析するスキャナーを追加 (`machoanalyzer/svc_scanner.go`)
- `NetworkAnalyzer` に `svc #0x80` 検出によるネットワークシグナル判定を追加
- `filevalidator` の `updateAnalysisRecord` に Mach-O arm64 スキャンを統合
- `SyscallAnalysisStore` キャッシュをランタイムパスに配線し、`runner.go` でストアを生成・注入
- `NewDefaultResourceManagerWithStores` を `NewDefaultResourceManager` にリネームし、旧シグネチャのラッパーをテスト専用ヘルパーに移動

## Test plan

- [ ] `make test` が全て通過することを確認
- [ ] `make lint` がエラーなしで完了することを確認
- [ ] `internal/runner/security/machoanalyzer/svc_scanner_test.go` — svc スキャナーのユニットテスト
- [ ] `internal/runner/security/network_analyzer_test.go` — svc #0x80 シグナル検出のテスト
- [ ] `internal/filevalidator/validator_macho_test.go` — filevalidator 統合テスト

🤖 Generated with [Claude Code](https://claude.com/claude-code)