### PR TITLE
refactor(security): remove live binary analysis fallback from isNetwo…

### DIFF
--- a/docs/tasks/0095_macho_feature_parity/04_implementation_plan.md
+++ b/docs/tasks/0095_macho_feature_parity/04_implementation_plan.md
@@ -40,7 +40,7 @@
 - [x] `docs/tasks/0097_macho_arm64_syscall_analysis/02_architecture.md` を作成する
 - [x] `docs/tasks/0097_macho_arm64_syscall_analysis/03_detailed_specification.md` を作成する
 - [x] `docs/tasks/0097_macho_arm64_syscall_analysis/04_implementation_plan.md` を作成する
-- [ ] 実装・テストを行い PR をマージする
+- [x] 実装・テストを行い PR をマージする
 
 ### タスク 0098: Mach-O `.dylib` ベース名による既知ネットワークライブラリ検出（FR-4.8）
 

--- a/docs/tasks/0097_macho_arm64_syscall_analysis/04_implementation_plan.md
+++ b/docs/tasks/0097_macho_arm64_syscall_analysis/04_implementation_plan.md
@@ -265,9 +265,9 @@ go test -tags test -v ./internal/runner/
 
 ### 8.3 削除後の確認
 
-- [ ] `a.binaryAnalyzer.AnalyzeNetworkSymbols()` の呼び出しが `isNetworkViaBinaryAnalysis` から完全に除去されていること
-- [ ] `make test` が引き続き全 GREEN であること
-- [ ] `make lint` でデッドコード警告が出ないこと
+- [x] `a.binaryAnalyzer.AnalyzeNetworkSymbols()` の呼び出しが `isNetworkViaBinaryAnalysis` から完全に除去されていること
+- [x] `make test` が引き続き全 GREEN であること
+- [x] `make lint` でデッドコード警告が出ないこと
 
 ## 9. リスクと対策
 

--- a/internal/runner/security/command_analysis_test.go
+++ b/internal/runner/security/command_analysis_test.go
@@ -2370,25 +2370,6 @@ func TestMigration_MultipleRiskFactors(t *testing.T) {
 	}
 }
 
-// mockBinaryAnalyzer is a mock implementation of binaryanalyzer.BinaryAnalyzer for testing.
-type mockBinaryAnalyzer struct {
-	result             binaryanalyzer.AnalysisResult
-	symbols            []binaryanalyzer.DetectedSymbol
-	err                error
-	dynamicLoadSymbols []binaryanalyzer.DetectedSymbol
-	called             bool
-}
-
-func (m *mockBinaryAnalyzer) AnalyzeNetworkSymbols(_ string, _ string) binaryanalyzer.AnalysisOutput {
-	m.called = true
-	return binaryanalyzer.AnalysisOutput{
-		Result:             m.result,
-		DetectedSymbols:    m.symbols,
-		Error:              m.err,
-		DynamicLoadSymbols: m.dynamicLoadSymbols,
-	}
-}
-
 // TestIsNetworkOperation_Analysis tests analysis integration in IsNetworkOperation.
 // Binary analysis (live path) has been removed; unknown commands without a store
 // return false, false. Network detection for unknown commands is args-based only
