### PR TITLE
docs(0108): add architecture and detailed specification for trusted group whitelist

### DIFF
--- a/docs/tasks/0108_trusted_group_whitelist/02_architecture.md
+++ b/docs/tasks/0108_trusted_group_whitelist/02_architecture.md
@@ -1,0 +1,230 @@
+# アーキテクチャ設計書: ディレクトリセキュリティ検証における信頼済みグループホワイトリスト
+
+## 1. システム概要
+
+### 1.1 設計原則
+
+#### セキュリティファースト原則
+- **最小変更**: セキュリティ判定ロジックの変更を最小限に抑え、誤用リスクを低減する
+- **プラットフォーム分離**: プラットフォーム固有の定数をビルドタグで分岐し、コアロジックを汚染しない
+- **後方互換性**: GID=0（root グループ）は引き続き信頼済みとして扱い、既存の動作を維持する
+
+#### 関心の分離
+- **定数定義**: プラットフォームごとのデフォルト信頼済み GID はビルドタグで分岐したファイルに置く
+- **ロジック**: `validateGroupWritePermissions` はプラットフォーム固有コードを含まない
+- **設定**: Linux 向けの追加 GID は TOML 設定ファイル経由で注入する
+
+### 1.2 アーキテクチャ目標
+
+1. **機能目標**
+   - macOS の `/Applications`（uid=0, gid=80, perm=0775）をエラーなく通過させる
+   - Linux で `trusted_gids` 設定による追加 GID のホワイトリスト化を実現する
+
+2. **品質目標**
+   - 既存テストをすべて通過させる
+   - 新プラットフォーム対応は定義ファイルの追加のみで完結する
+
+3. **保守性目標**
+   - コアロジックの変更箇所を最小限に抑える（`validateGroupWritePermissions` の1箇所）
+
+## 2. システムアーキテクチャ
+
+### 2.1 全体アーキテクチャ図
+
+```mermaid
+graph TB
+    subgraph "設定レイヤー"
+        A["TOML 設定ファイル\n[security]\ntrusted_gids = [10]"]
+        B[("ConfigSpec\n.Security.TrustedGIDs")]
+        A --> B
+    end
+
+    subgraph "security パッケージ"
+        C["trusted_gids_darwin.go\n//go:build darwin\ndefaultTrustedGIDs={0,80}\nisTrustedGroup: default のみ"]
+        D["trusted_gids_linux.go\n//go:build linux\ndefaultTrustedGIDs={0}\nisTrustedGroup: default ∪ configured"]
+        E["trusted_gids_other.go\n//go:build !darwin && !linux\ndefaultTrustedGIDs={0}\nisTrustedGroup: default ∪ configured"]
+        F["Config.TrustedGIDs\n(追加 GID セット)"]
+        H["validateGroupWritePermissions\nisTrustedOwnership = uid==0 && isTrustedGroup(gid)"]
+
+        C --> H
+        D --> H
+        E --> H
+        F --> D
+        F --> E
+    end
+
+    subgraph "呼び出し元"
+        I[validateDirectoryComponentPermissions]
+        J[ValidateDirectoryPermissions]
+        K[ValidateOutputWritePermission]
+    end
+
+    B --> F
+    H --> I
+    I --> J
+    I --> K
+```
+
+### 2.2 コンポーネント構成
+
+#### 新規ファイル
+
+| ファイル | 役割 |
+|---------|------|
+| `internal/runner/security/trusted_gids_darwin.go` | macOS: デフォルト信頼済み GID 定義（GID 0, 80）+ `isTrustedGroup` 実装（Config.TrustedGIDs 無視） |
+| `internal/runner/security/trusted_gids_linux.go` | Linux: デフォルト信頼済み GID 定義（GID 0）+ `isTrustedGroup` 実装（Config.TrustedGIDs 参照） |
+| `internal/runner/security/trusted_gids_other.go` | その他 OS: デフォルト信頼済み GID 定義（GID 0）+ `isTrustedGroup` 実装（Config.TrustedGIDs 参照） |
+
+#### 変更ファイル
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `internal/runner/security/types.go` | `Config` に `TrustedGIDs []uint32` フィールドを追加 |
+| `internal/runner/security/file_validation.go` | `validateGroupWritePermissions` の `isRootOwned` 判定を `isTrustedOwnership` へ置き換え |
+| `internal/runner/runnertypes/spec.go` | `SecuritySpec` 型と `ConfigSpec.Security` フィールドを追加 |
+| `internal/runner/runner.go` | `securityConfig.TrustedGIDs` に `configSpec.Security.TrustedGIDs` を転写 |
+
+### 2.3 データフロー
+
+#### macOS での判定フロー
+
+```mermaid
+flowchart TD
+    A["ディレクトリ stat\nuid=0, gid=80, perm=0775"] --> B{perm & 0o020 != 0?}
+    B -- Yes --> C[validateGroupWritePermissions]
+    C --> D{testPermissiveMode?}
+    D -- No --> E["isTrustedOwnership\n= uid==0 && isTrustedGroup(80)"]
+    E --> F["isTrustedGroup(80)\ndefaultTrustedGIDs={0,80}\n→ true"]
+    F --> G["return nil ✓"]
+
+    style G fill:#c8e6c9
+```
+
+#### Linux での判定フロー（trusted_gids 設定あり）
+
+```mermaid
+flowchart TD
+    A["ディレクトリ stat\nuid=0, gid=10, perm=0775"] --> B{perm & 0o020 != 0?}
+    B -- Yes --> C[validateGroupWritePermissions]
+    C --> D{testPermissiveMode?}
+    D -- No --> E["isTrustedOwnership\n= uid==0 && isTrustedGroup(10)"]
+    E --> F["isTrustedGroup(10)\ndefault={0} ∪ configured={10}\n→ true"]
+    F --> G["return nil ✓"]
+
+    style G fill:#c8e6c9
+```
+
+#### 非信頼グループの判定フロー
+
+```mermaid
+flowchart TD
+    A["ディレクトリ stat\nuid=0, gid=1000, perm=0775"] --> B{perm & 0o020 != 0?}
+    B -- Yes --> C[validateGroupWritePermissions]
+    C --> D{testPermissiveMode?}
+    D -- No --> E["isTrustedOwnership\n= uid==0 && isTrustedGroup(1000)"]
+    E --> F["isTrustedGroup(1000)\ndefault={0} ∪ configured={}\n→ false"]
+    F --> G["CanUserSafelyWriteFile チェックへ進む"]
+
+    style G fill:#ffcdd2
+```
+
+## 3. セキュリティアーキテクチャ
+
+### 3.1 設計上のセキュリティ考慮
+
+#### プラットフォーム固定値の採用
+
+macOS の `admin` グループ（GID 80）は全バージョンで固定値であるため、ビルドタグで静的に定義する。設定ファイルで上書き可能にするよりも、攻撃面が小さい。
+
+#### Linux のデフォルトを GID 0 のみに限定
+
+GID 10 (`wheel`) は RHEL/Arch 系では管理者グループだが、Debian/Ubuntu では `uucp`（シリアル通信グループ）である。デフォルトホワイトリストに GID 10 を含めると、Debian/Ubuntu 環境でセキュリティリスクが生じる。したがって Linux のデフォルトは GID 0 のみとし、追加は設定ファイルで明示的に指定させる。
+
+#### `others` 書き込みビットの検証は変更なし
+
+`perm & 0o002` の検証は `validateGroupWritePermissions` の呼び出し元（`validateDirectoryComponentPermissions`）が担う。本タスクではこの検証を変更しない。
+
+### 3.2 変更の影響範囲
+
+```mermaid
+graph LR
+    A["validateGroupWritePermissions\n（変更箇所）"] --> B["validateDirectoryComponentPermissions\n（変更なし）"]
+    B --> C["validateCompletePath\n（変更なし）"]
+    C --> D["ValidateDirectoryPermissions\n（変更なし）"]
+    C --> E["validateOutputDirectoryAccess\n（変更なし）"]
+```
+
+変更は `validateGroupWritePermissions` 内の `isRootOwned` 判定の置き換えのみ。呼び出しシグネチャは変更しない。
+
+## 4. TOML 設定スキーマ設計
+
+### 4.1 新規セクション
+
+```toml
+# Linux 環境での追加信頼済みグループ GID（任意）
+[security]
+trusted_gids = [10]  # 例: RHEL/Arch の wheel グループ (GID 10)
+```
+
+### 4.2 設計上の制約
+
+| 制約 | 内容 |
+|------|------|
+| macOS では無視 | macOS では `trusted_gids` 設定値を読み飛ばす（`admin` GID 80 はビルドタグで固定） |
+| 省略可能 | `[security]` セクション全体が省略可能（後方互換） |
+| GID=0 は常に信頼済み | `trusted_gids` に 0 を含まなくてもデフォルトで信頼済み |
+
+### 4.3 設定の流れ
+
+```mermaid
+flowchart LR
+    A[("TOML ファイル\n[security]\ntrusted_gids = [10]")] --> B["ConfigSpec\n.Security.TrustedGIDs\n= []uint32{10}"]
+    B --> C["runner.go\nsecurityConfig.TrustedGIDs\n= configSpec.Security.TrustedGIDs"]
+    C --> D["security.Config\n.TrustedGIDs\n= []uint32{10}"]
+    D --> E["Validator\nisTrustedGroup(gid)\n（macOS では無視）"]
+```
+
+## 5. 実装方針
+
+### 5.1 ビルドタグ戦略
+
+プラットフォーム定義ファイルには `//go:build` ディレクティブを使用する。
+
+```
+trusted_gids_darwin.go  // go:build darwin
+trusted_gids_linux.go   // go:build linux
+trusted_gids_other.go   // go:build !darwin && !linux
+```
+
+各ファイルは同じシグネチャの `defaultTrustedGIDs` 変数を定義し、コアロジックはこの変数を参照する。
+
+### 5.2 GID セットの表現
+
+実行時に `isTrustedGroup(gid uint32) bool` を `O(1)` で判定するため、GID セットを `map[uint32]struct{}` で保持する。
+
+- `defaultTrustedGIDs`: ビルドタグで決まるプラットフォーム固有の定数セット
+- `Config.TrustedGIDs`: 設定ファイルで追加される GID スライス
+
+`isTrustedGroup` は両方を合わせてチェックする。
+
+### 5.3 後方互換性の確保
+
+変更前の `isRootOwned`（uid=0 && gid=0）は `isTrustedOwnership`（uid=0 && isTrustedGroup(gid)）の特殊ケースである。GID 0 はすべてのプラットフォームで `defaultTrustedGIDs` に含まれるため、既存の動作は維持される。
+
+## 6. テスト戦略
+
+### 6.1 テスト方針
+
+各受け入れ基準（AC-1〜AC-6）に対してユニットテストを作成する。プラットフォームに依存するテスト（AC-1, AC-5）はビルドタグや `runtime.GOOS` による条件付きスキップを用いる。
+
+### 6.2 テスト対象関数
+
+| 関数 | テスト内容 |
+|------|-----------|
+| `isTrustedGroup` | デフォルト GID・設定 GID・非信頼 GID の判定 |
+| `validateGroupWritePermissions` | `isTrustedOwnership` が true/false の場合の動作 |
+| TOML パース | `[security].trusted_gids` の読み込み |
+
+### 6.3 既存テストへの影響
+
+`validateGroupWritePermissions` のシグネチャは変更しないため、既存テストへの影響は最小限である。ただし、一部のテストが `isRootOwned` の挙動を前提としている場合は更新が必要になる可能性がある。

