### PR TITLE
fix(arm64): detect ORR XZR bitmask-immediate as syscall number setter

### DIFF
--- a/internal/runner/security/elfanalyzer/arm64_decoder.go
+++ b/internal/runner/security/elfanalyzer/arm64_decoder.go
@@ -104,8 +104,7 @@ func arm64OrrZeroRegImm(a arm64asm.Inst, regs ...arm64asm.Reg) (bool, int64) {
 		return false, 0
 	}
 	// Source must be the zero register (XZR or WZR).
-	src, ok := a.Args[1].(arm64asm.Reg)
-	if !ok || (src != arm64asm.XZR && src != arm64asm.WZR) {
+	if !arm64MatchesReg(a.Args[1], arm64asm.XZR) && !arm64MatchesReg(a.Args[1], arm64asm.WZR) {
 		return false, 0
 	}
 	val, ok := arm64ImmValue(a.Args[2])
@@ -142,8 +141,7 @@ func (d *ARM64Decoder) IsImmediateToSyscallNumberRegister(inst DecodedInstructio
 		if a.Args[0] == nil || a.Args[1] == nil {
 			return false, 0
 		}
-		reg, ok := a.Args[0].(arm64asm.Reg)
-		if !ok || (reg != arm64asm.W8 && reg != arm64asm.X8) {
+		if !arm64MatchesReg(a.Args[0], arm64asm.W8) && !arm64MatchesReg(a.Args[0], arm64asm.X8) {
 			return false, 0
 		}
 		val, ok := arm64ImmValue(a.Args[1])
@@ -216,8 +214,7 @@ func (d *ARM64Decoder) IsImmediateToFirstArgRegister(inst DecodedInstruction) (i
 		if a.Args[0] == nil || a.Args[1] == nil {
 			return 0, false
 		}
-		reg, ok := a.Args[0].(arm64asm.Reg)
-		if !ok || (reg != arm64asm.X0 && reg != arm64asm.W0) {
+		if !arm64MatchesReg(a.Args[0], arm64asm.X0) && !arm64MatchesReg(a.Args[0], arm64asm.W0) {
 			return 0, false
 		}
 		val, ok := arm64ImmValue(a.Args[1])
@@ -257,8 +254,7 @@ func (d *ARM64Decoder) IsImmediateToThirdArgRegister(inst DecodedInstruction) (b
 		if a.Args[0] == nil || a.Args[1] == nil {
 			return false, 0
 		}
-		reg, ok := a.Args[0].(arm64asm.Reg)
-		if !ok || (reg != arm64asm.W2 && reg != arm64asm.X2) {
+		if !arm64MatchesReg(a.Args[0], arm64asm.W2) && !arm64MatchesReg(a.Args[0], arm64asm.X2) {
 			return false, 0
 		}
 		val, ok := arm64ImmValue(a.Args[1])

--- a/internal/runner/security/elfanalyzer/arm64_decoder.go
+++ b/internal/runner/security/elfanalyzer/arm64_decoder.go
@@ -65,6 +65,53 @@ func arm64ReadOnlyFirstOperandOp(op arm64asm.Op) bool {
 	return false
 }
 
+// arm64MatchesReg returns true if arg represents the specified register.
+// It handles both arm64asm.Reg and arm64asm.RegSP types: arm64asm encodes the
+// destination operand of ORR-immediate instructions as RegSP rather than Reg,
+// which causes a simple type assertion to arm64asm.Reg to fail for those cases.
+func arm64MatchesReg(arg arm64asm.Arg, reg arm64asm.Reg) bool {
+	if r, ok := arg.(arm64asm.Reg); ok {
+		return r == reg
+	}
+	if rSP, ok := arg.(arm64asm.RegSP); ok {
+		return arm64asm.Reg(rSP) == reg
+	}
+	return false
+}
+
+// arm64OrrZeroRegImm returns (true, value) if a is "ORR dst, XZR/WZR, #imm"
+// and dst matches one of the given registers.
+// This encoding is used when a constant cannot be represented as a 16-bit MOVZ
+// immediate but fits the ARM64 bitmask-immediate format; it is functionally
+// identical to "MOV dst, #imm".
+func arm64OrrZeroRegImm(a arm64asm.Inst, regs ...arm64asm.Reg) (bool, int64) {
+	if a.Op != arm64asm.ORR {
+		return false, 0
+	}
+	if a.Args[0] == nil || a.Args[1] == nil || a.Args[2] == nil {
+		return false, 0
+	}
+	// Destination must be one of the target registers.
+	// ORR-immediate uses arm64asm.RegSP for the destination operand.
+	matched := false
+	for _, reg := range regs {
+		if arm64MatchesReg(a.Args[0], reg) {
+			matched = true
+			break
+		}
+	}
+	if !matched {
+		return false, 0
+	}
+	// Source must be the zero register (XZR or WZR).
+	src, ok := a.Args[1].(arm64asm.Reg)
+	if !ok || (src != arm64asm.XZR && src != arm64asm.WZR) {
+		return false, 0
+	}
+	val, ok := arm64ImmValue(a.Args[2])
+	return ok, val
+}
+
 // ModifiesSyscallNumberRegister returns true if the instruction writes to
 // the arm64 syscall number register (W8 or X8).
 func (d *ARM64Decoder) ModifiesSyscallNumberRegister(inst DecodedInstruction) bool {
@@ -78,33 +125,31 @@ func (d *ARM64Decoder) ModifiesSyscallNumberRegister(inst DecodedInstruction) bo
 	if a.Args[0] == nil {
 		return false
 	}
-	reg, ok := a.Args[0].(arm64asm.Reg)
-	if !ok {
-		return false
-	}
-	return reg == arm64asm.W8 || reg == arm64asm.X8
+	return arm64MatchesReg(a.Args[0], arm64asm.W8) || arm64MatchesReg(a.Args[0], arm64asm.X8)
 }
 
 // IsImmediateToSyscallNumberRegister returns (true, value) if inst sets
 // W8 or X8 to a known immediate value.
-// arm64asm normalises MOVZ to MOV, so we check for MOV.
+// Handles two encodings:
+//   - MOV W8/X8, #imm  (arm64asm normalises MOVZ to MOV)
+//   - ORR W8/X8, WZR/XZR, #imm  (bitmask-immediate; functionally identical to MOV)
 func (d *ARM64Decoder) IsImmediateToSyscallNumberRegister(inst DecodedInstruction) (bool, int64) {
 	a, ok := inst.arch.(arm64asm.Inst)
 	if !ok {
 		return false, 0
 	}
-	if a.Op != arm64asm.MOV {
-		return false, 0
+	if a.Op == arm64asm.MOV {
+		if a.Args[0] == nil || a.Args[1] == nil {
+			return false, 0
+		}
+		reg, ok := a.Args[0].(arm64asm.Reg)
+		if !ok || (reg != arm64asm.W8 && reg != arm64asm.X8) {
+			return false, 0
+		}
+		val, ok := arm64ImmValue(a.Args[1])
+		return ok, val
 	}
-	if a.Args[0] == nil || a.Args[1] == nil {
-		return false, 0
-	}
-	reg, ok := a.Args[0].(arm64asm.Reg)
-	if !ok || (reg != arm64asm.W8 && reg != arm64asm.X8) {
-		return false, 0
-	}
-	val, ok := arm64ImmValue(a.Args[1])
-	return ok, val
+	return arm64OrrZeroRegImm(a, arm64asm.W8, arm64asm.X8)
 }
 
 // IsControlFlowInstruction returns true if inst changes the instruction pointer.
@@ -159,20 +204,27 @@ func (d *ARM64Decoder) GetCallTarget(inst DecodedInstruction, instAddr uint64) (
 // IsImmediateToFirstArgRegister returns (value, true) if inst sets the arm64
 // first argument register (X0 or W0) to an immediate.
 // arm64 Go ABI uses X0 for the first integer argument.
+// Handles two encodings:
+//   - MOV X0/W0, #imm  (arm64asm normalises MOVZ to MOV)
+//   - ORR X0/W0, XZR/WZR, #imm  (bitmask-immediate; functionally identical to MOV)
 func (d *ARM64Decoder) IsImmediateToFirstArgRegister(inst DecodedInstruction) (int64, bool) {
 	a, ok := inst.arch.(arm64asm.Inst)
-	if !ok || a.Op != arm64asm.MOV {
+	if !ok {
 		return 0, false
 	}
-	if a.Args[0] == nil || a.Args[1] == nil {
-		return 0, false
+	if a.Op == arm64asm.MOV {
+		if a.Args[0] == nil || a.Args[1] == nil {
+			return 0, false
+		}
+		reg, ok := a.Args[0].(arm64asm.Reg)
+		if !ok || (reg != arm64asm.X0 && reg != arm64asm.W0) {
+			return 0, false
+		}
+		val, ok := arm64ImmValue(a.Args[1])
+		return val, ok
 	}
-	reg, ok := a.Args[0].(arm64asm.Reg)
-	if !ok || (reg != arm64asm.X0 && reg != arm64asm.W0) {
-		return 0, false
-	}
-	val, ok := arm64ImmValue(a.Args[1])
-	return val, ok
+	ok2, val := arm64OrrZeroRegImm(a, arm64asm.X0, arm64asm.W0)
+	return val, ok2
 }
 
 // ModifiesThirdArgRegister returns true if the instruction writes to
@@ -188,32 +240,31 @@ func (d *ARM64Decoder) ModifiesThirdArgRegister(inst DecodedInstruction) bool {
 	if a.Args[0] == nil {
 		return false
 	}
-	reg, ok := a.Args[0].(arm64asm.Reg)
-	if !ok {
-		return false
-	}
-	return reg == arm64asm.W2 || reg == arm64asm.X2
+	return arm64MatchesReg(a.Args[0], arm64asm.W2) || arm64MatchesReg(a.Args[0], arm64asm.X2)
 }
 
 // IsImmediateToThirdArgRegister returns (true, value) if inst sets
 // W2 or X2 to a known immediate value.
+// Handles two encodings:
+//   - MOV W2/X2, #imm  (arm64asm normalises MOVZ to MOV)
+//   - ORR W2/X2, WZR/XZR, #imm  (bitmask-immediate; functionally identical to MOV)
 func (d *ARM64Decoder) IsImmediateToThirdArgRegister(inst DecodedInstruction) (bool, int64) {
 	a, ok := inst.arch.(arm64asm.Inst)
 	if !ok {
 		return false, 0
 	}
-	if a.Op != arm64asm.MOV {
-		return false, 0
+	if a.Op == arm64asm.MOV {
+		if a.Args[0] == nil || a.Args[1] == nil {
+			return false, 0
+		}
+		reg, ok := a.Args[0].(arm64asm.Reg)
+		if !ok || (reg != arm64asm.W2 && reg != arm64asm.X2) {
+			return false, 0
+		}
+		val, ok := arm64ImmValue(a.Args[1])
+		return ok, val
 	}
-	if a.Args[0] == nil || a.Args[1] == nil {
-		return false, 0
-	}
-	reg, ok := a.Args[0].(arm64asm.Reg)
-	if !ok || (reg != arm64asm.W2 && reg != arm64asm.X2) {
-		return false, 0
-	}
-	val, ok := arm64ImmValue(a.Args[1])
-	return ok, val
+	return arm64OrrZeroRegImm(a, arm64asm.W2, arm64asm.X2)
 }
 
 // arm64ImmValue extracts an int64 immediate value from an arm64asm.Arg.

--- a/internal/runner/security/elfanalyzer/arm64_decoder_test.go
+++ b/internal/runner/security/elfanalyzer/arm64_decoder_test.go
@@ -102,6 +102,9 @@ func TestARM64Decoder_ModifiesSyscallNumberRegister(t *testing.T) {
 		{"mov w8, #198", []byte{0xC8, 0x18, 0x80, 0x52}, true},
 		{"mov x8, #198", []byte{0xC8, 0x18, 0x80, 0xD2}, true},
 		{"add x8, x0, x1", []byte{0x08, 0x00, 0x01, 0x8B}, true},
+		// orr x8, xzr, #0x38 — bitmask immediate; arm64asm uses RegSP for the
+		// destination, which must be handled alongside the regular Reg type.
+		{"orr x8, xzr, #0x38 (bitmask imm, RegSP dest)", []byte{0xe8, 0x0b, 0x7d, 0xb2}, true},
 		// Instructions that do NOT write to W8/X8
 		{"svc #0", []byte{0x01, 0x00, 0x00, 0xD4}, false},
 		{"mov x0, #41", []byte{0x20, 0x05, 0x80, 0xD2}, false},
@@ -128,6 +131,13 @@ func TestARM64Decoder_ModifiesSyscallNumberRegister(t *testing.T) {
 func TestARM64Decoder_IsImmediateToSyscallNumberRegister(t *testing.T) {
 	decoder := NewARM64Decoder()
 
+	// Verified ORR-immediate encodings (little-endian, bitmask immediate):
+	//   orr x8, xzr, #0x38  : e8 0b 7d b2  (open syscall, #56)
+	//   orr x8, xzr, #0x3f  : e8 17 40 b2  (read syscall, #63)
+	//   orr x8, xzr, #0x40  : e8 03 7a b2  (write syscall, #64)
+	//   orr x8, xzr, #0x7c  : e8 13 7e b2  (vgetrandom syscall, #124)
+	// These bitmask-immediate values cannot be encoded as 16-bit MOVZ immediates,
+	// so the assembler emits ORR instead of MOV.
 	tests := []struct {
 		name    string
 		code    []byte
@@ -138,6 +148,11 @@ func TestARM64Decoder_IsImmediateToSyscallNumberRegister(t *testing.T) {
 		{"mov x8, #198", []byte{0xC8, 0x18, 0x80, 0xD2}, true, 198},
 		{"mov w8, #41 (connect-like)", []byte{0x28, 0x05, 0x80, 0x52}, true, 41},
 		{"mov w8, #63 (read)", []byte{0xE8, 0x07, 0x80, 0x52}, true, 63},
+		// ORR x8/w8, xzr/wzr, #imm (bitmask-immediate encoding, same effect as MOV)
+		{"orr x8, xzr, #0x38 (open, bitmask imm)", []byte{0xe8, 0x0b, 0x7d, 0xb2}, true, 0x38},
+		{"orr x8, xzr, #0x3f (read, bitmask imm)", []byte{0xe8, 0x17, 0x40, 0xb2}, true, 0x3f},
+		{"orr x8, xzr, #0x40 (write, bitmask imm)", []byte{0xe8, 0x03, 0x7a, 0xb2}, true, 0x40},
+		{"orr x8, xzr, #0x7c (bitmask imm)", []byte{0xe8, 0x13, 0x7e, 0xb2}, true, 0x7c},
 		// Non-matching cases
 		{"svc #0 (not mov)", []byte{0x01, 0x00, 0x00, 0xD4}, false, 0},
 		{"mov x0, #41 (wrong register)", []byte{0x20, 0x05, 0x80, 0xD2}, false, 0},
@@ -262,6 +277,24 @@ func TestARM64Decoder_IsImmediateToFirstArgRegister(t *testing.T) {
 
 	t.Run("nop returns false", func(t *testing.T) {
 		inst, err := decoder.Decode([]byte{0x1F, 0x20, 0x03, 0xD5}, 0)
+		require.NoError(t, err)
+		_, ok := decoder.IsImmediateToFirstArgRegister(inst)
+		assert.False(t, ok)
+	})
+
+	// orr x0, xzr, #0x38 — bitmask-immediate encoding of x0 := 0x38 (openat syscall number).
+	// arm64asm uses RegSP for the destination operand of ORR-immediate instructions.
+	// Encoding: e0 0b 7d b2
+	t.Run("orr x0, xzr, #0x38 (bitmask imm, openat syscall number)", func(t *testing.T) {
+		inst, err := decoder.Decode([]byte{0xe0, 0x0b, 0x7d, 0xb2}, 0)
+		require.NoError(t, err)
+		imm, ok := decoder.IsImmediateToFirstArgRegister(inst)
+		assert.True(t, ok)
+		assert.Equal(t, int64(0x38), imm)
+	})
+
+	t.Run("orr x8, xzr, #0x38 (bitmask imm, wrong register)", func(t *testing.T) {
+		inst, err := decoder.Decode([]byte{0xe8, 0x0b, 0x7d, 0xb2}, 0)
 		require.NoError(t, err)
 		_, ok := decoder.IsImmediateToFirstArgRegister(inst)
 		assert.False(t, ok)

--- a/internal/runner/security/elfanalyzer/go_wrapper_resolver.go
+++ b/internal/runner/security/elfanalyzer/go_wrapper_resolver.go
@@ -13,13 +13,16 @@ const (
 	// needed to attempt syscall argument resolution.
 	minRecentInstructionsForScan = 2
 
-	// maxBackwardScanSteps is the maximum number of instructions to scan backward
-	// when resolving syscall arguments in wrapper calls.
-	maxBackwardScanSteps = 6
-
 	// maxRecentInstructionsToKeep is the maximum number of recent instructions
 	// to keep in memory for backward scanning.
-	maxRecentInstructionsToKeep = 10
+	maxRecentInstructionsToKeep = 12
+
+	// maxBackwardScanSteps is the maximum number of instructions to scan backward
+	// when resolving syscall arguments in wrapper calls.
+	// Set to maxRecentInstructionsToKeep - 1 so the entire available window is
+	// searched (the most recent slot holds the call instruction itself, so at most
+	// maxRecentInstructionsToKeep-1 pre-call instructions are available).
+	maxBackwardScanSteps = maxRecentInstructionsToKeep - 1
 )
 
 // GoSyscallWrapper represents the name of a known Go syscall wrapper function.

--- a/internal/runner/security/elfanalyzer/go_wrapper_resolver_test.go
+++ b/internal/runner/security/elfanalyzer/go_wrapper_resolver_test.go
@@ -99,15 +99,16 @@ func TestX86GoWrapperResolver_FindWrapperCalls_UnresolvedSyscall(t *testing.T) {
 	assert.Equal(t, DeterminationMethodUnknownWindowExhausted, result[0].DeterminationMethod)
 }
 
-func TestX86GoWrapperResolver_FindWrapperCalls_ScanLimitExceeded(t *testing.T) {
+func TestX86GoWrapperResolver_FindWrapperCalls_WindowExhausted(t *testing.T) {
 	resolver := newX86GoWrapperResolver()
 
 	wrapperAddr := uint64(0x402000)
 	resolver.wrapperAddrs[wrapperAddr] = "syscall.Syscall"
 
-	// 7 nops + call: more than maxBackwardScanSteps(6) instructions before the
-	// call, so the scan hits the step limit before reaching the window start.
-	// Expected: scan_limit_exceeded (not window_exhausted).
+	// 7 nops + call: the entire buffer (7 nops + call = 8 entries, less than
+	// maxRecentInstructionsToKeep) is scanned without finding a syscall-number
+	// setter. Because the buffer is not full, all available instructions were
+	// examined → window_exhausted (not scan_limit_exceeded).
 	//
 	// CALL is at offset 7 (addr 0x401007), nextPC = 0x40100C.
 	// rel32 = 0x402000 - 0x40100C = 0xFF4 → bytes: f4 0f 00 00.
@@ -116,6 +117,40 @@ func TestX86GoWrapperResolver_FindWrapperCalls_ScanLimitExceeded(t *testing.T) {
 		0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, // nop x7
 		0xe8, 0xf4, 0x0f, 0x00, 0x00, // call rel32 → 0x402000
 	}
+
+	result, decodeFailures := resolver.FindWrapperCalls(code, baseAddr)
+	assert.Equal(t, 0, decodeFailures)
+
+	require.Len(t, result, 1)
+	assert.Equal(t, -1, result[0].SyscallNumber)
+	assert.False(t, result[0].Resolved)
+	assert.Equal(t, DeterminationMethodUnknownWindowExhausted, result[0].DeterminationMethod)
+}
+
+func TestX86GoWrapperResolver_FindWrapperCalls_ScanLimitExceeded(t *testing.T) {
+	resolver := newX86GoWrapperResolver()
+
+	wrapperAddr := uint64(0x402000)
+	resolver.wrapperAddrs[wrapperAddr] = "syscall.Syscall"
+
+	// maxRecentInstructionsToKeep nops + call: fills the rolling buffer exactly,
+	// so the scan exhausts maxBackwardScanSteps steps before reaching the window
+	// start. Expected: scan_limit_exceeded (not window_exhausted).
+	//
+	// CALL is at offset maxRecentInstructionsToKeep (one byte per nop).
+	// rel32 = wrapperAddr - (baseAddr + maxRecentInstructionsToKeep + 5).
+	baseAddr := uint64(0x401000)
+	nopCount := maxRecentInstructionsToKeep
+	rel32 := int32(wrapperAddr) - int32(baseAddr+uint64(nopCount)+5) //nolint:gosec // G115: addresses are test constants that fit int32
+	code := make([]byte, nopCount+5)
+	for i := range nopCount {
+		code[i] = 0x90 // nop
+	}
+	code[nopCount] = 0xe8
+	code[nopCount+1] = byte(rel32)
+	code[nopCount+2] = byte(rel32 >> 8)
+	code[nopCount+3] = byte(rel32 >> 16)
+	code[nopCount+4] = byte(rel32 >> 24)
 
 	result, decodeFailures := resolver.FindWrapperCalls(code, baseAddr)
 	assert.Equal(t, 0, decodeFailures)

--- a/internal/runner/security/elfanalyzer/syscall_decoder.go
+++ b/internal/runner/security/elfanalyzer/syscall_decoder.go
@@ -45,6 +45,7 @@ type MachineCodeDecoder interface {
 	// instruction sets the syscall number register to a known immediate.
 	// x86_64: MOV EAX/RAX, imm  or  XOR EAX, EAX (zeroing idiom)
 	// arm64:  MOV W8/X8, #imm  (arm64asm normalizes MOVZ to MOV)
+	//         ORR W8/X8, WZR/XZR, #imm  (bitmask-immediate encoding)
 	IsImmediateToSyscallNumberRegister(inst DecodedInstruction) (bool, int64)
 
 	// IsControlFlowInstruction returns true if the instruction changes the
@@ -74,6 +75,7 @@ type MachineCodeDecoder interface {
 	// sets the first integer argument register to a known immediate.
 	// x86_64: MOV EAX/RAX, imm  (RAX is the first argument register in Go ABI)
 	// arm64:  MOV W0/X0, #imm   (X0 is the first argument register in Go ABI)
+	//         ORR X0/W0, XZR/WZR, #imm  (bitmask-immediate encoding)
 	// Returns (0, false) otherwise.
 	IsImmediateToFirstArgRegister(inst DecodedInstruction) (int64, bool)
 
@@ -87,5 +89,6 @@ type MachineCodeDecoder interface {
 	// sets the third argument register to a known immediate.
 	// x86_64: MOV EDX/RDX, imm  or  XOR EDX, EDX (zeroing idiom)
 	// arm64:  MOV W2/X2, #imm
+	//         ORR W2/X2, WZR/XZR, #imm  (bitmask-immediate encoding)
 	IsImmediateToThirdArgRegister(inst DecodedInstruction) (bool, int64)
 }


### PR DESCRIPTION
## Summary

- ARM64 encodes some immediates as `ORR Xd, XZR, #bitmask` when the value cannot fit in a 16-bit MOVZ immediate (e.g. `0x38`=open, `0x3f`=read, `0x40`=write, `0x7c`=vgetrandom). The `arm64asm` library decodes these as `ORR` (not `MOV`) and uses `arm64asm.RegSP` for the destination operand, causing the previous `Reg` type assertion to silently fail.
- Also increases `maxBackwardScanSteps` from 6 to `maxRecentInstructionsToKeep-1` (11) so the entire instruction buffer is always scanned — fixing `syscall.readlinkat` where `MOV X0` appeared 7 instructions before the `BL`.
- Result on `build/prod/record`: unknown syscall entries reduced from **11/69 → 0/69**.

## Changes

### Root causes
1. `ORR X8, XZR, #imm` — `arm64asm` uses `RegSP` type for the destination; `ModifiesSyscallNumberRegister` used `.(arm64asm.Reg)` type assertion which always fails for ORR
2. `IsImmediateToSyscallNumberRegister` / `IsImmediateToFirstArgRegister` — only handled `MOV`, not `ORR Xd, XZR, #bitmask`
3. `maxBackwardScanSteps = 6` — too small to reach `MOV X0` placed 7 instructions before a `BL` call

### Fixes
- Add `arm64MatchesReg` helper handling both `Reg` and `RegSP` destination types
- Add `arm64OrrZeroRegImm` helper recognising `ORR rd, XZR/WZR, #imm`
- Update `ModifiesSyscallNumberRegister`, `IsImmediateToSyscallNumberRegister`, `IsImmediateToFirstArgRegister`, `ModifiesThirdArgRegister`, `IsImmediateToThirdArgRegister`
- Set `maxBackwardScanSteps = maxRecentInstructionsToKeep - 1` so the full available window is always searched

## Test plan

- [ ] `make test` passes (all existing + new tests)
- [ ] `make lint` passes
- [ ] New decoder tests cover `orr x8/x0, xzr, #imm` encoding detection
- [ ] Updated `ScanLimitExceeded` test now uses `maxRecentInstructionsToKeep` NOPs to reliably fill the buffer; added separate `WindowExhausted` test for the partial-buffer case

🤖 Generated with [Claude Code](https://claude.com/claude-code)