@@ -2492,7 +2473,7 @@ func TestNewNetworkAnalyzer(t *testing.T) {
 	})
 
 	t.Run("with nil store → binary analysis skipped", func(t *testing.T) {
-		analyzer := newNetworkAnalyzer(nil, nil)
+		analyzer := newNetworkAnalyzer(nil)
 		assert.NotNil(t, analyzer)
 
 		// With nil store, binary analysis is skipped and returns false, false.
@@ -2529,7 +2510,7 @@ func TestIsNetworkViaBinaryAnalysis_Cache(t *testing.T) {
 	const cmdPath = "/usr/bin/curl"
 	const contentHash = "sha256:abc123"
 
-	t.Run("cache hit DetectedSymbols=[socket] → NetworkDetected, BinaryAnalyzer not called", func(t *testing.T) {
+	t.Run("cache hit DetectedSymbols=[socket] → NetworkDetected", func(t *testing.T) {
 		store := &stubNetworkSymbolStore{
 			data: &fileanalysis.SymbolAnalysisData{
 				DetectedSymbols: []fileanalysis.DetectedSymbolEntry{
@@ -2537,30 +2518,23 @@ func TestIsNetworkViaBinaryAnalysis_Cache(t *testing.T) {
 				},
 			},
 		}
-		mock := &mockBinaryAnalyzer{result: binaryanalyzer.NoNetworkSymbols}
-		analyzer := newNetworkAnalyzer(mock, store)
+		analyzer := newNetworkAnalyzer(store)
 		isNet, isHigh := analyzer.isNetworkViaBinaryAnalysis(cmdPath, contentHash)
 		assert.True(t, isNet, "expected network detected from cache")
 		assert.False(t, isHigh, "expected not high risk (no dlopen)")
-		// BinaryAnalyzer must not have been called.
-		assert.False(t, mock.called, "BinaryAnalyzer must not be called on cache hit")
 	})
 
-	t.Run("cache hit DetectedSymbols=nil → NoNetworkSymbols, BinaryAnalyzer not called", func(t *testing.T) {
+	t.Run("cache hit DetectedSymbols=nil → NoNetworkSymbols", func(t *testing.T) {
 		store := &stubNetworkSymbolStore{
 			data: &fileanalysis.SymbolAnalysisData{
 				DetectedSymbols:    nil,
 				DynamicLoadSymbols: nil,
 			},
 		}
-		// Mock returns NetworkDetected to confirm it is never consulted.
-		mock := &mockBinaryAnalyzer{result: binaryanalyzer.NetworkDetected}
-		analyzer := newNetworkAnalyzer(mock, store)
+		analyzer := newNetworkAnalyzer(store)
 		isNet, isHigh := analyzer.isNetworkViaBinaryAnalysis(cmdPath, contentHash)
 		assert.False(t, isNet, "expected no network from cache")
 		assert.False(t, isHigh, "expected not high risk")
-		// BinaryAnalyzer must not have been called.
-		assert.False(t, mock.called, "BinaryAnalyzer must not be called on cache hit")
 	})
 
 	t.Run("cache hit DynamicLoadSymbols=[dlopen] → isHighRisk=true", func(t *testing.T) {
@@ -2571,53 +2545,42 @@ func TestIsNetworkViaBinaryAnalysis_Cache(t *testing.T) {
 				},
 			},
 		}
-		mock := &mockBinaryAnalyzer{result: binaryanalyzer.NoNetworkSymbols}
-		analyzer := newNetworkAnalyzer(mock, store)
+		analyzer := newNetworkAnalyzer(store)
 		isNet, isHigh := analyzer.isNetworkViaBinaryAnalysis(cmdPath, contentHash)
 		assert.False(t, isNet, "expected no network (DetectedSymbols=nil)")
 		assert.True(t, isHigh, "expected high risk from dlopen in cache")
 	})
 
-	t.Run("ErrNoNetworkSymbolAnalysis (no syscallStore) → false, false (static binary, no live fallback)", func(t *testing.T) {
+	t.Run("ErrNoNetworkSymbolAnalysis (no syscallStore) → false, false (static binary)", func(t *testing.T) {
 		store := &stubNetworkSymbolStore{err: fileanalysis.ErrNoNetworkSymbolAnalysis}
-		mock := &mockBinaryAnalyzer{result: binaryanalyzer.NetworkDetected}
-		analyzer := newNetworkAnalyzer(mock, store)
+		analyzer := newNetworkAnalyzer(store)
 		isNet, isHigh := analyzer.isNetworkViaBinaryAnalysis(cmdPath, contentHash)
 		assert.False(t, isNet, "static binary with no svc should return false")
 		assert.False(t, isHigh, "static binary with no svc should return false")
-		assert.False(t, mock.called, "BinaryAnalyzer must not be called (live fallback removed)")
 	})
 
-	t.Run("SchemaVersionMismatchError → high risk, BinaryAnalyzer not called", func(t *testing.T) {
+	t.Run("SchemaVersionMismatchError → high risk", func(t *testing.T) {
 		schemaErr := &fileanalysis.SchemaVersionMismatchError{Expected: fileanalysis.CurrentSchemaVersion, Actual: fileanalysis.CurrentSchemaVersion - 1}
 		store := &stubNetworkSymbolStore{err: schemaErr}
-		mock := &mockBinaryAnalyzer{result: binaryanalyzer.NetworkDetected}
-		analyzer := newNetworkAnalyzer(mock, store)
+		analyzer := newNetworkAnalyzer(store)
 		isNet, isHigh := analyzer.isNetworkViaBinaryAnalysis(cmdPath, contentHash)
 		assert.True(t, isNet, "schema mismatch must return isNetwork=true as safety measure")
 		assert.True(t, isHigh, "schema mismatch must return high risk")
-		assert.False(t, mock.called, "BinaryAnalyzer must not be called on schema mismatch")
 	})
 
-	t.Run("nil store → false, false (live analysis removed)", func(t *testing.T) {
-		mock := &mockBinaryAnalyzer{result: binaryanalyzer.NetworkDetected}
-		analyzer := newNetworkAnalyzer(mock, nil)
+	t.Run("nil store → false, false", func(t *testing.T) {
+		analyzer := newNetworkAnalyzer(nil)
 		isNet, isHigh := analyzer.isNetworkViaBinaryAnalysis(cmdPath, contentHash)
 		assert.False(t, isNet, "nil store must return false (no live binary analysis)")
 		assert.False(t, isHigh, "nil store must return false (no live binary analysis)")
-		assert.False(t, mock.called, "BinaryAnalyzer must not be called (live analysis removed)")
 	})
 
-	t.Run("empty contentHash → cache and BinaryAnalyzer both skipped", func(t *testing.T) {
-		// BinaryAnalyzer.AnalyzeNetworkSymbols requires a non-empty contentHash.
-		// When no hash is available, both cache and live analysis must be skipped.
+	t.Run("empty contentHash → cache skipped", func(t *testing.T) {
 		storeCalled := false
 		store := &callTrackingStore{called: &storeCalled, err: fileanalysis.ErrHashMismatch}
-		mock := &mockBinaryAnalyzer{result: binaryanalyzer.NetworkDetected}
-		analyzer := newNetworkAnalyzer(mock, store)
+		analyzer := newNetworkAnalyzer(store)
 		isNet, isHigh := analyzer.isNetworkViaBinaryAnalysis(cmdPath, "")
 		assert.False(t, storeCalled, "store must not be called when contentHash is empty")
-		assert.False(t, mock.called, "BinaryAnalyzer must not be called when contentHash is empty")
 		assert.False(t, isNet, "expected no network result when contentHash is empty")
 		assert.False(t, isHigh, "expected no high-risk result when contentHash is empty")
 	})
@@ -2629,12 +2592,10 @@ func TestIsNetworkViaBinaryAnalysis_Cache(t *testing.T) {
 				KnownNetworkLibDeps: []string{"libcurl.so.4"},
 			},
 		}
-		mock := &mockBinaryAnalyzer{result: binaryanalyzer.NoNetworkSymbols}
-		analyzer := newNetworkAnalyzer(mock, store)
+		analyzer := newNetworkAnalyzer(store)
 		isNet, isHigh := analyzer.isNetworkViaBinaryAnalysis(cmdPath, contentHash)
 		assert.True(t, isNet, "expected network detected from KnownNetworkLibDeps in cache")
 		assert.False(t, isHigh, "expected not high risk")
-		assert.False(t, mock.called, "BinaryAnalyzer must not be called on cache hit")
 	})
 
 	t.Run("cache hit KnownNetworkLibDeps empty, DetectedSymbols empty → NoNetworkSymbols", func(t *testing.T) {
@@ -2644,12 +2605,10 @@ func TestIsNetworkViaBinaryAnalysis_Cache(t *testing.T) {
 				KnownNetworkLibDeps: nil,
 			},
 		}
-		mock := &mockBinaryAnalyzer{result: binaryanalyzer.NetworkDetected}
-		analyzer := newNetworkAnalyzer(mock, store)
+		analyzer := newNetworkAnalyzer(store)
 		isNet, isHigh := analyzer.isNetworkViaBinaryAnalysis(cmdPath, contentHash)
 		assert.False(t, isNet, "expected no network when both DetectedSymbols and KnownNetworkLibDeps are empty")
 		assert.False(t, isHigh, "expected not high risk")
-		assert.False(t, mock.called, "BinaryAnalyzer must not be called on cache hit")
 	})
 }
 
@@ -2689,15 +2648,11 @@ func TestNetworkSymbolCache_RecordToRunner(t *testing.T) {
 	// Create a NetworkSymbolStore backed by the real Store.
 	symStore := fileanalysis.NewNetworkSymbolStore(store)
 
-	// BinaryAnalyzer mock returns NoNetworkSymbols to prove it is never called.
-	mock := &mockBinaryAnalyzer{result: binaryanalyzer.NoNetworkSymbols}
-	analyzer := newNetworkAnalyzer(mock, symStore)
+	analyzer := newNetworkAnalyzer(symStore)
 
 	isNet, _ := analyzer.isNetworkViaBinaryAnalysis(cmdPath, fakeHash)
 
 	assert.True(t, isNet, "cache hit should report network detected")
-	// If BinaryAnalyzer were called it would have returned NoNetworkSymbols,
-	// so a true result proves only the cache path was taken.
 }
 
 // TestAnalyzeCommandSecurity_StandardDirHashValidationAlwaysRuns is a regression

--- a/internal/runner/security/command_analysis_test.go
+++ b/internal/runner/security/command_analysis_test.go
@@ -2389,96 +2389,52 @@ func (m *mockBinaryAnalyzer) AnalyzeNetworkSymbols(_ string, _ string) binaryana
 	}
 }
 
-// TestIsNetworkOperation_ELFAnalysis tests ELF analysis integration in IsNetworkOperation.
-func TestIsNetworkOperation_ELFAnalysis(t *testing.T) {
+// TestIsNetworkOperation_Analysis tests analysis integration in IsNetworkOperation.
+// Binary analysis (live path) has been removed; unknown commands without a store
+// return false, false. Network detection for unknown commands is args-based only
+// unless a cache store is provided.
+func TestIsNetworkOperation_Analysis(t *testing.T) {
 	tests := []struct {
 		name          string
 		cmdName       string
 		args          []string
-		mockResult    binaryanalyzer.AnalysisResult
-		mockSymbols   []binaryanalyzer.DetectedSymbol
-		mockError     error
 		expectNetwork bool
 	}{
 		{
 			name:          "profile command curl",
 			cmdName:       "curl",
 			args:          []string{"http://example.com"},
-			mockResult:    binaryanalyzer.NoNetworkSymbols,
 			expectNetwork: true,
 		},
 		{
 			name:          "profile command git without network subcommand",
 			cmdName:       "git",
 			args:          []string{"status"},
-			mockResult:    binaryanalyzer.NoNetworkSymbols,
 			expectNetwork: false,
 		},
 		{
 			name:          "profile command git with network subcommand",
 			cmdName:       "git",
 			args:          []string{"fetch", "origin"},
-			mockResult:    binaryanalyzer.NoNetworkSymbols,
 			expectNetwork: true,
 		},
 		{
-			name:       "unknown command with network symbols detected",
-			cmdName:    "/bin/ls", // Use absolute path for ELF analysis
-			args:       []string{"-la"},
-			mockResult: binaryanalyzer.NetworkDetected,
-			mockSymbols: []binaryanalyzer.DetectedSymbol{
-				{Name: "socket", Category: "socket"},
-			},
-			expectNetwork: true,
-		},
-		{
-			name:          "unknown command with no network symbols",
-			cmdName:       "/bin/ls", // Use absolute path for ELF analysis
+			name:          "unknown command with no store → false",
+			cmdName:       "/bin/ls",
 			args:          []string{"-la"},
-			mockResult:    binaryanalyzer.NoNetworkSymbols,
 			expectNetwork: false,
 		},
 		{
-			name:          "unknown command - not an ELF binary (e.g. Mach-O on macOS)",
-			cmdName:       "/bin/ls", // Use absolute path for ELF analysis
-			args:          []string{},
-			mockResult:    binaryanalyzer.NotSupportedBinary,
-			expectNetwork: false, // Non-ELF executables are treated same as ELF with no network symbols
-		},
-		{
-			name:          "unknown command - static binary",
-			cmdName:       "/bin/ls", // Use absolute path for ELF analysis
-			args:          []string{},
-			mockResult:    binaryanalyzer.StaticBinary,
-			expectNetwork: false,
-		},
-		{
-			name:          "unknown command - analysis error treats as network",
-			cmdName:       "/bin/ls", // Use absolute path for ELF analysis
-			args:          []string{},
-			mockResult:    binaryanalyzer.AnalysisError,
-			mockError:     fmt.Errorf("permission denied"),
-			expectNetwork: true, // Safety: analysis failure = assume network
-		},
-		{
-			name:          "unknown command with URL in args (fallback detection)",
-			cmdName:       "/bin/ls", // Use absolute path for ELF analysis
+			name:          "unknown command with URL in args (argument-based detection)",
+			cmdName:       "/bin/ls",
 			args:          []string{"http://example.com"},
-			mockResult:    binaryanalyzer.NoNetworkSymbols,
-			expectNetwork: true, // Detected via argument, not ELF
+			expectNetwork: true, // Detected via argument, not binary analysis
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			// Set up mock analyzer
-			mock := &mockBinaryAnalyzer{
-				result:  tc.mockResult,
-				symbols: tc.mockSymbols,
-				err:     tc.mockError,
-			}
-
-			analyzer := newNetworkAnalyzer(mock, nil)
+			analyzer := NewNetworkAnalyzer()
 			isNetwork, _ := analyzer.IsNetworkOperation(tc.cmdName, tc.args, "sha256:dummy")
 			assert.Equal(t, tc.expectNetwork, isNetwork, "isNetwork mismatch")
 		})
@@ -2535,94 +2491,15 @@ func TestNewNetworkAnalyzer(t *testing.T) {
 		assert.NotNil(t, analyzer)
 	})
 
-	t.Run("with custom binaryAnalyzer", func(t *testing.T) {
-		mock := &mockBinaryAnalyzer{result: binaryanalyzer.NoNetworkSymbols}
-		analyzer := newNetworkAnalyzer(mock, nil)
+	t.Run("with nil store → binary analysis skipped", func(t *testing.T) {
+		analyzer := newNetworkAnalyzer(nil, nil)
 		assert.NotNil(t, analyzer)
 
-		// Verify mock is used by calling IsNetworkOperation on an absolute path
-		// (binary analysis is skipped for non-absolute paths)
-		isNet, _ := analyzer.IsNetworkOperation("/usr/bin/unknowncmd", []string{}, "sha256:dummy")
-		// Since mock returns NoNetworkSymbols and no network args, result should be false
-		_ = isNet // Just verify no panic
+		// With nil store, binary analysis is skipped and returns false, false.
+		isNet, isHigh := analyzer.IsNetworkOperation("/usr/bin/unknowncmd", []string{}, "sha256:dummy")
+		assert.False(t, isNet, "nil store must return false")
+		assert.False(t, isHigh, "nil store must return false")
 	})
-}
-
-// TestIsNetworkOperation_HasDynamicLoad verifies that DynamicLoadSymbols causes
-// isNetworkViaBinaryAnalysis to return isHighRisk=true independently of network detection.
-//
-// Condition 491: DynamicLoadSymbols non-empty, NetworkDetected=false → (false, true)
-// Condition 492: DynamicLoadSymbols non-empty, NetworkDetected=true  → (true, true)
-func TestIsNetworkOperation_HasDynamicLoad(t *testing.T) {
-	dlopenSym := []binaryanalyzer.DetectedSymbol{{Name: "dlopen", Category: "dynamic_load"}}
-
-	tests := []struct {
-		name               string
-		mockResult         binaryanalyzer.AnalysisResult
-		dynamicLoadSymbols []binaryanalyzer.DetectedSymbol
-		expectNetwork      bool
-		expectHighRisk     bool
-	}{
-		{
-			name:               "dlopen only (no network symbols) → not network, but high risk",
-			mockResult:         binaryanalyzer.NoNetworkSymbols,
-			dynamicLoadSymbols: dlopenSym,
-			expectNetwork:      false,
-			expectHighRisk:     true,
-		},
-		{
-			name:               "dlopen + socket (both signals) → network AND high risk",
-			mockResult:         binaryanalyzer.NetworkDetected,
-			dynamicLoadSymbols: dlopenSym,
-			expectNetwork:      true,
-			expectHighRisk:     true,
-		},
-		{
-			name:               "socket only (no dlopen) → network, not high risk from dlopen",
-			mockResult:         binaryanalyzer.NetworkDetected,
-			dynamicLoadSymbols: nil,
-			expectNetwork:      true,
-			expectHighRisk:     false,
-		},
-		{
-			name:               "no symbols, no dlopen → not network, not high risk",
-			mockResult:         binaryanalyzer.NoNetworkSymbols,
-			dynamicLoadSymbols: nil,
-			expectNetwork:      false,
-			expectHighRisk:     false,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			mock := &mockBinaryAnalyzer{
-				result:             tc.mockResult,
-				dynamicLoadSymbols: tc.dynamicLoadSymbols,
-			}
-			analyzer := newNetworkAnalyzer(mock, nil)
-			isNet, isHigh := analyzer.IsNetworkOperation("/usr/bin/somecmd", []string{}, "sha256:dummy")
-			assert.Equal(t, tc.expectNetwork, isNet, "isNetwork mismatch")
-			assert.Equal(t, tc.expectHighRisk, isHigh, "isHighRisk mismatch")
-		})
-	}
-}
-
-// TestIsNetworkOperation_AnalysisError verifies that AnalysisError result leads to high risk.
-//
-// This covers the ErrSyscallHashMismatch path: when the stored syscall analysis
-// record was created for a different binary (binary may have been swapped),
-// AnalyzeNetworkSymbols returns AnalysisError, which must propagate as
-// isNetwork=true AND isHighRisk=true so that execution is blocked.
-func TestIsNetworkOperation_AnalysisError(t *testing.T) {
-	sentinel := fmt.Errorf("binary may have changed since record time: /usr/bin/somecmd")
-	mock := &mockBinaryAnalyzer{
-		result: binaryanalyzer.AnalysisError,
-		err:    sentinel,
-	}
-	analyzer := newNetworkAnalyzer(mock, nil)
-	isNet, isHigh := analyzer.IsNetworkOperation("/usr/bin/somecmd", []string{}, "sha256:abc123")
-	assert.True(t, isNet, "AnalysisError must report network=true (fail-safe)")
-	assert.True(t, isHigh, "AnalysisError must report highRisk=true (hash mismatch is security-relevant)")
 }
 
 // stubNetworkSymbolStore is a test double for fileanalysis.NetworkSymbolStore.
@@ -2722,11 +2599,13 @@ func TestIsNetworkViaBinaryAnalysis_Cache(t *testing.T) {
 		assert.False(t, mock.called, "BinaryAnalyzer must not be called on schema mismatch")
 	})
 
-	t.Run("nil store → BinaryAnalyzer called directly", func(t *testing.T) {
+	t.Run("nil store → false, false (live analysis removed)", func(t *testing.T) {
 		mock := &mockBinaryAnalyzer{result: binaryanalyzer.NetworkDetected}
 		analyzer := newNetworkAnalyzer(mock, nil)
-		isNet, _ := analyzer.isNetworkViaBinaryAnalysis(cmdPath, contentHash)
-		assert.True(t, isNet, "expected network detected via live binary analysis")
+		isNet, isHigh := analyzer.isNetworkViaBinaryAnalysis(cmdPath, contentHash)
+		assert.False(t, isNet, "nil store must return false (no live binary analysis)")
+		assert.False(t, isHigh, "nil store must return false (no live binary analysis)")
+		assert.False(t, mock.called, "BinaryAnalyzer must not be called (live analysis removed)")
 	})
 
 	t.Run("empty contentHash → cache and BinaryAnalyzer both skipped", func(t *testing.T) {

--- a/internal/runner/security/network_analyzer.go
+++ b/internal/runner/security/network_analyzer.go
@@ -67,12 +67,11 @@ func NewNetworkAnalyzerWithStores(
 // Returns (isNetwork, isHighRisk) where isHighRisk indicates symlink depth exceeded.
 //
 // contentHash is a pre-computed hash in "algo:hex" format (e.g. "sha256:abc123...").
-// Forwarded to ELF analysis for static binaries to avoid re-reading the binary.
-// Must be non-empty when binary analysis may run.
+// Used to verify cache record freshness when store-based binary analysis runs.
 //
 // Detection priority:
 // 1. commandProfileDefinitions (hardcoded list) - takes precedence
-// 2. ELF .dynsym analysis for unknown commands
+// 2. Cache-backed binary analysis for unknown commands (requires store and contentHash)
 // 3. Argument-based detection (URLs, SSH-style addresses)
 func (a *NetworkAnalyzer) IsNetworkOperation(cmdName string, args []string, contentHash string) (bool, bool) {
 	// Extract all possible command names including symlink targets
@@ -152,9 +151,8 @@ func hasNetworkArguments(args []string) bool {
 // already resolved by the caller (via verification.PathResolver.ResolvePath()).
 // This ensures TOCTOU safety and consistency across all security checks.
 //
-// contentHash is a pre-computed hash in "algo:hex" format required by
-// BinaryAnalyzer.AnalyzeNetworkSymbols. Must be non-empty; binary analysis
-// is skipped (returning false, false) when no hash is available.
+// contentHash is a pre-computed hash in "algo:hex" format. Used to verify cache
+// record freshness; when empty or store is nil, analysis is skipped (returning false, false).
 func (a *NetworkAnalyzer) isNetworkViaBinaryAnalysis(cmdPath string, contentHash string) (isNetwork, isHighRisk bool) {
 	// Validate that cmdPath is an absolute path.
 	// The caller (EvaluateRisk via group_executor) must have already resolved the path.
@@ -265,14 +263,8 @@ func (a *NetworkAnalyzer) isNetworkViaBinaryAnalysis(cmdPath string, contentHash
 		return handleAnalysisOutput(output, cmdPath)
 	}
 
-	// Fallback: live binary analysis.
-	// BinaryAnalyzer.AnalyzeNetworkSymbols requires a non-empty contentHash.
-	// Skip when no hash is available rather than violating the contract.
-	if contentHash == "" {
-		return false, false
-	}
-	output := a.binaryAnalyzer.AnalyzeNetworkSymbols(cmdPath, contentHash)
-	return handleAnalysisOutput(output, cmdPath)
+	// No store configured or contentHash empty: skip analysis.
+	return false, false
 }
 
 // syscallAnalysisHasSVCSignal reports whether the given SyscallAnalysisResult

--- a/internal/runner/security/network_analyzer.go
+++ b/internal/runner/security/network_analyzer.go
@@ -20,9 +20,8 @@ const gosDarwin = "darwin"
 
 // NetworkAnalyzer provides network operation detection for commands.
 type NetworkAnalyzer struct {
-	binaryAnalyzer binaryanalyzer.BinaryAnalyzer
-	store          fileanalysis.NetworkSymbolStore   // nil means cache disabled
-	syscallStore   fileanalysis.SyscallAnalysisStore // nil means svc cache disabled
+	store        fileanalysis.NetworkSymbolStore   // nil means cache disabled
+	syscallStore fileanalysis.SyscallAnalysisStore // nil means svc cache disabled
 }
 
 // NewBinaryAnalyzer creates a BinaryAnalyzer appropriate for the current platform.
@@ -39,13 +38,12 @@ func NewBinaryAnalyzer() binaryanalyzer.BinaryAnalyzer {
 // NewNetworkAnalyzer creates a new NetworkAnalyzer.
 // On macOS, uses StandardMachOAnalyzer; on Linux and other platforms, uses StandardELFAnalyzer.
 func NewNetworkAnalyzer() *NetworkAnalyzer {
-	return &NetworkAnalyzer{binaryAnalyzer: NewBinaryAnalyzer()}
+	return &NetworkAnalyzer{}
 }
 
 // NewNetworkAnalyzerWithStore creates a NetworkAnalyzer with a store for cache-based analysis.
-// If store is nil, falls back to live binary analysis.
 func NewNetworkAnalyzerWithStore(store fileanalysis.NetworkSymbolStore) *NetworkAnalyzer {
-	return &NetworkAnalyzer{binaryAnalyzer: NewBinaryAnalyzer(), store: store}
+	return &NetworkAnalyzer{store: store}
 }
 
 // NewNetworkAnalyzerWithStores creates a NetworkAnalyzer with both
@@ -56,9 +54,8 @@ func NewNetworkAnalyzerWithStores(
 	svcStore fileanalysis.SyscallAnalysisStore,
 ) *NetworkAnalyzer {
 	return &NetworkAnalyzer{
-		binaryAnalyzer: NewBinaryAnalyzer(),
-		store:          symStore,
-		syscallStore:   svcStore,
+		store:        symStore,
+		syscallStore: svcStore,
 	}
 }
 

--- a/internal/runner/security/network_analyzer_test.go
+++ b/internal/runner/security/network_analyzer_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/isseis/go-safe-cmd-runner/internal/common"
 	"github.com/isseis/go-safe-cmd-runner/internal/fileanalysis"
-	"github.com/isseis/go-safe-cmd-runner/internal/runner/security/binaryanalyzer"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -86,18 +85,16 @@ func networkDetectedData() *fileanalysis.SymbolAnalysisData {
 }
 
 // TestIsNetworkViaBinaryAnalysis_SymbolAnalysisCacheMiss verifies that an unexpected
-// SymbolAnalysis load error returns AnalysisError (true, true) without calling BinaryAnalyzer.
+// SymbolAnalysis load error returns AnalysisError (true, true).
 func TestIsNetworkViaBinaryAnalysis_SymbolAnalysisCacheMiss(t *testing.T) {
 	symStore := &stubNetworkSymbolStore{err: errors.New("unexpected I/O error")}
 	svcStore := &mockFileanalysisSyscallStore{err: fileanalysis.ErrNoSyscallAnalysis}
-	mock := &mockBinaryAnalyzer{result: binaryanalyzer.NoNetworkSymbols}
-	analyzer := newNetworkAnalyzerWithStores(mock, symStore, svcStore)
+	analyzer := newNetworkAnalyzerWithStores(symStore, svcStore)
 
 	isNet, isHigh := analyzer.isNetworkViaBinaryAnalysis(testCmdPath, testContentHash)
 
 	assert.True(t, isNet, "unexpected SymbolAnalysis error should return true (AnalysisError)")
 	assert.True(t, isHigh, "unexpected SymbolAnalysis error should return high risk")
-	assert.False(t, mock.called, "BinaryAnalyzer must not be called (live fallback removed)")
 }
 
 // TestIsNetworkViaBinaryAnalysis_SymbolAnalysis_HashMismatch verifies that ErrHashMismatch
@@ -105,14 +102,12 @@ func TestIsNetworkViaBinaryAnalysis_SymbolAnalysisCacheMiss(t *testing.T) {
 func TestIsNetworkViaBinaryAnalysis_SymbolAnalysis_HashMismatch(t *testing.T) {
 	symStore := &stubNetworkSymbolStore{err: fileanalysis.ErrHashMismatch}
 	svcStore := &mockFileanalysisSyscallStore{err: fileanalysis.ErrNoSyscallAnalysis}
-	mock := &mockBinaryAnalyzer{result: binaryanalyzer.NoNetworkSymbols}
-	analyzer := newNetworkAnalyzerWithStores(mock, symStore, svcStore)
+	analyzer := newNetworkAnalyzerWithStores(symStore, svcStore)
 
 	isNet, isHigh := analyzer.isNetworkViaBinaryAnalysis(testCmdPath, testContentHash)
 
 	assert.True(t, isNet, "ErrHashMismatch should return true (AnalysisError)")
 	assert.True(t, isHigh, "ErrHashMismatch should return high risk")
-	assert.False(t, mock.called, "BinaryAnalyzer must not be called")
 }
 
 // TestIsNetworkViaBinaryAnalysis_SymbolAnalysis_SchemaMismatch verifies that a
@@ -124,14 +119,12 @@ func TestIsNetworkViaBinaryAnalysis_SymbolAnalysis_SchemaMismatch(t *testing.T) 
 	}
 	symStore := &stubNetworkSymbolStore{err: schemaErr}
 	svcStore := &mockFileanalysisSyscallStore{err: fileanalysis.ErrNoSyscallAnalysis}
-	mock := &mockBinaryAnalyzer{result: binaryanalyzer.NoNetworkSymbols}
-	analyzer := newNetworkAnalyzerWithStores(mock, symStore, svcStore)
+	analyzer := newNetworkAnalyzerWithStores(symStore, svcStore)
 
 	isNet, isHigh := analyzer.isNetworkViaBinaryAnalysis(testCmdPath, testContentHash)
 
 	assert.True(t, isNet, "SchemaVersionMismatchError should return true (AnalysisError)")
 	assert.True(t, isHigh, "SchemaVersionMismatchError should return high risk")
-	assert.False(t, mock.called, "BinaryAnalyzer must not be called")
 }
 
 // TestIsNetworkViaBinaryAnalysis_StaticBinary_SVCCacheHit verifies that a static binary
@@ -139,14 +132,12 @@ func TestIsNetworkViaBinaryAnalysis_SymbolAnalysis_SchemaMismatch(t *testing.T) 
 func TestIsNetworkViaBinaryAnalysis_StaticBinary_SVCCacheHit(t *testing.T) {
 	symStore := &stubNetworkSymbolStore{err: fileanalysis.ErrNoNetworkSymbolAnalysis}
 	svcStore := &mockFileanalysisSyscallStore{result: svcResult()}
-	mock := &mockBinaryAnalyzer{result: binaryanalyzer.NoNetworkSymbols}
-	analyzer := newNetworkAnalyzerWithStores(mock, symStore, svcStore)
+	analyzer := newNetworkAnalyzerWithStores(symStore, svcStore)
 
 	isNet, isHigh := analyzer.isNetworkViaBinaryAnalysis(testCmdPath, testContentHash)
 
 	assert.True(t, isNet, "static binary + svc signal should return true")
 	assert.True(t, isHigh, "static binary + svc signal should return high risk")
-	assert.False(t, mock.called, "BinaryAnalyzer must not be called")
 }
 
 // TestIsNetworkViaBinaryAnalysis_StaticBinary_SVCSignalPresent verifies that a static binary
@@ -154,8 +145,7 @@ func TestIsNetworkViaBinaryAnalysis_StaticBinary_SVCCacheHit(t *testing.T) {
 func TestIsNetworkViaBinaryAnalysis_StaticBinary_SVCSignalPresent(t *testing.T) {
 	symStore := &stubNetworkSymbolStore{err: fileanalysis.ErrNoNetworkSymbolAnalysis}
 	svcStore := &mockFileanalysisSyscallStore{result: svcResult()}
-	mock := &mockBinaryAnalyzer{result: binaryanalyzer.NoNetworkSymbols}
-	analyzer := newNetworkAnalyzerWithStores(mock, symStore, svcStore)
+	analyzer := newNetworkAnalyzerWithStores(symStore, svcStore)
 
 	isNet, isHigh := analyzer.isNetworkViaBinaryAnalysis(testCmdPath, testContentHash)
 
@@ -168,14 +158,12 @@ func TestIsNetworkViaBinaryAnalysis_StaticBinary_SVCSignalPresent(t *testing.T) 
 func TestIsNetworkViaBinaryAnalysis_StaticBinary_NoSVC(t *testing.T) {
 	symStore := &stubNetworkSymbolStore{err: fileanalysis.ErrNoNetworkSymbolAnalysis}
 	svcStore := &mockFileanalysisSyscallStore{err: fileanalysis.ErrNoSyscallAnalysis}
-	mock := &mockBinaryAnalyzer{result: binaryanalyzer.NetworkDetected}
-	analyzer := newNetworkAnalyzerWithStores(mock, symStore, svcStore)
+	analyzer := newNetworkAnalyzerWithStores(symStore, svcStore)
 
 	isNet, isHigh := analyzer.isNetworkViaBinaryAnalysis(testCmdPath, testContentHash)
 
 	assert.False(t, isNet, "static binary + no svc should return false")
 	assert.False(t, isHigh, "static binary + no svc should return false")
-	assert.False(t, mock.called, "BinaryAnalyzer must not be called")
 }
 
 // TestIsNetworkViaBinaryAnalysis_NoNetworkSymbols_SVCCacheHit verifies that a binary with
@@ -183,14 +171,12 @@ func TestIsNetworkViaBinaryAnalysis_StaticBinary_NoSVC(t *testing.T) {
 func TestIsNetworkViaBinaryAnalysis_NoNetworkSymbols_SVCCacheHit(t *testing.T) {
 	symStore := &stubNetworkSymbolStore{data: noNetworkSymbolData()}
 	svcStore := &mockFileanalysisSyscallStore{result: svcResult()}
-	mock := &mockBinaryAnalyzer{result: binaryanalyzer.NoNetworkSymbols}
-	analyzer := newNetworkAnalyzerWithStores(mock, symStore, svcStore)
+	analyzer := newNetworkAnalyzerWithStores(symStore, svcStore)
 
 	isNet, isHigh := analyzer.isNetworkViaBinaryAnalysis(testCmdPath, testContentHash)
 
 	assert.True(t, isNet, "svc signal should escalate to true even for NoNetworkSymbols")
 	assert.True(t, isHigh, "svc signal should set high risk")
-	assert.False(t, mock.called, "BinaryAnalyzer must not be called")
 }
 
 // TestIsNetworkViaBinaryAnalysis_NoNetworkSymbols_SVCCacheNil verifies that a binary with
@@ -199,14 +185,12 @@ func TestIsNetworkViaBinaryAnalysis_NoNetworkSymbols_SVCCacheNil(t *testing.T) {
 	symStore := &stubNetworkSymbolStore{data: noNetworkSymbolData()}
 	// LoadSyscallAnalysis returns nil result (no svc signal).
 	svcStore := &mockFileanalysisSyscallStore{result: nil}
-	mock := &mockBinaryAnalyzer{result: binaryanalyzer.NetworkDetected}
-	analyzer := newNetworkAnalyzerWithStores(mock, symStore, svcStore)
+	analyzer := newNetworkAnalyzerWithStores(symStore, svcStore)
 
 	isNet, isHigh := analyzer.isNetworkViaBinaryAnalysis(testCmdPath, testContentHash)
 
 	assert.False(t, isNet, "NoNetworkSymbols + no svc should return false")
 	assert.False(t, isHigh, "NoNetworkSymbols + no svc should return false")
-	assert.False(t, mock.called, "BinaryAnalyzer must not be called")
 }
 
 // TestIsNetworkViaBinaryAnalysis_NoNetworkSymbols_SVCHashMismatch verifies that
@@ -214,14 +198,12 @@ func TestIsNetworkViaBinaryAnalysis_NoNetworkSymbols_SVCCacheNil(t *testing.T) {
 func TestIsNetworkViaBinaryAnalysis_NoNetworkSymbols_SVCHashMismatch(t *testing.T) {
 	symStore := &stubNetworkSymbolStore{data: noNetworkSymbolData()}
 	svcStore := &mockFileanalysisSyscallStore{err: fileanalysis.ErrHashMismatch}
-	mock := &mockBinaryAnalyzer{result: binaryanalyzer.NoNetworkSymbols}
-	analyzer := newNetworkAnalyzerWithStores(mock, symStore, svcStore)
+	analyzer := newNetworkAnalyzerWithStores(symStore, svcStore)
 
 	isNet, isHigh := analyzer.isNetworkViaBinaryAnalysis(testCmdPath, testContentHash)
 
 	assert.True(t, isNet, "SVC ErrHashMismatch should return true (AnalysisError)")
 	assert.True(t, isHigh, "SVC ErrHashMismatch should return high risk")
-	assert.False(t, mock.called, "BinaryAnalyzer must not be called")
 }
 
 // TestIsNetworkViaBinaryAnalysis_NoNetworkSymbols_SVCNoSyscallAnalysis verifies that
@@ -230,14 +212,12 @@ func TestIsNetworkViaBinaryAnalysis_NoNetworkSymbols_SVCHashMismatch(t *testing.
 func TestIsNetworkViaBinaryAnalysis_NoNetworkSymbols_SVCNoSyscallAnalysis(t *testing.T) {
 	symStore := &stubNetworkSymbolStore{data: noNetworkSymbolData()}
 	svcStore := &mockFileanalysisSyscallStore{err: fileanalysis.ErrNoSyscallAnalysis}
-	mock := &mockBinaryAnalyzer{result: binaryanalyzer.NetworkDetected}
-	analyzer := newNetworkAnalyzerWithStores(mock, symStore, svcStore)
+	analyzer := newNetworkAnalyzerWithStores(symStore, svcStore)
 
 	isNet, isHigh := analyzer.isNetworkViaBinaryAnalysis(testCmdPath, testContentHash)
 
 	assert.False(t, isNet, "ErrNoSyscallAnalysis should fall through to NoNetworkSymbols result")
 	assert.False(t, isHigh)
-	assert.False(t, mock.called, "BinaryAnalyzer must not be called (no live fallback)")
 }
 
 // TestIsNetworkViaBinaryAnalysis_NoNetworkSymbols_SVCSchemaMismatch verifies that a
@@ -249,14 +229,12 @@ func TestIsNetworkViaBinaryAnalysis_NoNetworkSymbols_SVCSchemaMismatch(t *testin
 	}
 	symStore := &stubNetworkSymbolStore{data: noNetworkSymbolData()}
 	svcStore := &mockFileanalysisSyscallStore{err: schemaErr}
-	mock := &mockBinaryAnalyzer{result: binaryanalyzer.NoNetworkSymbols}
-	analyzer := newNetworkAnalyzerWithStores(mock, symStore, svcStore)
+	analyzer := newNetworkAnalyzerWithStores(symStore, svcStore)
 
 	isNet, isHigh := analyzer.isNetworkViaBinaryAnalysis(testCmdPath, testContentHash)
 
 	assert.True(t, isNet, "SVC SchemaVersionMismatchError should return AnalysisError")
 	assert.True(t, isHigh, "SVC SchemaVersionMismatchError should return high risk")
-	assert.False(t, mock.called, "BinaryAnalyzer must not be called")
 }
 
 // TestIsNetworkViaBinaryAnalysis_NoNetworkSymbols_SVCRecordNotFound verifies that
@@ -265,8 +243,7 @@ func TestIsNetworkViaBinaryAnalysis_NoNetworkSymbols_SVCSchemaMismatch(t *testin
 func TestIsNetworkViaBinaryAnalysis_NoNetworkSymbols_SVCRecordNotFound(t *testing.T) {
 	symStore := &stubNetworkSymbolStore{data: noNetworkSymbolData()}
 	svcStore := &mockFileanalysisSyscallStore{err: fileanalysis.ErrRecordNotFound}
-	mock := &mockBinaryAnalyzer{result: binaryanalyzer.NoNetworkSymbols}
-	analyzer := newNetworkAnalyzerWithStores(mock, symStore, svcStore)
+	analyzer := newNetworkAnalyzerWithStores(symStore, svcStore)
 
 	assert.Panics(t, func() {
 		analyzer.isNetworkViaBinaryAnalysis(testCmdPath, testContentHash)
@@ -278,14 +255,12 @@ func TestIsNetworkViaBinaryAnalysis_NoNetworkSymbols_SVCRecordNotFound(t *testin
 func TestIsNetworkViaBinaryAnalysis_NetworkDetected_SVCCacheHit(t *testing.T) {
 	symStore := &stubNetworkSymbolStore{data: networkDetectedData()}
 	svcStore := &mockFileanalysisSyscallStore{result: svcResult()}
-	mock := &mockBinaryAnalyzer{result: binaryanalyzer.NoNetworkSymbols}
-	analyzer := newNetworkAnalyzerWithStores(mock, symStore, svcStore)
+	analyzer := newNetworkAnalyzerWithStores(symStore, svcStore)
 
 	isNet, isHigh := analyzer.isNetworkViaBinaryAnalysis(testCmdPath, testContentHash)
 
 	assert.True(t, isNet, "NetworkDetected + svc should return true")
 	assert.True(t, isHigh, "svc signal should escalate isHighRisk to true")
-	assert.False(t, mock.called, "BinaryAnalyzer must not be called")
 }
 
 // TestIsNetworkViaBinaryAnalysis_NetworkDetected_SVCNoSyscallAnalysis verifies that
@@ -293,14 +268,12 @@ func TestIsNetworkViaBinaryAnalysis_NetworkDetected_SVCCacheHit(t *testing.T) {
 func TestIsNetworkViaBinaryAnalysis_NetworkDetected_SVCNoSyscallAnalysis(t *testing.T) {
 	symStore := &stubNetworkSymbolStore{data: networkDetectedData()}
 	svcStore := &mockFileanalysisSyscallStore{err: fileanalysis.ErrNoSyscallAnalysis}
-	mock := &mockBinaryAnalyzer{result: binaryanalyzer.NoNetworkSymbols}
-	analyzer := newNetworkAnalyzerWithStores(mock, symStore, svcStore)
+	analyzer := newNetworkAnalyzerWithStores(symStore, svcStore)
 
 	isNet, isHigh := analyzer.isNetworkViaBinaryAnalysis(testCmdPath, testContentHash)
 
 	assert.True(t, isNet, "NetworkDetected should return true")
 	assert.False(t, isHigh, "ErrNoSyscallAnalysis should not escalate isHighRisk")
-	assert.False(t, mock.called, "BinaryAnalyzer must not be called")
 }
 
 // TestIsNetworkViaBinaryAnalysis_NetworkDetected_NoSVC verifies that NetworkDetected
@@ -308,12 +281,10 @@ func TestIsNetworkViaBinaryAnalysis_NetworkDetected_SVCNoSyscallAnalysis(t *test
 func TestIsNetworkViaBinaryAnalysis_NetworkDetected_NoSVC(t *testing.T) {
 	symStore := &stubNetworkSymbolStore{data: networkDetectedData()}
 	svcStore := &mockFileanalysisSyscallStore{result: noSVCResult()}
-	mock := &mockBinaryAnalyzer{result: binaryanalyzer.NoNetworkSymbols}
-	analyzer := newNetworkAnalyzerWithStores(mock, symStore, svcStore)
+	analyzer := newNetworkAnalyzerWithStores(symStore, svcStore)
 
 	isNet, isHigh := analyzer.isNetworkViaBinaryAnalysis(testCmdPath, testContentHash)
 
 	assert.True(t, isNet, "NetworkDetected should return true")
 	assert.False(t, isHigh, "no svc signal should not escalate isHighRisk")
-	assert.False(t, mock.called, "BinaryAnalyzer must not be called")
 }

--- a/internal/runner/security/network_analyzer_test_helpers.go
+++ b/internal/runner/security/network_analyzer_test_helpers.go
@@ -4,26 +4,23 @@ package security
 
 import (
 	"github.com/isseis/go-safe-cmd-runner/internal/fileanalysis"
-	"github.com/isseis/go-safe-cmd-runner/internal/runner/security/binaryanalyzer"
 )
 
-// newNetworkAnalyzer creates a NetworkAnalyzer with a custom BinaryAnalyzer and store for testing.
+// newNetworkAnalyzer creates a NetworkAnalyzer with a store for testing.
 // Pass nil for store to disable cache-based analysis.
 // This function is only available in test builds.
 func newNetworkAnalyzer(
-	analyzer binaryanalyzer.BinaryAnalyzer,
 	store fileanalysis.NetworkSymbolStore,
 ) *NetworkAnalyzer {
-	return &NetworkAnalyzer{binaryAnalyzer: analyzer, store: store}
+	return &NetworkAnalyzer{store: store}
 }
 
-// newNetworkAnalyzerWithStores creates a NetworkAnalyzer with a custom BinaryAnalyzer,
-// symbol store, and syscall store for testing.
+// newNetworkAnalyzerWithStores creates a NetworkAnalyzer with a symbol store and
+// syscall store for testing.
 // This function is only available in test builds.
 func newNetworkAnalyzerWithStores(
-	analyzer binaryanalyzer.BinaryAnalyzer,
 	symStore fileanalysis.NetworkSymbolStore,
 	svcStore fileanalysis.SyscallAnalysisStore,
 ) *NetworkAnalyzer {
-	return &NetworkAnalyzer{binaryAnalyzer: analyzer, store: symStore, syscallStore: svcStore}
+	return &NetworkAnalyzer{store: symStore, syscallStore: svcStore}
 }


### PR DESCRIPTION
…rkViaBinaryAnalysis

Delete the a.binaryAnalyzer.AnalyzeNetworkSymbols() call that served as a fallback when the SymbolAnalysis/SyscallAnalysis cache was unavailable. The cache-backed path (task 0097) now covers all production paths; the live analysis fallback is no longer needed.

When a.store is nil or contentHash is empty the function now returns false, false directly instead of attempting live analysis.

Update command_analysis_test.go to remove tests that exercised the deleted live-analysis path and update the "nil store" test case.