--- a/docs/tasks/0108_trusted_group_whitelist/02_architecture.md
+++ b/docs/tasks/0108_trusted_group_whitelist/02_architecture.md
@@ -191,9 +191,9 @@ flowchart LR
 プラットフォーム定義ファイルには `//go:build` ディレクティブを使用する。
 
 ```
-trusted_gids_darwin.go  // go:build darwin
-trusted_gids_linux.go   // go:build linux
-trusted_gids_other.go   // go:build !darwin && !linux
+trusted_gids_darwin.go  //go:build darwin
+trusted_gids_linux.go   //go:build linux
+trusted_gids_other.go   //go:build !darwin && !linux
 ```
 
 各ファイルは `defaultTrustedGIDs` 変数と同じシグネチャの `isTrustedGroup(gid uint32) bool` を定義する。
@@ -208,7 +208,8 @@ trusted_gids_other.go   // go:build !darwin && !linux
 - `defaultTrustedGIDs`: ビルドタグで決まるプラットフォーム固有の定数セット
 - `Config.TrustedGIDs`: 設定ファイルで追加される GID スライス
 
-`isTrustedGroup` は両方を合わせてチェックする。
+`isTrustedGroup` は Linux/other では両方を合わせてチェックし、macOS では
+`defaultTrustedGIDs` のみをチェックする。
 
 ### 5.3 後方互換性の確保
 

