### PR TITLE
feat(0104): Add Mach-O arm64 syscall number analysis (Steps 1-4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,20 +77,16 @@ jobs:
 
       - name: Run golangci-lint security scan (gosec)
         run: |
+          # Use "sarif:filename" format so golangci-lint writes the file itself
+          # rather than relying on shell redirection, which can leave a
+          # truncated (invalid) JSON file when the process is killed.
           golangci-lint run \
             --enable gosec \
             --disable-all \
             --build-tags test \
-            --out-format sarif \
+            --out-format sarif:golangci-security.sarif \
             --timeout=5m \
-            ./... > golangci-security.sarif 2>/dev/null || true
-          # Remove invalid SARIF to prevent upload-sarif from failing with
-          # "Invalid SARIF. JSON syntax error: Unexpected end of JSON input"
-          # which can happen when golangci-lint is killed mid-run.
-          if [ -f golangci-security.sarif ]; then
-            python3 -c "import json,sys; json.load(open('golangci-security.sarif'))" 2>/dev/null \
-              || { echo "Invalid SARIF output (likely truncated), skipping upload"; rm -f golangci-security.sarif; }
-          fi
+            ./... || true
         continue-on-error: true
 
       - name: Upload golangci-lint security SARIF file

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,13 @@ jobs:
             --out-format sarif \
             --timeout=5m \
             ./... > golangci-security.sarif 2>/dev/null || true
+          # Remove invalid SARIF to prevent upload-sarif from failing with
+          # "Invalid SARIF. JSON syntax error: Unexpected end of JSON input"
+          # which can happen when golangci-lint is killed mid-run.
+          if [ -f golangci-security.sarif ]; then
+            python3 -c "import json,sys; json.load(open('golangci-security.sarif'))" 2>/dev/null \
+              || { echo "Invalid SARIF output (likely truncated), skipping upload"; rm -f golangci-security.sarif; }
+          fi
         continue-on-error: true
 
       - name: Upload golangci-lint security SARIF file

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,25 +72,25 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      - name: Install Gosec
-        run: go install github.com/securego/gosec/v2/cmd/gosec@latest
+      - name: Install golangci-lint
+        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v2.11.4
 
-      - name: Run Gosec security scanner
-        run: gosec -fmt sarif -out gosec-report.sarif -stdout -verbose=text ./...
+      - name: Run golangci-lint security scan (gosec)
+        run: |
+          golangci-lint run \
+            --enable gosec \
+            --disable-all \
+            --build-tags test \
+            --out-format sarif \
+            --timeout=5m \
+            ./... > golangci-security.sarif 2>/dev/null || true
         continue-on-error: true
 
-      - name: Fix Gosec SARIF (ensure relationships is array)
-        if: always() && hashFiles('gosec-report.sarif') != ''
-        run: |
-          jq '(.runs[].tool.driver.rules[]?.relationships) |= (if (. | type) == "array" then map(select(. != null)) else [] end)' \
-            gosec-report.sarif > gosec-report-fixed.sarif
-          mv gosec-report-fixed.sarif gosec-report.sarif
-
-      - name: Upload Gosec SARIF file
+      - name: Upload golangci-lint security SARIF file
         uses: github/codeql-action/upload-sarif@v4
-        if: always() && hashFiles('gosec-report.sarif') != ''
+        if: always() && hashFiles('golangci-security.sarif') != ''
         with:
-          sarif_file: gosec-report.sarif
+          sarif_file: golangci-security.sarif
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
           cache: true
 
       - name: Install golangci-lint
-        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v2.11.4
+        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4
 
       - name: Run golangci-lint security scan (gosec)
         run: |

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -43,6 +43,7 @@ linters:
             - "**/internal/**"
           allow:
             - $gostd
+            - github.com/isseis/go-safe-cmd-runner/internal/arm64util
             - github.com/isseis/go-safe-cmd-runner/internal/cmdcommon
             - github.com/isseis/go-safe-cmd-runner/internal/common
             - github.com/isseis/go-safe-cmd-runner/internal/dynlib

--- a/Makefile
+++ b/Makefile
@@ -74,12 +74,15 @@ define format_files_from_list
 endef
 
 
+GO_VERSION_IN_MOD=$(shell awk '/^go /{print $$2}' go.mod)
+
 ENVSET=$(ENVCMD) -i \
 	HOME=$(HOME) \
 	USER=$(USER) \
 	PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/go/bin:/opt/homebrew/bin \
 	LANG=C \
 	TERM=$(TERM) \
+	GOTOOLCHAIN=go$(GO_VERSION_IN_MOD) \
 	TEST_GLOBAL_VAR=global_test_value \
 	COMPREHENSIVE_TEST=enabled \
 	NODE_ENV=test \

--- a/cmd/record/main.go
+++ b/cmd/record/main.go
@@ -160,6 +160,7 @@ func run(args []string, d deps, stdout, stderr io.Writer) int {
 			return 1
 		}
 		fv.SetLibSystemCache(libccache.NewMachoLibSystemAdapter(machoCacheMgr, fs))
+		fv.SetMachoSyscallTable(libccache.MacOSSyscallTable{})
 	}
 
 	return processFiles(validator, cfg, stdout, stderr)

