### PR TITLE
docs(0105): add design documents for record filter removal

### DIFF
--- a/docs/tasks/0104_macho_syscall_number_analysis/03_detailed_specification.md
+++ b/docs/tasks/0104_macho_syscall_number_analysis/03_detailed_specification.md
@@ -505,9 +505,14 @@ type MachoSyscallAnalyzerInterface interface {
 
 ## 9. `internal/runner/security/network_analyzer.go` 変更
 
-### 9.1 `syscallAnalysisHasSVCSignal` の削除
+### 9.1 `syscallAnalysisHasSVCSignal` の扱い
 
-`syscallAnalysisHasSVCSignal` 関数を削除する。この関数は `DeterminationMethod == "direct_svc_0x80"` を検索するものであり、v16 レコードには該当エントリが存在しない。
+この節の初版では `syscallAnalysisHasSVCSignal` 関数の削除を前提としていたが、後続タスク 0105 で方針が更新された。
+
+- 0104 完了時点の意図: v16 レコードでは `DeterminationMethod == "direct_svc_0x80"` を高リスク判定に直接使わない
+- 0105 以降の確定方針: `syscallAnalysisHasSVCSignal` 自体は保持し、`Number == -1` かつ `DeterminationMethod == "direct_svc_0x80"` の未解決 svc のみを高リスクシグナルとして扱う
+
+したがって、本節の「削除」は superseded とし、実装時は 0105 の要件・設計を優先する。
 
 ### 9.2 `isNetworkViaBinaryAnalysis` の判定ロジック変更
 
@@ -521,7 +526,7 @@ if syscallAnalysisHasNetworkSignal(svcResult) {
 }
 ```
 
-変更後（v16 ロジック）：
+変更後（0104 初版で想定していた v16 ロジック）：
 ```go
 if syscallAnalysisHasNetworkSignal(svcResult) {
     return true, true  // ネットワーク syscall 検出 → 高リスク確定
@@ -532,6 +537,8 @@ if syscallAnalysisHasNetworkSignal(svcResult) {
 ```
 
 `syscallAnalysisHasNetworkSignal` は `IsNetwork == true` のエントリのみを判定条件とし、`DeterminationMethod`（`direct_svc_0x80` など）を参照しない実装にする。
+
+注記: 0105 では `syscallAnalysisHasSVCSignal` を保持したまま、未解決 svc のみを高リスクとする条件が追加された。ここでの network 判定変更自体は 0105 後も維持される。
 
 戻り値を `true, true`（高リスク確定）に変更する。変更前は `true, false` を返していたが、v16 では Pass 1/Pass 2 で確認されたネットワーク syscall は常に `isHighRisk = true` とする（FR-3.3.1 要件変更）。
 

--- a/docs/tasks/0104_macho_syscall_number_analysis/04_implementation_plan.md
+++ b/docs/tasks/0104_macho_syscall_number_analysis/04_implementation_plan.md
@@ -240,7 +240,7 @@ const CurrentSchemaVersion = 16
 
 **変更内容:**
 
-1. `syscallAnalysisHasSVCSignal` 関数を削除
+1. `syscallAnalysisHasSVCSignal` 関数を削除せず、未解決 svc (`Number == -1`) のみを高リスク判定する条件へ修正する
    - superseded: 0105 以降は削除しない。`Number == -1` 条件を追加して保持する
 2. `isNetworkViaBinaryAnalysis` 内の `SyscallAnalysis` 参照ブロックを以下に変更:
    ```go

--- a/docs/tasks/0104_macho_syscall_number_analysis/04_implementation_plan.md
+++ b/docs/tasks/0104_macho_syscall_number_analysis/04_implementation_plan.md
@@ -236,9 +236,12 @@ const CurrentSchemaVersion = 16
 
 ### ステップ 8: `internal/runner/security/network_analyzer.go` — 判定ロジック変更
 
+注記: このステップの初版には `syscallAnalysisHasSVCSignal` 削除案が含まれていたが、後続タスク 0105 で superseded となった。実装・レビュー時は「削除」ではなく「未解決 svc (`Number == -1`) のみを高リスク判定する条件へ修正」を正とする。
+
 **変更内容:**
 
 1. `syscallAnalysisHasSVCSignal` 関数を削除
+   - superseded: 0105 以降は削除しない。`Number == -1` 条件を追加して保持する
 2. `isNetworkViaBinaryAnalysis` 内の `SyscallAnalysis` 参照ブロックを以下に変更:
    ```go
    // 変更前: syscallAnalysisHasSVCSignal → true, true
@@ -258,7 +261,7 @@ const CurrentSchemaVersion = 16
 - [ ] `IsNetwork=false` のみ → `SymbolAnalysis` 判定に委譲（AC-4）
 - [ ] `SyscallAnalysis==nil`（`nil, nil`）→ `SymbolAnalysis` 判定に委譲（AC-4）
 - [ ] v15 レコード（`SchemaVersionMismatchError`）→ `true, true`（AC-4）
-- [ ] `"direct_svc_0x80"` を判定条件に使うコードが存在しないこと（AC-4）
+- [ ] 未解決 svc (`Number == -1` かつ `"direct_svc_0x80"`) のみを高リスク判定すること（0105 で更新）
 
 ---
 

--- a/docs/tasks/0105_remove_record_filter/02_architecture.md
+++ b/docs/tasks/0105_remove_record_filter/02_architecture.md
@@ -121,7 +121,7 @@ flowchart TD
         E3 --> E4[("detected_syscalls<br>全エントリ記録")]
     end
 
-    subgraph MacOパス
+    subgraph Mach-Oパス
         M1[("Mach-O バイナリ")] --> M2["ScanSyscallInfos<br>（svc #0x80 スキャン）"]
         M1 --> M3["GetSyscallInfos<br>（libSystem シンボルマッチ）"]
         M2 -->|"svc エントリ"| M4["mergeMachoSyscallInfos"]

--- a/docs/tasks/0105_remove_record_filter/02_architecture.md
+++ b/docs/tasks/0105_remove_record_filter/02_architecture.md
@@ -1,0 +1,223 @@
+# アーキテクチャ設計書: record コマンドのシステムコールフィルタリング削除
+
+## 1. システム概要
+
+### 1.1 アーキテクチャ目標
+
+- `record` コンポーネントからリスク判断ロジックを除去し、関心の分離を徹底する
+- `runner` コンポーネントがフィルタリングされていない全システムコール情報を基にリスク判定できるようにする
+- macOS BSD syscall テーブルを自動生成化し、手動管理コストを排除する
+
+### 1.2 設計原則
+
+- **関心の分離**: `record` はシステムコールを記録するのみ。フィルタリングは `runner` 側の責務
+- **後方互換性**: JSON スキーマは変更しない。`detected_syscalls` の内容が増えるのみ
+- **YAGNI**: 既存の構造・インターフェースを活用し、不要な抽象化を追加しない
+
+## 2. 変更前後のアーキテクチャ
+
+### 2.1 変更前: フィルタリングあり
+
+```mermaid
+flowchart TD
+    classDef data fill:#e6f7ff,stroke:#1f77b4,stroke-width:1px,color:#0b3d91;
+    classDef process fill:#fff1e6,stroke:#ff7f0e,stroke-width:1px,color:#8a3e00;
+    classDef changed fill:#ffe6e6,stroke:#cc0000,stroke-width:2px,color:#800000;
+
+    A[("バイナリファイル")] -->|"ELF/Mach-O 解析"| B["buildSyscallData<br>buildMachoSyscallData"]
+    B -->|"全システムコール"| C["FilterSyscallsForStorage<br>（IsNetwork または Number==-1 のみ残す）"]
+    C -->|"フィルタ済みエントリ"| D[("JSON レコード<br>detected_syscalls")]
+    D -->|"ロード"| E["network_analyzer<br>syscallAnalysisHasSVCSignal<br>syscallAnalysisHasNetworkSignal"]
+    E -->|"リスク判定"| F["isHighRisk / isNetwork"]
+
+    class A,D data;
+    class B,E,F process;
+    class C changed;
+```
+
+### 2.2 変更後: フィルタリングなし
+
+```mermaid
+flowchart TD
+    classDef data fill:#e6f7ff,stroke:#1f77b4,stroke-width:1px,color:#0b3d91;
+    classDef process fill:#fff1e6,stroke:#ff7f0e,stroke-width:1px,color:#8a3e00;
+    classDef changed fill:#e8f5e8,stroke:#2e8b57,stroke-width:2px,color:#006400;
+
+    A[("バイナリファイル")] -->|"ELF/Mach-O 解析"| B["buildSyscallData<br>buildMachoSyscallData"]
+    B -->|"全システムコール（フィルタなし）"| D[("JSON レコード<br>detected_syscalls")]
+    D -->|"ロード"| E["network_analyzer<br>syscallAnalysisHasSVCSignal<br>syscallAnalysisHasNetworkSignal"]
+    E -->|"リスク判定"| F["isHighRisk / isNetwork"]
+
+    class A,D data;
+    class B,F process;
+    class E changed;
+```
+
+**凡例（Legend）**
+
+```mermaid
+flowchart LR
+    classDef data fill:#e6f7ff,stroke:#1f77b4,stroke-width:1px,color:#0b3d91;
+    classDef process fill:#fff1e6,stroke:#ff7f0e,stroke-width:1px,color:#8a3e00;
+    classDef changed fill:#e8f5e8,stroke:#2e8b57,stroke-width:2px,color:#006400;
+
+    D1[("データ")] --> P1["既存コンポーネント"] --> E1["変更コンポーネント"]
+    class D1 data
+    class P1 process
+    class E1 changed
+```
+
+## 3. コンポーネント設計
+
+### 3.1 変更コンポーネント一覧
+
+```mermaid
+graph TB
+    classDef data fill:#e6f7ff,stroke:#1f77b4,stroke-width:1px,color:#0b3d91;
+    classDef process fill:#fff1e6,stroke:#ff7f0e,stroke-width:1px,color:#8a3e00;
+    classDef changed fill:#e8f5e8,stroke:#2e8b57,stroke-width:2px,color:#006400;
+    classDef new fill:#f0e6ff,stroke:#7f2fd4,stroke-width:2px,color:#4b0082;
+
+    subgraph "internal/fileanalysis"
+        A["syscall_store.go<br>FilterSyscallsForStorage 削除"]
+    end
+
+    subgraph "internal/filevalidator"
+        B["validator.go<br>buildSyscallData: FilterSyscallsForStorage 呼び出し削除<br>buildMachoSyscallData: FilterSyscallsForStorage 呼び出し削除<br>AnalysisWarnings ロジック修正"]
+    end
+
+    subgraph "internal/runner/security"
+        C["network_analyzer.go<br>syscallAnalysisHasSVCSignal: Number==-1 条件追加<br>syscallAnalysisHasNetworkSignal: DeterminationMethod 除外削除"]
+    end
+
+    subgraph "internal/libccache"
+        D["macos_syscall_table.go<br>macOSSyscallEntries 定義削除"]
+        E["macos_syscall_numbers.go<br>（新規・自動生成）<br>全 BSD syscall 収録"]
+    end
+
+    subgraph "scripts"
+        F["generate_syscall_table.py<br>--macos-header オプション追加"]
+    end
+
+    subgraph "Makefile"
+        G["generate-syscall-tables ターゲット更新<br>macOS SDK ヘッダー対応"]
+    end
+
+    class A,B,C,D,F,G changed;
+    class E new;
+```
+
+### 3.2 `record` パスのデータフロー
+
+```mermaid
+flowchart TD
+    classDef data fill:#e6f7ff,stroke:#1f77b4,stroke-width:1px,color:#0b3d91;
+    classDef process fill:#fff1e6,stroke:#ff7f0e,stroke-width:1px,color:#8a3e00;
+    classDef changed fill:#e8f5e8,stroke:#2e8b57,stroke-width:2px,color:#006400;
+
+    subgraph ELFパス
+        E1[("ELF バイナリ")] --> E2["AnalyzeSyscallsFromELF<br>（libc シンボルマッチ）"]
+        E2 -->|"全 syscall エントリ"| E3["buildSyscallData<br>（フィルタリングなし）"]
+        E3 --> E4[("detected_syscalls<br>全エントリ記録")]
+    end
+
+    subgraph MacOパス
+        M1[("Mach-O バイナリ")] --> M2["ScanSyscallInfos<br>（svc #0x80 スキャン）"]
+        M1 --> M3["GetSyscallInfos<br>（libSystem シンボルマッチ）"]
+        M2 -->|"svc エントリ"| M4["mergeMachoSyscallInfos"]
+        M3 -->|"libSystem エントリ"| M4
+        M4 -->|"マージ済み全エントリ"| M5["buildMachoSyscallData<br>（フィルタリングなし）"]
+        M5 -->|"未解決 svc のみ"| M6{"Number == -1 AND<br>DeterminationMethod ==<br>direct_svc_0x80?"}
+        M6 -->|"あり"| M7["AnalysisWarnings<br>警告セット"]
+        M6 -->|"なし"| M8["AnalysisWarnings<br>空"]
+        M5 --> M9[("detected_syscalls<br>全エントリ記録")]
+    end
+
+    class E1,E4,M1,M9 data;
+    class E2,M2,M3,M4 process;
+    class E3,M5,M6,M7,M8 changed;
+```
+
+### 3.3 `runner` パスのリスク判定フロー
+
+```mermaid
+flowchart TD
+    classDef data fill:#e6f7ff,stroke:#1f77b4,stroke-width:1px,color:#0b3d91;
+    classDef process fill:#fff1e6,stroke:#ff7f0e,stroke-width:1px,color:#8a3e00;
+    classDef changed fill:#e8f5e8,stroke:#2e8b57,stroke-width:2px,color:#006400;
+
+    R[("JSON レコード<br>detected_syscalls")] --> S1["syscallAnalysisHasSVCSignal"]
+    S1 -->|"Number==-1 AND<br>DeterminationMethod==direct_svc_0x80<br>のエントリが存在？"| S2{{"存在する"}}
+    S2 -->|"Yes"| HR["isHighRisk = true"]
+    S2 -->|"No"| S3["syscallAnalysisHasNetworkSignal"]
+    S3 -->|"IsNetwork==true<br>のエントリが存在？<br>（DeterminationMethod 不問）"| S4{{"存在する"}}
+    S4 -->|"Yes"| NW["isNetwork = true"]
+    S4 -->|"No"| OK["isHighRisk=false, isNetwork=false"]
+
+    class R data;
+    class S1,S3 changed;
+    class HR,NW,OK process;
+```
+
+## 4. macOS syscall テーブル自動生成設計
+
+### 4.1 ファイル役割分担
+
+| ファイル | 変更種別 | 内容 |
+|---------|---------|------|
+| `internal/libccache/macos_syscall_numbers.go` | 新規（自動生成） | `macOSSyscallEntries` マップ変数（全 BSD syscall） |
+| `internal/libccache/macos_syscall_table.go` | 修正 | `macOSSyscallEntries` 定義を削除。`MacOSSyscallTable` 構造体・メソッド・`networkSyscallWrapperNames` は残す |
+
+### 4.2 生成スクリプトの拡張
+
+```mermaid
+flowchart LR
+    classDef data fill:#e6f7ff,stroke:#1f77b4,stroke-width:1px,color:#0b3d91;
+    classDef process fill:#fff1e6,stroke:#ff7f0e,stroke-width:1px,color:#8a3e00;
+    classDef changed fill:#e8f5e8,stroke:#2e8b57,stroke-width:2px,color:#006400;
+
+    H1[("macOS SDK<br>sys/syscall.h")] -->|"--macos-header"| S["generate_syscall_table.py<br>（拡張）"]
+    H2[("Linux x86_64<br>unistd_64.h")] -->|"--x86-header"| S
+    H3[("Linux arm64<br>unistd.h")] -->|"--arm64-header"| S
+    S -->|"SYS_<name> パース"| G1[("macos_syscall_numbers.go")]
+    S -->|"__NR_<name> パース"| G2[("x86_syscall_numbers.go")]
+    S -->|"__NR_<name> パース"| G3[("arm64_syscall_numbers.go")]
+
+    class H1,H2,H3,G1,G2,G3 data;
+    class S changed;
+```
+
+### 4.3 macOS ネットワーク syscall セット
+
+Linux の `NETWORK_SYSCALL_NAMES` から macOS で存在しない名前（`accept4`・`recvmmsg`・`sendmmsg`）を除いたセットを `MACOS_NETWORK_SYSCALL_NAMES` として定義する。
+
+### 4.4 Makefile の更新方針
+
+- `MACOS_SYSCALL_HEADER` 変数を追加（デフォルト: `xcrun --show-sdk-path` 経由で取得）
+- `SYSCALL_TABLE_OUTPUTS` に `internal/libccache/macos_syscall_numbers.go` を追加
+- macOS SDK ヘッダーが存在しない環境（Linux CI 等）では macOS テーブル生成をスキップし、コミット済みファイルをそのまま使用する
+
+## 5. テスト戦略
+
+### 5.1 影響を受けるテストファイル
+
+| テストファイル | 変更内容 |
+|-------------|---------|
+| `internal/fileanalysis/syscall_store_test.go` | `FilterSyscallsForStorage` 前提テスト削除または置換 |
+| `internal/filevalidator/validator_test.go` | 非ネットワーク・解決済み syscall が保持されるよう更新 |
+| `internal/filevalidator/validator_macho_test.go` | 解決済み非ネットワーク svc 保持・未解決 svc のみ警告発出の前提に更新 |
+| `internal/runner/security/network_analyzer_test.go` | 未解決 svc のみ high risk・IsNetwork 不問での network signal 判定に更新 |
+| `internal/libccache/` テスト | macOS syscall テーブル拡張後の `GetSyscallName`・`IsNetworkSyscall` 動作検証 |
+
+### 5.2 テスト方針
+
+- 各 AC（受け入れ基準）に対して最低 1 つのテストを用意する
+- 境界値: 解決済み svc（Number != -1）は高リスク判定しない、未解決 svc（Number == -1）は高リスク判定する
+- 後方互換性: 旧レコード（フィルタリング済み）でも runner が正しく動作することを確認する
+
+## 6. 変更対象外
+
+- `SymbolAnalysis`（`AnalyzeNetworkSymbols`）のフィルタリングロジック
+- JSON スキーマバージョン（`CurrentSchemaVersion`）
+- `mergeMachoSyscallInfos` の並べ替えロジック
+- `internal/libccache/macos_syscall_table.go` の `MacOSSyscallTable` 構造体・メソッド・`networkSyscallWrapperNames`

--- a/docs/tasks/0105_remove_record_filter/02_architecture.md
+++ b/docs/tasks/0105_remove_record_filter/02_architecture.md
@@ -189,7 +189,13 @@ flowchart LR
 
 ### 4.3 macOS ネットワーク syscall セット
 
-Linux の `NETWORK_SYSCALL_NAMES` から macOS で存在しない名前（`accept4`・`recvmmsg`・`sendmmsg`）を除いたセットを `MACOS_NETWORK_SYSCALL_NAMES` として定義する。
+`MACOS_NETWORK_SYSCALL_NAMES` は既存の `networkSyscallWrapperNames`（`internal/libccache/macos_syscall_table.go`）と一致させる。
+具体的には、Linux の `NETWORK_SYSCALL_NAMES` を基に以下の調整を行う:
+
+- **除外**: Linux 固有で macOS に存在しない `accept4`・`recvmmsg`・`sendmmsg`
+- **追加**: macOS でソケット操作に使われ `networkSyscallWrapperNames` に含まれる `shutdown`・`setsockopt`・`getsockopt`・`getpeername`・`getsockname`
+
+`sendfile` は macOS でファイル-to-ソケット転送に使えるが、既存の `networkSyscallWrapperNames` に含まれておらず Linux 側の `NETWORK_SYSCALL_NAMES` にも含まれないため、両プラットフォームとも対象外とする。
 
 ### 4.4 Makefile の更新方針
 

--- a/docs/tasks/0105_remove_record_filter/02_architecture.md
+++ b/docs/tasks/0105_remove_record_filter/02_architecture.md
@@ -215,6 +215,17 @@ Linux の `NETWORK_SYSCALL_NAMES` から macOS で存在しない名前（`accep
 - 境界値: 解決済み svc（Number != -1）は高リスク判定しない、未解決 svc（Number == -1）は高リスク判定する
 - 後方互換性: 旧レコード（フィルタリング済み）でも runner が正しく動作することを確認する
 
+### 5.3 受け入れ基準と確認方法
+
+| 観点 | 確認方法 |
+|---|---|
+| AC-1, AC-2, AC-3 | `validator_test.go` / `validator_macho_test.go` の単体テストで `DetectedSyscalls` と `AnalysisWarnings` を確認する |
+| AC-4, AC-5 | `network_analyzer_test.go` で未解決 svc と解決済みネットワーク svc の判定分岐を確認する |
+| AC-6 | `internal/libccache` 配下のテストと `make generate-syscall-tables` で生成結果と API 挙動を確認する |
+| AC-7 | `make test` / `make lint` を実行して既存テストの回帰がないことを確認する |
+| AC-8 | `docs/tasks/0104_macho_syscall_number_analysis/03_detailed_specification.md` と `04_implementation_plan.md` の superseded 記述をレビューして整合を確認する |
+| NFR-1 | `network_analyzer_test.go` で旧レコード相当のフィルタ済み `DetectedSyscalls` を与え、判定が変わらないことを確認する |
+
 ## 6. 変更対象外
 
 - `SymbolAnalysis`（`AnalyzeNetworkSymbols`）のフィルタリングロジック

--- a/docs/tasks/0105_remove_record_filter/03_detailed_specification.md
+++ b/docs/tasks/0105_remove_record_filter/03_detailed_specification.md
@@ -308,6 +308,8 @@ func syscallAnalysisHasNetworkSignal(result *fileanalysis.SyscallAnalysisResult)
 
 **変更内容の方向性:**
 
+加えて、旧レコード互換性（NFR-1）を確認するため、フィルタリング済み `DetectedSyscalls` のみを持つ入力に対しても判定結果が変わらないケースを残す。
+
 `syscallAnalysisHasSVCSignal` テストケース:
 
 | テスト名 | 入力 | 期待される出力 |
@@ -326,7 +328,7 @@ func syscallAnalysisHasNetworkSignal(result *fileanalysis.SyscallAnalysisResult)
 | 非ネットワーク | IsNetwork=false | false |
 | nil | nil | false |
 
-**対応 AC:** AC-4、AC-5、AC-7
+**対応 AC/NFR:** AC-4、AC-5、AC-7、NFR-1
 
 ## 10. `internal/libccache/macos_syscall_table.go`
 
@@ -501,6 +503,10 @@ generate-syscall-tables:
 - 「削除する」という記述を「本タスク（0105）で `Number == -1` 条件を追加して修正した」という旨に変更する、または
 - superseded として明示する
 
+対象ファイル:
+- `docs/tasks/0104_macho_syscall_number_analysis/03_detailed_specification.md`
+- `docs/tasks/0104_macho_syscall_number_analysis/04_implementation_plan.md`
+
 **対応 AC:** AC-8
 
 ## 15. 受け入れ基準とテストの対応
@@ -514,4 +520,5 @@ generate-syscall-tables:
 | AC-5: 解決済みネットワーク svc 判定 | `network_analyzer_test.go` | IsNetwork=true, DeterminationMethod="direct_svc_0x80" → isNetwork=true |
 | AC-6: macOS syscall テーブル拡張 | `libccache` テスト | GetSyscallName(3)="read", IsNetworkSyscall(97)=true, IsNetworkSyscall(3)=false |
 | AC-7: 既存テスト通過 | 全テストファイル | `make test` `make lint` エラーなし |
-| AC-8: 関連ドキュメント整合 | — | 0104 配下のドキュメント更新確認 |
+| AC-8: 関連ドキュメント整合 | `docs/tasks/0104_macho_syscall_number_analysis/03_detailed_specification.md`, `docs/tasks/0104_macho_syscall_number_analysis/04_implementation_plan.md` | `syscallAnalysisHasSVCSignal` 削除前提が superseded または 0105 方針へ更新されていることを確認する |
+| NFR-1: 既存レコード互換性 | `network_analyzer_test.go` | 旧レコード相当のフィルタ済み `DetectedSyscalls` でも判定が維持されることを確認する |

--- a/docs/tasks/0105_remove_record_filter/03_detailed_specification.md
+++ b/docs/tasks/0105_remove_record_filter/03_detailed_specification.md
@@ -302,6 +302,18 @@ func syscallAnalysisHasNetworkSignal(result *fileanalysis.SyscallAnalysisResult)
 
 **対応 AC:** AC-5
 
+### 8.3 変更しない: キャッシュエラー処理
+
+`isNetworkViaBinaryAnalysis` のキャッシュエラー処理（`SchemaVersionMismatchError`・`ErrRecordNotFound`・`nil` 結果）は 0105 では変更しない。既存の挙動を明示的に維持する:
+
+| エラー条件 | 挙動 | 理由 |
+|-----------|------|------|
+| `SchemaVersionMismatchError`（SymbolAnalysis または SyscallAnalysis） | `return true, true`（高リスク確定） | 古いスキーマのレコードは信頼できないため、許容するのではなく保守的に高リスクとする |
+| `ErrRecordNotFound`（SyscallAnalysis のみ） | panic | SymbolAnalysis レコードが存在するのに SyscallAnalysis レコードが存在しない場合は一貫性バグであり、サイレントに許容してはならない |
+| `nil` result（SyscallAnalysis） | SVC シグナルなしとして SymbolAnalysis 判定に委ねる | syscall 解析が存在しない静的バイナリ等では正常ケース |
+
+**実装上の注意:** 0105 ではスキーマバージョンを変更しない（既存 v16 レコードの後方互換を維持）。そのため、フィルタリング前の旧レコードは `SchemaVersionMismatchError` を発生させず、より少ない `DetectedSyscalls` のまま利用される。これは意図的な設計であり（NFR-1）、`record` を再実行すれば最新の（フィルタなし）レコードへ自動的に上書きされる。
+
 ## 9. `internal/runner/security/network_analyzer_test.go`
 
 ### 9.1 変更内容: SVC / network signal テストの更新
@@ -402,11 +414,14 @@ MACOS_NETWORK_SYSCALL_NAMES = {
     "getsockopt",
     "getpeername",
     "getsockname",
-    "sendfile",
 }
 ```
 
-Linux 固有（macOS に存在しない）を除外: `accept4`、`recvmmsg`、`sendmmsg`
+Linux 固有（macOS に存在しない）を除外: `accept4`・`recvmmsg`・`sendmmsg`
+Linux にはないが macOS でソケット操作に使われるため追加: `shutdown`・`setsockopt`・`getsockopt`・`getpeername`・`getsockname`
+（これらは既存の `networkSyscallWrapperNames` と一致させる）
+
+`sendfile` は macOS でファイル-to-ソケット転送に使える syscall だが、既存の `networkSyscallWrapperNames` には含まれていないため追加しない。Linux の `NETWORK_SYSCALL_NAMES` にも含まれておらず、一貫性の観点から除外する。
 
 #### 12.1.2 `parse_macos_header` 関数の追加
 

--- a/docs/tasks/0105_remove_record_filter/03_detailed_specification.md
+++ b/docs/tasks/0105_remove_record_filter/03_detailed_specification.md
@@ -1,0 +1,517 @@
+# 詳細仕様書: record コマンドのシステムコールフィルタリング削除
+
+## 1. 概要
+
+本ドキュメントはアーキテクチャ設計書（`02_architecture.md`）を基に、各変更ファイルの具体的な実装仕様を定義する。受け入れ基準（AC-1〜AC-8）と各テストケースの対応関係も示す。
+
+## 2. 変更ファイル一覧
+
+| ファイル | 変更種別 |
+|---------|---------|
+| `internal/fileanalysis/syscall_store.go` | 削除（関数） |
+| `internal/fileanalysis/syscall_store_test.go` | テスト削除・置換 |
+| `internal/filevalidator/validator.go` | 修正 |
+| `internal/filevalidator/validator_test.go` | テスト更新 |
+| `internal/filevalidator/validator_macho_test.go` | テスト更新 |
+| `internal/runner/security/network_analyzer.go` | 修正 |
+| `internal/runner/security/network_analyzer_test.go` | テスト更新 |
+| `internal/libccache/macos_syscall_table.go` | 修正（マップ定義削除） |
+| `internal/libccache/macos_syscall_numbers.go` | 新規（自動生成ファイル） |
+| `scripts/generate_syscall_table.py` | 拡張 |
+| `Makefile` | 更新 |
+
+## 3. `internal/fileanalysis/syscall_store.go`
+
+### 3.1 変更内容: `FilterSyscallsForStorage` 関数の削除
+
+**削除対象:**
+
+```go
+// FilterSyscallsForStorage filters a slice of SyscallInfo to only entries
+// relevant to risk assessment:
+//   - Network-related syscalls (IsNetwork == true)
+//   - Syscalls with unknown numbers (Number == -1)
+func FilterSyscallsForStorage(syscalls []common.SyscallInfo) []common.SyscallInfo {
+    filtered := make([]common.SyscallInfo, 0, len(syscalls))
+    for _, s := range syscalls {
+        if s.IsNetwork || s.Number == -1 {
+            filtered = append(filtered, s)
+        }
+    }
+    return filtered
+}
+```
+
+**対応 AC:** AC-1（`FilterSyscallsForStorage` が削除されていること）
+
+## 4. `internal/fileanalysis/syscall_store_test.go`
+
+### 4.1 変更内容: `FilterSyscallsForStorage` 前提テストの削除
+
+削除対象テスト:
+- `TestFilterSyscallsForStorage`
+- `TestFilterSyscallsForStorage_Empty`
+
+**対応 AC:** AC-7
+
+## 5. `internal/filevalidator/validator.go`
+
+### 5.1 変更内容: `buildSyscallData`（ELF）のフィルタリング削除
+
+**対象箇所:** `buildSyscallData` 関数
+
+**変更前:**
+```go
+func buildSyscallData(all []common.SyscallInfo, argEvalResults []common.SyscallArgEvalResult, machine elf.Machine) *fileanalysis.SyscallAnalysisData {
+    retained := fileanalysis.FilterSyscallsForStorage(all)
+
+    return &fileanalysis.SyscallAnalysisData{
+        SyscallAnalysisResultCore: common.SyscallAnalysisResultCore{
+            Architecture:     elfArchName(machine),
+            DetectedSyscalls: retained,
+            ArgEvalResults:   argEvalResults,
+        },
+    }
+}
+```
+
+**変更後:**
+```go
+func buildSyscallData(all []common.SyscallInfo, argEvalResults []common.SyscallArgEvalResult, machine elf.Machine) *fileanalysis.SyscallAnalysisData {
+    return &fileanalysis.SyscallAnalysisData{
+        SyscallAnalysisResultCore: common.SyscallAnalysisResultCore{
+            Architecture:     elfArchName(machine),
+            DetectedSyscalls: all,
+            ArgEvalResults:   argEvalResults,
+        },
+    }
+}
+```
+
+**対応 AC:** AC-1
+
+### 5.2 変更内容: `buildMachoSyscallData`（Mach-O）のフィルタリング削除と警告ロジック修正
+
+**対象箇所:** `buildMachoSyscallData` 関数（関数コメントを含む）
+
+**変更前（コメント含む）:**
+```go
+// buildMachoSyscallData merges svc and libSystem entries and constructs
+// SyscallAnalysisData.
+// AnalysisWarnings is populated only when unresolved svc #0x80 entries remain
+// after filtering (i.e., entries with DeterminationMethod="direct_svc_0x80").
+// When all svc entries are resolved to non-network syscalls they are dropped by
+// FilterSyscallsForStorage and no warning is emitted.
+// DetectedSyscalls is sorted by Number (svc entries with Number=-1 appear first).
+func buildMachoSyscallData(
+    svcEntries []common.SyscallInfo,
+    libsysEntries []common.SyscallInfo,
+    arch string,
+) *fileanalysis.SyscallAnalysisData {
+    merged := mergeMachoSyscallInfos(svcEntries, libsysEntries)
+    retained := fileanalysis.FilterSyscallsForStorage(merged)
+
+    var warnings []string
+    for _, s := range retained {
+        if s.DeterminationMethod == common.DeterminationMethodDirectSVC0x80 {
+            warnings = []string{"svc #0x80 detected: syscall number unresolved, direct kernel call bypassing libSystem.dylib"}
+            break
+        }
+    }
+
+    return &fileanalysis.SyscallAnalysisData{
+        SyscallAnalysisResultCore: common.SyscallAnalysisResultCore{
+            Architecture:     arch,
+            AnalysisWarnings: warnings,
+            DetectedSyscalls: retained,
+        },
+    }
+}
+```
+
+**変更後（コメント含む）:**
+```go
+// buildMachoSyscallData merges svc and libSystem entries and constructs
+// SyscallAnalysisData.
+// AnalysisWarnings is populated only when unresolved svc #0x80 entries exist
+// (i.e., entries with DeterminationMethod="direct_svc_0x80" AND Number == -1).
+// When all svc entries are resolved (Number != -1), no warning is emitted.
+// DetectedSyscalls contains all entries without filtering.
+func buildMachoSyscallData(
+    svcEntries []common.SyscallInfo,
+    libsysEntries []common.SyscallInfo,
+    arch string,
+) *fileanalysis.SyscallAnalysisData {
+    merged := mergeMachoSyscallInfos(svcEntries, libsysEntries)
+
+    var warnings []string
+    for _, s := range merged {
+        if s.DeterminationMethod == common.DeterminationMethodDirectSVC0x80 && s.Number == -1 {
+            warnings = []string{"svc #0x80 detected: syscall number unresolved, direct kernel call bypassing libSystem.dylib"}
+            break
+        }
+    }
+
+    return &fileanalysis.SyscallAnalysisData{
+        SyscallAnalysisResultCore: common.SyscallAnalysisResultCore{
+            Architecture:     arch,
+            AnalysisWarnings: warnings,
+            DetectedSyscalls: merged,
+        },
+    }
+}
+```
+
+**ポイント:**
+- `FilterSyscallsForStorage` の呼び出しを削除し `retained` 変数を排除
+- 警告判定を `retained` から `merged` に変更
+- 警告条件に `s.Number == -1` を追加（解決済み svc では警告を発しない）
+- `DetectedSyscalls` に `retained` ではなく `merged`（全エントリ）を格納
+
+**対応 AC:** AC-2、AC-3
+
+### 5.3 `fileanalysis` パッケージのインポート
+
+`buildSyscallData` と `buildMachoSyscallData` の両方から `fileanalysis.FilterSyscallsForStorage` の呼び出しが削除される。もし `fileanalysis` パッケージのインポートが `FilterSyscallsForStorage` のためだけであれば削除を検討するが、`fileanalysis.SyscallAnalysisData` 等の型参照が残るため実際には削除不要。
+
+## 6. `internal/filevalidator/validator_test.go`
+
+### 6.1 変更内容: `buildSyscallData` テストの更新
+
+**変更内容の方向性:**
+- フィルタリング前提のアサーションを削除する
+- 非ネットワーク・解決済み syscall（例: `write()`、`read()`）が `DetectedSyscalls` に含まれることを検証するテストケースを追加または更新する
+
+**対応 AC:** AC-1、AC-7
+
+## 7. `internal/filevalidator/validator_macho_test.go`
+
+### 7.1 変更内容: `buildMachoSyscallData` テストの更新
+
+**変更内容の方向性:**
+- 解決済み非ネットワーク svc（例: `read()`、`Number=3`）が `DetectedSyscalls` に含まれることを検証するテストを追加または更新する
+- 未解決 svc（`Number == -1`）が存在する場合のみ `AnalysisWarnings` に警告が含まれることを検証する
+- 全エントリが解決済みの場合は `AnalysisWarnings` が空であることを検証する
+
+**テストケース例:**
+
+| テスト名 | 入力 | 期待される出力 |
+|---------|------|--------------|
+| 全エントリ解決済み | Number=97（socket, IsNetwork=true, DeterminationMethod="direct_svc_0x80"） | AnalysisWarnings=[]、DetectedSyscalls に socket エントリ含む |
+| 未解決 svc あり | Number=-1（DeterminationMethod="direct_svc_0x80"） | AnalysisWarnings に警告含む |
+| 混在 | Number=97 + Number=-1 | AnalysisWarnings に警告含む（未解決があるため）|
+| 非ネットワーク解決済み svc | Number=3（read, IsNetwork=false, DeterminationMethod="direct_svc_0x80"） | AnalysisWarnings=[]、DetectedSyscalls に read エントリ含む |
+
+**対応 AC:** AC-2、AC-3、AC-7
+
+## 8. `internal/runner/security/network_analyzer.go`
+
+### 8.1 変更内容: `syscallAnalysisHasSVCSignal` の修正
+
+**対象箇所:** `syscallAnalysisHasSVCSignal` 関数（関数コメントを含む）
+
+**変更前（コメント含む）:**
+```go
+// syscallAnalysisHasSVCSignal reports whether the given SyscallAnalysisResult
+// contains evidence of svc #0x80 direct syscall usage.
+// Returns true only when any DetectedSyscall has DeterminationMethod == "direct_svc_0x80".
+// AnalysisWarnings is not checked here because it may contain warnings from ELF syscall
+// analysis that are unrelated to svc #0x80, which would cause false positives.
+func syscallAnalysisHasSVCSignal(result *fileanalysis.SyscallAnalysisResult) bool {
+    if result == nil {
+        return false
+    }
+    for _, s := range result.DetectedSyscalls {
+        if s.DeterminationMethod == common.DeterminationMethodDirectSVC0x80 {
+            return true
+        }
+    }
+    return false
+}
+```
+
+**変更後（コメント含む）:**
+```go
+// syscallAnalysisHasSVCSignal reports whether the given SyscallAnalysisResult
+// contains evidence of unresolved svc #0x80 direct syscall usage (high risk).
+// Returns true only when any DetectedSyscall has both
+// DeterminationMethod == "direct_svc_0x80" AND Number == -1.
+// Resolved svc entries (Number != -1) are not treated as high risk here;
+// their network classification is handled by syscallAnalysisHasNetworkSignal.
+func syscallAnalysisHasSVCSignal(result *fileanalysis.SyscallAnalysisResult) bool {
+    if result == nil {
+        return false
+    }
+    for _, s := range result.DetectedSyscalls {
+        if s.DeterminationMethod == common.DeterminationMethodDirectSVC0x80 && s.Number == -1 {
+            return true
+        }
+    }
+    return false
+}
+```
+
+**変更理由:** フィルタリング削除後、解決済み svc（Number != -1）も `DetectedSyscalls` に含まれるため、`DeterminationMethod` のみの判定では解決済みの非リスク svc でも誤って高リスク判定してしまう。
+
+**対応 AC:** AC-4
+
+### 8.2 変更内容: `syscallAnalysisHasNetworkSignal` の修正
+
+**対象箇所:** `syscallAnalysisHasNetworkSignal` 関数（関数コメントを含む）
+
+**変更前（コメント含む）:**
+```go
+// syscallAnalysisHasNetworkSignal reports whether the given SyscallAnalysisResult
+// contains any detected syscall classified as a network syscall (IsNetwork == true)
+// that was not identified as a direct svc #0x80 instruction.
+// Direct svc #0x80 entries are handled separately by syscallAnalysisHasSVCSignal
+// (which escalates to high risk) and are therefore excluded here.
+func syscallAnalysisHasNetworkSignal(result *fileanalysis.SyscallAnalysisResult) bool {
+    if result == nil {
+        return false
+    }
+    for _, s := range result.DetectedSyscalls {
+        if s.IsNetwork && s.DeterminationMethod != common.DeterminationMethodDirectSVC0x80 {
+            return true
+        }
+    }
+    return false
+}
+```
+
+**変更後（コメント含む）:**
+```go
+// syscallAnalysisHasNetworkSignal reports whether the given SyscallAnalysisResult
+// contains any detected syscall classified as a network syscall (IsNetwork == true).
+// This includes resolved svc entries (DeterminationMethod == "direct_svc_0x80" AND Number != -1)
+// whose network classification is determined by the syscall table lookup.
+func syscallAnalysisHasNetworkSignal(result *fileanalysis.SyscallAnalysisResult) bool {
+    if result == nil {
+        return false
+    }
+    for _, s := range result.DetectedSyscalls {
+        if s.IsNetwork {
+            return true
+        }
+    }
+    return false
+}
+```
+
+**変更理由:** フィルタリング削除後、解決済みネットワーク svc（`IsNetwork=true`、`DeterminationMethod="direct_svc_0x80"`、`Number != -1`）も `DetectedSyscalls` に含まれる。これらを `DeterminationMethod` で除外すると、ネットワーク syscall を見逃す。`DeterminationMethod` による除外条件を削除し、`IsNetwork` のみで判定する。
+
+**対応 AC:** AC-5
+
+## 9. `internal/runner/security/network_analyzer_test.go`
+
+### 9.1 変更内容: SVC / network signal テストの更新
+
+**変更内容の方向性:**
+
+`syscallAnalysisHasSVCSignal` テストケース:
+
+| テスト名 | 入力 | 期待される出力 |
+|---------|------|--------------|
+| 未解決 svc | Number=-1, DeterminationMethod="direct_svc_0x80" | true（高リスク） |
+| 解決済み非ネットワーク svc | Number=3, DeterminationMethod="direct_svc_0x80", IsNetwork=false | false（高リスクでない） |
+| 解決済みネットワーク svc | Number=97, DeterminationMethod="direct_svc_0x80", IsNetwork=true | false（高リスクでない。network signal で検出） |
+| nil | nil | false |
+
+`syscallAnalysisHasNetworkSignal` テストケース:
+
+| テスト名 | 入力 | 期待される出力 |
+|---------|------|--------------|
+| libSystem ネットワーク | IsNetwork=true, DeterminationMethod="libSystem" | true |
+| 解決済みネットワーク svc | IsNetwork=true, DeterminationMethod="direct_svc_0x80", Number=97 | true |
+| 非ネットワーク | IsNetwork=false | false |
+| nil | nil | false |
+
+**対応 AC:** AC-4、AC-5、AC-7
+
+## 10. `internal/libccache/macos_syscall_table.go`
+
+### 10.1 変更内容: `macOSSyscallEntries` マップ定義の削除
+
+**削除対象:**
+```go
+var macOSSyscallEntries = map[int]macOSSyscallEntry{
+    27:  {name: "recvmsg", isNetwork: true},
+    // ... 17 エントリ
+}
+```
+
+`macOSSyscallEntries` の定義は `internal/libccache/macos_syscall_numbers.go`（自動生成）に移動される。`MacOSSyscallTable` 構造体・`GetSyscallName`・`IsNetworkSyscall` メソッド・`networkSyscallWrapperNames` は変更なし。
+
+**対応 AC:** AC-6
+
+## 11. `internal/libccache/macos_syscall_numbers.go`（新規）
+
+### 11.1 生成ファイルの構造
+
+`scripts/generate_syscall_table.py --macos-header` により生成される。
+
+**ファイルヘッダー:**
+```go
+// Code generated by scripts/generate_syscall_table.py; DO NOT EDIT.
+// Source: syscall.h
+// Regenerate: make generate-syscall-tables
+
+package libccache
+```
+
+**生成される変数:**
+```go
+var macOSSyscallEntries = map[int]macOSSyscallEntry{
+    1:   {name: "exit", isNetwork: false},
+    2:   {name: "fork", isNetwork: false},
+    3:   {name: "read", isNetwork: false},
+    4:   {name: "write", isNetwork: false},
+    // ... 全 BSD syscall
+    27:  {name: "recvmsg", isNetwork: true},
+    97:  {name: "socket", isNetwork: true},
+    // ...
+}
+```
+
+**注意:** `macOSSyscallEntry` 型は `macos_syscall_table.go` に残る。生成スクリプトは `macOSSyscallEntry` 型を使うコードを生成する。
+
+**対応 AC:** AC-6
+
+## 12. `scripts/generate_syscall_table.py`
+
+### 12.1 変更内容: macOS ヘッダーパーサーの追加
+
+#### 12.1.1 `MACOS_NETWORK_SYSCALL_NAMES` セットの追加
+
+```python
+MACOS_NETWORK_SYSCALL_NAMES = {
+    "socket",
+    "connect",
+    "accept",
+    "sendto",
+    "recvfrom",
+    "sendmsg",
+    "recvmsg",
+    "bind",
+    "listen",
+    "socketpair",
+    "shutdown",
+    "setsockopt",
+    "getsockopt",
+    "getpeername",
+    "getsockname",
+    "sendfile",
+}
+```
+
+Linux 固有（macOS に存在しない）を除外: `accept4`、`recvmmsg`、`sendmmsg`
+
+#### 12.1.2 `parse_macos_header` 関数の追加
+
+```python
+def parse_macos_header(path: str) -> dict[str, int]:
+    """Parse ``#define SYS_<name> <number>`` lines from a macOS syscall header.
+
+    Returns a dict mapping syscall name to number.
+    """
+    pattern = re.compile(r"^#define\s+SYS_(\w+)\s+(\d+)\s*$")
+    result: dict[str, int] = {}
+    with open(path, encoding="utf-8") as f:
+        for line in f:
+            m = pattern.match(line)
+            if m:
+                name, number = m.group(1), int(m.group(2))
+                result[name] = number
+    return result
+```
+
+#### 12.1.3 macOS 用 `generate_macos` 関数の追加
+
+macOS syscall テーブルは ELF テーブルと異なる型（`macOSSyscallEntry`）・パッケージ（`libccache`）を使うため、独立した生成関数を追加する。
+
+**生成されるコード形式:**
+
+```go
+var macOSSyscallEntries = map[int]macOSSyscallEntry{
+    3:   {name: "read", isNetwork: false},
+    97:  {name: "socket", isNetwork: true},
+    // ...
+}
+```
+
+#### 12.1.4 `--macos-header` オプションの追加
+
+```python
+parser.add_argument(
+    "--macos-header",
+    default=None,
+    help="Path to macOS BSD syscall header (e.g. $(xcrun --show-sdk-path)/usr/include/sys/syscall.h)",
+)
+```
+
+オプションが指定された場合のみ macOS テーブルを生成し、既存の `--x86-header`・`--arm64-header` の動作には影響しない。
+
+**対応 AC:** AC-6
+
+## 13. `Makefile`
+
+### 13.1 変更内容
+
+**追加変数:**
+```makefile
+MACOS_SYSCALL_HEADER ?= $(shell xcrun --show-sdk-path 2>/dev/null)/usr/include/sys/syscall.h
+```
+
+**`SYSCALL_TABLE_OUTPUTS` への追加:**
+```makefile
+SYSCALL_TABLE_OUTPUTS := \
+    internal/runner/security/elfanalyzer/x86_syscall_numbers.go \
+    internal/runner/security/elfanalyzer/arm64_syscall_numbers.go \
+    internal/libccache/macos_syscall_numbers.go
+```
+
+**`generate-syscall-tables` ターゲットの更新:**
+
+macOS SDK ヘッダーが存在する場合に `--macos-header` オプションを追加してスクリプトを呼び出す。存在しない環境（Linux CI 等）では macOS テーブル生成をスキップし、コミット済みファイルを使用する。
+
+```makefile
+generate-syscall-tables:
+    # ... 既存の Linux ヘッダーチェック ...
+    @if [ -f "$(MACOS_SYSCALL_HEADER)" ]; then \
+        $(PYTHON) $(SYSCALL_TABLE_SCRIPT) \
+            --x86-header $(X86_SYSCALL_HEADER) \
+            --arm64-header $(ARM64_SYSCALL_HEADER) \
+            --macos-header $(MACOS_SYSCALL_HEADER); \
+    else \
+        $(PYTHON) $(SYSCALL_TABLE_SCRIPT) \
+            --x86-header $(X86_SYSCALL_HEADER) \
+            --arm64-header $(ARM64_SYSCALL_HEADER); \
+    fi
+    $(GOFUMPTCMD) -w $(SYSCALL_TABLE_OUTPUTS)
+```
+
+**対応 AC:** AC-6
+
+## 14. 関連ドキュメントの更新
+
+### 14.1 `docs/tasks/0104_macho_syscall_number_analysis/` の整合修正
+
+当該ディレクトリ配下に「`syscallAnalysisHasSVCSignal` を削除する」という記述がある場合、本タスク後の方針（削除ではなく `Number == -1` 条件追加により保持）と矛盾しないよう更新する。具体的には：
+
+- 「削除する」という記述を「本タスク（0105）で `Number == -1` 条件を追加して修正した」という旨に変更する、または
+- superseded として明示する
+
+**対応 AC:** AC-8
+
+## 15. 受け入れ基準とテストの対応
+
+| 受け入れ基準 | 対応テストファイル | テスト内容 |
+|------------|----------------|----------|
+| AC-1: ELF 全 syscall 記録 | `validator_test.go` | 非ネットワーク・解決済み syscall が `DetectedSyscalls` に含まれる |
+| AC-2: Mach-O 全 syscall 記録 | `validator_macho_test.go` | libSystem + svc 全エントリが `DetectedSyscalls` に含まれる |
+| AC-3: `AnalysisWarnings` 正確な発出 | `validator_macho_test.go` | 未解決 svc のみ警告。解決済みのみの場合は警告なし |
+| AC-4: 未解決 svc 高リスク判定 | `network_analyzer_test.go` | Number=-1 → high risk。Number!=−1 非ネットワーク → high risk でない |
+| AC-5: 解決済みネットワーク svc 判定 | `network_analyzer_test.go` | IsNetwork=true, DeterminationMethod="direct_svc_0x80" → isNetwork=true |
+| AC-6: macOS syscall テーブル拡張 | `libccache` テスト | GetSyscallName(3)="read", IsNetworkSyscall(97)=true, IsNetworkSyscall(3)=false |
+| AC-7: 既存テスト通過 | 全テストファイル | `make test` `make lint` エラーなし |
+| AC-8: 関連ドキュメント整合 | — | 0104 配下のドキュメント更新確認 |

--- a/docs/tasks/0105_remove_record_filter/03_detailed_specification.md
+++ b/docs/tasks/0105_remove_record_filter/03_detailed_specification.md
@@ -531,7 +531,7 @@ generate-syscall-tables:
 | AC-1: ELF 全 syscall 記録 | `validator_test.go` | 非ネットワーク・解決済み syscall が `DetectedSyscalls` に含まれる |
 | AC-2: Mach-O 全 syscall 記録 | `validator_macho_test.go` | libSystem + svc 全エントリが `DetectedSyscalls` に含まれる |
 | AC-3: `AnalysisWarnings` 正確な発出 | `validator_macho_test.go` | 未解決 svc のみ警告。解決済みのみの場合は警告なし |
-| AC-4: 未解決 svc 高リスク判定 | `network_analyzer_test.go` | Number=-1 → high risk。Number!=−1 非ネットワーク → high risk でない |
+| AC-4: 未解決 svc 高リスク判定 | `network_analyzer_test.go` | Number=-1 → high risk。Number!=-1 非ネットワーク → high risk でない |
 | AC-5: 解決済みネットワーク svc 判定 | `network_analyzer_test.go` | IsNetwork=true, DeterminationMethod="direct_svc_0x80" → isNetwork=true |
 | AC-6: macOS syscall テーブル拡張 | `libccache` テスト | GetSyscallName(3)="read", IsNetworkSyscall(97)=true, IsNetworkSyscall(3)=false |
 | AC-7: 既存テスト通過 | 全テストファイル | `make test` `make lint` エラーなし |

--- a/docs/tasks/0105_remove_record_filter/03_detailed_specification.md
+++ b/docs/tasks/0105_remove_record_filter/03_detailed_specification.md
@@ -461,7 +461,7 @@ parser.add_argument(
 
 **追加変数:**
 ```makefile
-MACOS_SYSCALL_HEADER ?= $(shell xcrun --show-sdk-path 2>/dev/null)/usr/include/sys/syscall.h
+MACOS_SYSCALL_HEADER ?= $(shell xcrun --show-sdk-path 2>/dev/null | awk 'NF{print $$0"/usr/include/sys/syscall.h"}')
 ```
 
 **`SYSCALL_TABLE_OUTPUTS` への追加:**

--- a/docs/tasks/0105_remove_record_filter/04_implementation_plan.md
+++ b/docs/tasks/0105_remove_record_filter/04_implementation_plan.md
@@ -1,0 +1,156 @@
+# 実装計画書: record コマンドのシステムコールフィルタリング削除
+
+## 1. 実装の進め方
+
+本実装計画書は 03_detailed_specification.md に基づき、record 側の責務整理、runner 側の判定修正、macOS syscall テーブル自動生成、既存テストの更新を段階的に進めるためのチェックリストを定義する。
+
+### 実装ステップ概要
+
+1. Step 1: record 側の syscall 保存経路からフィルタリングを除去する
+2. Step 2: runner 側の SVC / network 判定を未解決 svc 前提に修正する
+3. Step 3: macOS BSD syscall テーブルの自動生成を追加する
+4. Step 4: 既存テストを新しい保存・判定前提に更新する
+5. Step 5: 最終検証と関連ドキュメント整合を確認する
+
+## 2. 事前確認事項
+
+### 2.1 依存方向の確認
+
+- [ ] internal/fileanalysis は syscall 保存対象の選別を持たず、解析データ構造の責務に留める
+- [ ] internal/filevalidator は fileanalysis のデータ型を利用するが、runner の判定ロジックを持ち込まない
+- [ ] internal/runner/security は保存済み record を評価する責務に留まり、record 側の保存方針へ逆依存しない
+- [ ] internal/libccache の macOS syscall テーブル拡張は既存 API を維持し、呼び出し側の変更を不要にする
+
+### 2.2 既存実装の確認
+
+- [ ] internal/fileanalysis/syscall_store.go に FilterSyscallsForStorage が存在し、削除対象が明確である
+- [ ] internal/filevalidator/validator.go に buildSyscallData と buildMachoSyscallData の 2 箇所の呼び出しが存在する
+- [ ] internal/runner/security/network_analyzer.go に syscallAnalysisHasSVCSignal と syscallAnalysisHasNetworkSignal の現行判定が存在する
+- [ ] scripts/generate_syscall_table.py と Makefile に Linux 用自動生成フローがあり、macOS 向け追加先が明確である
+
+### 2.3 事前に完了済みのドキュメント整合
+
+- [x] docs/tasks/0105_remove_record_filter/02_architecture.md と 03_detailed_specification.md のテストカバー観点を見直した
+- [x] docs/tasks/0104_macho_syscall_number_analysis/03_detailed_specification.md の syscallAnalysisHasSVCSignal 削除前提を superseded として明示した
+- [x] docs/tasks/0104_macho_syscall_number_analysis/04_implementation_plan.md の旧方針を 0105 の方針に合わせて注記した
+
+## 3. Step 1: record 側の保存フィルタ削除
+
+**対象ファイル:**
+- internal/fileanalysis/syscall_store.go
+- internal/fileanalysis/syscall_store_test.go
+- internal/filevalidator/validator.go
+- internal/filevalidator/validator_test.go
+- internal/filevalidator/validator_macho_test.go
+
+### 3.1 実装チェックリスト
+
+- [ ] FilterSyscallsForStorage を削除する
+- [ ] buildSyscallData で all をそのまま DetectedSyscalls に格納する
+- [ ] buildMachoSyscallData で merge 結果をそのまま DetectedSyscalls に格納する
+- [ ] buildMachoSyscallData の warnings 判定を merged に対して実行する
+- [ ] buildMachoSyscallData の warnings 条件を direct_svc_0x80 かつ Number == -1 に限定する
+- [ ] 関数コメントをフィルタなし前提へ更新する
+
+### 3.2 テストチェックリスト
+
+- [ ] internal/fileanalysis/syscall_store_test.go の FilterSyscallsForStorage 前提テストを削除または置換する
+- [ ] internal/filevalidator/validator_test.go で非ネットワーク・解決済み syscall が DetectedSyscalls に残ることを確認する
+- [ ] internal/filevalidator/validator_macho_test.go で解決済み非ネットワーク svc が DetectedSyscalls に残ることを確認する
+- [ ] internal/filevalidator/validator_macho_test.go で libSystem と svc の全エントリが保持されることを確認する
+- [ ] internal/filevalidator/validator_macho_test.go で未解決 svc のみ AnalysisWarnings を発火させることを確認する
+
+## 4. Step 2: runner 側の判定修正
+
+**対象ファイル:**
+- internal/runner/security/network_analyzer.go
+- internal/runner/security/network_analyzer_test.go
+
+### 4.1 実装チェックリスト
+
+- [ ] syscallAnalysisHasSVCSignal を削除せずに保持する
+- [ ] syscallAnalysisHasSVCSignal の高リスク条件を direct_svc_0x80 かつ Number == -1 のみに修正する
+- [ ] syscallAnalysisHasNetworkSignal の direct_svc_0x80 除外条件を削除する
+- [ ] syscallAnalysisHasNetworkSignal を IsNetwork のみで判定する実装に更新する
+- [ ] 関数コメントを未解決 svc と解決済みネットワーク svc の責務分担に合わせて更新する
+
+### 4.2 テストチェックリスト
+
+- [ ] 未解決 svc を high risk と判定するテストを維持または追加する
+- [ ] 解決済み非ネットワーク svc を high risk と判定しないテストを追加する
+- [ ] 解決済みネットワーク svc を network signal として検出するテストを追加する
+- [ ] libSystem 由来ネットワーク syscall を network signal として検出する既存テストを維持する
+- [ ] 旧レコード相当のフィルタ済み DetectedSyscalls でも判定が変わらないことを確認する
+
+## 5. Step 3: macOS BSD syscall テーブル自動生成
+
+**対象ファイル:**
+- internal/libccache/macos_syscall_table.go
+- internal/libccache/macos_syscall_numbers.go
+- scripts/generate_syscall_table.py
+- Makefile
+- internal/libccache 配下の関連テスト
+
+### 5.1 実装チェックリスト
+
+- [ ] macos_syscall_table.go から手動定義の macOSSyscallEntries を削除する
+- [ ] macos_syscall_numbers.go を自動生成ファイルとして追加する
+- [ ] macos_syscall_numbers.go をコミット対象に含め、macOS ヘッダーがない環境でも既存生成物を利用できる状態にする
+- [ ] generate_syscall_table.py に MACOS_NETWORK_SYSCALL_NAMES を追加する
+- [ ] generate_syscall_table.py に parse_macos_header を追加する
+- [ ] generate_syscall_table.py に macOS 用生成関数を追加する
+- [ ] generate_syscall_table.py に --macos-header オプションを追加する
+- [ ] Makefile に MACOS_SYSCALL_HEADER を追加する
+- [ ] generate-syscall-tables ターゲットで macOS ヘッダーがある場合のみ生成する
+- [ ] gofumpt 対象に macos_syscall_numbers.go を追加する
+
+### 5.2 テストチェックリスト
+
+- [ ] MacOSSyscallTable.GetSyscallName(3) == read を確認する
+- [ ] MacOSSyscallTable.IsNetworkSyscall(97) == true を確認する
+- [ ] MacOSSyscallTable.IsNetworkSyscall(3) == false を確認する
+- [ ] make generate-syscall-tables で macOS 環境の再生成が成立することを確認する
+- [ ] macOS ヘッダー非存在環境でも既存ファイル利用でビルドが維持されることを確認する
+
+## 6. Step 4: テスト更新と回帰確認
+
+**対象ファイル:**
+- internal/filevalidator/validator_test.go
+- internal/filevalidator/validator_macho_test.go
+- internal/runner/security/network_analyzer_test.go
+- internal/fileanalysis/syscall_store_test.go
+- internal/libccache 配下の関連テスト
+
+### 6.1 テスト更新チェックリスト
+
+- [ ] AC-1 を validator_test.go の保持テストでカバーする
+- [ ] AC-2 と AC-3 を validator_macho_test.go の全件保持と warning 条件でカバーする
+- [ ] AC-4 と AC-5 を network_analyzer_test.go の分岐テストでカバーする
+- [ ] AC-6 を libccache テストでカバーする
+- [ ] NFR-1 を network_analyzer_test.go の旧レコード互換ケースでカバーする
+- [ ] 不要になった旧前提テスト名やコメントを更新する
+
+## 7. Step 5: 最終検証
+
+### 7.1 実行チェックリスト
+
+- [ ] make fmt
+- [ ] make build
+- [ ] make test
+- [ ] make lint
+- [ ] 必要に応じて make generate-syscall-tables を実行し、生成物に差分がないことを確認する
+
+### 7.2 ドキュメント整合チェックリスト
+
+- [ ] docs/tasks/0105_remove_record_filter/01_requirements.md の AC-1 から AC-8 が実装・テスト・文書確認のいずれかに対応付いていることを確認する
+- [ ] docs/tasks/0105_remove_record_filter/02_architecture.md と 03_detailed_specification.md の記述が最終実装と一致することを確認する
+- [ ] docs/tasks/0104_macho_syscall_number_analysis 配下に 0105 と矛盾する記述が残っていないことを確認する
+
+## 8. 完了条件
+
+- [ ] record は全 syscall をフィルタなしで保存する
+- [ ] runner は未解決 svc のみを high risk とし、解決済みネットワーク syscall を見逃さない
+- [ ] macOS BSD syscall テーブルが自動生成に移行している
+- [ ] 既存テストと追加テストで AC-1 から AC-8、および NFR-1 を確認できる
+- [ ] make build が通過する
+- [ ] make test と make lint が通過する


### PR DESCRIPTION
## Summary

- Add architecture doc (`02_architecture.md`) and detailed specification (`03_detailed_specification.md`) for task 0105: removing syscall filtering from the `record` component
- Add implementation plan (`04_implementation_plan.md`) for task 0105
- Update task 0104 design docs to align with the revised 0105 policy (retain `syscallAnalysisHasSVCSignal`, treat only unresolved svc entries as high-risk)

## Test plan

- [ ] Review architecture diagrams and data flow in `docs/tasks/0105_remove_record_filter/02_architecture.md`
- [ ] Review acceptance criteria coverage in `docs/tasks/0105_remove_record_filter/03_detailed_specification.md`
- [ ] Verify implementation plan checkboxes in `docs/tasks/0105_remove_record_filter/04_implementation_plan.md` reflect the spec
- [ ] Confirm 0104 doc updates correctly reflect the superseded deletion of `syscallAnalysisHasSVCSignal`

🤖 Generated with [Claude Code](https://claude.com/claude-code)