--- a/docs/tasks/0108_trusted_group_whitelist/02_architecture.md
+++ b/docs/tasks/0108_trusted_group_whitelist/02_architecture.md
@@ -196,11 +196,14 @@ trusted_gids_linux.go   // go:build linux
 trusted_gids_other.go   // go:build !darwin && !linux
 ```
 
-各ファイルは同じシグネチャの `defaultTrustedGIDs` 変数を定義し、コアロジックはこの変数を参照する。
+各ファイルは `defaultTrustedGIDs` 変数と同じシグネチャの `isTrustedGroup(gid uint32) bool` を定義する。
+`validateGroupWritePermissions` はプラットフォーム分岐を持たず、`isTrustedGroup` を呼び出すだけに留める。
 
 ### 5.2 GID セットの表現
 
-実行時に `isTrustedGroup(gid uint32) bool` を `O(1)` で判定するため、GID セットを `map[uint32]struct{}` で保持する。
+デフォルトの信頼済み GID セットは `map[uint32]struct{}` で保持し、プラットフォーム固有の既知 GID を `O(1)` で判定する。
+設定ファイルから読み込む追加 GID は `Config.TrustedGIDs []uint32` として保持し、Linux/other の `isTrustedGroup` で順に照合する。
+これにより TOML スキーマを単純に保ちつつ、既定値の判定コストを一定にできる。
 
 - `defaultTrustedGIDs`: ビルドタグで決まるプラットフォーム固有の定数セット
 - `Config.TrustedGIDs`: 設定ファイルで追加される GID スライス

--- a/docs/tasks/0108_trusted_group_whitelist/03_detailed_specification.md
+++ b/docs/tasks/0108_trusted_group_whitelist/03_detailed_specification.md
@@ -157,7 +157,8 @@ type Config struct {
 
 ### 2.4 `internal/runner/security/file_validation.go` への変更
 
-`isTrustedGroup` はプラットフォーム固有ファイル（`trusted_gids_*.go`）に定義するため、`file_validation.go` への追加はない。
+`isTrustedGroup` はプラットフォーム固有ファイル（`trusted_gids_*.go`）に定義する。
+`file_validation.go` では `validateGroupWritePermissions` の root 判定を置き換え、信頼済み所有権を通した場合のデバッグログを追加する。
 
 #### `validateGroupWritePermissions` の変更箇所
 
@@ -175,6 +176,10 @@ if isRootOwned {
 // Safe case: root-owned directory with trusted group
 isTrustedOwnership := stat.Uid == UIDRoot && v.isTrustedGroup(stat.Gid)
 if isTrustedOwnership {
+    slog.Debug("Directory has trusted ownership, group write allowed",
+        slog.String("path", dirPath),
+        slog.Any("gid", stat.Gid),
+        slog.String("permissions", fmt.Sprintf("%04o", perm)))
     return nil
 }
 ```