--- a/docs/tasks/0067_template_inheritance_enhancement/04_implementation_plan.md
+++ b/docs/tasks/0067_template_inheritance_enhancement/04_implementation_plan.md
@@ -435,7 +435,7 @@ func expandTemplateToSpec(
 - TestTemplateInheritance_CommandReferences: テンプレート参照とオーバーライドの確認（5ケース）
 - TestTemplateInheritance_GlobalConfig: グローバル設定の確認
 
-**注記**: 
+**注記**:
 - テンプレート展開/継承のランタイム動作テストは Phase 3 で実装済み
 - この Phase 5 では TOML ファイルの解析と構造の保持を確認
 

--- a/docs/tasks/0104_macho_syscall_number_analysis/04_implementation_plan.md
+++ b/docs/tasks/0104_macho_syscall_number_analysis/04_implementation_plan.md
@@ -284,17 +284,17 @@ const CurrentSchemaVersion = 16
 - [x] スキーマテスト更新
 
 ### ステップ 3: pclntab_macho.go
-- [ ] エラー定数定義
-- [ ] `MachoPclntabFunc`、`funcRange`、`isInsideRange` 実装
-- [ ] `ParseMachoPclntab` 実装
-- [ ] `detectMachoPclntabOffset` 実装
-- [ ] `pclntab_macho_test.go` 作成
+- [x] エラー定数定義
+- [x] `MachoPclntabFunc`、`funcRange`、`isInsideRange` 実装
+- [x] `ParseMachoPclntab` 実装
+- [x] `detectMachoPclntabOffset` 実装
+- [x] `pclntab_macho_test.go` 作成
 
 ### ステップ 4: pass1_scanner.go
-- [ ] `knownMachoSyscallImpls` 定義
-- [ ] `buildStubRanges` 実装
-- [ ] `scanSVCWithX16` 実装
-- [ ] `pass1_scanner_test.go` 作成
+- [x] `knownMachoSyscallImpls` 定義
+- [x] `buildStubRanges` 実装
+- [x] `scanSVCWithX16` 実装
+- [x] `pass1_scanner_test.go` 作成
 
 ### ステップ 5: pass2_scanner.go
 - [ ] `MachoWrapperCall` 型定義

--- a/docs/tasks/0104_macho_syscall_number_analysis/04_implementation_plan.md
+++ b/docs/tasks/0104_macho_syscall_number_analysis/04_implementation_plan.md
@@ -275,13 +275,13 @@ const CurrentSchemaVersion = 16
 ## 3. 進捗チェックリスト
 
 ### ステップ 1: libccache 公開化
-- [ ] `BackwardScanX16` 実装
-- [ ] `IsControlFlowInstruction` 実装（必要に応じて公開）
-- [ ] 既存テスト通過確認
+- [x] `BackwardScanX16` 実装
+- [x] `IsControlFlowInstruction` 実装（必要に応じて公開）
+- [x] 既存テスト通過確認
 
 ### ステップ 2: スキーマバージョン v16
-- [ ] `CurrentSchemaVersion = 16` 変更
-- [ ] スキーマテスト更新
+- [x] `CurrentSchemaVersion = 16` 変更
+- [x] スキーマテスト更新
 
 ### ステップ 3: pclntab_macho.go
 - [ ] エラー定数定義

--- a/internal/arm64util/arm64util.go
+++ b/internal/arm64util/arm64util.go
@@ -13,8 +13,15 @@ const (
 	movzX16Lsl16            = uint32(0xD2A00010) // MOVZ X16, #0, LSL #16
 	movkX16Base             = uint32(0xF2800010) // MOVK X16, #0, LSL #0
 	movkX16Lsl16            = uint32(0xF2A00010) // MOVK X16, #0, LSL #16
+	movzX0Base              = uint32(0xD2800000) // MOVZ X0, #0, LSL #0
+	movzX0Lsl16             = uint32(0xD2A00000) // MOVZ X0, #0, LSL #16
+	movkX0Base              = uint32(0xF2800000) // MOVK X0, #0, LSL #0
+	movkX0Lsl16             = uint32(0xF2A00000) // MOVK X0, #0, LSL #16
+	movzW0Base              = uint32(0x52800000) // MOVZ W0, #0, LSL #0
+	movkW0Base              = uint32(0x72800000) // MOVK W0, #0, LSL #0
 	imm16Mask               = uint32(0x001FFFE0) // bits[20:5]
 	imm16Shift              = 5
+	regEncodingX0           = uint32(0x00)         // arm64 register encoding for X0/W0
 	patternBLRBR            = uint32(0b1101011000) // bits[31:22] for BLR/BR
 	patternRET              = uint32(0b1101011001) // bits[31:22] for RET
 	patternCBZ              = uint32(0b011010)     // bits[30:25] for CBZ/CBNZ
@@ -87,6 +94,91 @@ func BackwardScanX16(code []byte, svcOffset int) (int, bool) {
 		}
 	}
 	return 0, false
+}
+
+// BackwardScanX0 walks backward from the BL instruction at code[blOffset]
+// and looks for an immediate-load sequence into X0 or W0 (first argument register
+// on arm64). When found, it returns the loaded value. The scan is limited to
+// maxBackwardScanInstr instructions.
+func BackwardScanX0(code []byte, blOffset int) (int, bool) {
+	startIdx := blOffset/instrLen - 1
+	endIdx := startIdx - maxBackwardScanInstr
+	if endIdx < 0 {
+		endIdx = -1
+	}
+
+	x0Lo := -1
+	x0Hi := -1
+
+	for i := startIdx; i > endIdx; i-- {
+		off := i * instrLen
+		if off < 0 {
+			break
+		}
+		if off+instrLen > len(code) {
+			break
+		}
+		word := binary.LittleEndian.Uint32(code[off:])
+
+		if word&^imm16Mask == movzX0Base {
+			lo := int((word & imm16Mask) >> imm16Shift)
+			hi := 0
+			if x0Hi >= 0 {
+				hi = x0Hi
+			}
+			return hi | lo, true
+		}
+
+		if word&^imm16Mask == movzX0Lsl16 {
+			hi := int((word&imm16Mask)>>imm16Shift) << imm16HighShift
+			lo := 0
+			if x0Lo >= 0 {
+				lo = x0Lo
+			}
+			return hi | lo, true
+		}
+
+		if word&^imm16Mask == movzW0Base {
+			return int((word & imm16Mask) >> imm16Shift), true
+		}
+
+		if word&^imm16Mask == movkX0Base {
+			x0Lo = int((word & imm16Mask) >> imm16Shift)
+			continue
+		}
+
+		if word&^imm16Mask == movkX0Lsl16 {
+			x0Hi = int((word&imm16Mask)>>imm16Shift) << imm16HighShift
+			continue
+		}
+
+		if word&^imm16Mask == movkW0Base {
+			x0Lo = int((word & imm16Mask) >> imm16Shift)
+			continue
+		}
+
+		if isControlFlowInstruction(word) {
+			break
+		}
+
+		if writesX0NotMovzMovk(word) {
+			break
+		}
+	}
+	return 0, false
+}
+
+// writesX0NotMovzMovk reports whether word is an instruction that writes to
+// X0 or W0, excluding MOVZ and MOVK (which are handled by BackwardScanX0).
+// Used as a conservative stop signal during backward scanning.
+func writesX0NotMovzMovk(word uint32) bool {
+	if (word>>bitShiftMovWide)&field6Mask == patternMovWideBits28_23 {
+		opc := (word >> bitShiftOpc) & opcMask
+		if opc == opcMOVZ || opc == opcMOVK {
+			return false
+		}
+	}
+	return word&0x1F == regEncodingX0
 }
 
 func stripBSDPrefix(v int) int {

--- a/internal/arm64util/arm64util.go
+++ b/internal/arm64util/arm64util.go
@@ -21,7 +21,6 @@ const (
 	movkW0Base              = uint32(0x72800000) // MOVK W0, #0, LSL #0
 	imm16Mask               = uint32(0x001FFFE0) // bits[20:5]
 	imm16Shift              = 5
-	regEncodingX0           = uint32(0x00)         // arm64 register encoding for X0/W0
 	patternBLRBR            = uint32(0b1101011000) // bits[31:22] for BLR/BR
 	patternRET              = uint32(0b1101011001) // bits[31:22] for RET
 	patternCBZ              = uint32(0b011010)     // bits[30:25] for CBZ/CBNZ
@@ -101,84 +100,141 @@ func BackwardScanX16(code []byte, svcOffset int) (int, bool) {
 // on arm64). When found, it returns the loaded value. The scan is limited to
 // maxBackwardScanInstr instructions.
 func BackwardScanX0(code []byte, blOffset int) (int, bool) {
+	return backwardScanRegImm(code, blOffset, 0)
+}
+
+// BackwardScanStackTrap walks backward from the BL instruction at code[blOffset]
+// looking for a Go old-stack-ABI trap argument write: STR/STP xN, [SP, #8] (the
+// trap argument slot), followed by an immediate-load sequence into xN.
+//
+// This is the correct scan for syscall.Syscall/RawSyscall et al., which are
+// NOSPLIT assembly stubs using the old stack-based calling convention: the caller
+// stores trap+0(FP) = [SP+8] before the BL, not in a register passed via ABI.
+func BackwardScanStackTrap(code []byte, blOffset int) (int, bool) {
 	startIdx := blOffset/instrLen - 1
 	endIdx := startIdx - maxBackwardScanInstr
 	if endIdx < 0 {
 		endIdx = -1
 	}
-
-	x0Lo := -1
-	x0Hi := -1
-
 	for i := startIdx; i > endIdx; i-- {
 		off := i * instrLen
-		if off < 0 {
-			break
-		}
-		if off+instrLen > len(code) {
+		if off < 0 || off+instrLen > len(code) {
 			break
 		}
 		word := binary.LittleEndian.Uint32(code[off:])
-
-		if word&^imm16Mask == movzX0Base {
-			lo := int((word & imm16Mask) >> imm16Shift)
-			hi := 0
-			if x0Hi >= 0 {
-				hi = x0Hi
-			}
-			return hi | lo, true
-		}
-
-		if word&^imm16Mask == movzX0Lsl16 {
-			hi := int((word&imm16Mask)>>imm16Shift) << imm16HighShift
-			lo := 0
-			if x0Lo >= 0 {
-				lo = x0Lo
-			}
-			return hi | lo, true
-		}
-
-		if word&^imm16Mask == movzW0Base {
-			return int((word & imm16Mask) >> imm16Shift), true
-		}
-
-		if word&^imm16Mask == movkX0Base {
-			x0Lo = int((word & imm16Mask) >> imm16Shift)
-			continue
-		}
-
-		if word&^imm16Mask == movkX0Lsl16 {
-			x0Hi = int((word&imm16Mask)>>imm16Shift) << imm16HighShift
-			continue
-		}
-
-		if word&^imm16Mask == movkW0Base {
-			x0Lo = int((word & imm16Mask) >> imm16Shift)
-			continue
-		}
-
 		if isControlFlowInstruction(word) {
 			break
 		}
+		trapReg, found := trapStoreReg(word)
+		if !found {
+			continue
+		}
+		return backwardScanRegImm(code, off, trapReg)
+	}
+	return 0, false
+}
 
-		if writesX0NotMovzMovk(word) {
+// trapStoreReg checks whether word stores a register to [SP, #8] (the trap
+// argument slot in Go's old stack ABI). Returns (regN, true) where regN is
+// the register that holds the syscall number.
+//
+// Go old stack ABI frame for syscall.Syscall: SP+0=return addr, SP+8=trap,
+// SP+16=a1, ... The compiler emits STR xN,[SP,#8] or STP xN,xM,[SP,#8]
+// to set up the trap argument before BL.
+func trapStoreReg(word uint32) (uint32, bool) {
+	const (
+		strUnsignedOffset64 = uint32(0x3E4) // STR Xt,[Xn,#pimm] bits[31:22]
+		stpSignedOffset64   = uint32(0x2A4) // STP Xt1,Xt2,[Xn,#imm] bits[31:22]
+		strImm12Shift       = 10            // bit position of imm12 in STR unsigned-offset
+		stpImm7Shift        = 15            // bit position of imm7 in STP signed-offset
+		loadStoreRnShift    = 5             // bit position of Rn in load/store instructions
+		loadStoreRdMask     = uint32(0x1F)  // 5-bit mask for Rt/Rd in load/store
+		loadStoreImm12Mask  = uint32(0xFFF) // 12-bit mask for imm12
+		loadStoreImm7Mask   = uint32(0x7F)  // 7-bit mask for imm7
+		trapSlotImm         = uint32(1)     // imm=1 → offset=8 bytes (trap slot)
+		regSP               = uint32(31)
+	)
+	// STR xN, [SP, #8]: imm12=1 (=8/8), Rn=SP
+	if word>>22 == strUnsignedOffset64 &&
+		(word>>strImm12Shift)&loadStoreImm12Mask == trapSlotImm &&
+		(word>>loadStoreRnShift)&loadStoreRdMask == regSP {
+		return word & loadStoreRdMask, true
+	}
+	// STP xN, xM, [SP, #8]: imm7=1 (=8/8), Rn=SP; xN(Rt1) stored at SP+8 = trap slot
+	if word>>22 == stpSignedOffset64 &&
+		(word>>stpImm7Shift)&loadStoreImm7Mask == trapSlotImm &&
+		(word>>loadStoreRnShift)&loadStoreRdMask == regSP {
+		return word & loadStoreRdMask, true
+	}
+	return 0, false
+}
+
+// backwardScanRegImm scans backward from code[fromOffset] (exclusive) looking
+// for an immediate-load sequence into register regN (MOVZ/MOVK patterns).
+// The scan is limited to maxBackwardScanInstr instructions.
+func backwardScanRegImm(code []byte, fromOffset int, regN uint32) (int, bool) {
+	startIdx := fromOffset/instrLen - 1
+	endIdx := startIdx - maxBackwardScanInstr
+	if endIdx < 0 {
+		endIdx = -1
+	}
+	immLo := -1
+	immHi := -1
+	for i := startIdx; i > endIdx; i-- {
+		off := i * instrLen
+		if off < 0 || off+instrLen > len(code) {
+			break
+		}
+		word := binary.LittleEndian.Uint32(code[off:])
+		// MOVZ xN/wN, #imm, LSL#0 — terminal: assemble hi|lo and return
+		if word&^imm16Mask == movzX0Base|regN || word&^imm16Mask == movzW0Base|regN {
+			lo := int((word & imm16Mask) >> imm16Shift)
+			hi := 0
+			if immHi >= 0 {
+				hi = immHi
+			}
+			return hi | lo, true
+		}
+		// MOVZ xN, #imm, LSL#16 — terminal
+		if word&^imm16Mask == movzX0Lsl16|regN {
+			hi := int((word&imm16Mask)>>imm16Shift) << imm16HighShift
+			lo := 0
+			if immLo >= 0 {
+				lo = immLo
+			}
+			return hi | lo, true
+		}
+		// MOVK xN/wN, #imm, LSL#0 — accumulate low half
+		if word&^imm16Mask == movkX0Base|regN || word&^imm16Mask == movkW0Base|regN {
+			immLo = int((word & imm16Mask) >> imm16Shift)
+			continue
+		}
+		// MOVK xN, #imm, LSL#16 — accumulate high half
+		if word&^imm16Mask == movkX0Lsl16|regN {
+			immHi = int((word&imm16Mask)>>imm16Shift) << imm16HighShift
+			continue
+		}
+		if isControlFlowInstruction(word) {
+			break
+		}
+		if writesRegNotMovzMovk(word, regN) {
 			break
 		}
 	}
 	return 0, false
 }
 
-// writesX0NotMovzMovk reports whether word is an instruction that writes to
-// X0 or W0, excluding MOVZ and MOVK (which are handled by BackwardScanX0).
-// Used as a conservative stop signal during backward scanning.
-func writesX0NotMovzMovk(word uint32) bool {
+// writesRegNotMovzMovk reports whether word is an instruction that writes to
+// register regN, excluding MOVZ and MOVK. Used as a conservative stop signal
+// during backward immediate-load scanning.
+func writesRegNotMovzMovk(word, regN uint32) bool {
 	if (word>>bitShiftMovWide)&field6Mask == patternMovWideBits28_23 {
 		opc := (word >> bitShiftOpc) & opcMask
 		if opc == opcMOVZ || opc == opcMOVK {
 			return false
 		}
 	}
-	return word&0x1F == regEncodingX0
+	return word&0x1F == regN
 }
 
 func stripBSDPrefix(v int) int {

--- a/internal/arm64util/arm64util.go
+++ b/internal/arm64util/arm64util.go
@@ -2,7 +2,10 @@
 // Extracted to break the import cycle: machoanalyzer → libccache → filevalidator → machoanalyzer.
 package arm64util
 
-import "encoding/binary"
+import (
+	"encoding/binary"
+	"math/bits"
+)
 
 const (
 	instrLen                = 4
@@ -34,6 +37,11 @@ const (
 	opcMask                 = uint32(0x3)
 	opcMOVZ                 = uint32(0b10) // opc[30:29]=10 → MOVZ
 	opcMOVK                 = uint32(0b11) // opc[30:29]=11 → MOVK
+	arm64BitsPerWord        = uint32(64)   // bit width of a 64-bit ARM64 register
+	orrNBitPos              = uint32(22)   // bit position of N in ORR/logical immediate
+	orrImmrBitPos           = uint32(16)   // bit position of immr in logical immediate (bits[21:16])
+	orrImmsbitPos           = uint32(10)   // bit position of imms in logical immediate (bits[15:10])
+	bitmaskImmFieldWidth    = uint32(6)    // bit width of immr/imms fields in bitmask immediate
 )
 
 // BackwardScanX16 walks backward from the svc #0x80 instruction at code[svcOffset]
@@ -82,6 +90,11 @@ func BackwardScanX16(code []byte, svcOffset int) (int, bool) {
 		if word&^imm16Mask == movkX16Lsl16 {
 			x16Hi = int((word&imm16Mask)>>imm16Shift) << imm16HighShift
 			continue
+		}
+
+		// ORR X16, XZR, #imm (bitmask immediate form of MOV X16, #imm)
+		if val, ok := decodeORRX16XZR(word); ok {
+			return stripBSDPrefix(val), true
 		}
 
 		if isControlFlowInstruction(word) {
@@ -259,6 +272,66 @@ func isControlFlowInstruction(word uint32) bool {
 		return true
 	}
 	return false
+}
+
+// decodeORRX16XZR decodes an ORR X16, XZR, #imm instruction (bitmask immediate
+// form of MOV X16, #imm, as sometimes emitted by Go 1.25+ compilers) and returns
+// the immediate value. Returns (0, false) if word is not that instruction or if
+// the bitmask encoding is undefined.
+func decodeORRX16XZR(word uint32) (int, bool) {
+	// ORR (immediate) 64-bit: sf=1, opc=01, [28:23]=100100, Rn=XZR(31), Rd=X16(16)
+	// Fixed-bit mask covers bits[31:23] and bits[9:0] (Rn and Rd).
+	const orrX16XZRMask = uint32(0xFF8003FF)
+	const orrX16XZRFixed = uint32(0xB20003F0)
+	if word&orrX16XZRMask != orrX16XZRFixed {
+		return 0, false
+	}
+
+	N := (word >> orrNBitPos) & 1
+	immr := (word >> orrImmrBitPos) & field6Mask
+	imms := (word >> orrImmsbitPos) & field6Mask
+
+	// len = HighestSetBit(N:NOT(imms)) — ARMv8 Reference Manual bitmask decode
+	nNotImms := (N << bitmaskImmFieldWidth) | ((^imms) & field6Mask)
+	lenBits := bits.Len32(nNotImms) - 1
+	if lenBits < 1 {
+		return 0, false // undefined encoding
+	}
+
+	esize := uint32(1) << lenBits
+	levels := esize - 1
+	S := imms & levels
+	R := immr & levels
+
+	// All-ones within an element is undefined in ARM64 bitmask immediate.
+	if S == levels {
+		return 0, false
+	}
+
+	// Build S+1 consecutive ones (S < levels < esize ≤ 64, so S+1 ≤ 63 — no overflow).
+	welem := (uint64(1) << (S + 1)) - 1
+
+	// Rotate right by R within esize bits.
+	if R > 0 {
+		if esize == arm64BitsPerWord {
+			welem = bits.RotateLeft64(welem, -int(R))
+		} else {
+			mask := (uint64(1) << esize) - 1
+			welem = ((welem >> R) | (welem << (esize - R))) & mask
+		}
+	}
+
+	// Replicate the esize-bit pattern to fill 64 bits.
+	var result uint64
+	if esize == arm64BitsPerWord {
+		result = welem
+	} else {
+		for i := uint32(0); i < arm64BitsPerWord/esize; i++ {
+			result |= welem << (i * esize)
+		}
+	}
+
+	return int(result), true
 }
 
 // writesX16NotMovzMovk reports whether word is a 64-bit instruction that writes to x16,

--- a/internal/arm64util/arm64util.go
+++ b/internal/arm64util/arm64util.go
@@ -78,11 +78,11 @@ func BackwardScanX16(code []byte, svcOffset int) (int, bool) {
 			continue
 		}
 
-		if IsControlFlowInstruction(word) {
+		if isControlFlowInstruction(word) {
 			break
 		}
 
-		if WritesX16NotMovzMovk(word) {
+		if writesX16NotMovzMovk(word) {
 			break
 		}
 	}
@@ -96,8 +96,8 @@ func stripBSDPrefix(v int) int {
 	return v
 }
 
-// IsControlFlowInstruction reports whether word is a B/BL/BLR/BR/RET/CBZ/CBNZ/TBZ/TBNZ instruction.
-func IsControlFlowInstruction(word uint32) bool {
+// isControlFlowInstruction reports whether word is a B/BL/BLR/BR/RET/CBZ/CBNZ/TBZ/TBNZ instruction.
+func isControlFlowInstruction(word uint32) bool {
 	if word>>26 == 0b000101 || word>>26 == 0b100101 {
 		return true
 	}
@@ -113,9 +113,9 @@ func IsControlFlowInstruction(word uint32) bool {
 	return false
 }
 
-// WritesX16NotMovzMovk reports whether word is a 64-bit instruction that writes to x16,
+// writesX16NotMovzMovk reports whether word is a 64-bit instruction that writes to x16,
 // excluding MOVZ and MOVK (but not MOVN, which also writes its destination).
-func WritesX16NotMovzMovk(word uint32) bool {
+func writesX16NotMovzMovk(word uint32) bool {
 	if (word>>bitShiftMovWide)&field6Mask == patternMovWideBits28_23 {
 		opc := (word >> bitShiftOpc) & opcMask
 		if opc == opcMOVZ || opc == opcMOVK {

--- a/internal/arm64util/arm64util.go
+++ b/internal/arm64util/arm64util.go
@@ -1,0 +1,119 @@
+// Package arm64util provides shared ARM64 instruction decoding utilities.
+// Extracted to break the import cycle: machoanalyzer → libccache → filevalidator → machoanalyzer.
+package arm64util
+
+import "encoding/binary"
+
+const (
+	instrLen                 = 4
+	maxBackwardScanInstr     = 16
+	bsdSyscallClassPrefix    = 0x2000000
+	imm16HighShift           = 16
+	movzX16Base              = uint32(0xD2800010) // MOVZ X16, #0, LSL #0
+	movzX16Lsl16             = uint32(0xD2A00010) // MOVZ X16, #0, LSL #16
+	movkX16Base              = uint32(0xF2800010) // MOVK X16, #0, LSL #0
+	movkX16Lsl16             = uint32(0xF2A00010) // MOVK X16, #0, LSL #16
+	imm16Mask                = uint32(0x001FFFE0) // bits[20:5]
+	imm16Shift               = 5
+	patternBLRBR             = uint32(0b1101011000) // bits[31:22] for BLR/BR
+	patternRET               = uint32(0b1101011001) // bits[31:22] for RET
+	patternCBZ               = uint32(0b011010)     // bits[30:25] for CBZ/CBNZ
+	patternTBZ               = uint32(0b011011)     // bits[30:25] for TBZ/TBNZ
+	field6Mask               = uint32(0x3F)
+	patternMovzMovkBits28_23 = uint32(0b100101) // [28:23] shared by MOVZ and MOVK
+	bitShiftBLRBR            = 22
+	bitShiftCBZTBZ           = 25
+	bitShiftMovzMovk         = 23
+)
+
+// BackwardScanX16 walks backward from the svc #0x80 instruction at code[svcOffset]
+// and looks for an immediate-load sequence into x16. When found, it returns the syscall
+// number with the BSD class prefix removed. The scan is limited to maxBackwardScanInstr.
+func BackwardScanX16(code []byte, svcOffset int) (int, bool) {
+	startIdx := svcOffset/instrLen - 1
+	endIdx := startIdx - maxBackwardScanInstr
+	if endIdx < 0 {
+		endIdx = -1
+	}
+
+	x16Lo := -1
+	x16Hi := -1
+
+	for i := startIdx; i > endIdx; i-- {
+		off := i * instrLen
+		if off < 0 {
+			break
+		}
+		word := binary.LittleEndian.Uint32(code[off:])
+
+		if word&^imm16Mask == movzX16Base {
+			lo := int((word & imm16Mask) >> imm16Shift)
+			hi := 0
+			if x16Hi >= 0 {
+				hi = x16Hi
+			}
+			return stripBSDPrefix(hi | lo), true
+		}
+
+		if word&^imm16Mask == movzX16Lsl16 {
+			hi := int((word&imm16Mask)>>imm16Shift) << imm16HighShift
+			lo := 0
+			if x16Lo >= 0 {
+				lo = x16Lo
+			}
+			return stripBSDPrefix(hi | lo), true
+		}
+
+		if word&^imm16Mask == movkX16Base {
+			x16Lo = int((word & imm16Mask) >> imm16Shift)
+			continue
+		}
+
+		if word&^imm16Mask == movkX16Lsl16 {
+			x16Hi = int((word&imm16Mask)>>imm16Shift) << imm16HighShift
+			continue
+		}
+
+		if IsControlFlowInstruction(word) {
+			break
+		}
+
+		if WritesX16NotMovzMovk(word) {
+			break
+		}
+	}
+	return 0, false
+}
+
+func stripBSDPrefix(v int) int {
+	if v >= bsdSyscallClassPrefix {
+		return v - bsdSyscallClassPrefix
+	}
+	return v
+}
+
+// IsControlFlowInstruction reports whether word is a B/BL/BLR/BR/RET/CBZ/CBNZ/TBZ/TBNZ instruction.
+func IsControlFlowInstruction(word uint32) bool {
+	if word>>26 == 0b000101 || word>>26 == 0b100101 {
+		return true
+	}
+	if word>>bitShiftBLRBR == patternBLRBR || word>>bitShiftBLRBR == patternRET {
+		return true
+	}
+	if (word>>bitShiftCBZTBZ)&field6Mask == patternCBZ {
+		return true
+	}
+	if (word>>bitShiftCBZTBZ)&field6Mask == patternTBZ {
+		return true
+	}
+	return false
+}
+
+// WritesX16NotMovzMovk reports whether word is a 64-bit instruction that writes to x16,
+// excluding MOVZ and MOVK.
+func WritesX16NotMovzMovk(word uint32) bool {
+	if (word>>bitShiftMovzMovk)&field6Mask == patternMovzMovkBits28_23 {
+		return false
+	}
+	return word>>31 == 1 && word&0x1F == 0x10
+}

--- a/internal/arm64util/arm64util.go
+++ b/internal/arm64util/arm64util.go
@@ -5,25 +5,29 @@ package arm64util
 import "encoding/binary"
 
 const (
-	instrLen                 = 4
-	maxBackwardScanInstr     = 16
-	bsdSyscallClassPrefix    = 0x2000000
-	imm16HighShift           = 16
-	movzX16Base              = uint32(0xD2800010) // MOVZ X16, #0, LSL #0
-	movzX16Lsl16             = uint32(0xD2A00010) // MOVZ X16, #0, LSL #16
-	movkX16Base              = uint32(0xF2800010) // MOVK X16, #0, LSL #0
-	movkX16Lsl16             = uint32(0xF2A00010) // MOVK X16, #0, LSL #16
-	imm16Mask                = uint32(0x001FFFE0) // bits[20:5]
-	imm16Shift               = 5
-	patternBLRBR             = uint32(0b1101011000) // bits[31:22] for BLR/BR
-	patternRET               = uint32(0b1101011001) // bits[31:22] for RET
-	patternCBZ               = uint32(0b011010)     // bits[30:25] for CBZ/CBNZ
-	patternTBZ               = uint32(0b011011)     // bits[30:25] for TBZ/TBNZ
-	field6Mask               = uint32(0x3F)
-	patternMovzMovkBits28_23 = uint32(0b100101) // [28:23] shared by MOVZ and MOVK
-	bitShiftBLRBR            = 22
-	bitShiftCBZTBZ           = 25
-	bitShiftMovzMovk         = 23
+	instrLen                = 4
+	maxBackwardScanInstr    = 16
+	bsdSyscallClassPrefix   = 0x2000000
+	imm16HighShift          = 16
+	movzX16Base             = uint32(0xD2800010) // MOVZ X16, #0, LSL #0
+	movzX16Lsl16            = uint32(0xD2A00010) // MOVZ X16, #0, LSL #16
+	movkX16Base             = uint32(0xF2800010) // MOVK X16, #0, LSL #0
+	movkX16Lsl16            = uint32(0xF2A00010) // MOVK X16, #0, LSL #16
+	imm16Mask               = uint32(0x001FFFE0) // bits[20:5]
+	imm16Shift              = 5
+	patternBLRBR            = uint32(0b1101011000) // bits[31:22] for BLR/BR
+	patternRET              = uint32(0b1101011001) // bits[31:22] for RET
+	patternCBZ              = uint32(0b011010)     // bits[30:25] for CBZ/CBNZ
+	patternTBZ              = uint32(0b011011)     // bits[30:25] for TBZ/TBNZ
+	field6Mask              = uint32(0x3F)
+	patternMovWideBits28_23 = uint32(0b100101) // [28:23] shared by MOVN/MOVZ/MOVK
+	bitShiftBLRBR           = 22
+	bitShiftCBZTBZ          = 25
+	bitShiftMovWide         = 23
+	bitShiftOpc             = 29
+	opcMask                 = uint32(0x3)
+	opcMOVZ                 = uint32(0b10) // opc[30:29]=10 → MOVZ
+	opcMOVK                 = uint32(0b11) // opc[30:29]=11 → MOVK
 )
 
 // BackwardScanX16 walks backward from the svc #0x80 instruction at code[svcOffset]
@@ -110,10 +114,13 @@ func IsControlFlowInstruction(word uint32) bool {
 }
 
 // WritesX16NotMovzMovk reports whether word is a 64-bit instruction that writes to x16,
-// excluding MOVZ and MOVK.
+// excluding MOVZ and MOVK (but not MOVN, which also writes its destination).
 func WritesX16NotMovzMovk(word uint32) bool {
-	if (word>>bitShiftMovzMovk)&field6Mask == patternMovzMovkBits28_23 {
-		return false
+	if (word>>bitShiftMovWide)&field6Mask == patternMovWideBits28_23 {
+		opc := (word >> bitShiftOpc) & opcMask
+		if opc == opcMOVZ || opc == opcMOVK {
+			return false
+		}
 	}
 	return word>>31 == 1 && word&0x1F == 0x10
 }

--- a/internal/arm64util/arm64util_test.go
+++ b/internal/arm64util/arm64util_test.go
@@ -157,10 +157,75 @@ func TestBackwardScanStackTrap_IndirectRegWrite(t *testing.T) {
 	assert.False(t, ok, "indirect write to trap register must stop the scan")
 }
 
-// TestBackwardScanX0_IndirectWriteStopsScal verifies that a non-MOV write to X0
+// svcImm80 is the ARM64 encoding of SVC #0x80 (macOS BSD syscall trap).
+const svcImm80 = uint32(0xD4001001)
+
+// encodeORRX16 builds an ORR X16, XZR, #imm instruction word from a raw encoding
+// (caller supplies the exact 32-bit word; helper only exists for documentation).
+// The actual instruction words used in tests are computed from the ARM64 bitmask spec.
+
+// TestBackwardScanX16_ORRX16_Basic verifies that ORR X16, XZR, #1 (0xB24003F0)
+// immediately before svc #0x80 resolves to syscall number 1.
+func TestBackwardScanX16_ORRX16_Basic(t *testing.T) {
+	t.Parallel()
+	// ORR X16, XZR, #1 (N=1, immr=0, imms=0 → value=1); SVC #0x80
+	const orrX16XZR1 = uint32(0xB24003F0)
+	code := buildCodeSliceX0(orrX16XZR1, svcImm80)
+	num, ok := BackwardScanX16(code, 4) // SVC at offset 4
+	require.True(t, ok)
+	assert.Equal(t, 1, num)
+}
+
+// TestBackwardScanX16_ORRX16_BSDPrefix verifies that when ORR loads a BSD-prefixed
+// value the prefix is stripped before returning.
+// Encoding: ORR X16, XZR, #0x3FFFFFF (N=1, immr=0, imms=25 → 26 consecutive ones).
+// 0x3FFFFFF >= bsdSyscallClassPrefix(0x2000000), so result = 0x3FFFFFF - 0x2000000 = 0x1FFFFFF.
+func TestBackwardScanX16_ORRX16_BSDPrefix(t *testing.T) {
+	t.Parallel()
+	// ORR X16, XZR, #0x3FFFFFF: N=1, immr=0, imms=25=0x19
+	// word = 0xB2000000 | (1<<22) | (0<<16) | (0x19<<10) | (31<<5) | 16
+	//      = 0xB2400000 | 0x6400 | 0x3E0 | 0x10 = 0xB24067F0
+	const orrX16BSDPrefixed = uint32(0xB24067F0)
+	code := buildCodeSliceX0(orrX16BSDPrefixed, svcImm80)
+	num, ok := BackwardScanX16(code, 4)
+	require.True(t, ok)
+	assert.Equal(t, 0x1FFFFFF, num)
+}
+
+// TestDecodeORRX16XZR_N0 verifies correct decoding of a N=0 bitmask immediate
+// by calling decodeORRX16XZR directly (bypassing the BSD-prefix strip in
+// BackwardScanX16, which would change the result for large values).
+// Encoding: ORR X16, XZR, #0x0F0F0F0F0F0F0F0F
+//
+//	N=0, esize=8, S=3 (4 ones), R=0, imms=0x33, immr=0
+//	word = 0xB2000000 | (0x33<<10) | (31<<5) | 16 = 0xB200CFF0
+func TestDecodeORRX16XZR_N0(t *testing.T) {
+	t.Parallel()
+	val, ok := decodeORRX16XZR(0xB200CFF0)
+	require.True(t, ok)
+	assert.Equal(t, int(uint64(0x0F0F0F0F0F0F0F0F)), val)
+}
+
+// TestBackwardScanX16_ORRX16_DoesNotStopScan verifies that an ORR X16 instruction
+// that used to terminate the scan (via writesX16NotMovzMovk) now resolves correctly
+// even when preceded by other instructions.
+func TestBackwardScanX16_ORRX16_DoesNotStopScan(t *testing.T) {
+	t.Parallel()
+	// NOP-like instruction (MOV X3, X3 = ORR X3, XZR, X3 encoded differently)
+	// Use a simple ADD X1, X1, #0 as a harmless filler (does not write X16).
+	// ADD X1, X1, #0 = 0x91000021
+	const nopFiller = uint32(0x91000021)
+	const orrX16XZR1 = uint32(0xB24003F0) // ORR X16, XZR, #1
+	code := buildCodeSliceX0(orrX16XZR1, nopFiller, svcImm80)
+	num, ok := BackwardScanX16(code, 8)
+	require.True(t, ok)
+	assert.Equal(t, 1, num)
+}
+
+// TestBackwardScanX0_IndirectWriteStopsScan verifies that a non-MOV write to X0
 // (e.g., ADD X0, X1, X2 — encoded as a 64-bit instruction with Rd=0) stops the scan.
 // ADD X0, X1, X2: sf=1, op=0b0001011_000, Rm=X2(2), Rn=X1(1), Rd=X0(0) → 0x8B020020
-func TestBackwardScanX0_IndirectWriteStopsScal(t *testing.T) {
+func TestBackwardScanX0_IndirectWriteStopsScan(t *testing.T) {
 	t.Parallel()
 	const addX0X1X2 = uint32(0x8B020020) // ADD X0, X1, X2
 	code := buildCodeSliceX0(

--- a/internal/arm64util/arm64util_test.go
+++ b/internal/arm64util/arm64util_test.go
@@ -1,0 +1,107 @@
+//go:build test
+
+package arm64util
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// buildCodeSliceX0 assembles a slice of arm64 instructions for X0-scan tests.
+func buildCodeSliceX0(instrs ...uint32) []byte {
+	buf := make([]byte, len(instrs)*4)
+	for i, instr := range instrs {
+		binary.LittleEndian.PutUint32(buf[i*4:], instr)
+	}
+	return buf
+}
+
+// encodeMovzX0 encodes MOVZ X0, #imm, LSL #0.
+func encodeMovzX0(imm uint32) uint32 { return movzX0Base | ((imm & 0xFFFF) << imm16Shift) }
+
+// encodeMovzX0Lsl16 encodes MOVZ X0, #imm, LSL #16.
+func encodeMovzX0Lsl16(imm uint32) uint32 { return movzX0Lsl16 | ((imm & 0xFFFF) << imm16Shift) }
+
+// encodeMovkX0 encodes MOVK X0, #imm, LSL #0.
+func encodeMovkX0(imm uint32) uint32 { return movkX0Base | ((imm & 0xFFFF) << imm16Shift) }
+
+// encodeMovzW0 encodes MOVZ W0, #imm.
+func encodeMovzW0(imm uint32) uint32 { return movzW0Base | ((imm & 0xFFFF) << imm16Shift) }
+
+// encodeBLX0 encodes a BL instruction with a small forward offset.
+const blPlaceholder = uint32(0x94000001) // BL +4
+
+// TestBackwardScanX0_ImmediateX0 verifies MOVZ X0, #97 before BL → returns 97.
+func TestBackwardScanX0_ImmediateX0(t *testing.T) {
+	t.Parallel()
+	code := buildCodeSliceX0(encodeMovzX0(97), blPlaceholder)
+	num, ok := BackwardScanX0(code, 4) // BL is at offset 4
+	require.True(t, ok)
+	assert.Equal(t, 97, num)
+}
+
+// TestBackwardScanX0_ImmediateW0 verifies MOVZ W0, #98 before BL → returns 98.
+func TestBackwardScanX0_ImmediateW0(t *testing.T) {
+	t.Parallel()
+	code := buildCodeSliceX0(encodeMovzW0(98), blPlaceholder)
+	num, ok := BackwardScanX0(code, 4)
+	require.True(t, ok)
+	assert.Equal(t, 98, num)
+}
+
+// TestBackwardScanX0_MovzLsl16PlusMovk verifies a 32-bit value:
+// MOVZ X0, #0x0002, LSL#16 + MOVK X0, #0x0061 → value = 0x00020061 = 131169.
+func TestBackwardScanX0_MovzLsl16PlusMovk(t *testing.T) {
+	t.Parallel()
+	code := buildCodeSliceX0(
+		encodeMovzX0Lsl16(0x0002),
+		encodeMovkX0(0x0061),
+		blPlaceholder,
+	)
+	num, ok := BackwardScanX0(code, 8)
+	require.True(t, ok)
+	assert.Equal(t, 0x00020061, num)
+}
+
+// TestBackwardScanX0_NoPrecedingInstruction verifies that a BL with no
+// preceding X0 load returns (0, false).
+func TestBackwardScanX0_NoPrecedingInstruction(t *testing.T) {
+	t.Parallel()
+	code := buildCodeSliceX0(blPlaceholder)
+	num, ok := BackwardScanX0(code, 0)
+	assert.False(t, ok)
+	assert.Zero(t, num)
+}
+
+// TestBackwardScanX0_ControlFlowBoundary verifies that a B/BL between the
+// MOVZ X0 and the target BL causes the scan to stop → (0, false).
+func TestBackwardScanX0_ControlFlowBoundary(t *testing.T) {
+	t.Parallel()
+	code := buildCodeSliceX0(
+		encodeMovzX0(97),
+		blPlaceholder, // acts as a control-flow boundary
+		blPlaceholder, // the BL we're scanning back from
+	)
+	num, ok := BackwardScanX0(code, 8)
+	assert.False(t, ok, "scan must stop at BL boundary")
+	assert.Zero(t, num)
+}
+
+// TestBackwardScanX0_IndirectWriteStopsScal verifies that a non-MOV write to X0
+// (e.g., ADD X0, X1, X2 — encoded as a 64-bit instruction with Rd=0) stops the scan.
+// ADD X0, X1, X2: sf=1, op=0b0001011_000, Rm=X2(2), Rn=X1(1), Rd=X0(0) → 0x8B020020
+func TestBackwardScanX0_IndirectWriteStopsScal(t *testing.T) {
+	t.Parallel()
+	const addX0X1X2 = uint32(0x8B020020) // ADD X0, X1, X2
+	code := buildCodeSliceX0(
+		encodeMovzX0(97),
+		addX0X1X2, // overwrites X0 non-immediately → scan stops
+		blPlaceholder,
+	)
+	num, ok := BackwardScanX0(code, 8)
+	assert.False(t, ok, "indirect write to X0 must stop scan")
+	assert.Zero(t, num)
+}

--- a/internal/arm64util/arm64util_test.go
+++ b/internal/arm64util/arm64util_test.go
@@ -90,6 +90,73 @@ func TestBackwardScanX0_ControlFlowBoundary(t *testing.T) {
 	assert.Zero(t, num)
 }
 
+// encodeStrSp8 encodes STR xN, [SP, #8].
+func encodeStrSp8(regN uint32) uint32 {
+	// STR Xt,[Xn,#pimm]: bits[31:22]=0x3E4, imm12=1, Rn=SP(31), Rt=N
+	return 0xF9000000 | (1 << 10) | (31 << 5) | regN
+}
+
+// encodeStpSp8 encodes STP xN, xM, [SP, #8].
+func encodeStpSp8(regN, regM uint32) uint32 {
+	// STP Xt1,Xt2,[Xn,#imm]: bits[31:22]=0x2A4, imm7=1, Rt2=M, Rn=SP(31), Rt1=N
+	return 0xA9000000 | (1 << 15) | (regM << 10) | (31 << 5) | regN
+}
+
+// encodeMovzReg encodes MOVZ xN, #imm (LSL#0, 64-bit).
+func encodeMovzReg(regN, imm uint32) uint32 { //nolint:unparam
+	return 0xD2800000 | ((imm & 0xFFFF) << 5) | regN
+}
+
+// TestBackwardScanStackTrap_STRPattern verifies STR x5,#imm + STR x5,[SP,#8] + BL → syscall number.
+func TestBackwardScanStackTrap_STRPattern(t *testing.T) {
+	t.Parallel()
+	// MOVZ X5, #73; STR X5, [SP, #8]; BL placeholder
+	code := buildCodeSliceX0(encodeMovzReg(5, 73), encodeStrSp8(5), blPlaceholder)
+	num, ok := BackwardScanStackTrap(code, 8) // BL at offset 8
+	require.True(t, ok)
+	assert.Equal(t, 73, num)
+}
+
+// TestBackwardScanStackTrap_STPPattern verifies MOVZ xN + STP xN,xM,[SP,#8] + BL → syscall number.
+func TestBackwardScanStackTrap_STPPattern(t *testing.T) {
+	t.Parallel()
+	// MOVZ X5, #73; STP X5, X4, [SP, #8]; BL placeholder
+	code := buildCodeSliceX0(encodeMovzReg(5, 73), encodeStpSp8(5, 4), blPlaceholder)
+	num, ok := BackwardScanStackTrap(code, 8)
+	require.True(t, ok)
+	assert.Equal(t, 73, num)
+}
+
+// TestBackwardScanStackTrap_RegX0 verifies that regN=0 (X0) works correctly.
+func TestBackwardScanStackTrap_RegX0(t *testing.T) {
+	t.Parallel()
+	// MOVZ X0, #197; STR X0, [SP, #8]; BL placeholder
+	code := buildCodeSliceX0(encodeMovzX0(197), encodeStrSp8(0), blPlaceholder)
+	num, ok := BackwardScanStackTrap(code, 8)
+	require.True(t, ok)
+	assert.Equal(t, 197, num)
+}
+
+// TestBackwardScanStackTrap_NoStore verifies that a BL with no preceding store
+// to [SP, #8] returns (0, false).
+func TestBackwardScanStackTrap_NoStore(t *testing.T) {
+	t.Parallel()
+	code := buildCodeSliceX0(encodeMovzReg(5, 73), blPlaceholder)
+	_, ok := BackwardScanStackTrap(code, 4)
+	assert.False(t, ok)
+}
+
+// TestBackwardScanStackTrap_IndirectRegWrite verifies that a non-immediate write
+// to the trap register stops the scan.
+func TestBackwardScanStackTrap_IndirectRegWrite(t *testing.T) {
+	t.Parallel()
+	// ADD X5, X1, X2 → non-immediate write to X5
+	const addX5X1X2 = uint32(0x8B020025)
+	code := buildCodeSliceX0(encodeMovzReg(5, 73), addX5X1X2, encodeStrSp8(5), blPlaceholder)
+	_, ok := BackwardScanStackTrap(code, 12) // BL at offset 12
+	assert.False(t, ok, "indirect write to trap register must stop the scan")
+}
+
 // TestBackwardScanX0_IndirectWriteStopsScal verifies that a non-MOV write to X0
 // (e.g., ADD X0, X1, X2 — encoded as a 64-bit instruction with Rd=0) stops the scan.
 // ADD X0, X1, X2: sf=1, op=0b0001011_000, Rm=X2(2), Rn=X1(1), Rd=X0(0) → 0x8B020020

--- a/internal/fileanalysis/schema.go
+++ b/internal/fileanalysis/schema.go
@@ -6,6 +6,7 @@ import (
 
 const (
 	// CurrentSchemaVersion is the current analysis record schema version.
+	// v16: Pass 1/Pass 2 Mach-O arm64 syscall number analysis support.
 	// Version 2 adds DynLibDeps and HasDynamicLoad fields.
 	// Version 3 adds NetworkSymbolAnalysis (now renamed SymbolAnalysis) and removes HasDynamicLoad.
 	// Version 4 renames network_symbol_analysis to symbol_analysis and removes has_network_symbols.
@@ -21,14 +22,14 @@ const (
 	// Version 13 removes UpdatedAt field (was unused by verify; caused noisy diffs).
 	// Version 14 adds AnalysisWarnings to Record for dynlib analysis warnings.
 	// Mach-O binaries also record DynLibDeps starting with version 14.
-	// Version 15 adds Mach-O arm64 svc #0x80 scanning: records written at v15 or later
-	// guarantee that the svc scan was performed, so LoadSyscallAnalysis returning (nil, nil)
-	// means the scan ran and found nothing (safe to fall through to SymbolAnalysis-based decision).
-	// Load returns SchemaVersionMismatchError for records with schema_version != 15.
+	// Version 15 adds Mach-O arm64 svc #0x80 scanning.
+	// Version 16 adds Mach-O arm64 Pass 1 (direct svc) and Pass 2 (go_wrapper) syscall
+	// number analysis. Records at v16 carry precise syscall numbers with IsNetwork flags.
+	// Load returns SchemaVersionMismatchError for records with schema_version != 16.
 	// Store.Update treats older schemas (Actual < Expected) as overwritable;
 	// re-running `record` migrates old-schema records automatically (--force not required).
 	// Store.Update rejects newer schemas (Actual > Expected) to preserve forward compatibility.
-	CurrentSchemaVersion = 15
+	CurrentSchemaVersion = 16
 )
 
 // Record represents a unified file analysis record containing both

--- a/internal/filevalidator/sha256_path_hash_getter_test.go
+++ b/internal/filevalidator/sha256_path_hash_getter_test.go
@@ -123,7 +123,7 @@ func TestSHA256PathHashGetter_GetHashFilePath_DifferentHashDirs(t *testing.T) {
 		results[i] = result
 
 		// Verify the result uses the correct hash directory
-assert.Equal(t, hashDir.String(), filepath.Dir(result))
+		assert.Equal(t, hashDir.String(), filepath.Dir(result))
 	}
 
 	// All results should have different prefixes but same filename

--- a/internal/filevalidator/validator.go
+++ b/internal/filevalidator/validator.go
@@ -150,6 +150,7 @@ type Validator struct {
 	libcCache           LibcCacheInterface              // nil if libc cache is disabled
 	libSystemCache      LibSystemCacheInterface         // nil if Mach-O libSystem cache is disabled
 	syscallAnalyzer     SyscallAnalyzerInterface        // nil if syscall analysis is disabled
+	machoSyscallTable   SyscallNumberTable              // nil falls back to noop table in ScanSyscallInfos
 }
 
 // New initializes and returns a new Validator with the specified hash algorithm and hash directory.
@@ -439,6 +440,13 @@ func (v *Validator) checkNotShebang(path, role string) error {
 // SetLibSystemCache injects the LibSystemCacheInterface used during record operations.
 func (v *Validator) SetLibSystemCache(m LibSystemCacheInterface) {
 	v.libSystemCache = m
+}
+
+// SetMachoSyscallTable injects the SyscallNumberTable used for macOS BSD syscall
+// number resolution during Pass 1 and Pass 2 analysis. When nil, syscall names
+// and network flags are left empty but numbers are still resolved where possible.
+func (v *Validator) SetMachoSyscallTable(t SyscallNumberTable) {
+	v.machoSyscallTable = t
 }
 
 // SetELFDynLibAnalyzer injects the DynLibAnalyzer used during record operations.
@@ -818,33 +826,42 @@ func mergeMachoSyscallInfos(svcEntries, libsysEntries []common.SyscallInfo) []co
 	return merged
 }
 
-// analyzeMachoSyscalls runs the Mach-O svc #0x80 scan and libSystem import-symbol
-// matching, then stores the merged result in record.SyscallAnalysis.
-// It is a no-op (leaves SyscallAnalysis unchanged) when neither scan yields entries.
-// ScanSVCAddrs checks magic bytes and returns nil for non-Mach-O files, so this is
-// safe to call on all platforms and binary formats.
+// analyzeMachoSyscalls runs the Mach-O Pass 1 / Pass 2 syscall scan and
+// libSystem import-symbol matching, then stores the merged result in
+// record.SyscallAnalysis.
+//
+// Pass 1 (direct svc #0x80): resolves syscall numbers via X16 backward scan.
+// Pass 2 (Go wrapper calls): resolves syscall numbers via X0 backward scan at
+// BL call sites targeting known Go syscall stubs.
+//
+// It is a no-op (leaves SyscallAnalysis unchanged) when no entries are found.
+// ScanSyscallInfos checks magic bytes and returns nil for non-Mach-O files, so
+// this is safe to call on all platforms and binary formats.
 func (v *Validator) analyzeMachoSyscalls(record *fileanalysis.Record, filePath string) error {
-	addrs, err := machoanalyzer.ScanSVCAddrs(filePath, v.fileSystem)
+	svcEntries, wrapperEntries, err := machoanalyzer.ScanSyscallInfos(filePath, v.fileSystem, v.machoSyscallTable)
 	if err != nil {
-		return fmt.Errorf("mach-o svc scan failed: %w", err)
+		return fmt.Errorf("mach-o syscall scan failed: %w", err)
 	}
-	svcEntries := buildSVCInfos(addrs)
 
 	libsysEntries, libsysArch, err := v.analyzeLibSystem(record, filePath)
 	if err != nil {
 		return fmt.Errorf("libSystem import analysis failed: %w", err)
 	}
 
-	if len(svcEntries)+len(libsysEntries) > 0 {
+	// Combine Go wrapper call results with libSystem entries: both are
+	// non-direct-svc detections and do not trigger the high-risk svc warning.
+	wrapperEntries = append(wrapperEntries, libsysEntries...)
+	combinedLibEntries := wrapperEntries
+
+	if len(svcEntries)+len(combinedLibEntries) > 0 {
 		// Use the architecture from the Mach-O slice used for libSystem analysis.
 		// Fall back to archNameArm64 when no libSystem info was available: svc scan
-		// (collectSVCAddresses) only processes arm64 slices, so svc entries always
-		// originate from an arm64 binary.
+		// only processes arm64 slices, so entries always originate from arm64.
 		arch := libsysArch
 		if arch == "" {
 			arch = archNameArm64
 		}
-		record.SyscallAnalysis = buildMachoSyscallData(svcEntries, libsysEntries, arch)
+		record.SyscallAnalysis = buildMachoSyscallData(svcEntries, combinedLibEntries, arch)
 	}
 	return nil
 }

--- a/internal/filevalidator/validator.go
+++ b/internal/filevalidator/validator.go
@@ -779,7 +779,10 @@ func buildSVCInfos(addrs []uint64) []common.SyscallInfo {
 
 // buildMachoSyscallData merges svc and libSystem entries and constructs
 // SyscallAnalysisData.
-// AnalysisWarnings is populated only when svc entries exist.
+// AnalysisWarnings is populated only when unresolved svc #0x80 entries remain
+// after filtering (i.e., entries with DeterminationMethod="direct_svc_0x80").
+// When all svc entries are resolved to non-network syscalls they are dropped by
+// FilterSyscallsForStorage and no warning is emitted.
 // DetectedSyscalls is sorted by Number (svc entries with Number=-1 appear first).
 func buildMachoSyscallData(
 	svcEntries []common.SyscallInfo,
@@ -790,8 +793,11 @@ func buildMachoSyscallData(
 	retained := fileanalysis.FilterSyscallsForStorage(merged)
 
 	var warnings []string
-	if len(svcEntries) > 0 {
-		warnings = []string{"svc #0x80 detected: direct syscall bypassing libSystem.dylib"}
+	for _, s := range retained {
+		if s.DeterminationMethod == common.DeterminationMethodDirectSVC0x80 {
+			warnings = []string{"svc #0x80 detected: syscall number unresolved, direct kernel call bypassing libSystem.dylib"}
+			break
+		}
 	}
 
 	return &fileanalysis.SyscallAnalysisData{

--- a/internal/filevalidator/validator_macho_test.go
+++ b/internal/filevalidator/validator_macho_test.go
@@ -720,8 +720,9 @@ func TestMergeMachoSyscallInfos_MixedNumbersSortedFirst(t *testing.T) {
 }
 
 // TestBuildMachoSyscallAnalysisData_WarningOnlyWhenSVC verifies that
-// AnalysisWarnings is populated only when svc entries are present, and that
-// non-network libSystem entries are filtered out of DetectedSyscalls.
+// AnalysisWarnings is populated only when there are unresolved svc entries
+// (Number=-1, DeterminationMethod="direct_svc_0x80"), and that resolved
+// non-network svc entries produce no warning.
 func TestBuildMachoSyscallAnalysisData_WarningOnlyWhenSVC(t *testing.T) {
 	// IsNetwork is false (default): non-network libSystem entry must be filtered out.
 	libsysEntries := []common.SyscallInfo{
@@ -733,12 +734,29 @@ func TestBuildMachoSyscallAnalysisData_WarningOnlyWhenSVC(t *testing.T) {
 	assert.Empty(t, result.AnalysisWarnings, "no warning when no svc entries")
 	assert.Empty(t, result.DetectedSyscalls, "non-network libsys entry must be filtered")
 
-	// With svc entries: warning present; svc entry (Number=-1) retained, non-network libsys filtered.
-	svcEntries := []common.SyscallInfo{
-		{Number: -1, Source: "direct_svc_0x80"},
+	// Unresolved svc entry (Number=-1, DeterminationMethod=direct_svc_0x80): warning present.
+	unresolvedSVCEntries := []common.SyscallInfo{
+		{
+			Number:              -1,
+			Source:              common.DeterminationMethodDirectSVC0x80,
+			DeterminationMethod: common.DeterminationMethodDirectSVC0x80,
+		},
 	}
-	result = buildMachoSyscallData(svcEntries, libsysEntries, "arm64")
-	assert.Len(t, result.AnalysisWarnings, 1)
+	result = buildMachoSyscallData(unresolvedSVCEntries, libsysEntries, "arm64")
+	assert.Len(t, result.AnalysisWarnings, 1, "warning expected for unresolved svc entry")
 	require.Len(t, result.DetectedSyscalls, 1, "only svc entry (Number=-1) should remain")
 	assert.Equal(t, -1, result.DetectedSyscalls[0].Number)
+
+	// Resolved non-network svc entries (e.g., munmap=73): no warning, entries filtered out.
+	resolvedNonNetworkSVCEntries := []common.SyscallInfo{
+		{
+			Number:              73, // munmap — non-network
+			IsNetwork:           false,
+			Source:              common.DeterminationMethodDirectSVC0x80,
+			DeterminationMethod: common.DeterminationMethodDirectSVC0x80,
+		},
+	}
+	result = buildMachoSyscallData(resolvedNonNetworkSVCEntries, libsysEntries, "arm64")
+	assert.Empty(t, result.AnalysisWarnings, "no warning when all svc entries resolved to non-network")
+	assert.Empty(t, result.DetectedSyscalls, "resolved non-network svc entries must be filtered")
 }

--- a/internal/libccache/macho_analyzer.go
+++ b/internal/libccache/macho_analyzer.go
@@ -6,13 +6,9 @@ import (
 	"fmt"
 	"log/slog"
 	"sort"
+
+	"github.com/isseis/go-safe-cmd-runner/internal/arm64util"
 )
-
-// maxBackwardScanInstructions is the maximum number of instructions scanned backward from svc.
-const maxBackwardScanInstructions = 16
-
-// bsdSyscallClassPrefix is the macOS arm64 BSD syscall class prefix (0x2000000).
-const bsdSyscallClassPrefix = 0x2000000
 
 // svcMacOSEncoding is the little-endian uint32 encoding of the "svc #0x80" instruction.
 // ARM64 encoding: 0xD4001001.
@@ -21,32 +17,6 @@ const svcMacOSEncoding = uint32(0xD4001001)
 // machoSymTypeDebugMin is the minimum n_type value for debug/stab entries (N_STAB range).
 // Symbols with type >= this value are compiler-generated debug entries and should be excluded.
 const machoSymTypeDebugMin = uint8(0x20)
-
-// arm64Imm16HighShift is the bit shift used to place a 16-bit immediate into the upper
-// word when constructing a 32-bit value from MOVZ/MOVK LSL #16 instructions.
-const arm64Imm16HighShift = 16
-
-// ARM64 instruction pattern constants for control-flow detection.
-const (
-	// arm64PatternBLRBR matches bits [31:22] for BLR / BR instructions.
-	arm64PatternBLRBR = uint32(0b1101011000) // 0x36C
-	// arm64PatternRET matches bits [31:22] for RET instructions (bit 22 differs from BLR/BR).
-	arm64PatternRET = uint32(0b1101011001) // 0x36D
-	// arm64PatternCBZ matches bits [30:25] for CBZ / CBNZ instructions.
-	arm64PatternCBZ = uint32(0b011010) // 0x1A
-	// arm64PatternTBZ matches bits [30:25] for TBZ / TBNZ instructions.
-	arm64PatternTBZ = uint32(0b011011) // 0x1B
-	// arm64Field6Mask is a 6-bit mask used to extract a 6-bit field from an instruction.
-	arm64Field6Mask = uint32(0x3F)
-	// arm64PatternMovzMovkBits28_23 is the [28:23] pattern shared by MOVZ and MOVK.
-	arm64PatternMovzMovkBits28_23 = uint32(0b100101) // 0x25
-	// arm64BitShiftBLRBR is the right-shift to extract bits [31:22] for BLR/BR/RET.
-	arm64BitShiftBLRBR = 22
-	// arm64BitShiftCBZTBZ is the right-shift to extract bits [30:25] for CBZ/CBNZ/TBZ/TBNZ.
-	arm64BitShiftCBZTBZ = 25
-	// arm64BitShiftMovzMovk is the right-shift to extract bits [28:23] for MOVZ/MOVK.
-	arm64BitShiftMovzMovk = 23
-)
 
 // MachoLibSystemAnalyzer analyzes a libsystem_kernel.dylib Mach-O file and returns
 // a list of syscall wrapper functions.
@@ -200,160 +170,12 @@ func analyzeWrapperFunction(funcCode []byte) (int, bool) {
 	return first, true
 }
 
-// BackwardScanX16 walks backward from the svc #0x80 instruction at funcCode[svcOffset]
-// and looks for an immediate-load sequence into x16. When found, it returns the
-// syscall number with the BSD class prefix removed. The scan is limited to
-// maxBackwardScanInstructions instructions.
-//
-// Supported instruction patterns:
-//   - MOVZ X16, #imm                           (single-instruction: imm < 0x10000)
-//   - MOVZ X16, #hi, LSL #16                   (upper 16 bits only)
-//   - MOVZ X16, #hi, LSL #16 + MOVK X16, #lo  (32-bit value sequence)
-//
-// arm64asm is intentionally not used here. Only a small subset of fixed encodings
-// is needed, and direct decoding keeps the dependency surface small.
+// BackwardScanX16 delegates to arm64util.BackwardScanX16.
 func BackwardScanX16(funcCode []byte, svcOffset int) (int, bool) {
-	const instrLen = 4
-
-	// MOVZ X16, #imm, LSL #shift encoding (ARM64):
-	//   [31]:   sf=1 (64-bit)
-	//   [30:29]: opc=10 (MOVZ)
-	//   [28:23]: 100101
-	//   [22:21]: hw (shift: 00=0, 01=16, 10=32, 11=48)
-	//   [20:5]:  imm16
-	//   [4:0]:   Rd=16 (x16)
-	//
-	// MOVK X16, #imm, LSL #shift encoding (ARM64):
-	//   [31]:   sf=1
-	//   [30:29]: opc=11 (MOVK)
-	//   [28:23]: 100101
-	//   [22:21]: hw
-	//   [20:5]:  imm16
-	//   [4:0]:   Rd=16 (x16)
-
-	const (
-		movzX16Base  = uint32(0xD2800010) // MOVZ X16, #0, LSL #0
-		movzX16Lsl16 = uint32(0xD2A00010) // MOVZ X16, #0, LSL #16
-		movkX16Base  = uint32(0xF2800010) // MOVK X16, #0, LSL #0
-		movkX16Lsl16 = uint32(0xF2A00010) // MOVK X16, #0, LSL #16
-		imm16Mask    = uint32(0x001FFFE0) // bits[20:5]
-		imm16Shift   = 5
-	)
-
-	// Scan backward from the instruction immediately before svc.
-	startIdx := svcOffset/instrLen - 1
-	endIdx := startIdx - maxBackwardScanInstructions
-	if endIdx < 0 {
-		endIdx = -1
-	}
-
-	// Keep partial values so a MOVZ+MOVK sequence can be reconstructed.
-	// -1 means "not observed yet".
-	x16Lo := -1 // Lower 16 bits recorded from MOVK X16, #imm, LSL #0.
-	x16Hi := -1 // Upper 16 bits recorded from MOVK X16, #imm, LSL #16.
-
-	for i := startIdx; i > endIdx; i-- {
-		off := i * instrLen
-		if off < 0 {
-			break
-		}
-		word := binary.LittleEndian.Uint32(funcCode[off:])
-
-		// MOVZ X16, #imm (LSL #0) terminates the sequence and sets the low bits.
-		// Combine it with a previously observed MOVK #hi if present.
-		if word&^imm16Mask == movzX16Base {
-			lo := int((word & imm16Mask) >> imm16Shift)
-			hi := 0
-			if x16Hi >= 0 {
-				hi = x16Hi
-			}
-			return stripBSDPrefix(hi | lo), true
-		}
-
-		// MOVZ X16, #imm, LSL #16 terminates the sequence and sets the high bits.
-		// Combine it with a previously observed MOVK #lo if present.
-		if word&^imm16Mask == movzX16Lsl16 {
-			hi := int((word&imm16Mask)>>imm16Shift) << arm64Imm16HighShift
-			lo := 0
-			if x16Lo >= 0 {
-				lo = x16Lo
-			}
-			return stripBSDPrefix(hi | lo), true
-		}
-
-		// MOVK X16, #imm (LSL #0): record the low 16 bits and continue scanning.
-		if word&^imm16Mask == movkX16Base {
-			x16Lo = int((word & imm16Mask) >> imm16Shift)
-			continue
-		}
-
-		// MOVK X16, #imm, LSL #16: record the high 16 bits and continue scanning.
-		if word&^imm16Mask == movkX16Lsl16 {
-			x16Hi = int((word&imm16Mask)>>imm16Shift) << arm64Imm16HighShift
-			continue
-		}
-
-		// Stop when a control-flow instruction is reached.
-		if IsControlFlowInstruction(word) {
-			break
-		}
-
-		// Stop when some other instruction writes to x16.
-		if writesX16NotMovzMovk(word) {
-			break
-		}
-	}
-	return 0, false
+	return arm64util.BackwardScanX16(funcCode, svcOffset)
 }
 
-// stripBSDPrefix removes the macOS BSD syscall class prefix (0x2000000) that ARM64
-// wrappers encode in the high bits of x16 before the svc instruction.
-func stripBSDPrefix(value int) int {
-	if value >= bsdSyscallClassPrefix {
-		return value - bsdSyscallClassPrefix
-	}
-	return value
-}
-
-// IsControlFlowInstruction reports whether an ARM64 instruction is a control-flow instruction.
-// It recognizes B / BL / BLR / BR / RET / CBZ / CBNZ / TBZ / TBNZ.
+// IsControlFlowInstruction delegates to arm64util.IsControlFlowInstruction.
 func IsControlFlowInstruction(word uint32) bool {
-	// B:  [31:26] = 000101
-	// BL: [31:26] = 100101
-	if word>>26 == 0b000101 || word>>26 == 0b100101 {
-		return true
-	}
-	// BLR / BR / RET: [31:22] = arm64PatternBLRBR or arm64PatternRET
-	if word>>arm64BitShiftBLRBR == arm64PatternBLRBR || word>>arm64BitShiftBLRBR == arm64PatternRET {
-		return true
-	}
-	// CBZ / CBNZ: [30:25] = arm64PatternCBZ
-	if (word>>arm64BitShiftCBZTBZ)&arm64Field6Mask == arm64PatternCBZ {
-		return true
-	}
-	// TBZ / TBNZ: [30:25] = arm64PatternTBZ
-	if (word>>arm64BitShiftCBZTBZ)&arm64Field6Mask == arm64PatternTBZ {
-		return true
-	}
-	return false
-}
-
-// writesX16NotMovzMovk detects 64-bit instructions that write to x16,
-// excluding MOVZ and MOVK.
-// It is used after MOVZ/MOVK handling inside backwardScanX16.
-//
-// MOVZ/MOVK share a fixed [28:23] = 100101 pattern.
-// When that pattern is present, this helper returns false because the caller
-// already handled those instructions.
-func writesX16NotMovzMovk(word uint32) bool {
-	// MOVZ/MOVK: [28:23] = 100101, with Rd encoded in [4:0].
-	// Reaching this point means either MOVZ/MOVK targeting another register
-	// or a different encoding, so perform a generic x16-write check.
-	bits28_23 := (word >> arm64BitShiftMovzMovk) & arm64Field6Mask
-	if bits28_23 == arm64PatternMovzMovkBits28_23 {
-		// MOVZ or MOVK encoding for some Rd: already handled by the caller.
-		return false
-	}
-	// 64-bit instruction (sf=1) with Rd=16 ([4:0] = 0b10000).
-	return word>>31 == 1 && word&0x1F == 0x10
+	return arm64util.IsControlFlowInstruction(word)
 }

--- a/internal/libccache/macho_analyzer.go
+++ b/internal/libccache/macho_analyzer.go
@@ -149,7 +149,7 @@ func analyzeWrapperFunction(funcCode []byte) (int, bool) {
 			continue
 		}
 		// Found svc #0x80. Scan backward to find the immediate loaded into x16.
-		num, ok := BackwardScanX16(funcCode, i)
+		num, ok := arm64util.BackwardScanX16(funcCode, i)
 		if !ok {
 			return 0, false
 		}
@@ -168,14 +168,4 @@ func analyzeWrapperFunction(funcCode []byte) (int, bool) {
 		}
 	}
 	return first, true
-}
-
-// BackwardScanX16 delegates to arm64util.BackwardScanX16.
-func BackwardScanX16(funcCode []byte, svcOffset int) (int, bool) {
-	return arm64util.BackwardScanX16(funcCode, svcOffset)
-}
-
-// IsControlFlowInstruction delegates to arm64util.IsControlFlowInstruction.
-func IsControlFlowInstruction(word uint32) bool {
-	return arm64util.IsControlFlowInstruction(word)
 }

--- a/internal/libccache/macho_analyzer.go
+++ b/internal/libccache/macho_analyzer.go
@@ -179,7 +179,7 @@ func analyzeWrapperFunction(funcCode []byte) (int, bool) {
 			continue
 		}
 		// Found svc #0x80. Scan backward to find the immediate loaded into x16.
-		num, ok := backwardScanX16(funcCode, i)
+		num, ok := BackwardScanX16(funcCode, i)
 		if !ok {
 			return 0, false
 		}
@@ -200,7 +200,7 @@ func analyzeWrapperFunction(funcCode []byte) (int, bool) {
 	return first, true
 }
 
-// backwardScanX16 walks backward from the svc #0x80 instruction at funcCode[svcOffset]
+// BackwardScanX16 walks backward from the svc #0x80 instruction at funcCode[svcOffset]
 // and looks for an immediate-load sequence into x16. When found, it returns the
 // syscall number with the BSD class prefix removed. The scan is limited to
 // maxBackwardScanInstructions instructions.
@@ -212,7 +212,7 @@ func analyzeWrapperFunction(funcCode []byte) (int, bool) {
 //
 // arm64asm is intentionally not used here. Only a small subset of fixed encodings
 // is needed, and direct decoding keeps the dependency surface small.
-func backwardScanX16(funcCode []byte, svcOffset int) (int, bool) {
+func BackwardScanX16(funcCode []byte, svcOffset int) (int, bool) {
 	const instrLen = 4
 
 	// MOVZ X16, #imm, LSL #shift encoding (ARM64):
@@ -294,7 +294,7 @@ func backwardScanX16(funcCode []byte, svcOffset int) (int, bool) {
 		}
 
 		// Stop when a control-flow instruction is reached.
-		if isControlFlowInstruction(word) {
+		if IsControlFlowInstruction(word) {
 			break
 		}
 
@@ -315,9 +315,9 @@ func stripBSDPrefix(value int) int {
 	return value
 }
 
-// isControlFlowInstruction reports whether an ARM64 instruction is a control-flow instruction.
+// IsControlFlowInstruction reports whether an ARM64 instruction is a control-flow instruction.
 // It recognizes B / BL / BLR / BR / RET / CBZ / CBNZ / TBZ / TBNZ.
-func isControlFlowInstruction(word uint32) bool {
+func IsControlFlowInstruction(word uint32) bool {
 	// B:  [31:26] = 000101
 	// BL: [31:26] = 100101
 	if word>>26 == 0b000101 || word>>26 == 0b100101 {

--- a/internal/runner/security/machoanalyzer/analyzer_test.go
+++ b/internal/runner/security/machoanalyzer/analyzer_test.go
@@ -82,19 +82,18 @@ func TestStandardMachOAnalyzer_NoNetworkSymbols(t *testing.T) {
 	assert.Equal(t, binaryanalyzer.NoNetworkSymbols, output.Result)
 }
 
-// TestStandardMachOAnalyzer_SVCOnly_HighRisk tests that a binary containing only svc #0x80
-// returns AnalysisError wrapping ErrDirectSyscall. (AC-6)
-func TestStandardMachOAnalyzer_SVCOnly_HighRisk(t *testing.T) {
+// TestStandardMachOAnalyzer_SVCOnly_NoNetworkSymbols tests that a binary containing only
+// svc #0x80 (no network symbols) returns NoNetworkSymbols from AnalyzeNetworkSymbols.
+// svc #0x80 risk is evaluated separately via SyscallAnalysis (ScanSyscallInfos).
+func TestStandardMachOAnalyzer_SVCOnly_NoNetworkSymbols(t *testing.T) {
 	path := testdataPath("svc_only_arm64")
 	skipIfNotExist(t, path)
 
 	analyzer := NewStandardMachOAnalyzer(nil)
 	output := analyzer.AnalyzeNetworkSymbols(path, "sha256:dummy")
 
-	assert.Equal(t, binaryanalyzer.AnalysisError, output.Result)
-	require.Error(t, output.Error)
-	assert.True(t, errors.Is(output.Error, ErrDirectSyscall),
-		"expected ErrDirectSyscall, got: %v", output.Error)
+	assert.Equal(t, binaryanalyzer.NoNetworkSymbols, output.Result)
+	assert.NoError(t, output.Error)
 }
 
 // TestStandardMachOAnalyzer_NetworkSymbols_SVCIgnored tests that network symbols take priority

--- a/internal/runner/security/machoanalyzer/pass1_scanner.go
+++ b/internal/runner/security/machoanalyzer/pass1_scanner.go
@@ -26,13 +26,13 @@ const (
 	determinationMethodUnknownIndirect = "unknown:indirect_setting" // elfanalyzer.DeterminationMethodUnknownIndirectSetting
 )
 
-// syscallNumberTable provides syscall name and network-risk classification by
+// SyscallNumberTable provides syscall name and network-risk classification by
 // BSD syscall number.
 // Structurally identical to libccache.SyscallNumberTable and
 // filevalidator.SyscallNumberTable; defined here to avoid an import cycle:
 //
 //	machoanalyzer → libccache → filevalidator → machoanalyzer
-type syscallNumberTable interface {
+type SyscallNumberTable interface {
 	GetSyscallName(number int) string
 	IsNetworkSyscall(number int) bool
 }
@@ -72,7 +72,7 @@ func scanSVCWithX16(
 	code []byte,
 	textBase uint64, //nolint:unparam // textBase will vary in production use
 	stubRanges []funcRange,
-	table syscallNumberTable,
+	table SyscallNumberTable,
 ) []common.SyscallInfo {
 	var results []common.SyscallInfo
 

--- a/internal/runner/security/machoanalyzer/pass1_scanner.go
+++ b/internal/runner/security/machoanalyzer/pass1_scanner.go
@@ -1,9 +1,9 @@
 package machoanalyzer
 
 import (
-	"encoding/binary"
 	"sort"
 
+	"github.com/isseis/go-safe-cmd-runner/internal/arm64util"
 	"github.com/isseis/go-safe-cmd-runner/internal/common"
 )
 
@@ -82,12 +82,12 @@ func scanSVCWithX16(
 			continue
 		}
 
-		if addr < textBase {
-			continue
+		if addr < textBase || addr >= textBase+uint64(len(code)) {
+			panic("svc address out of bounds")
 		}
-		svcOffset := int(addr - textBase) //nolint:gosec // G115: addr >= textBase verified above
+		svcOffset := int(addr - textBase)
 
-		num, ok := arm64BackwardScanX16(code, svcOffset)
+		num, ok := arm64util.BackwardScanX16(code, svcOffset)
 
 		var info common.SyscallInfo
 		if ok {
@@ -113,145 +113,4 @@ func scanSVCWithX16(
 	}
 
 	return results
-}
-
-// arm64BackwardScanX16 mirrors libccache.BackwardScanX16.
-// Duplicated here to avoid an import cycle:
-//
-//	machoanalyzer → libccache → filevalidator → machoanalyzer
-//
-// When libccache.BackwardScanX16 is updated, this function must be updated too.
-//
-// arm64BackwardScanX16 walks backward from the svc #0x80 instruction at
-// code[svcOffset] and looks for an immediate-load sequence into x16.
-// When found, it returns the syscall number with the BSD class prefix removed.
-// The scan is limited to maxX16BackwardScan instructions.
-func arm64BackwardScanX16(code []byte, svcOffset int) (int, bool) {
-	const (
-		instrLen  = 4
-		maxScan   = 16
-		bsdPrefix = 0x2000000
-
-		movzX16Base  = uint32(0xD2800010) // MOVZ X16, #0, LSL #0
-		movzX16Lsl16 = uint32(0xD2A00010) // MOVZ X16, #0, LSL #16
-		movkX16Base  = uint32(0xF2800010) // MOVK X16, #0, LSL #0
-		movkX16Lsl16 = uint32(0xF2A00010) // MOVK X16, #0, LSL #16
-		imm16Mask    = uint32(0x001FFFE0) // bits[20:5]
-		imm16Shift   = 5
-		imm16HiShift = 16 // for LSL#16 variants
-
-	)
-
-	startIdx := svcOffset/instrLen - 1
-	endIdx := startIdx - maxScan
-	if endIdx < 0 {
-		endIdx = -1
-	}
-
-	x16Lo := -1
-	x16Hi := -1
-
-	for i := startIdx; i > endIdx; i-- {
-		off := i * instrLen
-		if off < 0 {
-			break
-		}
-		word := binary.LittleEndian.Uint32(code[off:])
-
-		if word&^imm16Mask == movzX16Base {
-			lo := int((word & imm16Mask) >> imm16Shift)
-			hi := 0
-			if x16Hi >= 0 {
-				hi = x16Hi
-			}
-			v := hi | lo
-			if v >= bsdPrefix {
-				v -= bsdPrefix
-			}
-			return v, true
-		}
-
-		if word&^imm16Mask == movzX16Lsl16 {
-			hi := int((word&imm16Mask)>>imm16Shift) << imm16HiShift
-			lo := 0
-			if x16Lo >= 0 {
-				lo = x16Lo
-			}
-			v := hi | lo
-			if v >= bsdPrefix {
-				v -= bsdPrefix
-			}
-			return v, true
-		}
-
-		if word&^imm16Mask == movkX16Base {
-			x16Lo = int((word & imm16Mask) >> imm16Shift)
-			continue
-		}
-
-		if word&^imm16Mask == movkX16Lsl16 {
-			x16Hi = int((word&imm16Mask)>>imm16Shift) << imm16HiShift
-			continue
-		}
-
-		if arm64IsControlFlowInstr(word) {
-			break
-		}
-
-		// Stop when another instruction writes to x16.
-		if arm64WritesX16NotMovzMovk(word) {
-			break
-		}
-	}
-	return 0, false
-}
-
-// arm64IsControlFlowInstr mirrors libccache.IsControlFlowInstruction.
-// See the note on arm64BackwardScanX16 about the duplication rationale.
-func arm64IsControlFlowInstr(word uint32) bool {
-	const (
-		blBranchShift   = 26
-		blBranchB       = uint32(0b000101)
-		blBranchBL      = uint32(0b100101)
-		brRegShift      = 22
-		brRegPatternBLR = uint32(0b1101011000)
-		brRegPatternBR  = uint32(0b1101011001)
-		cbBranchShift   = 25
-		cbBranchMask    = uint32(0x3F)
-		cbzCbnzPattern  = uint32(0b011010)
-		tbzTbnzPattern  = uint32(0b011011)
-	)
-	// B, BL: [31:26] = 000101 or 100101
-	if word>>blBranchShift == blBranchB || word>>blBranchShift == blBranchBL {
-		return true
-	}
-	// BLR, BR, RET: [31:22] = 1101011000 or 1101011001
-	hi10 := word >> brRegShift
-	if hi10 == brRegPatternBLR || hi10 == brRegPatternBR {
-		return true
-	}
-	// CBZ, CBNZ: [30:25] = 011010
-	hi6 := (word >> cbBranchShift) & cbBranchMask
-	if hi6 == cbzCbnzPattern {
-		return true
-	}
-	// TBZ, TBNZ: [30:25] = 011011
-	if hi6 == tbzTbnzPattern {
-		return true
-	}
-	return false
-}
-
-// arm64WritesX16NotMovzMovk detects 64-bit instructions that write to x16,
-// excluding MOVZ and MOVK. Mirrors libccache.writesX16NotMovzMovk.
-func arm64WritesX16NotMovzMovk(word uint32) bool {
-	const (
-		patMovzMovk   = uint32(0b100101)
-		shiftMovzMovk = 23
-		mask6         = uint32(0x3F)
-	)
-	if (word>>shiftMovzMovk)&mask6 == patMovzMovk {
-		return false
-	}
-	return word>>31 == 1 && word&0x1F == 0x10
 }

--- a/internal/runner/security/machoanalyzer/pass1_scanner.go
+++ b/internal/runner/security/machoanalyzer/pass1_scanner.go
@@ -85,7 +85,7 @@ func scanSVCWithX16(
 		if addr < textBase || addr >= textBase+uint64(len(code)) {
 			panic("svc address out of bounds")
 		}
-		svcOffset := int(addr - textBase)
+		svcOffset := int(addr - textBase) //nolint:gosec // G115: addr-textBase < len(code) which fits in int
 
 		num, ok := arm64util.BackwardScanX16(code, svcOffset)
 

--- a/internal/runner/security/machoanalyzer/pass1_scanner.go
+++ b/internal/runner/security/machoanalyzer/pass1_scanner.go
@@ -83,14 +83,7 @@ func scanSVCWithX16(
 		}
 
 		if addr < textBase || addr >= textBase+uint64(len(code)) {
-			results = append(results, common.SyscallInfo{
-				Number:              -1,
-				Name:                "",
-				IsNetwork:           false,
-				Location:            addr,
-				DeterminationMethod: determinationMethodUnknownIndirect,
-				Source:              "",
-			})
+			results = append(results, unknownSyscallInfo(addr))
 			continue
 		}
 		svcOffset := int(addr - textBase) //nolint:gosec // G115: addr-textBase < len(code) which fits in int
@@ -105,20 +98,20 @@ func scanSVCWithX16(
 				IsNetwork:           table.IsNetworkSyscall(num),
 				Location:            addr,
 				DeterminationMethod: determinationMethodImmediate,
-				Source:              "", // Mach-O direct svc entries have empty Source (same as ELF)
 			}
 		} else {
-			info = common.SyscallInfo{
-				Number:              -1,
-				Name:                "",
-				IsNetwork:           false,
-				Location:            addr,
-				DeterminationMethod: determinationMethodUnknownIndirect,
-				Source:              "",
-			}
+			info = unknownSyscallInfo(addr)
 		}
 		results = append(results, info)
 	}
 
 	return results
+}
+
+func unknownSyscallInfo(addr uint64) common.SyscallInfo {
+	return common.SyscallInfo{
+		Number:              -1,
+		Location:            addr,
+		DeterminationMethod: determinationMethodUnknownIndirect,
+	}
 }

--- a/internal/runner/security/machoanalyzer/pass1_scanner.go
+++ b/internal/runner/security/machoanalyzer/pass1_scanner.go
@@ -1,0 +1,257 @@
+package machoanalyzer
+
+import (
+	"encoding/binary"
+	"sort"
+
+	"github.com/isseis/go-safe-cmd-runner/internal/common"
+)
+
+// knownMachoSyscallImpls is the set of known Go syscall stub function names
+// whose bodies contain direct svc #0x80 with caller-supplied syscall numbers.
+// These stubs are excluded from Pass 1 and their call sites are analyzed by Pass 2.
+var knownMachoSyscallImpls = map[string]struct{}{
+	"syscall.Syscall":                   {},
+	"syscall.Syscall6":                  {},
+	"syscall.RawSyscall":                {},
+	"syscall.RawSyscall6":               {},
+	"internal/runtime/syscall.Syscall6": {},
+}
+
+// DeterminationMethod constants for Mach-O syscall analysis.
+// Values match the corresponding elfanalyzer constants for cross-architecture consistency.
+const (
+	determinationMethodImmediate       = "immediate"                // elfanalyzer.DeterminationMethodImmediate
+	determinationMethodGoWrapper       = "go_wrapper"               // elfanalyzer.DeterminationMethodGoWrapper
+	determinationMethodUnknownIndirect = "unknown:indirect_setting" // elfanalyzer.DeterminationMethodUnknownIndirectSetting
+)
+
+// syscallNumberTable provides syscall name and network-risk classification by
+// BSD syscall number.
+// Structurally identical to libccache.SyscallNumberTable and
+// filevalidator.SyscallNumberTable; defined here to avoid an import cycle:
+//
+//	machoanalyzer → libccache → filevalidator → machoanalyzer
+type syscallNumberTable interface {
+	GetSyscallName(number int) string
+	IsNetworkSyscall(number int) bool
+}
+
+// buildStubRanges builds a sorted slice of address ranges for known Go syscall
+// stub functions from the pclntab function map. The ranges are used in Pass 1
+// to exclude svc #0x80 instructions inside those stubs.
+func buildStubRanges(funcs map[string]MachoPclntabFunc) []funcRange {
+	var ranges []funcRange
+	for name, fn := range funcs {
+		if _, ok := knownMachoSyscallImpls[name]; ok {
+			if fn.End > fn.Entry {
+				ranges = append(ranges, funcRange{start: fn.Entry, end: fn.End})
+			}
+		}
+	}
+	// Sort by start address for binary search in isInsideRange.
+	sort.Slice(ranges, func(i, j int) bool {
+		return ranges[i].start < ranges[j].start
+	})
+	return ranges
+}
+
+// scanSVCWithX16 performs Pass 1 analysis: scans svc #0x80 addresses, skips
+// those inside known Go syscall stub address ranges, and resolves the X16
+// syscall number via backward scan.
+//
+//   - svcAddrs: virtual addresses of svc #0x80 instructions (from collectSVCAddresses)
+//   - code:     raw bytes of __TEXT,__text section
+//   - textBase: virtual address of the section start
+//   - stubRanges: address ranges of known Go syscall stub functions (from pclntab)
+//   - table: macOS BSD syscall table for name/network lookups
+//
+// Returns one SyscallInfo per svc #0x80 that was NOT excluded.
+func scanSVCWithX16(
+	svcAddrs []uint64,
+	code []byte,
+	textBase uint64, //nolint:unparam // textBase will vary in production use
+	stubRanges []funcRange,
+	table syscallNumberTable,
+) []common.SyscallInfo {
+	var results []common.SyscallInfo
+
+	for _, addr := range svcAddrs {
+		// Skip svc instructions inside known Go stub ranges (handled by Pass 2).
+		if isInsideRange(addr, stubRanges) {
+			continue
+		}
+
+		if addr < textBase {
+			continue
+		}
+		svcOffset := int(addr - textBase) //nolint:gosec // G115: addr >= textBase verified above
+
+		num, ok := arm64BackwardScanX16(code, svcOffset)
+
+		var info common.SyscallInfo
+		if ok {
+			info = common.SyscallInfo{
+				Number:              num,
+				Name:                table.GetSyscallName(num),
+				IsNetwork:           table.IsNetworkSyscall(num),
+				Location:            addr,
+				DeterminationMethod: determinationMethodImmediate,
+				Source:              "", // Mach-O direct svc entries have empty Source (same as ELF)
+			}
+		} else {
+			info = common.SyscallInfo{
+				Number:              -1,
+				Name:                "",
+				IsNetwork:           false,
+				Location:            addr,
+				DeterminationMethod: determinationMethodUnknownIndirect,
+				Source:              "",
+			}
+		}
+		results = append(results, info)
+	}
+
+	return results
+}
+
+// arm64BackwardScanX16 mirrors libccache.BackwardScanX16.
+// Duplicated here to avoid an import cycle:
+//
+//	machoanalyzer → libccache → filevalidator → machoanalyzer
+//
+// When libccache.BackwardScanX16 is updated, this function must be updated too.
+//
+// arm64BackwardScanX16 walks backward from the svc #0x80 instruction at
+// code[svcOffset] and looks for an immediate-load sequence into x16.
+// When found, it returns the syscall number with the BSD class prefix removed.
+// The scan is limited to maxX16BackwardScan instructions.
+func arm64BackwardScanX16(code []byte, svcOffset int) (int, bool) {
+	const (
+		instrLen  = 4
+		maxScan   = 16
+		bsdPrefix = 0x2000000
+
+		movzX16Base  = uint32(0xD2800010) // MOVZ X16, #0, LSL #0
+		movzX16Lsl16 = uint32(0xD2A00010) // MOVZ X16, #0, LSL #16
+		movkX16Base  = uint32(0xF2800010) // MOVK X16, #0, LSL #0
+		movkX16Lsl16 = uint32(0xF2A00010) // MOVK X16, #0, LSL #16
+		imm16Mask    = uint32(0x001FFFE0) // bits[20:5]
+		imm16Shift   = 5
+		imm16HiShift = 16 // for LSL#16 variants
+
+	)
+
+	startIdx := svcOffset/instrLen - 1
+	endIdx := startIdx - maxScan
+	if endIdx < 0 {
+		endIdx = -1
+	}
+
+	x16Lo := -1
+	x16Hi := -1
+
+	for i := startIdx; i > endIdx; i-- {
+		off := i * instrLen
+		if off < 0 {
+			break
+		}
+		word := binary.LittleEndian.Uint32(code[off:])
+
+		if word&^imm16Mask == movzX16Base {
+			lo := int((word & imm16Mask) >> imm16Shift)
+			hi := 0
+			if x16Hi >= 0 {
+				hi = x16Hi
+			}
+			v := hi | lo
+			if v >= bsdPrefix {
+				v -= bsdPrefix
+			}
+			return v, true
+		}
+
+		if word&^imm16Mask == movzX16Lsl16 {
+			hi := int((word&imm16Mask)>>imm16Shift) << imm16HiShift
+			lo := 0
+			if x16Lo >= 0 {
+				lo = x16Lo
+			}
+			v := hi | lo
+			if v >= bsdPrefix {
+				v -= bsdPrefix
+			}
+			return v, true
+		}
+
+		if word&^imm16Mask == movkX16Base {
+			x16Lo = int((word & imm16Mask) >> imm16Shift)
+			continue
+		}
+
+		if word&^imm16Mask == movkX16Lsl16 {
+			x16Hi = int((word&imm16Mask)>>imm16Shift) << imm16HiShift
+			continue
+		}
+
+		if arm64IsControlFlowInstr(word) {
+			break
+		}
+
+		// Stop when another instruction writes to x16.
+		if arm64WritesX16NotMovzMovk(word) {
+			break
+		}
+	}
+	return 0, false
+}
+
+// arm64IsControlFlowInstr mirrors libccache.IsControlFlowInstruction.
+// See the note on arm64BackwardScanX16 about the duplication rationale.
+func arm64IsControlFlowInstr(word uint32) bool {
+	const (
+		blBranchShift   = 26
+		blBranchB       = uint32(0b000101)
+		blBranchBL      = uint32(0b100101)
+		brRegShift      = 22
+		brRegPatternBLR = uint32(0b1101011000)
+		brRegPatternBR  = uint32(0b1101011001)
+		cbBranchShift   = 25
+		cbBranchMask    = uint32(0x3F)
+		cbzCbnzPattern  = uint32(0b011010)
+		tbzTbnzPattern  = uint32(0b011011)
+	)
+	// B, BL: [31:26] = 000101 or 100101
+	if word>>blBranchShift == blBranchB || word>>blBranchShift == blBranchBL {
+		return true
+	}
+	// BLR, BR, RET: [31:22] = 1101011000 or 1101011001
+	hi10 := word >> brRegShift
+	if hi10 == brRegPatternBLR || hi10 == brRegPatternBR {
+		return true
+	}
+	// CBZ, CBNZ: [30:25] = 011010
+	hi6 := (word >> cbBranchShift) & cbBranchMask
+	if hi6 == cbzCbnzPattern {
+		return true
+	}
+	// TBZ, TBNZ: [30:25] = 011011
+	if hi6 == tbzTbnzPattern {
+		return true
+	}
+	return false
+}
+
+// arm64WritesX16NotMovzMovk detects 64-bit instructions that write to x16,
+// excluding MOVZ and MOVK. Mirrors libccache.writesX16NotMovzMovk.
+func arm64WritesX16NotMovzMovk(word uint32) bool {
+	const (
+		patMovzMovk   = uint32(0b100101)
+		shiftMovzMovk = 23
+		mask6         = uint32(0x3F)
+	)
+	if (word>>shiftMovzMovk)&mask6 == patMovzMovk {
+		return false
+	}
+	return word>>31 == 1 && word&0x1F == 0x10
+}

--- a/internal/runner/security/machoanalyzer/pass1_scanner.go
+++ b/internal/runner/security/machoanalyzer/pass1_scanner.go
@@ -83,7 +83,15 @@ func scanSVCWithX16(
 		}
 
 		if addr < textBase || addr >= textBase+uint64(len(code)) {
-			panic("svc address out of bounds")
+			results = append(results, common.SyscallInfo{
+				Number:              -1,
+				Name:                "",
+				IsNetwork:           false,
+				Location:            addr,
+				DeterminationMethod: determinationMethodUnknownIndirect,
+				Source:              "",
+			})
+			continue
 		}
 		svcOffset := int(addr - textBase) //nolint:gosec // G115: addr-textBase < len(code) which fits in int
 

--- a/internal/runner/security/machoanalyzer/pass1_scanner_test.go
+++ b/internal/runner/security/machoanalyzer/pass1_scanner_test.go
@@ -3,7 +3,6 @@
 package machoanalyzer
 
 import (
-	"encoding/binary"
 	"testing"
 
 	"github.com/isseis/go-safe-cmd-runner/internal/arm64util"
@@ -64,10 +63,6 @@ func encodeMovkX16(imm uint32) uint32 {
 	return 0xF2800010 | ((imm & 0xFFFF) << 5)
 }
 
-// svcEncodingPass1 is the little-endian encoding of "svc #0x80" for arm64.
-// Named with Pass1 suffix to avoid redeclaration with svc_scanner_test.go.
-const svcEncodingPass1 = uint32(0xD4001001)
-
 // encodeBL encodes a BL instruction with a PC-relative offset (in bytes).
 // The offset must be a multiple of 4.
 func encodeBL(offsetBytes int32) uint32 {
@@ -83,46 +78,11 @@ func encodeLDRX16SP(offset uint32) uint32 {
 	return 0xF9400010 | (imm12 << 10) | (31 << 5)
 }
 
-// buildCodeSlice assembles a sequence of 32-bit ARM64 instructions into a byte slice.
-func buildCodeSlice(instrs ...uint32) []byte {
-	buf := make([]byte, len(instrs)*4)
-	for i, instr := range instrs {
-		binary.LittleEndian.PutUint32(buf[i*4:], instr)
-	}
-	return buf
-}
-
 // TestScanSVCWithX16_ImmediateNetworkSyscall verifies that MOVZ X16, #98 + svc
 // produces Number=98 (connect), IsNetwork=true, Method="immediate".
 func TestScanSVCWithX16_ImmediateNetworkSyscall(t *testing.T) {
 	t.Parallel()
-	// BSD syscall 98 = connect (network), 0x2000000+98 = 0x2000062
-	// MOVZ X16, #98: 0xD2800010 | (98 << 5) = 0xD2800010 | 0xC40 = 0xD2800C50
-	// Wait, imm=98 dec = 0x62, (0x62 << 5) = 0xC40
-	// 0xD2800010 | 0xC40 = 0xD2800C50... let me recalculate
-	// encodeMovzX16(98) = 0xD2800010 | ((98 & 0xFFFF) << 5) = 0xD2800010 | (98*32) = 0xD2800010 | 0xC40
-	// = 0xD2800C50... hmm, that gives Rd=0x10 | (imm<<5) part?
-	// Actually the encoding is:
-	//   [31]:    sf=1
-	//   [30:29]: opc=10 (MOVZ)
-	//   [28:23]: 100101 = 0x25
-	//   [22:21]: hw=00 (LSL #0)
-	//   [20:5]:  imm16
-	//   [4:0]:   Rd=16=0x10
-	// So base = 0xD2800010 = 1101 0010 1000 0000 0000 0000 0001 0000
-	// imm16 goes to bits [20:5], so shift by 5
-	// For imm=98: (98 << 5) = 3136 = 0xC40
-	// base | (98<<5) = 0xD2800010 | 0xC40 = 0xD2800C50... wait that shifts into bit 11
-	// Actually imm16Mask = 0x001FFFE0 (bits [20:5]), imm16Shift = 5
-	// encodeMovzX16(98) = 0xD2800010 | ((98 & 0xFFFF) << 5)
-	// = 0xD2800010 | 0xC40 = 0xD2800C50
-	// Let me verify: 0xD2800C50 & ^imm16Mask = 0xD2800C50 & 0xFFE0001F
-	//   = 0xD2800010... wait: 0xD2800C50 = 1101 0010 1000 0000 0000 1100 0101 0000
-	//   ^imm16Mask = ~0x001FFFE0 = 0xFFE0001F
-	//   0xD2800C50 & 0xFFE0001F = 1101 0010 1000 0000 0000 0000 0001 0000 = 0xD2800010 ✓
-	// And (0xD2800C50 & imm16Mask) >> 5 = (0xC40) >> 5 = 0x62 = 98 ✓
-
-	code := buildCodeSlice(encodeMovzX16(98), svcEncodingPass1)
+	code := buildCodeSlice(encodeMovzX16(98), svcEncoding)
 	const textBase = uint64(0x100000000)
 	svcAddr := textBase + 4 // second instruction
 
@@ -141,7 +101,7 @@ func TestScanSVCWithX16_ImmediateNetworkSyscall(t *testing.T) {
 // produces Number=3, IsNetwork=false.
 func TestScanSVCWithX16_ImmediateNonNetworkSyscall(t *testing.T) {
 	t.Parallel()
-	code := buildCodeSlice(encodeMovzX16(3), svcEncodingPass1)
+	code := buildCodeSlice(encodeMovzX16(3), svcEncoding)
 	const textBase = uint64(0x100000000)
 	svcAddr := textBase + 4
 
@@ -164,7 +124,7 @@ func TestScanSVCWithX16_BSDPrefix32bit(t *testing.T) {
 	code := buildCodeSlice(
 		encodeMovzX16Lsl16(0x0200), // sets X16 = 0x02000000
 		encodeMovkX16(0x0062),      // X16 |= 0x62 → 0x02000062
-		svcEncodingPass1,
+		svcEncoding,
 	)
 	const textBase = uint64(0x100000000)
 	svcAddr := textBase + 8 // third instruction
@@ -180,7 +140,7 @@ func TestScanSVCWithX16_BSDPrefix32bit(t *testing.T) {
 // produces Number=-1, Method="unknown:indirect_setting".
 func TestScanSVCWithX16_IndirectLoad(t *testing.T) {
 	t.Parallel()
-	code := buildCodeSlice(encodeLDRX16SP(24), svcEncodingPass1)
+	code := buildCodeSlice(encodeLDRX16SP(24), svcEncoding)
 	const textBase = uint64(0x100000000)
 	svcAddr := textBase + 4
 
@@ -206,7 +166,7 @@ func TestScanSVCWithX16_ControlFlowBoundary(t *testing.T) {
 	code := buildCodeSlice(
 		encodeMovzX16(98), // offset 0: MOVZ X16, #98
 		encodeBL(-4),      // offset 4: BL (control-flow; scan stops here)
-		svcEncodingPass1,  // offset 8: svc #0x80
+		svcEncoding,       // offset 8: svc #0x80
 	)
 	const textBase = uint64(0x100000000)
 	svcAddr := textBase + 8 // third instruction
@@ -222,7 +182,7 @@ func TestScanSVCWithX16_ControlFlowBoundary(t *testing.T) {
 // range is excluded from Pass 1 results.
 func TestScanSVCWithX16_SVCInsideStubRange(t *testing.T) {
 	t.Parallel()
-	code := buildCodeSlice(encodeMovzX16(98), svcEncodingPass1)
+	code := buildCodeSlice(encodeMovzX16(98), svcEncoding)
 	const textBase = uint64(0x100000000)
 	svcAddr := textBase + 4
 
@@ -239,7 +199,7 @@ func TestScanSVCWithX16_SVCInsideStubRange(t *testing.T) {
 // is included in Pass 1 results.
 func TestScanSVCWithX16_SVCOutsideStubRange(t *testing.T) {
 	t.Parallel()
-	code := buildCodeSlice(encodeMovzX16(98), svcEncodingPass1)
+	code := buildCodeSlice(encodeMovzX16(98), svcEncoding)
 	const textBase = uint64(0x100000000)
 	svcAddr := textBase + 4
 
@@ -273,7 +233,7 @@ func TestBuildStubRanges(t *testing.T) {
 // text section produces an unknown-syscall entry instead of panicking.
 func TestScanSVCWithX16_OutOfBoundsAddress(t *testing.T) {
 	t.Parallel()
-	code := buildCodeSlice(encodeMovzX16(98), svcEncodingPass1)
+	code := buildCodeSlice(encodeMovzX16(98), svcEncoding)
 	const textBase = uint64(0x100000000)
 	table := newStubSyscallTable()
 
@@ -300,8 +260,7 @@ func TestScanSVCWithX16_OutOfBoundsAddress(t *testing.T) {
 // preceding MOVZ/MOVK instructions returns (0, false).
 func TestArm64BackwardScanX16_NoPrecedingInstruction(t *testing.T) {
 	t.Parallel()
-	// Just the svc instruction at offset 0.
-	code := buildCodeSlice(svcEncodingPass1)
+	code := buildCodeSlice(svcEncoding)
 	num, ok := arm64util.BackwardScanX16(code, 0)
 	assert.False(t, ok)
 	assert.Zero(t, num)

--- a/internal/runner/security/machoanalyzer/pass1_scanner_test.go
+++ b/internal/runner/security/machoanalyzer/pass1_scanner_test.go
@@ -269,6 +269,33 @@ func TestBuildStubRanges(t *testing.T) {
 	}
 }
 
+// TestScanSVCWithX16_OutOfBoundsAddress verifies that an svc address outside the
+// text section produces an unknown-syscall entry instead of panicking.
+func TestScanSVCWithX16_OutOfBoundsAddress(t *testing.T) {
+	t.Parallel()
+	code := buildCodeSlice(encodeMovzX16(98), svcEncodingPass1)
+	const textBase = uint64(0x100000000)
+	table := newStubSyscallTable()
+
+	tests := []struct {
+		name    string
+		svcAddr uint64
+	}{
+		{"below textBase", textBase - 4},
+		{"beyond end", textBase + uint64(len(code))},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			results := scanSVCWithX16([]uint64{tc.svcAddr}, code, textBase, nil, table)
+			require.Len(t, results, 1)
+			assert.Equal(t, -1, results[0].Number)
+			assert.Equal(t, determinationMethodUnknownIndirect, results[0].DeterminationMethod)
+			assert.Equal(t, tc.svcAddr, results[0].Location)
+		})
+	}
+}
+
 // TestArm64BackwardScanX16_NoPrecedingInstruction verifies that a svc with no
 // preceding MOVZ/MOVK instructions returns (0, false).
 func TestArm64BackwardScanX16_NoPrecedingInstruction(t *testing.T) {

--- a/internal/runner/security/machoanalyzer/pass1_scanner_test.go
+++ b/internal/runner/security/machoanalyzer/pass1_scanner_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/binary"
 	"testing"
 
+	"github.com/isseis/go-safe-cmd-runner/internal/arm64util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -274,7 +275,7 @@ func TestArm64BackwardScanX16_NoPrecedingInstruction(t *testing.T) {
 	t.Parallel()
 	// Just the svc instruction at offset 0.
 	code := buildCodeSlice(svcEncodingPass1)
-	num, ok := arm64BackwardScanX16(code, 0)
+	num, ok := arm64util.BackwardScanX16(code, 0)
 	assert.False(t, ok)
 	assert.Zero(t, num)
 }

--- a/internal/runner/security/machoanalyzer/pass1_scanner_test.go
+++ b/internal/runner/security/machoanalyzer/pass1_scanner_test.go
@@ -1,0 +1,280 @@
+//go:build test
+
+package machoanalyzer
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubSyscallTable is a minimal in-process syscall table for tests.
+// It maps a few well-known BSD syscall numbers to names and network flags.
+type stubSyscallTable struct {
+	entries map[int]struct {
+		name      string
+		isNetwork bool
+	}
+}
+
+func newStubSyscallTable() *stubSyscallTable {
+	return &stubSyscallTable{
+		entries: map[int]struct {
+			name      string
+			isNetwork bool
+		}{
+			3:  {name: "read", isNetwork: false},
+			49: {name: "munmap", isNetwork: false},
+			97: {name: "socket", isNetwork: true},
+			98: {name: "connect", isNetwork: true},
+		},
+	}
+}
+
+func (t *stubSyscallTable) GetSyscallName(number int) string {
+	if e, ok := t.entries[number]; ok {
+		return e.name
+	}
+	return ""
+}
+
+func (t *stubSyscallTable) IsNetworkSyscall(number int) bool {
+	if e, ok := t.entries[number]; ok {
+		return e.isNetwork
+	}
+	return false
+}
+
+// encodeMovzX16 encodes MOVZ X16, #imm (LSL #0).
+// ARM64: sf=1, opc=10, [28:23]=100101, hw=00, imm16, Rd=16
+func encodeMovzX16(imm uint32) uint32 {
+	return 0xD2800010 | ((imm & 0xFFFF) << 5)
+}
+
+// encodeMovzX16Lsl16 encodes MOVZ X16, #imm, LSL #16.
+func encodeMovzX16Lsl16(imm uint32) uint32 {
+	return 0xD2A00010 | ((imm & 0xFFFF) << 5)
+}
+
+// encodeMovkX16 encodes MOVK X16, #imm (LSL #0).
+func encodeMovkX16(imm uint32) uint32 {
+	return 0xF2800010 | ((imm & 0xFFFF) << 5)
+}
+
+// svcEncodingPass1 is the little-endian encoding of "svc #0x80" for arm64.
+// Named with Pass1 suffix to avoid redeclaration with svc_scanner_test.go.
+const svcEncodingPass1 = uint32(0xD4001001)
+
+// encodeBL encodes a BL instruction with a PC-relative offset (in bytes).
+// The offset must be a multiple of 4.
+func encodeBL(offsetBytes int32) uint32 {
+	imm26 := (offsetBytes / 4) & 0x03FFFFFF
+	return 0x94000000 | uint32(imm26)
+}
+
+// encodeLDRX16SP encodes LDR X16, [SP, #imm] where imm is a multiple of 8.
+// This is used to represent an indirect load that the scanner cannot resolve.
+func encodeLDRX16SP(offset uint32) uint32 {
+	// STR/LDR X16, [SP, #imm]: [31:30]=11, [29:27]=111, [26]=0, [25:24]=01, imm12=[21:10], Rn=SP(31), Rt=16
+	imm12 := (offset / 8) & 0xFFF
+	return 0xF9400010 | (imm12 << 10) | (31 << 5)
+}
+
+// buildCodeSlice assembles a sequence of 32-bit ARM64 instructions into a byte slice.
+func buildCodeSlice(instrs ...uint32) []byte {
+	buf := make([]byte, len(instrs)*4)
+	for i, instr := range instrs {
+		binary.LittleEndian.PutUint32(buf[i*4:], instr)
+	}
+	return buf
+}
+
+// TestScanSVCWithX16_ImmediateNetworkSyscall verifies that MOVZ X16, #98 + svc
+// produces Number=98 (connect), IsNetwork=true, Method="immediate".
+func TestScanSVCWithX16_ImmediateNetworkSyscall(t *testing.T) {
+	t.Parallel()
+	// BSD syscall 98 = connect (network), 0x2000000+98 = 0x2000062
+	// MOVZ X16, #98: 0xD2800010 | (98 << 5) = 0xD2800010 | 0xC40 = 0xD2800C50
+	// Wait, imm=98 dec = 0x62, (0x62 << 5) = 0xC40
+	// 0xD2800010 | 0xC40 = 0xD2800C50... let me recalculate
+	// encodeMovzX16(98) = 0xD2800010 | ((98 & 0xFFFF) << 5) = 0xD2800010 | (98*32) = 0xD2800010 | 0xC40
+	// = 0xD2800C50... hmm, that gives Rd=0x10 | (imm<<5) part?
+	// Actually the encoding is:
+	//   [31]:    sf=1
+	//   [30:29]: opc=10 (MOVZ)
+	//   [28:23]: 100101 = 0x25
+	//   [22:21]: hw=00 (LSL #0)
+	//   [20:5]:  imm16
+	//   [4:0]:   Rd=16=0x10
+	// So base = 0xD2800010 = 1101 0010 1000 0000 0000 0000 0001 0000
+	// imm16 goes to bits [20:5], so shift by 5
+	// For imm=98: (98 << 5) = 3136 = 0xC40
+	// base | (98<<5) = 0xD2800010 | 0xC40 = 0xD2800C50... wait that shifts into bit 11
+	// Actually imm16Mask = 0x001FFFE0 (bits [20:5]), imm16Shift = 5
+	// encodeMovzX16(98) = 0xD2800010 | ((98 & 0xFFFF) << 5)
+	// = 0xD2800010 | 0xC40 = 0xD2800C50
+	// Let me verify: 0xD2800C50 & ^imm16Mask = 0xD2800C50 & 0xFFE0001F
+	//   = 0xD2800010... wait: 0xD2800C50 = 1101 0010 1000 0000 0000 1100 0101 0000
+	//   ^imm16Mask = ~0x001FFFE0 = 0xFFE0001F
+	//   0xD2800C50 & 0xFFE0001F = 1101 0010 1000 0000 0000 0000 0001 0000 = 0xD2800010 ✓
+	// And (0xD2800C50 & imm16Mask) >> 5 = (0xC40) >> 5 = 0x62 = 98 ✓
+
+	code := buildCodeSlice(encodeMovzX16(98), svcEncodingPass1)
+	const textBase = uint64(0x100000000)
+	svcAddr := textBase + 4 // second instruction
+
+	table := newStubSyscallTable()
+	results := scanSVCWithX16([]uint64{svcAddr}, code, textBase, nil, table)
+
+	require.Len(t, results, 1)
+	assert.Equal(t, 98, results[0].Number)
+	assert.Equal(t, "connect", results[0].Name)
+	assert.True(t, results[0].IsNetwork)
+	assert.Equal(t, determinationMethodImmediate, results[0].DeterminationMethod)
+	assert.Equal(t, "", results[0].Source)
+}
+
+// TestScanSVCWithX16_ImmediateNonNetworkSyscall verifies MOVZ X16, #3 + svc
+// produces Number=3, IsNetwork=false.
+func TestScanSVCWithX16_ImmediateNonNetworkSyscall(t *testing.T) {
+	t.Parallel()
+	code := buildCodeSlice(encodeMovzX16(3), svcEncodingPass1)
+	const textBase = uint64(0x100000000)
+	svcAddr := textBase + 4
+
+	table := newStubSyscallTable()
+	results := scanSVCWithX16([]uint64{svcAddr}, code, textBase, nil, table)
+
+	require.Len(t, results, 1)
+	assert.Equal(t, 3, results[0].Number)
+	assert.Equal(t, "read", results[0].Name)
+	assert.False(t, results[0].IsNetwork)
+	assert.Equal(t, determinationMethodImmediate, results[0].DeterminationMethod)
+}
+
+// TestScanSVCWithX16_BSDPrefix32bit verifies a 32-bit value with BSD prefix:
+// MOVZ X16, #0x200, LSL#16 + MOVK X16, #0x62 + svc → Number=98.
+func TestScanSVCWithX16_BSDPrefix32bit(t *testing.T) {
+	t.Parallel()
+	// BSD prefix 0x2000000 = 0x200 << 16, syscall 98 = 0x62
+	// MOVZ X16, #0x0200, LSL#16 + MOVK X16, #0x0062
+	code := buildCodeSlice(
+		encodeMovzX16Lsl16(0x0200), // sets X16 = 0x02000000
+		encodeMovkX16(0x0062),      // X16 |= 0x62 → 0x02000062
+		svcEncodingPass1,
+	)
+	const textBase = uint64(0x100000000)
+	svcAddr := textBase + 8 // third instruction
+
+	table := newStubSyscallTable()
+	results := scanSVCWithX16([]uint64{svcAddr}, code, textBase, nil, table)
+
+	require.Len(t, results, 1)
+	assert.Equal(t, 98, results[0].Number, "expected BSD prefix stripped: 0x2000062 - 0x2000000 = 98")
+}
+
+// TestScanSVCWithX16_IndirectLoad verifies that LDR X16, [SP, #N] + svc
+// produces Number=-1, Method="unknown:indirect_setting".
+func TestScanSVCWithX16_IndirectLoad(t *testing.T) {
+	t.Parallel()
+	code := buildCodeSlice(encodeLDRX16SP(24), svcEncodingPass1)
+	const textBase = uint64(0x100000000)
+	svcAddr := textBase + 4
+
+	table := newStubSyscallTable()
+	results := scanSVCWithX16([]uint64{svcAddr}, code, textBase, nil, table)
+
+	require.Len(t, results, 1)
+	assert.Equal(t, -1, results[0].Number)
+	assert.Equal(t, determinationMethodUnknownIndirect, results[0].DeterminationMethod)
+}
+
+// TestScanSVCWithX16_ControlFlowBoundary verifies that a BL instruction between
+// MOVZ X16, #98 and svc causes the backward scan to stop, yielding Number=-1.
+func TestScanSVCWithX16_ControlFlowBoundary(t *testing.T) {
+	t.Parallel()
+	// Layout (ascending addresses):
+	//   offset 0: MOVZ X16, #98  — would set x16=98
+	//   offset 4: BL target      — control-flow boundary; backward scan stops here
+	//   offset 8: svc #0x80      — starting point for backward scan
+	//
+	// The backward scan from svc (startIdx=1) first sees BL at i=1 and stops,
+	// so MOVZ at i=0 is never reached → Number=-1.
+	code := buildCodeSlice(
+		encodeMovzX16(98), // offset 0: MOVZ X16, #98
+		encodeBL(-4),      // offset 4: BL (control-flow; scan stops here)
+		svcEncodingPass1,  // offset 8: svc #0x80
+	)
+	const textBase = uint64(0x100000000)
+	svcAddr := textBase + 8 // third instruction
+
+	table := newStubSyscallTable()
+	results := scanSVCWithX16([]uint64{svcAddr}, code, textBase, nil, table)
+
+	require.Len(t, results, 1)
+	assert.Equal(t, -1, results[0].Number, "expected scan to stop at BL, producing unknown result")
+}
+
+// TestScanSVCWithX16_SVCInsideStubRange verifies that svc inside a known stub
+// range is excluded from Pass 1 results.
+func TestScanSVCWithX16_SVCInsideStubRange(t *testing.T) {
+	t.Parallel()
+	code := buildCodeSlice(encodeMovzX16(98), svcEncodingPass1)
+	const textBase = uint64(0x100000000)
+	svcAddr := textBase + 4
+
+	// Mark the entire code range as a stub range.
+	stubRanges := []funcRange{{start: textBase, end: textBase + 100}}
+
+	table := newStubSyscallTable()
+	results := scanSVCWithX16([]uint64{svcAddr}, code, textBase, stubRanges, table)
+
+	assert.Empty(t, results, "svc inside stub range should be excluded from Pass 1")
+}
+
+// TestScanSVCWithX16_SVCOutsideStubRange verifies that svc outside stub ranges
+// is included in Pass 1 results.
+func TestScanSVCWithX16_SVCOutsideStubRange(t *testing.T) {
+	t.Parallel()
+	code := buildCodeSlice(encodeMovzX16(98), svcEncodingPass1)
+	const textBase = uint64(0x100000000)
+	svcAddr := textBase + 4
+
+	// Stub range does not cover the svc address.
+	stubRanges := []funcRange{{start: textBase + 0x1000, end: textBase + 0x2000}}
+
+	table := newStubSyscallTable()
+	results := scanSVCWithX16([]uint64{svcAddr}, code, textBase, stubRanges, table)
+
+	require.Len(t, results, 1, "svc outside stub range should be included in Pass 1")
+	assert.Equal(t, 98, results[0].Number)
+}
+
+// TestBuildStubRanges verifies that only known syscall stub names produce ranges.
+func TestBuildStubRanges(t *testing.T) {
+	t.Parallel()
+	funcs := map[string]MachoPclntabFunc{
+		"syscall.Syscall":  {Entry: 0x100, End: 0x200},
+		"syscall.Syscall6": {Entry: 0x300, End: 0x400},
+		"not.a.stub":       {Entry: 0x500, End: 0x600},
+	}
+	ranges := buildStubRanges(funcs)
+	assert.Len(t, ranges, 2, "expected only known stub names to produce ranges")
+	// Verify sorted order.
+	for i := 1; i < len(ranges); i++ {
+		assert.LessOrEqual(t, ranges[i-1].start, ranges[i].start)
+	}
+}
+
+// TestArm64BackwardScanX16_NoPrecedingInstruction verifies that a svc with no
+// preceding MOVZ/MOVK instructions returns (0, false).
+func TestArm64BackwardScanX16_NoPrecedingInstruction(t *testing.T) {
+	t.Parallel()
+	// Just the svc instruction at offset 0.
+	code := buildCodeSlice(svcEncodingPass1)
+	num, ok := arm64BackwardScanX16(code, 0)
+	assert.False(t, ok)
+	assert.Zero(t, num)
+}

--- a/internal/runner/security/machoanalyzer/pass2_scanner.go
+++ b/internal/runner/security/machoanalyzer/pass2_scanner.go
@@ -78,7 +78,13 @@ func isKnownWrapper(code []byte, textBase, target uint64, wrapperAddrs map[uint6
 
 // scanGoWrapperCalls performs Pass 2: scans the __TEXT,__text section for BL
 // instructions targeting known Go syscall stub addresses, then resolves the
-// syscall number from the preceding X0 register assignment.
+// syscall number from the preceding trap argument write to [SP, #8].
+//
+// syscall.Syscall/RawSyscall et al. use the old stack-based calling convention
+// (NOSPLIT assembly stubs): the caller stores the trap number at SP+8 (trap+0(FP))
+// before the BL, not in a register via the register ABI. BackwardScanStackTrap
+// detects the STR/STP to [SP, #8] and then backward-scans the source register
+// for an immediate-load sequence.
 //
 //   - code: raw bytes of __TEXT,__text section
 //   - textBase: virtual address of the section start

--- a/internal/runner/security/machoanalyzer/pass2_scanner.go
+++ b/internal/runner/security/machoanalyzer/pass2_scanner.go
@@ -1,0 +1,116 @@
+package machoanalyzer
+
+import (
+	"encoding/binary"
+
+	"github.com/isseis/go-safe-cmd-runner/internal/arm64util"
+	"github.com/isseis/go-safe-cmd-runner/internal/common"
+)
+
+// arm64BL constants for detecting and decoding BL instructions.
+const (
+	arm64BLOpcShift  = 26
+	arm64BLOpcode    = uint32(0b100101) // bits[31:26] of BL
+	arm64BLImmMask   = uint32(0x03ffffff)
+	arm64BLSignShift = uint32(6) // 32 - 26
+	arm64InstrLen    = 4
+)
+
+// buildWrapperAddrs builds a map from known Go syscall stub entry addresses to
+// their function names. Used by Pass 2 to detect BL calls into those stubs from
+// user code.
+func buildWrapperAddrs(funcs map[string]MachoPclntabFunc) map[uint64]string {
+	addrs := make(map[uint64]string, len(knownMachoSyscallImpls))
+	for name, fn := range funcs {
+		if _, ok := knownMachoSyscallImpls[name]; ok {
+			addrs[fn.Entry] = name
+		}
+	}
+	return addrs
+}
+
+// getBLTarget returns the target virtual address of a BL instruction.
+// instrAddr is the virtual address of the BL instruction itself.
+// Returns (target, true) on success, (0, false) if not a BL or if the target
+// address overflows.
+func getBLTarget(word uint32, instrAddr uint64) (uint64, bool) {
+	if word>>arm64BLOpcShift != arm64BLOpcode {
+		return 0, false
+	}
+	imm26Raw := word & arm64BLImmMask
+	imm26 := int32(imm26Raw<<arm64BLSignShift) >> int(arm64BLSignShift) //nolint:gosec // G115: imm26Raw is masked to 26 bits
+	base := int64(instrAddr)                                            //nolint:gosec // G115: instrAddr is a Mach-O VA, fits in int64
+	target := base + int64(imm26)*arm64InstrLen
+	if target < 0 {
+		return 0, false
+	}
+	return uint64(target), true //nolint:gosec // G115: target non-negative checked above
+}
+
+// scanGoWrapperCalls performs Pass 2: scans the __TEXT,__text section for BL
+// instructions targeting known Go syscall stub addresses, then resolves the
+// syscall number from the preceding X0 register assignment.
+//
+//   - code: raw bytes of __TEXT,__text section
+//   - textBase: virtual address of the section start
+//   - wrapperAddrs: map from wrapper entry address to wrapper name (from buildWrapperAddrs)
+//   - stubRanges: address ranges of known stubs; BL instructions inside these
+//     ranges are skipped (they are internal calls, not user-level syscall requests)
+//   - table: macOS BSD syscall table for name/network lookups
+//
+// Returns one SyscallInfo per BL call to a known wrapper that was NOT excluded.
+func scanGoWrapperCalls(
+	code []byte,
+	textBase uint64,
+	wrapperAddrs map[uint64]string,
+	stubRanges []funcRange,
+	table SyscallNumberTable,
+) []common.SyscallInfo {
+	if len(wrapperAddrs) == 0 {
+		return nil
+	}
+
+	var results []common.SyscallInfo
+
+	for offset := 0; offset+arm64InstrLen <= len(code); offset += arm64InstrLen {
+		word := binary.LittleEndian.Uint32(code[offset:])
+		instrAddr := textBase + uint64(offset) //nolint:gosec // G115: offset bounded by len(code)
+
+		target, ok := getBLTarget(word, instrAddr)
+		if !ok {
+			continue
+		}
+
+		if _, isWrapper := wrapperAddrs[target]; !isWrapper {
+			continue
+		}
+
+		// Skip BL instructions that originate from inside a stub body — those are
+		// internal calls within the Go runtime, not user-level syscall requests.
+		if isInsideRange(instrAddr, stubRanges) {
+			continue
+		}
+
+		num, resolved := arm64util.BackwardScanX0(code, offset)
+
+		var info common.SyscallInfo
+		if resolved {
+			info = common.SyscallInfo{
+				Number:              num,
+				Name:                table.GetSyscallName(num),
+				IsNetwork:           table.IsNetworkSyscall(num),
+				Location:            instrAddr,
+				DeterminationMethod: determinationMethodGoWrapper,
+			}
+		} else {
+			info = common.SyscallInfo{
+				Number:              -1,
+				Location:            instrAddr,
+				DeterminationMethod: determinationMethodUnknownIndirect,
+			}
+		}
+		results = append(results, info)
+	}
+
+	return results
+}

--- a/internal/runner/security/machoanalyzer/pass2_scanner.go
+++ b/internal/runner/security/machoanalyzer/pass2_scanner.go
@@ -7,12 +7,13 @@ import (
 	"github.com/isseis/go-safe-cmd-runner/internal/common"
 )
 
-// arm64BL constants for detecting and decoding BL instructions.
+// arm64 branch instruction constants for BL and B decoding.
 const (
 	arm64BLOpcShift  = 26
 	arm64BLOpcode    = uint32(0b100101) // bits[31:26] of BL
+	arm64BOpcode     = uint32(0b000101) // bits[31:26] of B (unconditional, no link)
 	arm64BLImmMask   = uint32(0x03ffffff)
-	arm64BLSignShift = uint32(6) // 32 - 26
+	arm64BLSignShift = uint32(6) // 32 - 26; also used for B imm26 sign-extension
 	arm64InstrLen    = 4
 )
 
@@ -45,6 +46,34 @@ func getBLTarget(word uint32, instrAddr uint64) (uint64, bool) {
 		return 0, false
 	}
 	return uint64(target), true //nolint:gosec // G115: target non-negative checked above
+}
+
+// isKnownWrapper reports whether target is a known Go syscall wrapper address,
+// handling single-instruction stub trampolines of the form "B wrapperAddr".
+// Go linkers sometimes emit a one-instruction trampoline at a near address that
+// simply branches to the actual wrapper; we resolve one level of such stubs.
+func isKnownWrapper(code []byte, textBase, target uint64, wrapperAddrs map[uint64]string) bool {
+	if _, ok := wrapperAddrs[target]; ok {
+		return true
+	}
+	// Attempt one-level stub resolution: if the instruction at target is a
+	// plain B (not BL), follow it and check whether the branch destination is
+	// a known wrapper.
+	if target < textBase {
+		return false
+	}
+	off := target - textBase
+	if off+arm64InstrLen > uint64(len(code)) { //nolint:gosec // G115: off bounded by section size
+		return false
+	}
+	word := binary.LittleEndian.Uint32(code[off:])
+	if word>>arm64BLOpcShift != arm64BOpcode {
+		return false
+	}
+	imm26 := int32(word&arm64BLImmMask<<arm64BLSignShift) >> int(arm64BLSignShift) //nolint:gosec // G115: masked to 26 bits
+	stubTarget := uint64(int64(target) + int64(imm26)*arm64InstrLen)               //nolint:gosec // G115: target is a Mach-O VA
+	_, ok := wrapperAddrs[stubTarget]
+	return ok
 }
 
 // scanGoWrapperCalls performs Pass 2: scans the __TEXT,__text section for BL
@@ -81,7 +110,7 @@ func scanGoWrapperCalls(
 			continue
 		}
 
-		if _, isWrapper := wrapperAddrs[target]; !isWrapper {
+		if !isKnownWrapper(code, textBase, target, wrapperAddrs) {
 			continue
 		}
 
@@ -91,7 +120,7 @@ func scanGoWrapperCalls(
 			continue
 		}
 
-		num, resolved := arm64util.BackwardScanX0(code, offset)
+		num, resolved := arm64util.BackwardScanStackTrap(code, offset)
 
 		var info common.SyscallInfo
 		if resolved {

--- a/internal/runner/security/machoanalyzer/pass2_scanner_test.go
+++ b/internal/runner/security/machoanalyzer/pass2_scanner_test.go
@@ -1,0 +1,186 @@
+//go:build test
+
+package machoanalyzer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// encodeMovzX0 encodes MOVZ X0, #imm, LSL #0.
+func encodeMovzX0(imm uint32) uint32 { //nolint:unparam
+	return 0xD2800000 | ((imm & 0xFFFF) << 5)
+}
+
+// encodeMovzW0 encodes MOVZ W0, #imm.
+func encodeMovzW0(imm uint32) uint32 {
+	return 0x52800000 | ((imm & 0xFFFF) << 5)
+}
+
+// encodeBLTo encodes a BL instruction that targets the given offset (in bytes)
+// relative to the BL instruction itself. The offset must be a multiple of 4.
+func encodeBLTo(offsetBytes int32) uint32 {
+	imm26 := (offsetBytes / 4) & 0x03FFFFFF
+	return 0x94000000 | uint32(imm26)
+}
+
+// TestScanGoWrapperCalls_ResolvedNetworkSyscall verifies that a BL targeting a
+// known wrapper address preceded by MOVZ X0, #97 is detected as syscall 97 (socket).
+func TestScanGoWrapperCalls_ResolvedNetworkSyscall(t *testing.T) {
+	t.Parallel()
+
+	const (
+		textBase    = uint64(0x100000000)
+		wrapperAddr = uint64(0x100001000)
+	)
+
+	// Layout:
+	//   offset 0: MOVZ X0, #97
+	//   offset 4: BL wrapperAddr  (target = textBase + 4 + offset_to_wrapper)
+	blOffset := int32(wrapperAddr-textBase) - 4 // relative from BL instruction at offset 4
+	code := buildCodeSlice(encodeMovzX0(97), encodeBLTo(blOffset))
+
+	wrapperAddrs := map[uint64]string{wrapperAddr: "syscall.Syscall"}
+	table := newStubSyscallTable()
+
+	results := scanGoWrapperCalls(code, textBase, wrapperAddrs, nil, table)
+
+	require.Len(t, results, 1)
+	assert.Equal(t, 97, results[0].Number)
+	assert.Equal(t, "socket", results[0].Name)
+	assert.True(t, results[0].IsNetwork)
+	assert.Equal(t, determinationMethodGoWrapper, results[0].DeterminationMethod)
+	assert.Equal(t, textBase+4, results[0].Location)
+}
+
+// TestScanGoWrapperCalls_ResolvedW0 verifies that MOVZ W0, #98 is also resolved.
+func TestScanGoWrapperCalls_ResolvedW0(t *testing.T) {
+	t.Parallel()
+
+	const (
+		textBase    = uint64(0x100000000)
+		wrapperAddr = uint64(0x100001000)
+	)
+
+	blOffset := int32(wrapperAddr-textBase) - 4
+	code := buildCodeSlice(encodeMovzW0(98), encodeBLTo(blOffset))
+
+	wrapperAddrs := map[uint64]string{wrapperAddr: "syscall.Syscall"}
+	table := newStubSyscallTable()
+
+	results := scanGoWrapperCalls(code, textBase, wrapperAddrs, nil, table)
+
+	require.Len(t, results, 1)
+	assert.Equal(t, 98, results[0].Number)
+	assert.Equal(t, "connect", results[0].Name)
+	assert.True(t, results[0].IsNetwork)
+}
+
+// TestScanGoWrapperCalls_UnresolvedX0 verifies that a BL to a wrapper without
+// a preceding X0 load produces Number=-1 and method="unknown:indirect_setting".
+func TestScanGoWrapperCalls_UnresolvedX0(t *testing.T) {
+	t.Parallel()
+
+	const (
+		textBase    = uint64(0x100000000)
+		wrapperAddr = uint64(0x100001000)
+	)
+
+	blOffset := int32(wrapperAddr - textBase)
+	code := buildCodeSlice(encodeBLTo(blOffset))
+
+	wrapperAddrs := map[uint64]string{wrapperAddr: "syscall.Syscall"}
+	table := newStubSyscallTable()
+
+	results := scanGoWrapperCalls(code, textBase, wrapperAddrs, nil, table)
+
+	require.Len(t, results, 1)
+	assert.Equal(t, -1, results[0].Number)
+	assert.Equal(t, determinationMethodUnknownIndirect, results[0].DeterminationMethod)
+}
+
+// TestScanGoWrapperCalls_UnknownTarget verifies that a BL to a non-wrapper
+// address is not reported.
+func TestScanGoWrapperCalls_UnknownTarget(t *testing.T) {
+	t.Parallel()
+
+	const textBase = uint64(0x100000000)
+	// BL targets offset +8, but that address is not in wrapperAddrs.
+	code := buildCodeSlice(encodeMovzX0(97), encodeBLTo(4))
+
+	wrapperAddrs := map[uint64]string{0x100001000: "syscall.Syscall"}
+	results := scanGoWrapperCalls(code, textBase, wrapperAddrs, nil, newStubSyscallTable())
+
+	assert.Empty(t, results)
+}
+
+// TestScanGoWrapperCalls_InsideStubRange verifies that a BL originating inside
+// a known stub range is excluded.
+func TestScanGoWrapperCalls_InsideStubRange(t *testing.T) {
+	t.Parallel()
+
+	const (
+		textBase    = uint64(0x100000000)
+		wrapperAddr = uint64(0x100001000)
+	)
+
+	blOffset := int32(wrapperAddr-textBase) - 4
+	code := buildCodeSlice(encodeMovzX0(97), encodeBLTo(blOffset))
+
+	// The BL at offset 4 (= textBase+4) falls inside the stub range.
+	stubRanges := []funcRange{{start: textBase, end: textBase + 100}}
+	wrapperAddrs := map[uint64]string{wrapperAddr: "syscall.Syscall"}
+
+	results := scanGoWrapperCalls(code, textBase, wrapperAddrs, stubRanges, newStubSyscallTable())
+
+	assert.Empty(t, results, "BL inside stub range must be excluded")
+}
+
+// TestScanGoWrapperCalls_EmptyWrapperAddrs verifies that an empty wrapperAddrs
+// map results in no entries (fast path).
+func TestScanGoWrapperCalls_EmptyWrapperAddrs(t *testing.T) {
+	t.Parallel()
+
+	code := buildCodeSlice(encodeMovzX0(97), encodeBLTo(4))
+	results := scanGoWrapperCalls(code, 0x100000000, nil, nil, newStubSyscallTable())
+	assert.Nil(t, results)
+}
+
+// TestBuildWrapperAddrs verifies that only known syscall stub names are included.
+func TestBuildWrapperAddrs(t *testing.T) {
+	t.Parallel()
+
+	funcs := map[string]MachoPclntabFunc{
+		"syscall.Syscall":  {Entry: 0x100, End: 0x200},
+		"syscall.Syscall6": {Entry: 0x300, End: 0x400},
+		"main.notAWrapper": {Entry: 0x500, End: 0x600},
+	}
+	addrs := buildWrapperAddrs(funcs)
+
+	assert.Len(t, addrs, 2)
+	assert.Contains(t, addrs, uint64(0x100))
+	assert.Contains(t, addrs, uint64(0x300))
+	assert.NotContains(t, addrs, uint64(0x500))
+}
+
+// TestGetBLTarget_ValidBL verifies BL target computation.
+func TestGetBLTarget_ValidBL(t *testing.T) {
+	t.Parallel()
+
+	// BL +8 from address 0x100000000: target = 0x100000000 + 8 = 0x100000008
+	word := encodeBLTo(8)
+	target, ok := getBLTarget(word, 0x100000000)
+	require.True(t, ok)
+	assert.Equal(t, uint64(0x100000008), target)
+}
+
+// TestGetBLTarget_NotBL verifies that a non-BL instruction returns (0, false).
+func TestGetBLTarget_NotBL(t *testing.T) {
+	t.Parallel()
+
+	const nop = uint32(0xD503201F)
+	_, ok := getBLTarget(nop, 0x100000000)
+	assert.False(t, ok)
+}

--- a/internal/runner/security/machoanalyzer/pass2_scanner_test.go
+++ b/internal/runner/security/machoanalyzer/pass2_scanner_test.go
@@ -26,8 +26,35 @@ func encodeBLTo(offsetBytes int32) uint32 {
 	return 0x94000000 | uint32(imm26)
 }
 
+// encodeBTo encodes an unconditional B (no link) instruction targeting the
+// given offset (in bytes) relative to the B instruction itself.
+func encodeBTo(offsetBytes int32) uint32 {
+	imm26 := (offsetBytes / 4) & 0x03FFFFFF
+	return 0x14000000 | uint32(imm26)
+}
+
+// encodeStrSp8 encodes STR xN, [SP, #8] — stores register N to the trap
+// argument slot used by Go's old stack ABI.
+func encodeStrSp8(regN uint32) uint32 {
+	// STR Xt,[Xn,#pimm]: bits[31:22]=0x3E4, imm12=1 (=8/8), Rn=SP(31), Rt=N
+	return 0xF9000000 | (1 << 10) | (31 << 5) | regN
+}
+
+// encodeStpSp8 encodes STP xN, xM, [SP, #8] — stores register N (trap) and M
+// (a1) to the first two argument slots used by Go's old stack ABI.
+func encodeStpSp8(regN, regM uint32) uint32 {
+	// STP Xt1,Xt2,[Xn,#imm]: bits[31:22]=0x2A4, imm7=1, Rt2=M, Rn=SP(31), Rt1=N
+	return 0xA9000000 | (1 << 15) | (regM << 10) | (31 << 5) | regN
+}
+
+// encodeMovzReg encodes MOVZ xN, #imm, LSL#0 (64-bit) for any register N.
+func encodeMovzReg(regN, imm uint32) uint32 { //nolint:unparam
+	return 0xD2800000 | ((imm & 0xFFFF) << 5) | regN
+}
+
 // TestScanGoWrapperCalls_ResolvedNetworkSyscall verifies that a BL targeting a
-// known wrapper address preceded by MOVZ X0, #97 is detected as syscall 97 (socket).
+// known wrapper address preceded by the Go old-stack-ABI store pattern
+// (MOVZ x5, #97; STR x5, [SP, #8]) is detected as syscall 97 (socket).
 func TestScanGoWrapperCalls_ResolvedNetworkSyscall(t *testing.T) {
 	t.Parallel()
 
@@ -37,10 +64,11 @@ func TestScanGoWrapperCalls_ResolvedNetworkSyscall(t *testing.T) {
 	)
 
 	// Layout:
-	//   offset 0: MOVZ X0, #97
-	//   offset 4: BL wrapperAddr  (target = textBase + 4 + offset_to_wrapper)
-	blOffset := int32(wrapperAddr-textBase) - 4 // relative from BL instruction at offset 4
-	code := buildCodeSlice(encodeMovzX0(97), encodeBLTo(blOffset))
+	//   offset 0: MOVZ X5, #97
+	//   offset 4: STR X5, [SP, #8]   (trap argument slot — old stack ABI)
+	//   offset 8: BL wrapperAddr
+	blOffset := int32(wrapperAddr-textBase) - 8 // relative from BL at offset 8
+	code := buildCodeSlice(encodeMovzReg(5, 97), encodeStrSp8(5), encodeBLTo(blOffset))
 
 	wrapperAddrs := map[uint64]string{wrapperAddr: "syscall.Syscall"}
 	table := newStubSyscallTable()
@@ -52,10 +80,11 @@ func TestScanGoWrapperCalls_ResolvedNetworkSyscall(t *testing.T) {
 	assert.Equal(t, "socket", results[0].Name)
 	assert.True(t, results[0].IsNetwork)
 	assert.Equal(t, determinationMethodGoWrapper, results[0].DeterminationMethod)
-	assert.Equal(t, textBase+4, results[0].Location)
+	assert.Equal(t, textBase+8, results[0].Location)
 }
 
-// TestScanGoWrapperCalls_ResolvedW0 verifies that MOVZ W0, #98 is also resolved.
+// TestScanGoWrapperCalls_ResolvedW0 verifies that MOVZ W0 (32-bit) stored via
+// STR X0,[SP,#8] is also resolved correctly.
 func TestScanGoWrapperCalls_ResolvedW0(t *testing.T) {
 	t.Parallel()
 
@@ -64,8 +93,9 @@ func TestScanGoWrapperCalls_ResolvedW0(t *testing.T) {
 		wrapperAddr = uint64(0x100001000)
 	)
 
-	blOffset := int32(wrapperAddr-textBase) - 4
-	code := buildCodeSlice(encodeMovzW0(98), encodeBLTo(blOffset))
+	// MOVZ W0, #98; STR X0, [SP, #8]; BL wrapperAddr
+	blOffset := int32(wrapperAddr-textBase) - 8
+	code := buildCodeSlice(encodeMovzW0(98), encodeStrSp8(0), encodeBLTo(blOffset))
 
 	wrapperAddrs := map[uint64]string{wrapperAddr: "syscall.Syscall"}
 	table := newStubSyscallTable()
@@ -126,10 +156,11 @@ func TestScanGoWrapperCalls_InsideStubRange(t *testing.T) {
 		wrapperAddr = uint64(0x100001000)
 	)
 
-	blOffset := int32(wrapperAddr-textBase) - 4
-	code := buildCodeSlice(encodeMovzX0(97), encodeBLTo(blOffset))
+	// MOVZ X5, #97; STR X5, [SP, #8]; BL wrapperAddr
+	// BL is at offset 8 (= textBase+8), which falls inside the stub range below.
+	blOffset := int32(wrapperAddr-textBase) - 8
+	code := buildCodeSlice(encodeMovzReg(5, 97), encodeStrSp8(5), encodeBLTo(blOffset))
 
-	// The BL at offset 4 (= textBase+4) falls inside the stub range.
 	stubRanges := []funcRange{{start: textBase, end: textBase + 100}}
 	wrapperAddrs := map[uint64]string{wrapperAddr: "syscall.Syscall"}
 
@@ -183,4 +214,108 @@ func TestGetBLTarget_NotBL(t *testing.T) {
 	const nop = uint32(0xD503201F)
 	_, ok := getBLTarget(nop, 0x100000000)
 	assert.False(t, ok)
+}
+
+// TestScanGoWrapperCalls_StackABI_STPPattern verifies that STP xN,xM,[SP,#8]
+// (the two-argument store form used by syscall.Syscall) is also resolved.
+func TestScanGoWrapperCalls_StackABI_STPPattern(t *testing.T) {
+	t.Parallel()
+
+	const (
+		textBase    = uint64(0x100000000)
+		wrapperAddr = uint64(0x100001000)
+	)
+
+	// Mirrors the Go compiler output for syscall.Syscall(socket, ...):
+	//   MOVZ X5, #97
+	//   STP  X5, X4, [SP, #8]   (trap at SP+8, a1 at SP+16)
+	//   BL   wrapperAddr
+	blOffset := int32(wrapperAddr-textBase) - 8
+	code := buildCodeSlice(encodeMovzReg(5, 97), encodeStpSp8(5, 4), encodeBLTo(blOffset))
+
+	wrapperAddrs := map[uint64]string{wrapperAddr: "syscall.Syscall"}
+	results := scanGoWrapperCalls(code, textBase, wrapperAddrs, nil, newStubSyscallTable())
+
+	require.Len(t, results, 1)
+	assert.Equal(t, 97, results[0].Number)
+	assert.Equal(t, determinationMethodGoWrapper, results[0].DeterminationMethod)
+}
+
+// TestScanGoWrapperCalls_StubTrampoline verifies that a BL targeting a single-
+// instruction trampoline stub (B wrapperAddr) is resolved as a wrapper call.
+// The Go linker sometimes emits near-branch stubs for far calls.
+func TestScanGoWrapperCalls_StubTrampoline(t *testing.T) {
+	t.Parallel()
+
+	const (
+		textBase    = uint64(0x100000000)
+		wrapperAddr = uint64(0x100002000) // actual wrapper
+		stubAddr    = uint64(0x100001000) // trampoline: B wrapperAddr
+	)
+
+	// Layout in __text (relative to textBase):
+	//   offset 0x000: MOVZ X5, #97
+	//   offset 0x004: STR  X5, [SP, #8]
+	//   offset 0x008: BL   stubAddr        (0x1000 bytes forward)
+	//   ...
+	//   offset 0x1000: B   wrapperAddr     (0x1000 bytes forward = actual wrapper)
+	//   offset 0x2000: <wrapper body>      (just a NOP for this test)
+
+	totalLen := int(wrapperAddr-textBase) + 4 // include first word of wrapper
+	code := make([]byte, totalLen)
+
+	// Encode call site at offset 0
+	putInstr := func(off int, w uint32) {
+		code[off] = byte(w)
+		code[off+1] = byte(w >> 8)
+		code[off+2] = byte(w >> 16)
+		code[off+3] = byte(w >> 24)
+	}
+	putInstr(0, encodeMovzReg(5, 97))
+	putInstr(4, encodeStrSp8(5))
+	blToStub := int32(stubAddr-textBase) - 8 // BL at offset 8, targeting stubAddr
+	putInstr(8, encodeBLTo(blToStub))
+
+	// Encode stub trampoline at stubAddr-textBase = 0x1000
+	stubOff := int(stubAddr - textBase)
+	bToWrapper := int32(wrapperAddr - stubAddr) // B at stubAddr, targeting wrapperAddr
+	putInstr(stubOff, encodeBTo(bToWrapper))
+
+	// wrapperAddrs only contains the actual wrapper, not the stub
+	wrapperAddrs := map[uint64]string{wrapperAddr: "syscall.Syscall"}
+	results := scanGoWrapperCalls(code, textBase, wrapperAddrs, nil, newStubSyscallTable())
+
+	require.Len(t, results, 1)
+	assert.Equal(t, 97, results[0].Number)
+	assert.Equal(t, determinationMethodGoWrapper, results[0].DeterminationMethod)
+	assert.Equal(t, textBase+8, results[0].Location)
+}
+
+// TestIsKnownWrapper_DirectAndStub verifies isKnownWrapper for both direct
+// wrapper addresses and single-instruction stub trampolines.
+func TestIsKnownWrapper_DirectAndStub(t *testing.T) {
+	t.Parallel()
+
+	const (
+		textBase    = uint64(0x100000000)
+		wrapperAddr = uint64(0x100002000)
+		stubAddr    = uint64(0x100001000)
+	)
+
+	// Build a minimal code slice with a stub at stubAddr.
+	totalLen := int(wrapperAddr-textBase) + 4
+	code := make([]byte, totalLen)
+	stubOff := int(stubAddr - textBase)
+	bToWrapper := int32(wrapperAddr - stubAddr)
+	w := encodeBTo(bToWrapper)
+	code[stubOff] = byte(w)
+	code[stubOff+1] = byte(w >> 8)
+	code[stubOff+2] = byte(w >> 16)
+	code[stubOff+3] = byte(w >> 24)
+
+	wrapperAddrs := map[uint64]string{wrapperAddr: "syscall.Syscall"}
+
+	assert.True(t, isKnownWrapper(code, textBase, wrapperAddr, wrapperAddrs), "direct wrapper must match")
+	assert.True(t, isKnownWrapper(code, textBase, stubAddr, wrapperAddrs), "stub trampoline must match")
+	assert.False(t, isKnownWrapper(code, textBase, textBase+100, wrapperAddrs), "unknown address must not match")
 }

--- a/internal/runner/security/machoanalyzer/pclntab_macho.go
+++ b/internal/runner/security/machoanalyzer/pclntab_macho.go
@@ -253,9 +253,17 @@ func collectBLDiffs(data []byte, textAddr uint64, sortedEntries []uint64, diffCo
 		instr := binary.LittleEndian.Uint32(data[i : i+arm64InstrSize])
 		if instr>>arm64BLOpcShift == arm64BLOpcode {
 			imm26Raw := instr & arm64BLImmMask
-			imm26 := int32(imm26Raw<<arm64BLSignShift) >> arm64BLSignShift       //nolint:gosec // G115: safe, imm26Raw is masked to 26 bits
-			target := textAddr + uint64(i) + uint64(int64(imm26)*arm64InstrSize) //nolint:gosec // G115: result bounded by address space
-			collectWindowDiffs(target, sortedEntries, diffCounts)
+			imm26 := int32(imm26Raw<<arm64BLSignShift) >> arm64BLSignShift //nolint:gosec // G115: safe, imm26Raw is masked to 26 bits
+			base := int64(textAddr) + int64(i)                             //nolint:gosec // G115: textAddr is a Mach-O VA, fits in int64
+			target := base + int64(imm26)*arm64InstrSize
+			if target < 0 {
+				continue
+			}
+			targetAddr := uint64(target)     //nolint:gosec // G115: target >= 0 checked above
+			if int64(targetAddr) != target { //nolint:gosec // G115: targetAddr == uint64(target), target >= 0
+				continue
+			}
+			collectWindowDiffs(targetAddr, sortedEntries, diffCounts)
 		}
 	}
 }

--- a/internal/runner/security/machoanalyzer/pclntab_macho.go
+++ b/internal/runner/security/machoanalyzer/pclntab_macho.go
@@ -1,0 +1,276 @@
+package machoanalyzer
+
+import (
+	"debug/gosym"
+	"debug/macho"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"slices"
+	"sort"
+)
+
+// machoTextSegName is the Mach-O segment name for the executable text segment.
+const machoTextSegName = "__TEXT"
+
+// Errors returned by ParseMachoPclntab.
+var (
+	// ErrNoPclntab is returned when no __gopclntab section is found.
+	// This typically means a stripped binary or a non-Go binary.
+	// Callers must continue Pass 1 and Pass 2 without exclusion/resolution.
+	ErrNoPclntab = errors.New("no __gopclntab section found")
+
+	// ErrUnsupportedPclntabVersion is returned when the pclntab magic is not
+	// 0xfffffff1 (Go 1.20+). Only Go 1.20+ (magic 0xfffffff1) is supported.
+	ErrUnsupportedPclntabVersion = errors.New("unsupported pclntab version: only magic 0xfffffff1 (Go 1.20+) is supported")
+
+	// ErrInvalidPclntab is returned when the pclntab data is too short to
+	// contain a valid magic number.
+	ErrInvalidPclntab = errors.New("invalid pclntab data")
+)
+
+// MachoPclntabFunc holds the address range of a function extracted from
+// the Mach-O __gopclntab section.
+type MachoPclntabFunc struct {
+	Name  string
+	Entry uint64
+	End   uint64
+}
+
+// funcRange represents a contiguous address range [start, end).
+// Used by both Pass 1 (stubRanges) and Pass 2 (wrapperRanges).
+type funcRange struct {
+	start uint64
+	end   uint64
+}
+
+// isInsideRange reports whether addr falls within any range in ranges.
+// ranges must be sorted by start for binary search (O(log n)).
+func isInsideRange(addr uint64, ranges []funcRange) bool {
+	// Binary search: find the last range with start <= addr.
+	n := sort.Search(len(ranges), func(i int) bool {
+		return ranges[i].start > addr
+	})
+	// n is the first index with start > addr, so the candidate is n-1.
+	if n == 0 {
+		return false
+	}
+	r := ranges[n-1]
+	return addr >= r.start && addr < r.end
+}
+
+// ParseMachoPclntab reads the __gopclntab section from a Mach-O file and
+// returns a map from function name to address range.
+//
+// Returns ErrNoPclntab when no __gopclntab section exists (stripped binary or
+// non-Go binary). Callers must continue Pass 1 and Pass 2 without exclusion/
+// resolution in that case.
+//
+// Only pclntab magic 0xfffffff1 (Go 1.20+) is supported; other versions
+// return ErrUnsupportedPclntabVersion.
+//
+// For CGO binaries, a constant address offset may exist between pclntab entries
+// and actual virtual addresses because C runtime startup code is inserted at the
+// beginning of __TEXT,__text. ParseMachoPclntab detects and corrects this offset.
+func ParseMachoPclntab(f *macho.File) (map[string]MachoPclntabFunc, error) {
+	functions, err := parseMachoPclntabFuncsRaw(f)
+	if err != nil {
+		return nil, err
+	}
+
+	// CGO binaries may have a constant address offset between pclntab entries
+	// and actual virtual addresses. Detect and apply the correction.
+	if offset := detectMachoPclntabOffset(f, functions); offset != 0 {
+		for name, fn := range functions {
+			functions[name] = MachoPclntabFunc{
+				Name:  fn.Name,
+				Entry: uint64(int64(fn.Entry) + offset), //nolint:gosec // G115: offset is bounded by binary size, no overflow risk
+				End:   uint64(int64(fn.End) + offset),   //nolint:gosec // G115: offset is bounded by binary size, no overflow risk
+			}
+		}
+	}
+
+	return functions, nil
+}
+
+// parseMachoPclntabFuncsRaw reads __gopclntab and returns function entries as
+// gosym reports them — without any CGO offset correction applied.
+func parseMachoPclntabFuncsRaw(f *macho.File) (map[string]MachoPclntabFunc, error) {
+	section := f.Section("__gopclntab")
+	if section == nil {
+		return nil, ErrNoPclntab
+	}
+
+	data, err := section.Data()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read __gopclntab: %w", err)
+	}
+
+	if err := checkMachoPclntabVersion(data); err != nil {
+		return nil, err
+	}
+
+	// The text start address is required by gosym.NewLineTable.
+	var textStart uint64
+	textSection := f.Section("__text")
+	if textSection != nil && textSection.Seg == machoTextSegName {
+		textStart = textSection.Addr
+	}
+
+	lineTable := gosym.NewLineTable(data, textStart)
+	symTable, err := gosym.NewTable(nil, lineTable)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrUnsupportedPclntabVersion, err)
+	}
+
+	functions := make(map[string]MachoPclntabFunc, len(symTable.Funcs))
+	for i := range symTable.Funcs {
+		fn := &symTable.Funcs[i]
+		functions[fn.Name] = MachoPclntabFunc{
+			Name:  fn.Name,
+			Entry: fn.Entry,
+			End:   fn.End,
+		}
+	}
+	return functions, nil
+}
+
+// checkMachoPclntabVersion verifies that the pclntab magic is supported.
+// Only magic 0xfffffff1 (Go 1.20+) is supported.
+func checkMachoPclntabVersion(data []byte) error {
+	const (
+		pclntabMagicSize = 4
+		go120Magic       = uint32(0xfffffff1) // Go 1.20+ (CurrentPCLnTabMagic)
+	)
+	if len(data) < pclntabMagicSize {
+		return ErrInvalidPclntab
+	}
+	// Mach-O arm64 is always little-endian.
+	magic := binary.LittleEndian.Uint32(data[0:pclntabMagicSize])
+	if magic != go120Magic {
+		return fmt.Errorf("%w (got magic 0x%x)", ErrUnsupportedPclntabVersion, magic)
+	}
+	return nil
+}
+
+// detectMachoPclntabOffset returns the address correction needed for pclntab entries
+// in CGO binaries. Uses BL instruction cross-referencing to detect the offset
+// without requiring a symbol table (supports stripped binaries).
+//
+// Returns 0 if no correction is needed (non-CGO binaries) or if detection fails.
+func detectMachoPclntabOffset(f *macho.File, pclntabFuncs map[string]MachoPclntabFunc) int64 {
+	textSection := f.Section("__text")
+	if textSection == nil || textSection.Seg != machoTextSegName {
+		return 0
+	}
+
+	offset := detectMachoOffsetByBLTargets(f, pclntabFuncs)
+	// A valid offset is strictly positive (C startup code always precedes Go text)
+	// and does not exceed the __text section size.
+	if offset <= 0 || uint64(offset) > textSection.Size { //nolint:gosec
+		return 0
+	}
+	return offset
+}
+
+// detectMachoOffsetByBLTargets detects the pclntab address offset in CGO binaries
+// by cross-referencing BL instruction targets with pclntab function entries.
+// Algorithm mirrors elfanalyzer.detectOffsetByCallTargets.
+func detectMachoOffsetByBLTargets(
+	f *macho.File,
+	pclntabFuncs map[string]MachoPclntabFunc,
+) int64 {
+	const (
+		scanLimit = 256 * 1024 // scan first 256 KB of __text
+		minVotes  = 3
+	)
+
+	textSection := f.Section("__text")
+	if textSection == nil || textSection.Seg != machoTextSegName {
+		return 0
+	}
+
+	sr := io.NewSectionReader(textSection, 0, int64(scanLimit)) //nolint:gosec
+	data, err := io.ReadAll(sr)
+	if err != nil {
+		return 0
+	}
+
+	// Build sorted slice of pclntab entry addresses.
+	sortedEntries := make([]uint64, 0, len(pclntabFuncs))
+	for _, fn := range pclntabFuncs {
+		if fn.Entry != 0 {
+			sortedEntries = append(sortedEntries, fn.Entry)
+		}
+	}
+	if len(sortedEntries) == 0 {
+		return 0
+	}
+	slices.Sort(sortedEntries)
+
+	diffCounts := make(map[int64]int)
+	textAddr := textSection.Addr
+
+	collectMachoArm64BLDiffs(data, textAddr, sortedEntries, diffCounts)
+
+	// Find the most frequent difference value with a unique winner.
+	var bestDiff int64
+	bestCount := 0
+	tied := false
+	for diff, count := range diffCounts {
+		if count > bestCount {
+			bestCount = count
+			bestDiff = diff
+			tied = false
+		} else if count == bestCount {
+			tied = true
+		}
+	}
+
+	if bestCount < minVotes || tied {
+		return 0
+	}
+	return bestDiff
+}
+
+// collectMachoArm64BLDiffs scans data for arm64 BL instructions and accumulates
+// (target_VA - E) differences for all pclntab entries E within the window.
+func collectMachoArm64BLDiffs(data []byte, textAddr uint64, sortedEntries []uint64, diffCounts map[int64]int) {
+	const (
+		arm64InstrSize   = 4
+		arm64BLOpcode    = uint32(0b100101) // bits[31:26] of BL instruction
+		arm64BLImmMask   = uint32(0x03ffffff)
+		arm64BLOpcShift  = 26
+		arm64BLImmBits   = 26
+		arm64BLSignShift = 32 - arm64BLImmBits // = 6
+	)
+	for i := 0; i+arm64InstrSize <= len(data); i += arm64InstrSize {
+		instr := binary.LittleEndian.Uint32(data[i : i+arm64InstrSize])
+		if instr>>arm64BLOpcShift == arm64BLOpcode {
+			imm26Raw := instr & arm64BLImmMask
+			imm26 := int32(imm26Raw<<arm64BLSignShift) >> arm64BLSignShift       //nolint:gosec // G115: safe, imm26Raw is masked to 26 bits
+			target := textAddr + uint64(i) + uint64(int64(imm26)*arm64InstrSize) //nolint:gosec // G115: result bounded by address space
+			collectMachoWindowDiffs(target, sortedEntries, diffCounts)
+		}
+	}
+}
+
+// maxMachoOffset is the upper bound for C startup code size (8 KB).
+const maxMachoOffset = int64(0x2000)
+
+// collectMachoWindowDiffs records (target - E) for all pclntab entries E
+// in the range [target - maxMachoOffset, target].
+func collectMachoWindowDiffs(target uint64, sortedEntries []uint64, diffCounts map[int64]int) {
+	lo := uint64(0)
+	if target > uint64(maxMachoOffset) {
+		lo = target - uint64(maxMachoOffset)
+	}
+	idxLo := sort.Search(len(sortedEntries), func(i int) bool {
+		return sortedEntries[i] >= lo
+	})
+	for i := idxLo; i < len(sortedEntries) && sortedEntries[i] <= target; i++ {
+		diff := int64(target - sortedEntries[i]) //nolint:gosec // G115: subtraction result bounded by maxMachoOffset
+		diffCounts[diff]++
+	}
+}

--- a/internal/runner/security/machoanalyzer/pclntab_macho.go
+++ b/internal/runner/security/machoanalyzer/pclntab_macho.go
@@ -191,7 +191,11 @@ func detectMachoOffsetByBLTargets(
 		return 0
 	}
 
-	sr := io.NewSectionReader(textSection, 0, int64(scanLimit)) //nolint:gosec
+	readLimit := int64(scanLimit)                                        //nolint:gosec
+	if sectionSize := int64(textSection.Size); sectionSize < readLimit { //nolint:gosec
+		readLimit = sectionSize
+	}
+	sr := io.NewSectionReader(textSection, 0, readLimit)
 	data, err := io.ReadAll(sr)
 	if err != nil {
 		return 0

--- a/internal/runner/security/machoanalyzer/pclntab_macho.go
+++ b/internal/runner/security/machoanalyzer/pclntab_macho.go
@@ -85,8 +85,8 @@ func ParseMachoPclntab(f *macho.File) (map[string]MachoPclntabFunc, error) {
 		for name, fn := range functions {
 			functions[name] = MachoPclntabFunc{
 				Name:  fn.Name,
-				Entry: uint64(int64(fn.Entry) + offset), //nolint:gosec // G115: offset is bounded by binary size, no overflow risk
-				End:   uint64(int64(fn.End) + offset),   //nolint:gosec // G115: offset is bounded by binary size, no overflow risk
+				Entry: fn.Entry + uint64(offset), //nolint:gosec // G115: offset verified positive in detectMachoPclntabOffset
+				End:   fn.End + uint64(offset),   //nolint:gosec // G115: offset verified positive in detectMachoPclntabOffset
 			}
 		}
 	}

--- a/internal/runner/security/machoanalyzer/pclntab_macho.go
+++ b/internal/runner/security/machoanalyzer/pclntab_macho.go
@@ -11,8 +11,8 @@ import (
 	"sort"
 )
 
-// machoTextSegName is the Mach-O segment name for the executable text segment.
-const machoTextSegName = "__TEXT"
+// textSegName is the Mach-O segment name for the executable text segment.
+const textSegName = "__TEXT"
 
 // Errors returned by ParseMachoPclntab.
 var (
@@ -114,7 +114,7 @@ func parseMachoPclntabFuncsRaw(f *macho.File) (map[string]MachoPclntabFunc, erro
 	// The text start address is required by gosym.NewLineTable.
 	var textStart uint64
 	textSection := f.Section("__text")
-	if textSection != nil && textSection.Seg == machoTextSegName {
+	if textSection != nil && textSection.Seg == textSegName {
 		textStart = textSection.Addr
 	}
 
@@ -161,7 +161,7 @@ func checkMachoPclntabVersion(data []byte) error {
 // Returns 0 if no correction is needed (non-CGO binaries) or if detection fails.
 func detectMachoPclntabOffset(f *macho.File, pclntabFuncs map[string]MachoPclntabFunc) int64 {
 	textSection := f.Section("__text")
-	if textSection == nil || textSection.Seg != machoTextSegName {
+	if textSection == nil || textSection.Seg != textSegName {
 		return 0
 	}
 
@@ -187,7 +187,7 @@ func detectMachoOffsetByBLTargets(
 	)
 
 	textSection := f.Section("__text")
-	if textSection == nil || textSection.Seg != machoTextSegName {
+	if textSection == nil || textSection.Seg != textSegName {
 		return 0
 	}
 
@@ -212,7 +212,7 @@ func detectMachoOffsetByBLTargets(
 	diffCounts := make(map[int64]int)
 	textAddr := textSection.Addr
 
-	collectMachoArm64BLDiffs(data, textAddr, sortedEntries, diffCounts)
+	collectBLDiffs(data, textAddr, sortedEntries, diffCounts)
 
 	// Find the most frequent difference value with a unique winner.
 	var bestDiff int64
@@ -234,9 +234,9 @@ func detectMachoOffsetByBLTargets(
 	return bestDiff
 }
 
-// collectMachoArm64BLDiffs scans data for arm64 BL instructions and accumulates
+// collectBLDiffs scans data for arm64 BL instructions and accumulates
 // (target_VA - E) differences for all pclntab entries E within the window.
-func collectMachoArm64BLDiffs(data []byte, textAddr uint64, sortedEntries []uint64, diffCounts map[int64]int) {
+func collectBLDiffs(data []byte, textAddr uint64, sortedEntries []uint64, diffCounts map[int64]int) {
 	const (
 		arm64InstrSize   = 4
 		arm64BLOpcode    = uint32(0b100101) // bits[31:26] of BL instruction
@@ -251,26 +251,26 @@ func collectMachoArm64BLDiffs(data []byte, textAddr uint64, sortedEntries []uint
 			imm26Raw := instr & arm64BLImmMask
 			imm26 := int32(imm26Raw<<arm64BLSignShift) >> arm64BLSignShift       //nolint:gosec // G115: safe, imm26Raw is masked to 26 bits
 			target := textAddr + uint64(i) + uint64(int64(imm26)*arm64InstrSize) //nolint:gosec // G115: result bounded by address space
-			collectMachoWindowDiffs(target, sortedEntries, diffCounts)
+			collectWindowDiffs(target, sortedEntries, diffCounts)
 		}
 	}
 }
 
-// maxMachoOffset is the upper bound for C startup code size (8 KB).
-const maxMachoOffset = int64(0x2000)
+// maxCStartupOffset is the upper bound for C startup code size before Go text (8 KB).
+const maxCStartupOffset = int64(0x2000)
 
-// collectMachoWindowDiffs records (target - E) for all pclntab entries E
-// in the range [target - maxMachoOffset, target].
-func collectMachoWindowDiffs(target uint64, sortedEntries []uint64, diffCounts map[int64]int) {
+// collectWindowDiffs records (target - E) for all pclntab entries E
+// in the range [target - maxCStartupOffset, target].
+func collectWindowDiffs(target uint64, sortedEntries []uint64, diffCounts map[int64]int) {
 	lo := uint64(0)
-	if target > uint64(maxMachoOffset) {
-		lo = target - uint64(maxMachoOffset)
+	if target > uint64(maxCStartupOffset) {
+		lo = target - uint64(maxCStartupOffset)
 	}
 	idxLo := sort.Search(len(sortedEntries), func(i int) bool {
 		return sortedEntries[i] >= lo
 	})
 	for i := idxLo; i < len(sortedEntries) && sortedEntries[i] <= target; i++ {
-		diff := int64(target - sortedEntries[i]) //nolint:gosec // G115: subtraction result bounded by maxMachoOffset
+		diff := int64(target - sortedEntries[i]) //nolint:gosec // G115: subtraction result bounded by maxCStartupOffset
 		diffCounts[diff]++
 	}
 }

--- a/internal/runner/security/machoanalyzer/pclntab_macho.go
+++ b/internal/runner/security/machoanalyzer/pclntab_macho.go
@@ -121,7 +121,7 @@ func parseMachoPclntabFuncsRaw(f *macho.File) (map[string]MachoPclntabFunc, erro
 	lineTable := gosym.NewLineTable(data, textStart)
 	symTable, err := gosym.NewTable(nil, lineTable)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %w", ErrUnsupportedPclntabVersion, err)
+		return nil, fmt.Errorf("%w: failed to parse __gopclntab: %w", ErrInvalidPclntab, err)
 	}
 
 	functions := make(map[string]MachoPclntabFunc, len(symTable.Funcs))

--- a/internal/runner/security/machoanalyzer/pclntab_macho_test.go
+++ b/internal/runner/security/machoanalyzer/pclntab_macho_test.go
@@ -304,7 +304,7 @@ func TestParseMachoPclntab_LiveBinary(t *testing.T) {
 	defer f.Close() //nolint:errcheck
 
 	funcs, err := ParseMachoPclntab(f)
-	if errors.Is(err, ErrNoPclntab) || errors.Is(err, ErrUnsupportedPclntabVersion) {
+	if errors.Is(err, ErrNoPclntab) || errors.Is(err, ErrUnsupportedPclntabVersion) || errors.Is(err, ErrInvalidPclntab) {
 		t.Skip("no suitable pclntab found in test binary")
 	}
 	require.NoError(t, err)

--- a/internal/runner/security/machoanalyzer/pclntab_macho_test.go
+++ b/internal/runner/security/machoanalyzer/pclntab_macho_test.go
@@ -289,38 +289,6 @@ func TestIsInsideRange_EmptySlice(t *testing.T) {
 	assert.False(t, isInsideRange(0x100, []funcRange{}))
 }
 
-// TestParseMachoPclntab_LiveBinary verifies that ParseMachoPclntab can parse
-// the actual test binary (go test builds contain __gopclntab) and finds known
-// Go runtime function names.
-func TestParseMachoPclntab_LiveBinary(t *testing.T) {
-	t.Parallel()
-
-	// Open the current test binary (self-test).
-	f, err := macho.Open("/proc/self/exe")
-	if err != nil {
-		// Not on macOS or not a Mach-O binary — skip.
-		t.Skip("skipping live binary test: cannot open /proc/self/exe as Mach-O")
-	}
-	defer f.Close() //nolint:errcheck
-
-	funcs, err := ParseMachoPclntab(f)
-	if errors.Is(err, ErrNoPclntab) || errors.Is(err, ErrUnsupportedPclntabVersion) || errors.Is(err, ErrInvalidPclntab) {
-		t.Skip("no suitable pclntab found in test binary")
-	}
-	require.NoError(t, err)
-	require.NotEmpty(t, funcs)
-
-	// Verify that at least one Go runtime function is present.
-	found := false
-	for name := range funcs {
-		if name == "testing.Main" || name == "testing.tRunner" || name == "main.main" {
-			found = true
-			break
-		}
-	}
-	assert.True(t, found, "expected at least one known Go runtime function in pclntab")
-}
-
 // TestParseMachoPclntab_MacOSTestBinary verifies ParseMachoPclntab on macOS
 // using the actual test runner binary (os.Args[0]).
 func TestParseMachoPclntab_MacOSTestBinary(t *testing.T) {

--- a/internal/runner/security/machoanalyzer/pclntab_macho_test.go
+++ b/internal/runner/security/machoanalyzer/pclntab_macho_test.go
@@ -1,0 +1,355 @@
+//go:build test
+
+package machoanalyzer
+
+import (
+	"bytes"
+	"debug/macho"
+	"encoding/binary"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// buildMachOWithPclntab constructs a minimal valid 64-bit Mach-O file in
+// memory containing a __TEXT,__text section and optionally a __gopclntab
+// section. This is sufficient for ParseMachoPclntab unit tests.
+//
+// textData may be nil (no __text section). pclntabData nil means no __gopclntab.
+func buildMachOWithPclntab(t *testing.T, pclntabData []byte) *macho.File {
+	t.Helper()
+
+	// We use macho.NewFile with a hand-crafted binary rather than relying on
+	// the OS to build one, to keep tests hermetic and cross-platform.
+	//
+	// Mach-O 64-bit header (little-endian, ARM64):
+	//   magic(4) + cputype(4) + cpusubtype(4) + filetype(4) +
+	//   ncmds(4) + sizeofcmds(4) + flags(4) + reserved(4) = 32 bytes
+
+	const (
+		machoMagic64    = uint32(0xFEEDFACF)
+		cpuArm64        = uint32(0x0100000C) // CPU_TYPE_ARM64
+		cpuSubtypeAll   = uint32(0x00000000)
+		fileTypeExec    = uint32(2) // MH_EXECUTE
+		headerSize      = 32        // mach_header_64
+		segCmdSize64    = 72        // sizeof(segment_command_64)
+		sectCmdSize64   = 80        // sizeof(section_64)
+		lcSegment64     = uint32(0x19)
+		vmProtNone      = uint32(0)
+		vmProtRX        = uint32(5)           // VM_PROT_READ | VM_PROT_EXECUTE
+		textSectionData = "\x00\x00\x00\x00"  // 4-byte placeholder
+		textVMAddr      = uint64(0x100000000) // typical macOS arm64 base
+	)
+
+	// Build section data layout:
+	// Sections are placed after all load commands.
+	// We need 1 segment (__TEXT) with up to 2 sections (__text + __gopclntab).
+	hasPclntab := pclntabData != nil
+	numSections := uint32(1)
+	if hasPclntab {
+		numSections = 2
+	}
+
+	segCmdTotalSize := segCmdSize64 + numSections*sectCmdSize64
+
+	// Calculate file offsets. Load commands follow immediately after the header.
+	lcOffset := uint32(headerSize)
+	// Section data starts after header + all load commands.
+	dataOffset := lcOffset + segCmdTotalSize
+
+	textBytes := []byte(textSectionData)
+	textOffset := dataOffset
+	textSize := uint32(len(textBytes))
+
+	var pclntabOffset, pclntabSize uint32
+	if hasPclntab {
+		pclntabOffset = textOffset + textSize
+		pclntabSize = uint32(len(pclntabData))
+	}
+
+	fileSize := pclntabOffset + pclntabSize
+	if !hasPclntab {
+		fileSize = textOffset + textSize
+	}
+
+	var buf bytes.Buffer
+	le := binary.LittleEndian
+
+	writeUint32 := func(v uint32) {
+		var b [4]byte
+		le.PutUint32(b[:], v)
+		buf.Write(b[:])
+	}
+	writeUint64 := func(v uint64) {
+		var b [8]byte
+		le.PutUint64(b[:], v)
+		buf.Write(b[:])
+	}
+	writeStr16 := func(s string) {
+		var b [16]byte
+		copy(b[:], s)
+		buf.Write(b[:])
+	}
+
+	// --- Mach-O header ---
+	writeUint32(machoMagic64)
+	writeUint32(cpuArm64)
+	writeUint32(cpuSubtypeAll)
+	writeUint32(fileTypeExec)
+	writeUint32(1)               // ncmds
+	writeUint32(segCmdTotalSize) // sizeofcmds
+	writeUint32(0)               // flags
+	writeUint32(0)               // reserved
+
+	// --- LC_SEGMENT_64 (__TEXT) ---
+	vmSize := uint64(textSize)
+	if hasPclntab {
+		vmSize += uint64(pclntabSize)
+	}
+	writeUint32(lcSegment64)
+	writeUint32(segCmdTotalSize)    // cmdsize
+	writeStr16("__TEXT")            // segname
+	writeUint64(textVMAddr)         // vmaddr
+	writeUint64(vmSize)             // vmsize
+	writeUint64(uint64(textOffset)) // fileoff
+	writeUint64(vmSize)             // filesize
+	writeUint32(vmProtRX)           // maxprot
+	writeUint32(vmProtRX)           // initprot
+	writeUint32(numSections)        // nsects
+	writeUint32(0)                  // flags
+
+	// --- Section: __text ---
+	writeStr16("__text")
+	writeStr16("__TEXT")
+	writeUint64(textVMAddr)       // addr
+	writeUint64(uint64(textSize)) // size
+	writeUint32(textOffset)       // offset
+	writeUint32(2)                // align (4 bytes)
+	writeUint32(0)                // reloff
+	writeUint32(0)                // nreloc
+	writeUint32(0x80000400)       // flags (S_REGULAR | S_ATTR_SOME_INSTRUCTIONS)
+	writeUint32(0)                // reserved1
+	writeUint32(0)                // reserved2
+	writeUint32(0)                // reserved3
+
+	// --- Section: __gopclntab (if present) ---
+	if hasPclntab {
+		pclntabVMAddr := textVMAddr + uint64(textSize)
+		writeStr16("__gopclntab")
+		writeStr16("__TEXT")
+		writeUint64(pclntabVMAddr)       // addr
+		writeUint64(uint64(pclntabSize)) // size
+		writeUint32(pclntabOffset)       // offset
+		writeUint32(0)                   // align
+		writeUint32(0)                   // reloff
+		writeUint32(0)                   // nreloc
+		writeUint32(0)                   // flags
+		writeUint32(0)                   // reserved1
+		writeUint32(0)                   // reserved2
+		writeUint32(0)                   // reserved3
+	}
+
+	// --- Section data ---
+	buf.Write(textBytes)
+	if hasPclntab {
+		buf.Write(pclntabData)
+	}
+
+	// Pad to fileSize if needed.
+	for buf.Len() < int(fileSize) {
+		buf.WriteByte(0)
+	}
+
+	f, err := macho.NewFile(bytes.NewReader(buf.Bytes()))
+	require.NoError(t, err)
+	return f
+}
+
+// buildMinimalPclntabData returns a Go 1.20+ pclntab header with the correct
+// magic (0xfffffff1). The body is minimal (just a header with quantum/ptrSize
+// fields); gosym.NewLineTable will return an empty table for it.
+func buildMinimalPclntabData() []byte {
+	// pclntab header for Go 1.20+ (magic 0xfffffff1):
+	//   [0:4]   magic    = 0xfffffff1 (little-endian)
+	//   [4]     pad1     = 0
+	//   [5]     pad2     = 0
+	//   [6]     quantum  = 1 (x86) or 4 (arm64)
+	//   [7]     ptrSize  = 4 or 8
+	// Followed by function count and data.
+	// For an empty table, we just need a valid header.
+	data := make([]byte, 8)
+	binary.LittleEndian.PutUint32(data[0:4], 0xfffffff1)
+	data[4] = 0
+	data[5] = 0
+	data[6] = 4 // quantum=4 (arm64)
+	data[7] = 8 // ptrSize=8 (64-bit)
+	return data
+}
+
+// buildInvalidMagicPclntab returns a pclntab with an unsupported magic number.
+func buildInvalidMagicPclntab() []byte {
+	data := buildMinimalPclntabData()
+	binary.LittleEndian.PutUint32(data[0:4], 0xfffffffb) // unknown magic
+	return data
+}
+
+// TestParseMachoPclntab_NoPclntabSection verifies that ErrNoPclntab is returned
+// when the Mach-O file has no __gopclntab section.
+func TestParseMachoPclntab_NoPclntabSection(t *testing.T) {
+	t.Parallel()
+	f := buildMachOWithPclntab(t, nil) // no __gopclntab
+	funcs, err := ParseMachoPclntab(f)
+	assert.Nil(t, funcs)
+	assert.True(t, errors.Is(err, ErrNoPclntab), "expected ErrNoPclntab, got %v", err)
+}
+
+// TestParseMachoPclntab_InvalidMagic verifies that ErrUnsupportedPclntabVersion
+// is returned when the pclntab magic is unknown.
+func TestParseMachoPclntab_InvalidMagic(t *testing.T) {
+	t.Parallel()
+	f := buildMachOWithPclntab(t, buildInvalidMagicPclntab())
+	funcs, err := ParseMachoPclntab(f)
+	assert.Nil(t, funcs)
+	assert.True(t, errors.Is(err, ErrUnsupportedPclntabVersion), "expected ErrUnsupportedPclntabVersion, got %v", err)
+}
+
+// TestParseMachoPclntab_TooShort verifies that ErrInvalidPclntab is returned
+// when the pclntab data is shorter than 4 bytes.
+func TestParseMachoPclntab_TooShort(t *testing.T) {
+	t.Parallel()
+	f := buildMachOWithPclntab(t, []byte{0x01, 0x02}) // only 2 bytes
+	funcs, err := ParseMachoPclntab(f)
+	assert.Nil(t, funcs)
+	assert.True(t, errors.Is(err, ErrInvalidPclntab), "expected ErrInvalidPclntab, got %v", err)
+}
+
+// TestParseMachoPclntab_ValidHeader verifies that a valid Go 1.20+ header is
+// accepted without error (empty function table is fine).
+func TestParseMachoPclntab_ValidHeader(t *testing.T) {
+	t.Parallel()
+	f := buildMachOWithPclntab(t, buildMinimalPclntabData())
+	funcs, err := ParseMachoPclntab(f)
+	// gosym may return an error for a minimal stub; accept either empty map or error.
+	// The important thing is that magic validation passes (no ErrUnsupportedPclntabVersion).
+	if err != nil {
+		assert.False(t, errors.Is(err, ErrUnsupportedPclntabVersion),
+			"should not return ErrUnsupportedPclntabVersion for valid magic")
+		assert.False(t, errors.Is(err, ErrNoPclntab),
+			"should not return ErrNoPclntab when section exists")
+	} else {
+		assert.NotNil(t, funcs)
+	}
+}
+
+// TestIsInsideRange tests the isInsideRange helper with sorted funcRange slices.
+func TestIsInsideRange(t *testing.T) {
+	t.Parallel()
+
+	ranges := []funcRange{
+		{start: 0x100, end: 0x200},
+		{start: 0x300, end: 0x400},
+		{start: 0x500, end: 0x600},
+	}
+
+	tests := []struct {
+		name string
+		addr uint64
+		want bool
+	}{
+		{"before first range", 0x50, false},
+		{"at start of first range", 0x100, true},
+		{"inside first range", 0x150, true},
+		{"at end of first range (exclusive)", 0x200, false},
+		{"between first and second range", 0x250, false},
+		{"at start of second range", 0x300, true},
+		{"inside second range", 0x350, true},
+		{"at end of second range (exclusive)", 0x400, false},
+		{"at start of third range", 0x500, true},
+		{"inside third range", 0x550, true},
+		{"at end of third range (exclusive)", 0x600, false},
+		{"after all ranges", 0x700, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := isInsideRange(tt.addr, ranges)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestIsInsideRange_EmptySlice verifies isInsideRange returns false for empty input.
+func TestIsInsideRange_EmptySlice(t *testing.T) {
+	t.Parallel()
+	assert.False(t, isInsideRange(0x100, nil))
+	assert.False(t, isInsideRange(0x100, []funcRange{}))
+}
+
+// TestParseMachoPclntab_LiveBinary verifies that ParseMachoPclntab can parse
+// the actual test binary (go test builds contain __gopclntab) and finds known
+// Go runtime function names.
+func TestParseMachoPclntab_LiveBinary(t *testing.T) {
+	t.Parallel()
+
+	// Open the current test binary (self-test).
+	f, err := macho.Open("/proc/self/exe")
+	if err != nil {
+		// Not on macOS or not a Mach-O binary — skip.
+		t.Skip("skipping live binary test: cannot open /proc/self/exe as Mach-O")
+	}
+	defer f.Close() //nolint:errcheck
+
+	funcs, err := ParseMachoPclntab(f)
+	if errors.Is(err, ErrNoPclntab) || errors.Is(err, ErrUnsupportedPclntabVersion) {
+		t.Skip("no suitable pclntab found in test binary")
+	}
+	require.NoError(t, err)
+	require.NotEmpty(t, funcs)
+
+	// Verify that at least one Go runtime function is present.
+	found := false
+	for name := range funcs {
+		if name == "testing.Main" || name == "testing.tRunner" || name == "main.main" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected at least one known Go runtime function in pclntab")
+}
+
+// TestParseMachoPclntab_MacOSTestBinary verifies ParseMachoPclntab on macOS
+// using the actual test runner binary (os.Args[0]).
+func TestParseMachoPclntab_MacOSTestBinary(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping macOS live binary test in short mode")
+	}
+
+	// On macOS the test runner binary (os.Args[0]) is a Mach-O file.
+	importPath := os.Args[0]
+	f, err := macho.Open(importPath)
+	if err != nil {
+		t.Skipf("skipping: cannot open %s as Mach-O: %v", importPath, err)
+	}
+	defer f.Close() //nolint:errcheck
+
+	funcs, err := ParseMachoPclntab(f)
+	if errors.Is(err, ErrNoPclntab) {
+		t.Skip("test binary has no __gopclntab (stripped)")
+	}
+	require.NoError(t, err)
+	require.NotEmpty(t, funcs)
+
+	// Check for known Go runtime functions.
+	found := false
+	for name := range funcs {
+		if name == "testing.Main" || name == "testing.tRunner" || name == "main.main" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected at least one known Go function in pclntab")
+}

--- a/internal/runner/security/machoanalyzer/pclntab_macho_test.go
+++ b/internal/runner/security/machoanalyzer/pclntab_macho_test.go
@@ -15,10 +15,10 @@ import (
 )
 
 // buildMachOWithPclntab constructs a minimal valid 64-bit Mach-O file in
-// memory containing a __TEXT,__text section and optionally a __gopclntab
-// section. This is sufficient for ParseMachoPclntab unit tests.
+// memory containing a __TEXT,__text section and, when pclntabData is not nil,
+// a __gopclntab section. This is sufficient for ParseMachoPclntab unit tests.
 //
-// textData may be nil (no __text section). pclntabData nil means no __gopclntab.
+// A nil pclntabData means no __gopclntab section is added.
 func buildMachOWithPclntab(t *testing.T, pclntabData []byte) *macho.File {
 	t.Helper()
 

--- a/internal/runner/security/machoanalyzer/pclntab_macho_test.go
+++ b/internal/runner/security/machoanalyzer/pclntab_macho_test.go
@@ -38,7 +38,6 @@ func buildMachOWithPclntab(t *testing.T, pclntabData []byte) *macho.File {
 		segCmdSize64    = 72        // sizeof(segment_command_64)
 		sectCmdSize64   = 80        // sizeof(section_64)
 		lcSegment64     = uint32(0x19)
-		vmProtNone      = uint32(0)
 		vmProtRX        = uint32(5)           // VM_PROT_READ | VM_PROT_EXECUTE
 		textSectionData = "\x00\x00\x00\x00"  // 4-byte placeholder
 		textVMAddr      = uint64(0x100000000) // typical macOS arm64 base

--- a/internal/runner/security/machoanalyzer/standard_analyzer.go
+++ b/internal/runner/security/machoanalyzer/standard_analyzer.go
@@ -12,7 +12,9 @@ import (
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/security/binaryanalyzer"
 )
 
-// ErrDirectSyscall indicates svc #0x80 was found, indicating a direct syscall.
+// ErrDirectSyscall is retained for backward compatibility.
+// It is no longer returned by AnalyzeNetworkSymbols; svc #0x80 risk
+// is evaluated separately via SyscallAnalysis (see svc_scanner.go).
 var ErrDirectSyscall = errors.New("direct syscall instruction detected (svc #0x80)")
 
 // ErrNotRegularFile indicates the target is not a regular file.
@@ -87,22 +89,10 @@ func (a *StandardMachOAnalyzer) analyzeSlice(f *macho.File) binaryanalyzer.Analy
 		}
 	}
 
-	hasSVC, err := containsSVCInstruction(f)
-	if err != nil {
-		return binaryanalyzer.AnalysisOutput{
-			Result:             binaryanalyzer.AnalysisError,
-			DynamicLoadSymbols: dynamicLoadSyms,
-			Error:              fmt.Errorf("svc scan failed: %w", err),
-		}
-	}
-	if hasSVC {
-		return binaryanalyzer.AnalysisOutput{
-			Result:             binaryanalyzer.AnalysisError,
-			DynamicLoadSymbols: dynamicLoadSyms,
-			Error:              fmt.Errorf("binary analysis: %w", ErrDirectSyscall),
-		}
-	}
-
+	// svc #0x80 presence is not evaluated here; it is handled separately by
+	// ScanSyscallInfos / analyzeMachoSyscalls which stores the result in
+	// SyscallAnalysis. That record is checked at verify time via
+	// syscallAnalysisHasSVCSignal (high-risk) and syscallAnalysisHasNetworkSignal.
 	return binaryanalyzer.AnalysisOutput{Result: binaryanalyzer.NoNetworkSymbols, DynamicLoadSymbols: dynamicLoadSyms}
 }
 

--- a/internal/runner/security/machoanalyzer/svc_scanner.go
+++ b/internal/runner/security/machoanalyzer/svc_scanner.go
@@ -108,7 +108,7 @@ func (noopSyscallTable) IsNetworkSyscall(_ int) bool { return false }
 // Pass 1: scans svc #0x80 addresses, excludes known Go stub bodies, and resolves
 // the X16 syscall number via backward scan.
 // Pass 2: scans BL calls to known Go syscall wrapper addresses and resolves the
-// X0 argument via backward scan.
+// trap argument from the preceding write to the stack slot [SP, #8] (old stack ABI).
 //
 // Returns:
 //   - directSVCInfos: Pass 1 results (actual svc #0x80 instructions in user code).
@@ -140,8 +140,14 @@ func analyzeArm64Slice(f *macho.File, table SyscallNumberTable) (directSVCInfos,
 
 	// Parse pclntab to obtain Go function address ranges.
 	// ErrNoPclntab is expected for non-Go or stripped binaries; continue without exclusion.
+	// ErrUnsupportedPclntabVersion means a Go binary with an older pclntab format; continue
+	// without exclusion/resolution rather than failing the entire analysis.
+	// Other errors (I/O failures, corrupt data) are propagated to the caller.
 	funcs, pclntabErr := ParseMachoPclntab(f)
 	if pclntabErr != nil {
+		if !errors.Is(pclntabErr, ErrNoPclntab) && !errors.Is(pclntabErr, ErrUnsupportedPclntabVersion) && !errors.Is(pclntabErr, ErrInvalidPclntab) {
+			return nil, nil, fmt.Errorf("failed to parse pclntab: %w", pclntabErr)
+		}
 		funcs = nil
 	}
 

--- a/internal/runner/security/machoanalyzer/svc_scanner.go
+++ b/internal/runner/security/machoanalyzer/svc_scanner.go
@@ -9,8 +9,14 @@ import (
 	"log/slog"
 	"os"
 
+	"github.com/isseis/go-safe-cmd-runner/internal/common"
 	"github.com/isseis/go-safe-cmd-runner/internal/safefileio"
 )
+
+// determinationMethodDirectSVC0x80 is the method string used for unresolved
+// svc #0x80 entries detected by Pass 1. It preserves the high-risk signal that
+// a direct kernel call was found, even when the syscall number could not be resolved.
+const determinationMethodDirectSVC0x80 = common.DeterminationMethodDirectSVC0x80
 
 // svcInstruction is the encoding of "svc #0x80" for arm64 (little-endian).
 // ARM64 encoding: 0xD4001001 → bytes [0x01, 0x10, 0x00, 0xD4]
@@ -88,6 +94,148 @@ func isMachOMagicAll(b []byte) bool {
 		return true
 	}
 	return false
+}
+
+// noopSyscallTable is a SyscallNumberTable that returns empty results.
+// Used when no table is provided to ScanSyscallInfos.
+type noopSyscallTable struct{}
+
+func (noopSyscallTable) GetSyscallName(_ int) string { return "" }
+func (noopSyscallTable) IsNetworkSyscall(_ int) bool { return false }
+
+// analyzeArm64Slice performs Pass 1 and Pass 2 analysis on a single arm64 Mach-O slice.
+//
+// Pass 1: scans svc #0x80 addresses, excludes known Go stub bodies, and resolves
+// the X16 syscall number via backward scan.
+// Pass 2: scans BL calls to known Go syscall wrapper addresses and resolves the
+// X0 argument via backward scan.
+//
+// Returns:
+//   - directSVCInfos: Pass 1 results (actual svc #0x80 instructions in user code).
+//   - wrapperCallInfos: Pass 2 results (BL calls to Go syscall wrappers from user code).
+//
+// Returns nil, nil, nil for non-arm64 slices or when no __TEXT,__text section exists.
+func analyzeArm64Slice(f *macho.File, table SyscallNumberTable) (directSVCInfos, wrapperCallInfos []common.SyscallInfo, err error) {
+	if f.Cpu != macho.CpuArm64 {
+		return nil, nil, nil
+	}
+
+	section := f.Section("__text")
+	if section == nil || section.Seg != "__TEXT" {
+		return nil, nil, nil
+	}
+
+	svcAddrs, err := collectSVCAddresses(f)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Read the full __text section for backward scanning.
+	r := io.NewSectionReader(section, 0, int64(section.Size)) //nolint:gosec // G115: section.Size is a Mach-O field
+	code, err := io.ReadAll(r)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to read __TEXT,__text section: %w", err)
+	}
+	textBase := section.Addr
+
+	// Parse pclntab to obtain Go function address ranges.
+	// ErrNoPclntab is expected for non-Go or stripped binaries; continue without exclusion.
+	funcs, pclntabErr := ParseMachoPclntab(f)
+	if pclntabErr != nil {
+		funcs = nil
+	}
+
+	stubRanges := buildStubRanges(funcs)
+
+	// Pass 1: resolve X16 via backward scan for each svc #0x80 outside stub bodies.
+	if len(svcAddrs) > 0 {
+		pass1 := scanSVCWithX16(svcAddrs, code, textBase, stubRanges, table)
+		for _, info := range pass1 {
+			if info.Number == -1 {
+				// Unresolved svc — preserve the "direct svc detected" signal.
+				info.DeterminationMethod = determinationMethodDirectSVC0x80
+				info.Source = determinationMethodDirectSVC0x80
+			}
+			directSVCInfos = append(directSVCInfos, info)
+		}
+	}
+
+	// Pass 2: resolve Go wrapper call sites.
+	wrapperAddrs := buildWrapperAddrs(funcs)
+	wrapperCallInfos = scanGoWrapperCalls(code, textBase, wrapperAddrs, stubRanges, table)
+
+	return directSVCInfos, wrapperCallInfos, nil
+}
+
+// ScanSyscallInfos opens the Mach-O file at filePath and performs Pass 1 and
+// Pass 2 syscall analysis on all arm64 slices.
+//
+// Pass 1 results (directSVCInfos) contain entries from actual svc #0x80
+// instructions found outside known Go stub bodies.  Entries with a resolved
+// syscall number carry DeterminationMethod="immediate"; unresolved entries
+// carry DeterminationMethod="direct_svc_0x80".
+//
+// Pass 2 results (wrapperCallInfos) contain entries from BL instructions that
+// target known Go syscall wrapper functions.  Resolved entries carry
+// DeterminationMethod="go_wrapper"; unresolved entries carry
+// DeterminationMethod="unknown:indirect_setting".
+//
+// Both slices are nil for non-Mach-O files or when no relevant instructions
+// are found.  table may be nil, in which case syscall names and network flags
+// are left empty.
+func ScanSyscallInfos(filePath string, fs safefileio.FileSystem, table SyscallNumberTable) (directSVCInfos, wrapperCallInfos []common.SyscallInfo, err error) {
+	if table == nil {
+		table = noopSyscallTable{}
+	}
+
+	f, err := fs.SafeOpenFile(filePath, os.O_RDONLY, 0)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to open file: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	magic := make([]byte, magicNumberSize)
+	if _, err := io.ReadFull(f, magic); err != nil {
+		return nil, nil, nil
+	}
+	if !isMachOMagicAll(magic) {
+		return nil, nil, nil
+	}
+
+	m := binary.LittleEndian.Uint32(magic)
+	if m == fatMagic || m == fatCigam {
+		fat, err := macho.NewFatFile(f)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to parse Fat binary: %w", err)
+		}
+		defer func() {
+			if closeErr := fat.Close(); closeErr != nil {
+				slog.Warn("error closing Fat Mach-O file during syscall scan", slog.Any("error", closeErr))
+			}
+		}()
+
+		for i := range fat.Arches {
+			d, w, sliceErr := analyzeArm64Slice(fat.Arches[i].File, table)
+			if sliceErr != nil {
+				return nil, nil, sliceErr
+			}
+			directSVCInfos = append(directSVCInfos, d...)
+			wrapperCallInfos = append(wrapperCallInfos, w...)
+		}
+		return directSVCInfos, wrapperCallInfos, nil
+	}
+
+	machOFile, err := macho.NewFile(f)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to parse Mach-O: %w", err)
+	}
+	defer func() {
+		if closeErr := machOFile.Close(); closeErr != nil {
+			slog.Warn("error closing Mach-O file during syscall scan", slog.Any("error", closeErr))
+		}
+	}()
+
+	return analyzeArm64Slice(machOFile, table)
 }
 
 // ScanSVCAddrs opens the file at filePath using fs, checks whether it is a

--- a/internal/runner/security/machoanalyzer/svc_scanner_test.go
+++ b/internal/runner/security/machoanalyzer/svc_scanner_test.go
@@ -15,9 +15,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// svcEncoding is the little-endian encoding of "svc #0x80" for arm64.
-const svcEncoding = uint32(0xD4001001)
-
 // nopEncoding is a common arm64 NOP instruction.
 const nopEncoding = uint32(0xD503201F)
 

--- a/internal/runner/security/machoanalyzer/testhelpers_test.go
+++ b/internal/runner/security/machoanalyzer/testhelpers_test.go
@@ -1,0 +1,17 @@
+//go:build test
+
+package machoanalyzer
+
+import "encoding/binary"
+
+// svcEncoding is the little-endian encoding of "svc #0x80" for arm64.
+const svcEncoding = uint32(0xD4001001)
+
+// buildCodeSlice assembles a sequence of 32-bit ARM64 instructions into a byte slice.
+func buildCodeSlice(instrs ...uint32) []byte {
+	buf := make([]byte, len(instrs)*4)
+	for i, instr := range instrs {
+		binary.LittleEndian.PutUint32(buf[i*4:], instr)
+	}
+	return buf
+}

--- a/internal/runner/security/network_analyzer_test.go
+++ b/internal/runner/security/network_analyzer_test.go
@@ -26,7 +26,7 @@ func TestSyscallAnalysisHasSVCSignal_Empty(t *testing.T) {
 func TestSyscallAnalysisHasSVCSignal_WithWarningsOnly(t *testing.T) {
 	r := &fileanalysis.SyscallAnalysisResult{
 		SyscallAnalysisResultCore: common.SyscallAnalysisResultCore{
-			AnalysisWarnings: []string{"svc #0x80 detected: direct syscall bypassing libSystem.dylib"},
+			AnalysisWarnings: []string{"svc #0x80 detected: syscall number unresolved, direct kernel call bypassing libSystem.dylib"},
 		},
 	}
 	assert.False(t, syscallAnalysisHasSVCSignal(r))


### PR DESCRIPTION
## Summary

- **Expose** `BackwardScanX16` and `IsControlFlowInstruction` from the arm64 disassembler; bump schema to v16
- **Add** Mach-O pclntab parser (`pclntab_macho.go`) to enumerate Go runtime function boundaries from the `__gopclntab` section
- **Add** Pass 1 `svc #0x80` scanner (`pass1_scanner.go`) that resolves syscall numbers by walking backwards from each `svc` instruction, using pclntab function boundaries as scan limits
- **Fix** false-positive high-risk judgement for legitimate Go binaries (including `record` itself) that use Go runtime syscall stubs with `svc #0x80`

### Motivation

Task 0097 flagged any binary containing `svc #0x80` as high-risk. Go binaries on macOS arm64 emit `svc #0x80` through runtime stubs (e.g. `syscall.RawSyscall`), causing the `record` binary itself to be rejected. This PR aligns macOS arm64 analysis with the ELF approach: analyze actual syscall numbers (via `x16`) rather than the presence of the instruction alone.

## Test plan

- [ ] `make test` passes (new unit tests for pclntab parser and Pass 1 scanner included)
- [ ] `make lint` passes
- [ ] Existing macOS arm64 integration tests (`internal/libccache`) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)