### PR TITLE
fix(machodylib): use absolute file offsets for symoff/stroff in dyld cache extraction

### DIFF
--- a/internal/libccache/schema.go
+++ b/internal/libccache/schema.go
@@ -2,7 +2,13 @@ package libccache
 
 // LibcCacheSchemaVersion is the current schema version for libc cache files.
 // Increment when making backward-incompatible schema changes.
-const LibcCacheSchemaVersion = 1
+//
+// Version history:
+//
+//	1 - initial schema
+//	2 - fix dyld shared cache extraction: symoff/stroff treated as absolute
+//	    sub-cache file offsets (was incorrectly adding linkeditSeg.fileOff)
+const LibcCacheSchemaVersion = 2
 
 // SourceLibcSymbolImport is the value of SyscallInfo.Source for syscalls detected
 // via libc import symbol matching.

--- a/internal/machodylib/dyld_extractor_darwin.go
+++ b/internal/machodylib/dyld_extractor_darwin.go
@@ -198,8 +198,6 @@ func extractLibSystemKernel(cachePath string) ([]byte, error) {
 	if linkeditFile == "" {
 		return nil, nil
 	}
-	linkeditFileOffInSub := linkeditSeg.fileOff
-
 	// Read the __TEXT segment data from the text sub-cache.
 	textData, err := readFileRange(textFile, textSeg.fileOff, textSeg.fileSize)
 	if err != nil {
@@ -207,11 +205,13 @@ func extractLibSystemKernel(cachePath string) ([]byte, error) {
 	}
 
 	// Read and compact the symbol table from the LINKEDIT sub-cache.
+	// symtab.symoff and symtab.stroff are absolute file offsets within the
+	// .dyldlinkedit sub-cache file, not relative to linkeditSeg.fileOff.
 	compactSyms, compactStrtab, err := buildCompactSymtab(
 		linkeditFile,
-		linkeditFileOffInSub+uint64(symtab.symoff),
+		uint64(symtab.symoff),
 		symtab.nsyms,
-		linkeditFileOffInSub+uint64(symtab.stroff),
+		uint64(symtab.stroff),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("build compact symtab: %w", err)

--- a/internal/machodylib/dyld_extractor_test.go
+++ b/internal/machodylib/dyld_extractor_test.go
@@ -3,6 +3,8 @@
 package machodylib
 
 import (
+	"bytes"
+	"debug/macho"
 	"os"
 	"runtime"
 	"strings"
@@ -12,25 +14,26 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// requireDyldCacheAvailable skips t when not on darwin/arm64 or when no dyld
+// shared cache file is found in dyldSharedCachePaths.
+func requireDyldCacheAvailable(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS != "darwin" || runtime.GOARCH != "arm64" {
+		t.Skip("dyld shared cache extraction only applicable on darwin/arm64")
+	}
+	for _, p := range dyldSharedCachePaths {
+		if _, err := os.Stat(p); err == nil {
+			return
+		}
+	}
+	t.Skipf("no dyld shared cache found in %v", dyldSharedCachePaths)
+}
+
 // TestExtractLibSystemKernel_Live skips the test when
 // the dyld shared cache cannot be expected to be present (non-darwin or non-arm64).
 // On darwin arm64, it attempts an actual extraction and verifies the invariants.
 func TestExtractLibSystemKernel_Live(t *testing.T) {
-	if runtime.GOOS != "darwin" || (runtime.GOARCH != "arm64") {
-		t.Skip("dyld shared cache extraction only applicable on darwin/arm64")
-	}
-
-	// Check if any known cache file is present; skip if not.
-	cacheFound := false
-	for _, p := range dyldSharedCachePaths {
-		if _, err := os.Stat(p); err == nil {
-			cacheFound = true
-			break
-		}
-	}
-	if !cacheFound {
-		t.Skipf("no dyld shared cache found in %v; skipping live extraction test", dyldSharedCachePaths)
-	}
+	requireDyldCacheAvailable(t)
 
 	result, err := ExtractLibSystemKernel()
 	require.NoError(t, err)
@@ -66,4 +69,63 @@ func TestExtractLibSystemKernel_NoCachePaths(t *testing.T) {
 	result, err := ExtractLibSystemKernel()
 	require.NoError(t, err)
 	assert.Nil(t, result, "expected nil result when no cache paths exist")
+}
+
+// TestExtractLibSystemKernel_SymbolNames verifies that the extracted Mach-O
+// contains known libsystem_kernel.dylib BSD syscall wrapper symbols and no
+// dyld-internal C++ symbols.
+//
+// Regression test for the bug where symtab.symoff and symtab.stroff were
+// incorrectly offset by linkeditSeg.fileOff, causing 256 nlist_64 entries to
+// be skipped and symbols from an adjacent library to appear instead.
+func TestExtractLibSystemKernel_SymbolNames(t *testing.T) {
+	requireDyldCacheAvailable(t)
+
+	result, err := ExtractLibSystemKernel()
+	require.NoError(t, err)
+	if result == nil {
+		t.Skip("ExtractLibSystemKernel returned nil; skipping symbol name test")
+	}
+
+	mf, err := macho.NewFile(bytes.NewReader(result.Data))
+	require.NoError(t, err)
+	defer func() { _ = mf.Close() }()
+
+	require.NotNil(t, mf.Symtab, "extracted Mach-O must have a symbol table")
+
+	symSet := make(map[string]bool, len(mf.Symtab.Syms))
+	for _, s := range mf.Symtab.Syms {
+		symSet[s.Name] = true
+	}
+
+	// The symbol count must be in a realistic range for libsystem_kernel.
+	// A count far below this indicates the wrong portion of the merged symbol
+	// table was read (the pre-fix extraction yielded only 94 symbols).
+	assert.Greater(t, len(mf.Symtab.Syms), 1000,
+		"extracted symbol count %d is too low; expected >1000 for libsystem_kernel.dylib "+
+			"(may indicate symoff/stroff are not treated as absolute file offsets)",
+		len(mf.Symtab.Syms))
+
+	// These BSD syscall wrapper symbols have been stable exports of
+	// libsystem_kernel.dylib across many macOS versions.
+	knownSymbols := []string{
+		"___accept",
+		"_close",
+		"_read",
+		"_write",
+		"___open",
+	}
+	for _, name := range knownSymbols {
+		assert.True(t, symSet[name],
+			"expected libsystem_kernel symbol %q not found "+
+				"(may indicate symbols from a different library were extracted)", name)
+	}
+
+	// dyld-internal C++ symbols must not appear. Their presence indicates
+	// that the symbol table offset was shifted to an adjacent library.
+	for _, s := range mf.Symtab.Syms {
+		if strings.HasPrefix(s.Name, "__ZN3lsl") {
+			t.Errorf("found dyld-internal symbol %q; wrong library's symbols were extracted", s.Name)
+		}
+	}
 }

--- a/internal/machodylib/dyld_parser_test.go
+++ b/internal/machodylib/dyld_parser_test.go
@@ -5,6 +5,7 @@ package machodylib
 import (
 	"bytes"
 	"encoding/binary"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -326,4 +327,63 @@ func TestReconstructMachO_BasicStructure(t *testing.T) {
 	// Verify magic is preserved.
 	magic := binary.LittleEndian.Uint32(machO[0:4])
 	assert.Equal(t, uint32(0xFEEDFACF), magic, "magic not preserved")
+}
+
+// TestBuildCompactSymtab_UsesAbsoluteFileOffsets verifies that symFileOff and
+// strFileOff are treated as absolute file offsets within the sub-cache file,
+// not as offsets relative to any base such as linkeditSeg.fileOff.
+//
+// Regression test for the bug where linkeditSeg.fileOff (= 0x4000) was
+// incorrectly added to symtab.symoff and symtab.stroff before calling
+// buildCompactSymtab, causing the reads to land 0x4000 bytes past the actual
+// symbol and string data, producing garbage symbol names from adjacent libraries.
+func TestBuildCompactSymtab_UsesAbsoluteFileOffsets(t *testing.T) {
+	const wantName = "___accept"
+
+	// Place the symbol table and string table at absolute offsets that are
+	// clearly distinct from zero. Using values larger than a typical
+	// linkeditSeg.fileOff (0x4000) ensures that any accidental addition of
+	// such an offset shifts the read past the data, causing a detectable failure.
+	const symoff = uint64(0x8000)
+	const stroff = uint64(0x9000)
+
+	// Build a minimal string table: [0x00 | wantName | 0x00]
+	strtab := []byte{0} // index 0 = empty string (Mach-O convention)
+	nameOffset := uint32(len(strtab))
+	strtab = append(strtab, []byte(wantName)...)
+	strtab = append(strtab, 0) // null terminator
+
+	// Build one nlist_64 entry pointing to wantName in the string table.
+	entry := make([]byte, nlist64Size)
+	binary.LittleEndian.PutUint32(entry[0:], nameOffset) // n_strx
+	entry[4] = 0x0F                                      // N_EXT | N_SECT
+	entry[5] = 1                                         // n_sect
+	binary.LittleEndian.PutUint64(entry[8:], 0x1804ab000)
+
+	// Allocate a buffer large enough to hold data at the absolute positions.
+	fileSize := int(stroff) + len(strtab)
+	buf := make([]byte, fileSize)
+	copy(buf[symoff:], entry)
+	copy(buf[stroff:], strtab)
+
+	f, err := os.CreateTemp(t.TempDir(), "buildcompact_*.bin")
+	require.NoError(t, err)
+	defer func() { _ = f.Close() }()
+	_, err = f.Write(buf)
+	require.NoError(t, err)
+
+	compactSyms, compactStrtab, err := buildCompactSymtab(f.Name(), symoff, 1, stroff)
+	require.NoError(t, err)
+	require.Len(t, compactSyms, nlist64Size, "expected exactly one nlist_64 entry")
+
+	// Decode the new n_strx from the compact symbol entry.
+	newStrx := binary.LittleEndian.Uint32(compactSyms[0:])
+	require.Less(t, int(newStrx), len(compactStrtab), "n_strx out of compact strtab bounds")
+
+	end := bytes.IndexByte(compactStrtab[newStrx:], 0)
+	require.GreaterOrEqual(t, end, 0, "null terminator not found in compact strtab")
+	gotName := string(compactStrtab[newStrx : int(newStrx)+end])
+
+	assert.Equal(t, wantName, gotName,
+		"symbol name mismatch: symoff/stroff must be used as absolute file offsets, not relative to any base")
 }


### PR DESCRIPTION
## Summary

- Fix incorrect symbol extraction from dyld shared cache for `libsystem_kernel.dylib`
- `LC_SYMTAB` `symoff` and `stroff` are absolute file offsets within the `.dyldlinkedit` sub-cache file; the code was incorrectly adding `linkeditSeg.fileOff` (= 0x4000) to both, shifting reads by 16384 bytes (256 nlist_64 entries) and returning symbols from adjacent libraries instead of libsystem_kernel's own symbols
- Bump `LibcCacheSchemaVersion` from 1 to 2 to force re-generation of cache files that were built with the wrong extraction logic

After the fix: extracted symbol count jumps from 94 (garbage) to 1,717 (matching `nm` output), with correct names like `___accept`, `_read`, `_write`.

## Root cause

Diagnosed via an ad-hoc diagnostic program that compared:

| Approach | symFileOff | First symbol |
|---|---|---|
| Current (wrong): `linkeditSeg.fileOff + symoff` | `0x34e6640` | `get_qos_class_np` (wrong library) |
| Fixed: `symoff` directly | `0x34e2640` | `_memcpy` (correct libsystem_kernel symbol) |

The `.dyldlinkedit` sub-cache stores all libraries' LINKEDIT data. `linkeditSeg.fileOff` (0x4000) is the offset of the merged LINKEDIT header area within that file. `symtab.symoff` and `symtab.stroff` are already absolute file offsets pointing into the merged symbol/string tables — adding `fileOff` double-counts the offset.

## Test plan

- [ ] `make test` passes (all 1717 symbols extracted correctly, no garbage names)
- [ ] `make lint` passes (0 issues)
- [ ] `TestExtractLibSystemKernel_Live` passes on darwin/arm64
- [ ] Old lib-cache files with `schema_version: 1` are automatically re-generated on next run

🤖 Generated with [Claude Code](https://claude.com/claude-code)