--- a/docs/tasks/0108_trusted_group_whitelist/03_detailed_specification.md
+++ b/docs/tasks/0108_trusted_group_whitelist/03_detailed_specification.md
@@ -45,16 +45,16 @@ graph TD
 
 package security
 
-// defaultTrustedGIDs は macOS のデフォルト信頼済みグループ GID セット。
-// GID 80 は macOS の admin グループ（全バージョンで固定値）。
-// GID 0 は root グループ（後方互換）。
+// defaultTrustedGIDs is the default trusted group GID set for macOS.
+// GID 80 is the macOS admin group (fixed across versions).
+// GID 0 is the root group (backward compatibility).
 var defaultTrustedGIDs = map[uint32]struct{}{
     0:  {},
     80: {},
 }
 
-// isTrustedGroup は macOS のデフォルト信頼済み GID セットのみを参照する。
-// macOS では trusted_gids 設定を無視する（admin GID 80 はビルドタグで固定）。
+// isTrustedGroup checks only the default trusted GID set on macOS.
+// On macOS, the trusted_gids config is ignored (admin GID 80 is fixed by build tag).
 func (v *Validator) isTrustedGroup(gid uint32) bool {
     _, ok := defaultTrustedGIDs[gid]
     return ok
@@ -68,15 +68,14 @@ func (v *Validator) isTrustedGroup(gid uint32) bool {
 
 package security
 
-// defaultTrustedGIDs は Linux のデフォルト信頼済みグループ GID セット。
-// GID 0 (root グループ) のみ。管理者グループ (wheel 等) の GID は
-// ディストリビューションによって異なるため、設定ファイルで指定する。
+// defaultTrustedGIDs is the default trusted group GID set for Linux.
+// Only GID 0 (root group) is included. Administrator groups (wheel, etc.)
+// vary by distribution and must be configured explicitly.
 var defaultTrustedGIDs = map[uint32]struct{}{
     0: {},
 }
 
-// isTrustedGroup は Linux のデフォルト信頼済み GID と Config.TrustedGIDs の
-// 両方を参照する。
+// isTrustedGroup checks both Linux default trusted GIDs and Config.TrustedGIDs.
 func (v *Validator) isTrustedGroup(gid uint32) bool {
     if _, ok := defaultTrustedGIDs[gid]; ok {
         return true
@@ -97,12 +96,12 @@ func (v *Validator) isTrustedGroup(gid uint32) bool {
 
 package security
 
-// defaultTrustedGIDs はその他 OS のデフォルト信頼済みグループ GID セット。
+// defaultTrustedGIDs is the default trusted group GID set for other platforms.
 var defaultTrustedGIDs = map[uint32]struct{}{
     0: {},
 }
 
-// isTrustedGroup はデフォルト信頼済み GID と Config.TrustedGIDs の両方を参照する。
+// isTrustedGroup checks both default trusted GIDs and Config.TrustedGIDs.
 func (v *Validator) isTrustedGroup(gid uint32) bool {
     if _, ok := defaultTrustedGIDs[gid]; ok {
         return true
@@ -121,10 +120,12 @@ func (v *Validator) isTrustedGroup(gid uint32) bool {
 #### 追加する型
 
 ```go
-// SecuritySpec は TOML 設定ファイルの [security] セクションに対応する。
+// SecuritySpec maps to the [security] section in a TOML configuration file.
 type SecuritySpec struct {
-    // TrustedGIDs は信頼済みグループ GID の追加リスト（Linux 向け）。
-    // macOS では無視される。省略した場合はデフォルトホワイトリストのみを使用する。
+    // TrustedGIDs is an additional trusted group GID list
+    // for Linux and other non-macOS platforms.
+    // On macOS, this field is ignored. When omitted, only default
+    // whitelist entries are used.
     TrustedGIDs []uint32 `toml:"trusted_gids"`
 }
 ```
@@ -148,9 +149,9 @@ type ConfigSpec struct {
 type Config struct {
     // ... 既存フィールド ...
 
-    // TrustedGIDs は設定ファイルで指定された追加の信頼済みグループ GID リスト。
-    // defaultTrustedGIDs と合わせて isTrustedGroup の判定に使用する。
-    // macOS ではこのフィールドを無視する。
+    // TrustedGIDs is an additional trusted group GID list from config.
+    // It is used with defaultTrustedGIDs in isTrustedGroup checks.
+    // This field is effective on non-macOS platforms and ignored on macOS.
     TrustedGIDs []uint32
 }
 ```
@@ -207,14 +208,14 @@ validator, err := security.NewValidator(securityConfig, security.WithGroupMember
 **テスト対象**: `validateGroupWritePermissions`
 
 ```go
-// テストケース（macOS のみ実行）
+// Test case (macOS only)
 //
-// AC-1 に対応するテスト
+// Test for AC-1
 func TestValidateGroupWritePermissions_MacOSAdmin(t *testing.T) {
     if runtime.GOOS != "darwin" {
         t.Skip("macOS only")
     }
-    // uid=0, gid=80, perm=0775 のディレクトリ → エラーなし
+    // uid=0, gid=80, perm=0775 directory -> no error
     stat := &syscall.Stat_t{Uid: 0, Gid: 80}
     // ...
 }
@@ -231,9 +232,9 @@ func TestValidateGroupWritePermissions_MacOSAdmin(t *testing.T) {
 **テスト対象**: `validateGroupWritePermissions`
 
 ```go
-// AC-3 に対応するテスト
+// Test for AC-3
 func TestValidateGroupWritePermissions_UntrustedGroup(t *testing.T) {
-    // uid=0, gid=1000 (非信頼済み), perm=0775 のディレクトリ → エラー
+    // uid=0, gid=1000 (untrusted), perm=0775 directory -> error
 }
 ```
 
@@ -242,9 +243,9 @@ func TestValidateGroupWritePermissions_UntrustedGroup(t *testing.T) {
 **テスト対象**: `validateGroupWritePermissions`
 
 ```go
-// AC-4 に対応するテスト（後方互換確認）
+// Test for AC-4 (backward compatibility)
 func TestValidateGroupWritePermissions_RootRoot(t *testing.T) {
-    // uid=0, gid=0, perm=0775 → エラーなし
+    // uid=0, gid=0, perm=0775 -> no error
 }
 ```
 
@@ -253,13 +254,13 @@ func TestValidateGroupWritePermissions_RootRoot(t *testing.T) {
 **テスト対象**: `isTrustedGroup`、TOML パース
 
 ```go
-// AC-5 に対応するテスト（Linux のみ実行）
+// Test for AC-5 (Linux only)
 func TestValidateGroupWritePermissions_LinuxTrustedGID(t *testing.T) {
     if runtime.GOOS != "linux" {
         t.Skip("Linux only")
     }
-    // trusted_gids = [10] の Config で uid=0, gid=10, perm=0775 → エラーなし
-    // trusted_gids 未指定の Config で uid=0, gid=10, perm=0775 → エラー
+    // With trusted_gids = [10], uid=0, gid=10, perm=0775 -> no error
+    // Without trusted_gids, uid=0, gid=10, perm=0775 -> error
 }
 ```
 

--- a/docs/tasks/0108_trusted_group_whitelist/03_detailed_specification.md
+++ b/docs/tasks/0108_trusted_group_whitelist/03_detailed_specification.md
@@ -1,0 +1,324 @@
+# 詳細仕様書: ディレクトリセキュリティ検証における信頼済みグループホワイトリスト
+
+## 1. ファイル構成
+
+### 1.1 新規ファイル
+
+```mermaid
+graph TD
+    subgraph "internal/runner/security/ （新規）"
+        A["trusted_gids_darwin.go\n//go:build darwin"]
+        B["trusted_gids_linux.go\n//go:build linux"]
+        C["trusted_gids_other.go\n//go:build !darwin && !linux"]
+    end
+
+    subgraph "変更ファイル"
+        D["runnertypes/spec.go\nSecuritySpec 追加"]
+        E["security/types.go\nConfig.TrustedGIDs 追加"]
+        F["security/file_validation.go\nisTrustedOwnership 実装"]
+        G["runner/runner.go\nTrustedGIDs 転写"]
+    end
+```
+
+### 1.2 変更ファイル一覧
+
+| ファイル | 変更種別 | 変更概要 |
+|---------|---------|---------|
+| `internal/runner/security/trusted_gids_darwin.go` | 新規 | macOS: `defaultTrustedGIDs` 定義 + `isTrustedGroup` 実装（Config.TrustedGIDs を無視） |
+| `internal/runner/security/trusted_gids_linux.go` | 新規 | Linux: `defaultTrustedGIDs` 定義 + `isTrustedGroup` 実装（Config.TrustedGIDs を参照） |
+| `internal/runner/security/trusted_gids_other.go` | 新規 | その他 OS: `defaultTrustedGIDs` 定義 + `isTrustedGroup` 実装（Config.TrustedGIDs を参照） |
+| `internal/runner/runnertypes/spec.go` | 変更 | `SecuritySpec` 型と `ConfigSpec.Security` フィールド追加 |
+| `internal/runner/security/types.go` | 変更 | `Config.TrustedGIDs` フィールド追加 |
+| `internal/runner/security/file_validation.go` | 変更 | `validateGroupWritePermissions` の `isRootOwned` を `isTrustedOwnership` へ置き換え |
+| `internal/runner/runner.go` | 変更 | `securityConfig.TrustedGIDs` に `configSpec.Security.TrustedGIDs` を転写 |
+
+## 2. 関数・型仕様
+
+### 2.1 プラットフォーム固有ファイル
+
+各ファイルは `defaultTrustedGIDs` 変数と `isTrustedGroup` メソッドの両方を定義する。macOS は `Config.TrustedGIDs` を無視する実装、Linux/other は両方を合わせてチェックする実装とすることで、プラットフォームごとの動作差をこれらのファイルに閉じ込める。
+
+#### `trusted_gids_darwin.go`
+
+```go
+//go:build darwin
+
+package security
+
+// defaultTrustedGIDs は macOS のデフォルト信頼済みグループ GID セット。
+// GID 80 は macOS の admin グループ（全バージョンで固定値）。
+// GID 0 は root グループ（後方互換）。
+var defaultTrustedGIDs = map[uint32]struct{}{
+    0:  {},
+    80: {},
+}
+
+// isTrustedGroup は macOS のデフォルト信頼済み GID セットのみを参照する。
+// macOS では trusted_gids 設定を無視する（admin GID 80 はビルドタグで固定）。
+func (v *Validator) isTrustedGroup(gid uint32) bool {
+    _, ok := defaultTrustedGIDs[gid]
+    return ok
+}
+```
+
+#### `trusted_gids_linux.go`
+
+```go
+//go:build linux
+
+package security
+
+// defaultTrustedGIDs は Linux のデフォルト信頼済みグループ GID セット。
+// GID 0 (root グループ) のみ。管理者グループ (wheel 等) の GID は
+// ディストリビューションによって異なるため、設定ファイルで指定する。
+var defaultTrustedGIDs = map[uint32]struct{}{
+    0: {},
+}
+
+// isTrustedGroup は Linux のデフォルト信頼済み GID と Config.TrustedGIDs の
+// 両方を参照する。
+func (v *Validator) isTrustedGroup(gid uint32) bool {
+    if _, ok := defaultTrustedGIDs[gid]; ok {
+        return true
+    }
+    for _, trusted := range v.config.TrustedGIDs {
+        if trusted == gid {
+            return true
+        }
+    }
+    return false
+}
+```
+
+#### `trusted_gids_other.go`
+
+```go
+//go:build !darwin && !linux
+
+package security
+
+// defaultTrustedGIDs はその他 OS のデフォルト信頼済みグループ GID セット。
+var defaultTrustedGIDs = map[uint32]struct{}{
+    0: {},
+}
+
+// isTrustedGroup はデフォルト信頼済み GID と Config.TrustedGIDs の両方を参照する。
+func (v *Validator) isTrustedGroup(gid uint32) bool {
+    if _, ok := defaultTrustedGIDs[gid]; ok {
+        return true
+    }
+    for _, trusted := range v.config.TrustedGIDs {
+        if trusted == gid {
+            return true
+        }
+    }
+    return false
+}
+```
+
+### 2.2 `internal/runner/runnertypes/spec.go` への追加
+
+#### 追加する型
+
+```go
+// SecuritySpec は TOML 設定ファイルの [security] セクションに対応する。
+type SecuritySpec struct {
+    // TrustedGIDs は信頼済みグループ GID の追加リスト（Linux 向け）。
+    // macOS では無視される。省略した場合はデフォルトホワイトリストのみを使用する。
+    TrustedGIDs []uint32 `toml:"trusted_gids"`
+}
+```
+
+#### `ConfigSpec` への追加フィールド
+
+```go
+type ConfigSpec struct {
+    // ... 既存フィールド ...
+
+    // Security はセキュリティ関連の設定（任意）
+    Security SecuritySpec `toml:"security"`
+}
+```
+
+### 2.3 `internal/runner/security/types.go` への追加
+
+#### `Config` への追加フィールド
+
+```go
+type Config struct {
+    // ... 既存フィールド ...
+
+    // TrustedGIDs は設定ファイルで指定された追加の信頼済みグループ GID リスト。
+    // defaultTrustedGIDs と合わせて isTrustedGroup の判定に使用する。
+    // macOS ではこのフィールドを無視する。
+    TrustedGIDs []uint32
+}
+```
+
+### 2.4 `internal/runner/security/file_validation.go` への変更
+
+`isTrustedGroup` はプラットフォーム固有ファイル（`trusted_gids_*.go`）に定義するため、`file_validation.go` への追加はない。
+
+#### `validateGroupWritePermissions` の変更箇所
+
+変更前:
+```go
+// Traditional safe case: root-owned directory
+isRootOwned := stat.Uid == UIDRoot && stat.Gid == GIDRoot
+if isRootOwned {
+    return nil
+}
+```
+
+変更後:
+```go
+// Safe case: root-owned directory with trusted group
+isTrustedOwnership := stat.Uid == UIDRoot && v.isTrustedGroup(stat.Gid)
+if isTrustedOwnership {
+    return nil
+}
+```
+
+### 2.5 `internal/runner/runner.go` への変更
+
+`runner.go` の `security.DefaultConfig()` 呼び出し直後に、`configSpec.Security.TrustedGIDs` を `securityConfig.TrustedGIDs` へ転写する。
+
+macOS では `isTrustedGroup` が `Config.TrustedGIDs` を無視するため、転写自体は OS を問わず無条件に行ってよい。
+
+```go
+// Create security config with hardcoded allowed commands
+securityConfig := security.DefaultConfig()
+// Transfer trusted GIDs from config spec (ignored on macOS by isTrustedGroup)
+securityConfig.TrustedGIDs = configSpec.Security.TrustedGIDs
+
+// Create validator with merged security config
+validator, err := security.NewValidator(securityConfig, security.WithGroupMembership(gmProvider))
+```
+
+## 3. 受け入れ基準とテストの対応
+
+### AC-1: `/Applications` でエラーが発生しない（macOS）
+
+**テスト対象**: `validateGroupWritePermissions`
+
+```go
+// テストケース（macOS のみ実行）
+//
+// AC-1 に対応するテスト
+func TestValidateGroupWritePermissions_MacOSAdmin(t *testing.T) {
+    if runtime.GOOS != "darwin" {
+        t.Skip("macOS only")
+    }
+    // uid=0, gid=80, perm=0775 のディレクトリ → エラーなし
+    stat := &syscall.Stat_t{Uid: 0, Gid: 80}
+    // ...
+}
+```
+
+### AC-2: `others` 書き込み可能ディレクトリは引き続き拒否
+
+**テスト対象**: `validateDirectoryComponentPermissions`
+
+既存テストが担保する。`validateGroupWritePermissions` の変更による影響はない。
+
+### AC-3: 非特権グループのグループ書き込みは引き続き拒否
+
+**テスト対象**: `validateGroupWritePermissions`
+
+```go
+// AC-3 に対応するテスト
+func TestValidateGroupWritePermissions_UntrustedGroup(t *testing.T) {
+    // uid=0, gid=1000 (非信頼済み), perm=0775 のディレクトリ → エラー
+}
+```
+
+### AC-4: root:root 所有ディレクトリは引き続き許容
+
+**テスト対象**: `validateGroupWritePermissions`
+
+```go
+// AC-4 に対応するテスト（後方互換確認）
+func TestValidateGroupWritePermissions_RootRoot(t *testing.T) {
+    // uid=0, gid=0, perm=0775 → エラーなし
+}
+```
+
+### AC-5: Linux で `trusted_gids` を設定すると追加 GID が信頼済みになる
+
+**テスト対象**: `isTrustedGroup`、TOML パース
+
+```go
+// AC-5 に対応するテスト（Linux のみ実行）
+func TestValidateGroupWritePermissions_LinuxTrustedGID(t *testing.T) {
+    if runtime.GOOS != "linux" {
+        t.Skip("Linux only")
+    }
+    // trusted_gids = [10] の Config で uid=0, gid=10, perm=0775 → エラーなし
+    // trusted_gids 未指定の Config で uid=0, gid=10, perm=0775 → エラー
+}
+```
+
+### AC-6: 既存テストの通過
+
+`make test` および `make lint` がエラーなしで通過することを確認する。
+
+## 4. エラーハンドリング
+
+### 4.1 変更による新規エラーパス
+
+本変更では新規エラーパスは発生しない。`isTrustedGroup` は `bool` を返すのみであり、エラーを返さない。
+
+### 4.2 既存エラーの維持
+
+変更後も `isTrustedOwnership` が false の場合は従来通り `CanUserSafelyWriteFile` によるチェックへ進む。このパスでのエラー型（`ErrInvalidDirPermissions`）は変更しない。
+
+## 5. ロギング
+
+### 5.1 ログ出力の変更
+
+`validateGroupWritePermissions` の `isRootOwned` パスを `isTrustedOwnership` パスへ置き換える。ログ出力は以下のように変更する。
+
+変更前（暗黙的にスキップ）:
+```go
+isRootOwned := stat.Uid == UIDRoot && stat.Gid == GIDRoot
+if isRootOwned {
+    return nil  // ログなし
+}
+```
+
+変更後（デバッグログを追加）:
+```go
+isTrustedOwnership := stat.Uid == UIDRoot && v.isTrustedGroup(stat.Gid)
+if isTrustedOwnership {
+    slog.Debug("Directory has trusted ownership, group write allowed",
+        slog.String("path", dirPath),
+        slog.Any("gid", stat.Gid),
+        slog.String("permissions", fmt.Sprintf("%04o", perm)))
+    return nil
+}
+```
+
+## 6. 後方互換性
+
+### 6.1 設定ファイルの後方互換性
+
+`[security]` セクションは省略可能であり、既存の設定ファイルは変更なしで動作する。
+
+### 6.2 動作の後方互換性
+
+| ケース | 変更前 | 変更後 |
+|-------|--------|--------|
+| uid=0, gid=0, perm=0775 | エラーなし | エラーなし（GID 0 はデフォルト信頼済み） |
+| uid=0, gid=80, perm=0775（macOS） | エラー（false positive） | エラーなし（修正） |
+| uid=0, gid=1000, perm=0775 | エラー（CanUserSafelyWriteFile で判定） | エラー（変更なし） |
+| perm=0777 | エラー | エラー（変更なし） |
+
+## 7. 実装上の注意事項
+
+### 7.1 循環参照の確認
+
+`runner.go` は `security` パッケージと `runnertypes` パッケージの両方を既に使用しており、新たな循環参照は生じない。
+
+### 7.2 macOS での `trusted_gids` 設定の無視
+
+macOS ビルドでは `runner.go` が `securityConfig.TrustedGIDs` に値を転写するが、`trusted_gids_darwin.go` の `isTrustedGroup` 実装が `Config.TrustedGIDs` を参照しない。したがって TOML で `trusted_gids` を指定しても macOS では効果がない。これにより macOS での誤設定（管理者でないグループを誤ってホワイトリスト化する等）を防止する。


### PR DESCRIPTION
## Summary

- Add `02_architecture.md` for trusted group whitelist feature (task 0108)
- Add `03_detailed_specification.md` with implementation details

## Changes

### Architecture document
- Design principles: minimal change, platform separation, backward compatibility
- Component diagram showing 3 new platform-specific files + 4 modified files
- Data flow diagrams for macOS, Linux (with `trusted_gids`), and untrusted group cases
- TOML config schema for `[security] trusted_gids`

### Detailed specification
- Platform-specific `trusted_gids_darwin/linux/other.go` code specs
  - macOS: `defaultTrustedGIDs = {0, 80}` + `isTrustedGroup` ignores `Config.TrustedGIDs`
  - Linux/other: `defaultTrustedGIDs = {0}` + `isTrustedGroup` checks both default and configured GIDs
- Type specs for `SecuritySpec` / `ConfigSpec.Security` in `runnertypes/spec.go`
- `validateGroupWritePermissions` change: `isRootOwned` → `isTrustedOwnership`
- `runner.go` transfer of `TrustedGIDs` from config spec to security config
- Test cases mapped to each acceptance criterion (AC-1 through AC-6)
- Backward compatibility table

## Test plan

- [ ] Review architecture diagram accuracy against existing codebase
- [ ] Verify no new files are created beyond what is specified
- [ ] Confirm acceptance criteria mapping is complete (AC-1 to AC-6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)