### PR TITLE
Fix ARM64 Go wrapper syscall resolution

### DIFF
--- a/internal/runner/security/elfanalyzer/arm64_decoder.go
+++ b/internal/runner/security/elfanalyzer/arm64_decoder.go
@@ -1,6 +1,7 @@
 package elfanalyzer
 
 import (
+	"encoding/binary"
 	"errors"
 	"math"
 
@@ -10,11 +11,34 @@ import (
 // arm64InstructionLen is the fixed length of all arm64 instructions in bytes.
 const arm64InstructionLen = 4
 
+const (
+	arm64PageMask                  = 0xfff
+	arm64LoadSize32                = 4
+	arm64LoadSize64                = 8
+	arm64ADRPBacktrackLimit        = 4
+	arm64LDRImm12Shift             = 10
+	arm64LDRSizeShift              = 30
+	arm64LDRImm12Mask       uint32 = 0x0fff
+	arm64LDRSizeMask        uint32 = 0x3
+)
+
 // ARM64Decoder implements MachineCodeDecoder for arm64.
-type ARM64Decoder struct{}
+type ARM64Decoder struct {
+	dataSections []arm64DataSection
+}
+
+type arm64DataSection struct {
+	Addr uint64
+	Data []byte
+}
 
 // NewARM64Decoder creates a new ARM64Decoder.
 func NewARM64Decoder() *ARM64Decoder { return &ARM64Decoder{} }
+
+// SetDataSections sets readonly data regions used to resolve ADRP+LDR loads.
+func (d *ARM64Decoder) SetDataSections(sections []arm64DataSection) {
+	d.dataSections = sections
+}
 
 var errCodeTooShort = errors.New("code too short for arm64 instruction")
 
@@ -224,6 +248,47 @@ func (d *ARM64Decoder) IsImmediateToFirstArgRegister(inst DecodedInstruction) (i
 	return val, ok2
 }
 
+// ModifiesFirstArgRegister returns true if the instruction writes to
+// the arm64 first syscall argument register (W0 or X0).
+func (d *ARM64Decoder) ModifiesFirstArgRegister(inst DecodedInstruction) bool {
+	a, ok := inst.arch.(arm64asm.Inst)
+	if !ok {
+		return false
+	}
+	if arm64ReadOnlyFirstOperandOp(a.Op) {
+		return false
+	}
+	if a.Args[0] == nil {
+		return false
+	}
+	return arm64MatchesReg(a.Args[0], arm64asm.W0) || arm64MatchesReg(a.Args[0], arm64asm.X0)
+}
+
+// TryResolveFirstArgFromGlobalLoad resolves X0/W0 value for the pattern:
+//
+//	ADRP Xn, <page>
+//	LDR  X0/W0, [Xn, #offset]
+func (d *ARM64Decoder) TryResolveFirstArgFromGlobalLoad(recentInstructions []DecodedInstruction, idx int) (int64, bool) {
+	if idx < 0 || idx >= len(recentInstructions) {
+		return 0, false
+	}
+	if len(d.dataSections) == 0 {
+		return 0, false
+	}
+
+	loadInfo, ok := d.decodeFirstArgGlobalLoad(recentInstructions[idx])
+	if !ok {
+		return 0, false
+	}
+
+	addr, ok := d.resolveADRPBacktrackAddress(recentInstructions, idx, loadInfo.base, loadInfo.offset)
+	if !ok {
+		return 0, false
+	}
+
+	return d.readResolvedFirstArg(addr, loadInfo.is64Bit)
+}
+
 // ModifiesThirdArgRegister returns true if the instruction writes to
 // the arm64 third syscall argument register (W2 or X2).
 func (d *ARM64Decoder) ModifiesThirdArgRegister(inst DecodedInstruction) bool {
@@ -274,4 +339,116 @@ func arm64ImmValue(arg arm64asm.Arg) (int64, bool) {
 		return int64(v.Imm), true //nolint:gosec // G115: caller validates range via maxValidSyscallNumber before using the value
 	}
 	return 0, false
+}
+
+func arm64UnsignedOffsetFromEnc(enc uint32) (uint64, bool) {
+	imm12 := (enc >> arm64LDRImm12Shift) & arm64LDRImm12Mask
+	size := (enc >> arm64LDRSizeShift) & arm64LDRSizeMask
+	if size > arm64LDRSizeMask {
+		return 0, false
+	}
+	return uint64(imm12) << size, true
+}
+
+func (d *ARM64Decoder) readUintAtVA(addr uint64, size int) (uint64, bool) {
+	for _, sec := range d.dataSections {
+		if addr < sec.Addr {
+			continue
+		}
+		off := addr - sec.Addr
+		if off > uint64(len(sec.Data)) {
+			continue
+		}
+		start := int(off) //nolint:gosec // G115: off bounded by section length above
+		if size > len(sec.Data)-start {
+			continue
+		}
+		if size == arm64LoadSize64 {
+			return binary.LittleEndian.Uint64(sec.Data[start : start+8]), true
+		}
+		if size == arm64LoadSize32 {
+			return uint64(binary.LittleEndian.Uint32(sec.Data[start : start+4])), true
+		}
+	}
+	return 0, false
+}
+
+type arm64FirstArgLoadInfo struct {
+	base    arm64asm.RegSP
+	offset  uint64
+	is64Bit bool
+}
+
+func (d *ARM64Decoder) decodeFirstArgGlobalLoad(inst DecodedInstruction) (arm64FirstArgLoadInfo, bool) {
+	a, ok := inst.arch.(arm64asm.Inst)
+	if !ok || a.Op != arm64asm.LDR || a.Args[0] == nil || a.Args[1] == nil {
+		return arm64FirstArgLoadInfo{}, false
+	}
+
+	isX0 := arm64MatchesReg(a.Args[0], arm64asm.X0)
+	isW0 := arm64MatchesReg(a.Args[0], arm64asm.W0)
+	if !isX0 && !isW0 {
+		return arm64FirstArgLoadInfo{}, false
+	}
+
+	mem, ok := a.Args[1].(arm64asm.MemImmediate)
+	if !ok || mem.Mode != arm64asm.AddrOffset {
+		return arm64FirstArgLoadInfo{}, false
+	}
+
+	loadEnc := binary.LittleEndian.Uint32(inst.Raw)
+	offset, ok := arm64UnsignedOffsetFromEnc(loadEnc)
+	if !ok {
+		return arm64FirstArgLoadInfo{}, false
+	}
+
+	info := arm64FirstArgLoadInfo{base: mem.Base, offset: offset, is64Bit: isX0}
+	return info, true
+}
+
+func (d *ARM64Decoder) resolveADRPBacktrackAddress(recentInstructions []DecodedInstruction, idx int, base arm64asm.RegSP, offset uint64) (uint64, bool) {
+	for j := idx - 1; j >= 0 && idx-j <= arm64ADRPBacktrackLimit; j-- {
+		prev := recentInstructions[j]
+		p, ok := prev.arch.(arm64asm.Inst)
+		if !ok || p.Op != arm64asm.ADRP || p.Args[0] == nil || p.Args[1] == nil {
+			continue
+		}
+		if !arm64MatchesReg(p.Args[0], arm64asm.Reg(base)) {
+			continue
+		}
+		rel, ok := p.Args[1].(arm64asm.PCRel)
+		if !ok {
+			continue
+		}
+		return arm64ResolveADRPAddress(prev.Offset, rel, offset)
+	}
+	return 0, false
+}
+
+func arm64ResolveADRPAddress(instOffset uint64, rel arm64asm.PCRel, offset uint64) (uint64, bool) {
+	pageBase := instOffset &^ uint64(arm64PageMask)
+	if pageBase > math.MaxInt64 {
+		return 0, false
+	}
+	targetPage := int64(pageBase) + int64(rel)
+	if targetPage < 0 {
+		return 0, false
+	}
+	return uint64(targetPage) + offset, true
+}
+
+func (d *ARM64Decoder) readResolvedFirstArg(addr uint64, is64Bit bool) (int64, bool) {
+	if is64Bit {
+		v, ok := d.readUintAtVA(addr, arm64LoadSize64)
+		if !ok || v > math.MaxInt64 {
+			return 0, false
+		}
+		return int64(v), true
+	}
+
+	v, ok := d.readUintAtVA(addr, arm64LoadSize32)
+	if !ok || v > math.MaxUint32 {
+		return 0, false
+	}
+	return int64(v), true
 }

--- a/internal/runner/security/elfanalyzer/arm64_decoder.go
+++ b/internal/runner/security/elfanalyzer/arm64_decoder.go
@@ -20,6 +20,10 @@ const (
 	arm64LDRSizeShift              = 30
 	arm64LDRImm12Mask       uint32 = 0x0fff
 	arm64LDRSizeMask        uint32 = 0x3
+	// arm64LDRSizeWord and arm64LDRSizeDWord are the expected values of bits[31:30]
+	// in the LDR unsigned-offset encoding for 32-bit (W) and 64-bit (X) registers.
+	arm64LDRSizeWord  uint32 = 2 // W registers: byte_size = 1 << 2 = 4
+	arm64LDRSizeDWord uint32 = 3 // X registers: byte_size = 1 << 3 = 8
 )
 
 // ARM64Decoder implements MachineCodeDecoder for arm64.
@@ -341,10 +345,14 @@ func arm64ImmValue(arg arm64asm.Arg) (int64, bool) {
 	return 0, false
 }
 
-func arm64UnsignedOffsetFromEnc(enc uint32) (uint64, bool) {
+func arm64UnsignedOffsetFromEnc(enc uint32, is64Bit bool) (uint64, bool) {
 	imm12 := (enc >> arm64LDRImm12Shift) & arm64LDRImm12Mask
 	size := (enc >> arm64LDRSizeShift) & arm64LDRSizeMask
-	if size > arm64LDRSizeMask {
+	expectedSize := arm64LDRSizeWord
+	if is64Bit {
+		expectedSize = arm64LDRSizeDWord
+	}
+	if size != expectedSize {
 		return 0, false
 	}
 	return uint64(imm12) << size, true
@@ -397,7 +405,7 @@ func (d *ARM64Decoder) decodeFirstArgGlobalLoad(inst DecodedInstruction) (arm64F
 	}
 
 	loadEnc := binary.LittleEndian.Uint32(inst.Raw)
-	offset, ok := arm64UnsignedOffsetFromEnc(loadEnc)
+	offset, ok := arm64UnsignedOffsetFromEnc(loadEnc, isX0)
 	if !ok {
 		return arm64FirstArgLoadInfo{}, false
 	}
@@ -433,8 +441,22 @@ func arm64ResolveADRPAddress(instOffset uint64, rel arm64asm.PCRel, offset uint6
 	if pageBase > math.MaxInt64 {
 		return 0, false
 	}
-	targetPage := int64(pageBase) + int64(rel)
+	pageBaseSigned := int64(pageBase)
+	relSigned := int64(rel)
+	// Check signed overflow: addition overflows when operands share the same sign
+	// but the result has the opposite sign.
+	if relSigned > 0 && pageBaseSigned > math.MaxInt64-relSigned {
+		return 0, false
+	}
+	if relSigned < 0 && pageBaseSigned < math.MinInt64-relSigned {
+		return 0, false
+	}
+	targetPage := pageBaseSigned + relSigned
 	if targetPage < 0 {
+		return 0, false
+	}
+	// Check unsigned overflow before adding the page offset.
+	if offset > math.MaxUint64-uint64(targetPage) {
 		return 0, false
 	}
 	return uint64(targetPage) + offset, true

--- a/internal/runner/security/elfanalyzer/arm64_decoder.go
+++ b/internal/runner/security/elfanalyzer/arm64_decoder.go
@@ -409,6 +409,9 @@ func (d *ARM64Decoder) decodeFirstArgGlobalLoad(inst DecodedInstruction) (arm64F
 func (d *ARM64Decoder) resolveADRPBacktrackAddress(recentInstructions []DecodedInstruction, idx int, base arm64asm.RegSP, offset uint64) (uint64, bool) {
 	for j := idx - 1; j >= 0 && idx-j <= arm64ADRPBacktrackLimit; j-- {
 		prev := recentInstructions[j]
+		if d.IsControlFlowInstruction(prev) {
+			return 0, false
+		}
 		p, ok := prev.arch.(arm64asm.Inst)
 		if !ok || p.Op != arm64asm.ADRP || p.Args[0] == nil || p.Args[1] == nil {
 			continue

--- a/internal/runner/security/elfanalyzer/arm64_decoder.go
+++ b/internal/runner/security/elfanalyzer/arm64_decoder.go
@@ -472,8 +472,8 @@ func (d *ARM64Decoder) readResolvedFirstArg(addr uint64, is64Bit bool) (int64, b
 	}
 
 	v, ok := d.readUintAtVA(addr, arm64LoadSize32)
-	if !ok || v > math.MaxUint32 {
+	if !ok {
 		return 0, false
 	}
-	return int64(v), true
+	return int64(v), true //nolint:gosec // G115: v is zero-extended from uint32, always fits int64
 }

--- a/internal/runner/security/elfanalyzer/arm64_decoder_test.go
+++ b/internal/runner/security/elfanalyzer/arm64_decoder_test.go
@@ -3,10 +3,12 @@
 package elfanalyzer
 
 import (
+	"encoding/binary"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/arch/arm64/arm64asm"
 )
 
 // Verified arm64 instruction byte sequences (little-endian, 4 bytes each):
@@ -396,4 +398,68 @@ func TestARM64Decoder_IsImmediateToThirdArgRegister(t *testing.T) {
 		ok, _ := decoder.IsImmediateToThirdArgRegister(inst)
 		assert.False(t, ok)
 	})
+}
+
+func TestARM64Decoder_ModifiesFirstArgRegister(t *testing.T) {
+	decoder := NewARM64Decoder()
+
+	t.Run("mov x0, x1 returns true", func(t *testing.T) {
+		// mov x0, x1
+		inst, err := decoder.Decode([]byte{0xE0, 0x03, 0x01, 0xAA}, 0)
+		require.NoError(t, err)
+		assert.True(t, decoder.ModifiesFirstArgRegister(inst))
+	})
+
+	t.Run("mov w0, #198 returns true", func(t *testing.T) {
+		inst, err := decoder.Decode([]byte{0xC0, 0x18, 0x80, 0x52}, 0)
+		require.NoError(t, err)
+		assert.True(t, decoder.ModifiesFirstArgRegister(inst))
+	})
+
+	t.Run("mov x8, #198 returns false", func(t *testing.T) {
+		inst, err := decoder.Decode([]byte{0xC8, 0x18, 0x80, 0xD2}, 0)
+		require.NoError(t, err)
+		assert.False(t, decoder.ModifiesFirstArgRegister(inst))
+	})
+
+	t.Run("str x0, [x1] returns false", func(t *testing.T) {
+		inst, err := decoder.Decode([]byte{0x20, 0x00, 0x00, 0xF9}, 0)
+		require.NoError(t, err)
+		assert.False(t, decoder.ModifiesFirstArgRegister(inst))
+	})
+}
+
+func TestARM64Decoder_TryResolveFirstArgFromGlobalLoad(t *testing.T) {
+	decoder := NewARM64Decoder()
+
+	adrpCode := []byte{0x1b, 0x89, 0x19, 0x90} // adrp x27, .+0x33120000
+	ldrCode := []byte{0x60, 0xd7, 0x42, 0xf9}  // ldr x0, [x27,#1448]
+	callCode := []byte{0x00, 0x00, 0x00, 0x94} // bl .
+
+	adrpInst, err := decoder.Decode(adrpCode, 0x401000)
+	require.NoError(t, err)
+	ldrInst, err := decoder.Decode(ldrCode, 0x401004)
+	require.NoError(t, err)
+	callInst, err := decoder.Decode(callCode, 0x401008)
+	require.NoError(t, err)
+
+	a := adrpInst.arch.(arm64asm.Inst)
+	rel, ok := a.Args[1].(arm64asm.PCRel)
+	require.True(t, ok)
+
+	pageBase := adrpInst.Offset &^ uint64(0xfff)
+	loadAddr := uint64(int64(pageBase)+int64(rel)) + 1448
+
+	blob := make([]byte, 16)
+	binary.LittleEndian.PutUint64(blob[:8], 25)
+	decoder.SetDataSections([]arm64DataSection{{Addr: loadAddr, Data: blob}})
+
+	insts := []DecodedInstruction{adrpInst, ldrInst, callInst}
+	value, ok := decoder.TryResolveFirstArgFromGlobalLoad(insts, 1)
+	assert.True(t, ok)
+	assert.Equal(t, int64(25), value)
+
+	value, ok = decoder.TryResolveFirstArgFromGlobalLoad(insts, 0)
+	assert.False(t, ok)
+	assert.Equal(t, int64(0), value)
 }

--- a/internal/runner/security/elfanalyzer/arm64_decoder_test.go
+++ b/internal/runner/security/elfanalyzer/arm64_decoder_test.go
@@ -462,4 +462,14 @@ func TestARM64Decoder_TryResolveFirstArgFromGlobalLoad(t *testing.T) {
 	value, ok = decoder.TryResolveFirstArgFromGlobalLoad(insts, 0)
 	assert.False(t, ok)
 	assert.Equal(t, int64(0), value)
+
+	t.Run("control flow boundary before adrp returns false", func(t *testing.T) {
+		branchInst, err := decoder.Decode([]byte{0x02, 0x00, 0x00, 0x14}, 0x401004)
+		require.NoError(t, err)
+
+		instsWithBranch := []DecodedInstruction{adrpInst, branchInst, ldrInst, callInst}
+		value, ok := decoder.TryResolveFirstArgFromGlobalLoad(instsWithBranch, 2)
+		assert.False(t, ok)
+		assert.Equal(t, int64(0), value)
+	})
 }

--- a/internal/runner/security/elfanalyzer/arm64_go_wrapper_resolver.go
+++ b/internal/runner/security/elfanalyzer/arm64_go_wrapper_resolver.go
@@ -2,6 +2,18 @@ package elfanalyzer
 
 import (
 	"debug/elf"
+	"sort"
+
+	"golang.org/x/arch/arm64/arm64asm"
+)
+
+const (
+	arm64ReloadSearchWindow     = 8
+	arm64HelperSearchWindow     = 15
+	arm64SaveSearchWindow       = 15
+	arm64PrologueSearchWindow   = 6
+	arm64FunctionTailSearchSpan = 24
+	decimalBase                 = 10
 )
 
 // ARM64GoWrapperResolver implements GoWrapperResolver for arm64 binaries.
@@ -21,6 +33,7 @@ func NewARM64GoWrapperResolver(elfFile *elf.File) (*ARM64GoWrapperResolver, erro
 	if err := r.loadFromPclntab(elfFile); err != nil {
 		return r, err
 	}
+	r.decoder.SetDataSections(loadARM64DataSections(elfFile))
 	r.hasSymbols = len(r.symbols) > 0
 	return r, nil
 }
@@ -43,7 +56,218 @@ func newARM64GoWrapperResolver() *ARM64GoWrapperResolver {
 // On arm64, all instructions are exactly 4 bytes. On decode failure, the scanner
 // advances by 4 bytes (InstructionAlignment) to stay aligned.
 func (r *ARM64GoWrapperResolver) FindWrapperCalls(code []byte, baseAddr uint64) ([]WrapperCall, int) {
+	r.discoverTransparentWrappers(code, baseAddr)
 	return r.findWrapperCalls(code, baseAddr, r.decoder)
+}
+
+func loadARM64DataSections(elfFile *elf.File) []arm64DataSection {
+	sectionNames := []string{".noptrdata", ".rodata", ".data"}
+	sections := make([]arm64DataSection, 0, len(sectionNames))
+	for _, name := range sectionNames {
+		sec := elfFile.Section(name)
+		if sec == nil {
+			continue
+		}
+		data, err := sec.Data()
+		if err != nil || len(data) == 0 {
+			continue
+		}
+		sections = append(sections, arm64DataSection{Addr: sec.Addr, Data: data})
+	}
+	return sections
+}
+
+func (r *ARM64GoWrapperResolver) discoverTransparentWrappers(code []byte, baseAddr uint64) {
+	if len(r.wrapperAddrs) == 0 || len(code) == 0 {
+		return
+	}
+
+	insts := make([]DecodedInstruction, 0, len(code)/arm64InstructionLen)
+	for pos := 0; pos+arm64InstructionLen <= len(code); pos += arm64InstructionLen {
+		inst, err := r.decoder.Decode(code[pos:], baseAddr+uint64(pos)) //nolint:gosec // G115: pos bounded by loop condition
+		if err != nil {
+			continue
+		}
+		insts = append(insts, inst)
+	}
+
+	for idx := range insts {
+		r.addTransparentWrapperFromCall(insts, idx)
+	}
+
+	r.sortAndDedupWrapperRanges()
+}
+
+func (r *ARM64GoWrapperResolver) addTransparentWrapperFromCall(insts []DecodedInstruction, callIdx int) {
+	target, ok := r.decoder.GetCallTarget(insts[callIdx], insts[callIdx].Offset)
+	if !ok {
+		return
+	}
+	wrapperName, ok := r.wrapperAddrs[target]
+	if !ok {
+		return
+	}
+
+	loadIdx, stackOff, ok := findArm64StackReloadBeforeCall(insts, callIdx)
+	if !ok {
+		return
+	}
+	helperIdx, ok := findArm64NonWrapperCallBefore(insts, loadIdx, r.wrapperAddrs, r.decoder)
+	if !ok {
+		return
+	}
+	saveIdx, ok := findArm64StackSaveBeforeHelper(insts, helperIdx, stackOff)
+	if !ok {
+		return
+	}
+	prologueIdx, ok := findArm64PrologueBefore(insts, saveIdx)
+	if !ok {
+		return
+	}
+
+	r.registerTransparentWrapper(insts, prologueIdx, callIdx, wrapperName)
+}
+
+func (r *ARM64GoWrapperResolver) registerTransparentWrapper(insts []DecodedInstruction, prologueIdx, callIdx int, wrapperName GoSyscallWrapper) {
+	start := insts[prologueIdx].Offset
+	if _, exists := r.wrapperAddrs[start]; !exists {
+		r.wrapperAddrs[start] = wrapperName
+	}
+
+	end := insts[callIdx].Offset + uint64(arm64InstructionLen)
+	for j := callIdx + 1; j < len(insts) && j <= callIdx+arm64FunctionTailSearchSpan; j++ {
+		a, ok := insts[j].arch.(arm64asm.Inst)
+		if ok && a.Op == arm64asm.RET {
+			end = insts[j].Offset + uint64(arm64InstructionLen)
+			break
+		}
+	}
+	if end > start {
+		r.wrapperRanges = append(r.wrapperRanges, wrapperRange{start: start, end: end})
+	}
+}
+
+func (r *ARM64GoWrapperResolver) sortAndDedupWrapperRanges() {
+	if len(r.wrapperRanges) <= 1 {
+		return
+	}
+	sort.Slice(r.wrapperRanges, func(i, j int) bool {
+		if r.wrapperRanges[i].start == r.wrapperRanges[j].start {
+			return r.wrapperRanges[i].end < r.wrapperRanges[j].end
+		}
+		return r.wrapperRanges[i].start < r.wrapperRanges[j].start
+	})
+	dedup := r.wrapperRanges[:0]
+	for i := range r.wrapperRanges {
+		if len(dedup) == 0 {
+			dedup = append(dedup, r.wrapperRanges[i])
+			continue
+		}
+		last := dedup[len(dedup)-1]
+		if last.start == r.wrapperRanges[i].start && last.end == r.wrapperRanges[i].end {
+			continue
+		}
+		dedup = append(dedup, r.wrapperRanges[i])
+	}
+	r.wrapperRanges = dedup
+}
+
+func findArm64StackReloadBeforeCall(insts []DecodedInstruction, callIdx int) (int, int64, bool) {
+	start := max(callIdx-arm64ReloadSearchWindow, 0)
+	for i := callIdx - 1; i >= start; i-- {
+		a, ok := insts[i].arch.(arm64asm.Inst)
+		if !ok || a.Op != arm64asm.LDR || a.Args[0] == nil || a.Args[1] == nil {
+			continue
+		}
+		if !arm64MatchesReg(a.Args[0], arm64asm.X0) {
+			continue
+		}
+		mem, ok := a.Args[1].(arm64asm.MemImmediate)
+		if !ok || mem.Mode != arm64asm.AddrOffset || mem.Base != arm64asm.RegSP(arm64asm.SP) {
+			continue
+		}
+		return i, int64(arm64MemImmediateOffsetFromString(mem)), true
+	}
+	return -1, 0, false
+}
+
+func findArm64NonWrapperCallBefore(insts []DecodedInstruction, idx int, wrapperAddrs map[uint64]GoSyscallWrapper, decoder *ARM64Decoder) (int, bool) {
+	start := max(idx-arm64HelperSearchWindow, 0)
+	for i := idx - 1; i >= start; i-- {
+		target, ok := decoder.GetCallTarget(insts[i], insts[i].Offset)
+		if !ok {
+			continue
+		}
+		if _, isWrapper := wrapperAddrs[target]; isWrapper {
+			continue
+		}
+		return i, true
+	}
+	return -1, false
+}
+
+func findArm64StackSaveBeforeHelper(insts []DecodedInstruction, helperIdx int, stackOff int64) (int, bool) {
+	start := max(helperIdx-arm64SaveSearchWindow, 0)
+	for i := helperIdx - 1; i >= start; i-- {
+		a, ok := insts[i].arch.(arm64asm.Inst)
+		if !ok || a.Op != arm64asm.STR || a.Args[0] == nil || a.Args[1] == nil {
+			continue
+		}
+		if !arm64MatchesReg(a.Args[0], arm64asm.X0) {
+			continue
+		}
+		mem, ok := a.Args[1].(arm64asm.MemImmediate)
+		if !ok || mem.Mode != arm64asm.AddrOffset || mem.Base != arm64asm.RegSP(arm64asm.SP) {
+			continue
+		}
+		if int64(arm64MemImmediateOffsetFromString(mem)) == stackOff {
+			return i, true
+		}
+	}
+	return -1, false
+}
+
+func findArm64PrologueBefore(insts []DecodedInstruction, saveIdx int) (int, bool) {
+	start := max(saveIdx-arm64PrologueSearchWindow, 0)
+	for i := saveIdx - 1; i >= start; i-- {
+		a, ok := insts[i].arch.(arm64asm.Inst)
+		if !ok || a.Op != arm64asm.STR || a.Args[0] == nil || a.Args[1] == nil {
+			continue
+		}
+		if !arm64MatchesReg(a.Args[0], arm64asm.X30) {
+			continue
+		}
+		mem, ok := a.Args[1].(arm64asm.MemImmediate)
+		if !ok || mem.Mode != arm64asm.AddrPreIndex || mem.Base != arm64asm.RegSP(arm64asm.SP) {
+			continue
+		}
+		return i, true
+	}
+	return -1, false
+}
+
+func arm64MemImmediateOffsetFromString(m arm64asm.MemImmediate) int {
+	// arm64asm.MemImmediate has an unexported offset field.
+	// Parse from its stable string form: [SP,#104] / [SP,#-16]!
+	text := m.String()
+	for i := 0; i < len(text); i++ {
+		if text[i] != '#' {
+			continue
+		}
+		i++
+		sign := 1
+		if i < len(text) && text[i] == '-' {
+			sign = -1
+			i++
+		}
+		v := 0
+		for i < len(text) && text[i] >= '0' && text[i] <= '9' {
+			v = v*decimalBase + int(text[i]-'0')
+			i++
+		}
+		return sign * v
+	}
+	return 0
 }
 
 // GetWrapperAddresses returns all known wrapper function addresses.

--- a/internal/runner/security/elfanalyzer/arm64_go_wrapper_resolver.go
+++ b/internal/runner/security/elfanalyzer/arm64_go_wrapper_resolver.go
@@ -97,7 +97,11 @@ func (r *ARM64GoWrapperResolver) discoverTransparentWrappers(code []byte, baseAd
 
 	// Fill the initial window.
 	for len(win) < winSize {
-		inst, ok := r.decodeOneAt(code, baseAddr, &pos)
+		var (
+			inst DecodedInstruction
+			ok   bool
+		)
+		inst, pos, ok = r.decodeOneAt(code, baseAddr, pos)
 		if !ok {
 			break
 		}
@@ -113,7 +117,12 @@ func (r *ARM64GoWrapperResolver) discoverTransparentWrappers(code []byte, baseAd
 		// Advance: drop the oldest instruction and append the next decoded one.
 		copy(win, win[1:])
 		win = win[:len(win)-1]
-		if inst, ok := r.decodeOneAt(code, baseAddr, &pos); ok {
+		var (
+			inst DecodedInstruction
+			ok   bool
+		)
+		inst, pos, ok = r.decodeOneAt(code, baseAddr, pos)
+		if ok {
 			win = append(win, inst)
 		}
 	}
@@ -121,15 +130,18 @@ func (r *ARM64GoWrapperResolver) discoverTransparentWrappers(code []byte, baseAd
 	r.sortAndDedupWrapperRanges()
 }
 
-func (r *ARM64GoWrapperResolver) decodeOneAt(code []byte, baseAddr uint64, pos *int) (DecodedInstruction, bool) {
-	for *pos+arm64InstructionLen <= len(code) {
-		inst, err := r.decoder.Decode(code[*pos:], baseAddr+uint64(*pos)) //nolint:gosec // G115: pos bounded by loop condition
-		*pos += arm64InstructionLen
+// decodeOneAt decodes the next valid instruction starting at pos, skipping
+// any undecodable bytes. Returns (instruction, advancedPos, true) on success,
+// or (zero, pos, false) when the end of code is reached without a valid instruction.
+func (r *ARM64GoWrapperResolver) decodeOneAt(code []byte, baseAddr uint64, pos int) (DecodedInstruction, int, bool) {
+	for pos+arm64InstructionLen <= len(code) {
+		inst, err := r.decoder.Decode(code[pos:], baseAddr+uint64(pos)) //nolint:gosec // G115: pos bounded by loop condition
+		pos += arm64InstructionLen
 		if err == nil {
-			return inst, true
+			return inst, pos, true
 		}
 	}
-	return DecodedInstruction{}, false
+	return DecodedInstruction{}, pos, false
 }
 
 func (r *ARM64GoWrapperResolver) addTransparentWrapperFromCall(insts []DecodedInstruction, callIdx int) {

--- a/internal/runner/security/elfanalyzer/arm64_go_wrapper_resolver.go
+++ b/internal/runner/security/elfanalyzer/arm64_go_wrapper_resolver.go
@@ -131,7 +131,8 @@ func (r *ARM64GoWrapperResolver) discoverTransparentWrappers(code []byte, baseAd
 }
 
 // decodeOneAt decodes the next valid instruction starting at pos, skipping
-// any undecodable bytes. Returns (instruction, advancedPos, true) on success,
+// undecodable 4-byte chunks to stay instruction-aligned (ARM64 is fixed-width).
+// Returns (instruction, advancedPos, true) on success,
 // or (zero, pos, false) when the end of code is reached without a valid instruction.
 func (r *ARM64GoWrapperResolver) decodeOneAt(code []byte, baseAddr uint64, pos int) (DecodedInstruction, int, bool) {
 	for pos+arm64InstructionLen <= len(code) {

--- a/internal/runner/security/elfanalyzer/arm64_go_wrapper_resolver.go
+++ b/internal/runner/security/elfanalyzer/arm64_go_wrapper_resolver.go
@@ -82,17 +82,52 @@ func (r *ARM64GoWrapperResolver) discoverTransparentWrappers(code []byte, baseAd
 		return
 	}
 
-	insts := make([]DecodedInstruction, 0, len(code)/arm64InstructionLen)
-	for pos := 0; pos+arm64InstructionLen <= len(code); pos += arm64InstructionLen {
-		inst, err := r.decoder.Decode(code[pos:], baseAddr+uint64(pos)) //nolint:gosec // G115: pos bounded by loop condition
-		if err != nil {
-			continue
+	// totalLookback is the maximum number of instructions that must precede the
+	// call candidate for the backward-scan chain to succeed:
+	//   reload(8) + helper(15) + save(15) + prologue(6) = 44.
+	// arm64FunctionTailSearchSpan is the lookahead needed to find the closing RET.
+	// The window holds at most winSize instructions at any one time, so memory is
+	// O(1) with respect to binary size instead of O(len(code)/4).
+	const totalLookback = arm64ReloadSearchWindow + arm64HelperSearchWindow +
+		arm64SaveSearchWindow + arm64PrologueSearchWindow // 44
+	const winSize = totalLookback + 1 + arm64FunctionTailSearchSpan // 69
+
+	win := make([]DecodedInstruction, 0, winSize)
+	pos := 0
+
+	// decodeOne advances pos to the next successfully decoded instruction.
+	decodeOne := func() (DecodedInstruction, bool) {
+		for pos+arm64InstructionLen <= len(code) {
+			inst, err := r.decoder.Decode(code[pos:], baseAddr+uint64(pos)) //nolint:gosec // G115: pos bounded by loop condition
+			pos += arm64InstructionLen
+			if err == nil {
+				return inst, true
+			}
 		}
-		insts = append(insts, inst)
+		return DecodedInstruction{}, false
 	}
 
-	for idx := range insts {
-		r.addTransparentWrapperFromCall(insts, idx)
+	// Fill the initial window.
+	for len(win) < winSize {
+		inst, ok := decodeOne()
+		if !ok {
+			break
+		}
+		win = append(win, inst)
+	}
+
+	// Slide: win[totalLookback] is the call candidate; it has totalLookback
+	// instructions of lookback history and up to arm64FunctionTailSearchSpan
+	// instructions of lookahead for RET detection.
+	for len(win) > totalLookback {
+		r.addTransparentWrapperFromCall(win, totalLookback)
+
+		// Advance: drop the oldest instruction and append the next decoded one.
+		copy(win, win[1:])
+		win = win[:len(win)-1]
+		if inst, ok := decodeOne(); ok {
+			win = append(win, inst)
+		}
 	}
 
 	r.sortAndDedupWrapperRanges()

--- a/internal/runner/security/elfanalyzer/arm64_go_wrapper_resolver.go
+++ b/internal/runner/security/elfanalyzer/arm64_go_wrapper_resolver.go
@@ -95,21 +95,9 @@ func (r *ARM64GoWrapperResolver) discoverTransparentWrappers(code []byte, baseAd
 	win := make([]DecodedInstruction, 0, winSize)
 	pos := 0
 
-	// decodeOne advances pos to the next successfully decoded instruction.
-	decodeOne := func() (DecodedInstruction, bool) {
-		for pos+arm64InstructionLen <= len(code) {
-			inst, err := r.decoder.Decode(code[pos:], baseAddr+uint64(pos)) //nolint:gosec // G115: pos bounded by loop condition
-			pos += arm64InstructionLen
-			if err == nil {
-				return inst, true
-			}
-		}
-		return DecodedInstruction{}, false
-	}
-
 	// Fill the initial window.
 	for len(win) < winSize {
-		inst, ok := decodeOne()
+		inst, ok := r.decodeOneAt(code, baseAddr, &pos)
 		if !ok {
 			break
 		}
@@ -125,12 +113,23 @@ func (r *ARM64GoWrapperResolver) discoverTransparentWrappers(code []byte, baseAd
 		// Advance: drop the oldest instruction and append the next decoded one.
 		copy(win, win[1:])
 		win = win[:len(win)-1]
-		if inst, ok := decodeOne(); ok {
+		if inst, ok := r.decodeOneAt(code, baseAddr, &pos); ok {
 			win = append(win, inst)
 		}
 	}
 
 	r.sortAndDedupWrapperRanges()
+}
+
+func (r *ARM64GoWrapperResolver) decodeOneAt(code []byte, baseAddr uint64, pos *int) (DecodedInstruction, bool) {
+	for *pos+arm64InstructionLen <= len(code) {
+		inst, err := r.decoder.Decode(code[*pos:], baseAddr+uint64(*pos)) //nolint:gosec // G115: pos bounded by loop condition
+		*pos += arm64InstructionLen
+		if err == nil {
+			return inst, true
+		}
+	}
+	return DecodedInstruction{}, false
 }
 
 func (r *ARM64GoWrapperResolver) addTransparentWrapperFromCall(insts []DecodedInstruction, callIdx int) {

--- a/internal/runner/security/elfanalyzer/arm64_go_wrapper_resolver.go
+++ b/internal/runner/security/elfanalyzer/arm64_go_wrapper_resolver.go
@@ -155,19 +155,19 @@ func (r *ARM64GoWrapperResolver) addTransparentWrapperFromCall(insts []DecodedIn
 		return
 	}
 
-	loadIdx, stackOff, ok := findArm64StackReloadBeforeCall(insts, callIdx)
+	loadIdx, stackOff, ok := findArm64StackReload(insts, callIdx)
 	if !ok {
 		return
 	}
-	helperIdx, ok := findArm64NonWrapperCallBefore(insts, loadIdx, r.wrapperAddrs, r.decoder)
+	helperIdx, ok := findArm64HelperCall(insts, loadIdx, r.wrapperAddrs, r.decoder)
 	if !ok {
 		return
 	}
-	saveIdx, ok := findArm64StackSaveBeforeHelper(insts, helperIdx, stackOff)
+	saveIdx, ok := findArm64StackSave(insts, helperIdx, stackOff)
 	if !ok {
 		return
 	}
-	prologueIdx, ok := findArm64PrologueBefore(insts, saveIdx)
+	prologueIdx, ok := findArm64Prologue(insts, saveIdx)
 	if !ok {
 		return
 	}
@@ -219,7 +219,7 @@ func (r *ARM64GoWrapperResolver) sortAndDedupWrapperRanges() {
 	r.wrapperRanges = dedup
 }
 
-func findArm64StackReloadBeforeCall(insts []DecodedInstruction, callIdx int) (int, int64, bool) {
+func findArm64StackReload(insts []DecodedInstruction, callIdx int) (int, int64, bool) {
 	start := max(callIdx-arm64ReloadSearchWindow, 0)
 	for i := callIdx - 1; i >= start; i-- {
 		a, ok := insts[i].arch.(arm64asm.Inst)
@@ -233,12 +233,12 @@ func findArm64StackReloadBeforeCall(insts []DecodedInstruction, callIdx int) (in
 		if !ok || mem.Mode != arm64asm.AddrOffset || mem.Base != arm64asm.RegSP(arm64asm.SP) {
 			continue
 		}
-		return i, int64(arm64MemImmediateOffsetFromString(mem)), true
+		return i, int64(arm64ImmOffset(mem)), true
 	}
 	return -1, 0, false
 }
 
-func findArm64NonWrapperCallBefore(insts []DecodedInstruction, idx int, wrapperAddrs map[uint64]GoSyscallWrapper, decoder *ARM64Decoder) (int, bool) {
+func findArm64HelperCall(insts []DecodedInstruction, idx int, wrapperAddrs map[uint64]GoSyscallWrapper, decoder *ARM64Decoder) (int, bool) {
 	start := max(idx-arm64HelperSearchWindow, 0)
 	for i := idx - 1; i >= start; i-- {
 		target, ok := decoder.GetCallTarget(insts[i], insts[i].Offset)
@@ -253,7 +253,7 @@ func findArm64NonWrapperCallBefore(insts []DecodedInstruction, idx int, wrapperA
 	return -1, false
 }
 
-func findArm64StackSaveBeforeHelper(insts []DecodedInstruction, helperIdx int, stackOff int64) (int, bool) {
+func findArm64StackSave(insts []DecodedInstruction, helperIdx int, stackOff int64) (int, bool) {
 	start := max(helperIdx-arm64SaveSearchWindow, 0)
 	for i := helperIdx - 1; i >= start; i-- {
 		a, ok := insts[i].arch.(arm64asm.Inst)
@@ -267,14 +267,14 @@ func findArm64StackSaveBeforeHelper(insts []DecodedInstruction, helperIdx int, s
 		if !ok || mem.Mode != arm64asm.AddrOffset || mem.Base != arm64asm.RegSP(arm64asm.SP) {
 			continue
 		}
-		if int64(arm64MemImmediateOffsetFromString(mem)) == stackOff {
+		if int64(arm64ImmOffset(mem)) == stackOff {
 			return i, true
 		}
 	}
 	return -1, false
 }
 
-func findArm64PrologueBefore(insts []DecodedInstruction, saveIdx int) (int, bool) {
+func findArm64Prologue(insts []DecodedInstruction, saveIdx int) (int, bool) {
 	start := max(saveIdx-arm64PrologueSearchWindow, 0)
 	for i := saveIdx - 1; i >= start; i-- {
 		a, ok := insts[i].arch.(arm64asm.Inst)
@@ -293,7 +293,7 @@ func findArm64PrologueBefore(insts []DecodedInstruction, saveIdx int) (int, bool
 	return -1, false
 }
 
-func arm64MemImmediateOffsetFromString(m arm64asm.MemImmediate) int {
+func arm64ImmOffset(m arm64asm.MemImmediate) int {
 	// arm64asm.MemImmediate has an unexported offset field.
 	// Parse from its stable string form: [SP,#104] / [SP,#-16]!
 	text := m.String()

--- a/internal/runner/security/elfanalyzer/arm64_go_wrapper_resolver.go
+++ b/internal/runner/security/elfanalyzer/arm64_go_wrapper_resolver.go
@@ -2,6 +2,7 @@ package elfanalyzer
 
 import (
 	"debug/elf"
+	"encoding/binary"
 	"sort"
 
 	"golang.org/x/arch/arm64/arm64asm"
@@ -13,7 +14,6 @@ const (
 	arm64SaveSearchWindow       = 15
 	arm64PrologueSearchWindow   = 6
 	arm64FunctionTailSearchSpan = 24
-	decimalBase                 = 10
 )
 
 // ARM64GoWrapperResolver implements GoWrapperResolver for arm64 binaries.
@@ -233,7 +233,11 @@ func findArm64StackReload(insts []DecodedInstruction, callIdx int) (int, int64, 
 		if !ok || mem.Mode != arm64asm.AddrOffset || mem.Base != arm64asm.RegSP(arm64asm.SP) {
 			continue
 		}
-		return i, int64(arm64ImmOffset(mem)), true
+		off, ok := arm64UnsignedOffsetFromEnc(binary.LittleEndian.Uint32(insts[i].Raw), true)
+		if !ok {
+			continue
+		}
+		return i, int64(off), true //nolint:gosec // G115: max off = 4095<<3 = 32760, safely fits int64
 	}
 	return -1, 0, false
 }
@@ -267,7 +271,11 @@ func findArm64StackSave(insts []DecodedInstruction, helperIdx int, stackOff int6
 		if !ok || mem.Mode != arm64asm.AddrOffset || mem.Base != arm64asm.RegSP(arm64asm.SP) {
 			continue
 		}
-		if int64(arm64ImmOffset(mem)) == stackOff {
+		off, ok := arm64UnsignedOffsetFromEnc(binary.LittleEndian.Uint32(insts[i].Raw), true)
+		if !ok {
+			continue
+		}
+		if int64(off) == stackOff { //nolint:gosec // G115: max off = 4095<<3 = 32760, safely fits int64
 			return i, true
 		}
 	}
@@ -291,30 +299,6 @@ func findArm64Prologue(insts []DecodedInstruction, saveIdx int) (int, bool) {
 		return i, true
 	}
 	return -1, false
-}
-
-func arm64ImmOffset(m arm64asm.MemImmediate) int {
-	// arm64asm.MemImmediate has an unexported offset field.
-	// Parse from its stable string form: [SP,#104] / [SP,#-16]!
-	text := m.String()
-	for i := 0; i < len(text); i++ {
-		if text[i] != '#' {
-			continue
-		}
-		i++
-		sign := 1
-		if i < len(text) && text[i] == '-' {
-			sign = -1
-			i++
-		}
-		v := 0
-		for i < len(text) && text[i] >= '0' && text[i] <= '9' {
-			v = v*decimalBase + int(text[i]-'0')
-			i++
-		}
-		return sign * v
-	}
-	return 0
 }
 
 // GetWrapperAddresses returns all known wrapper function addresses.

--- a/internal/runner/security/elfanalyzer/arm64_go_wrapper_resolver_test.go
+++ b/internal/runner/security/elfanalyzer/arm64_go_wrapper_resolver_test.go
@@ -4,10 +4,12 @@ package elfanalyzer
 
 import (
 	"debug/elf"
+	"encoding/binary"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/arch/arm64/arm64asm"
 )
 
 func TestNewARM64GoWrapperResolver_NoPclntab(t *testing.T) {
@@ -179,4 +181,59 @@ func TestARM64GoWrapperResolver_FindWrapperCalls_NoWrappers(t *testing.T) {
 	result, decodeFailures := resolver.FindWrapperCalls(code, 0x401000)
 	assert.Nil(t, result)
 	assert.Equal(t, 0, decodeFailures)
+}
+
+func TestARM64GoWrapperResolver_FindWrapperCalls_IndirectBeforeControlFlow(t *testing.T) {
+	resolver := newARM64GoWrapperResolver()
+
+	wrapperAddr := uint64(0x402000)
+	resolver.wrapperAddrs[wrapperAddr] = "syscall.RawSyscall6"
+
+	baseAddr := uint64(0x401000)
+	code := []byte{
+		0x00, 0x00, 0x00, 0x94, // bl . (helper call, control flow)
+		0xE0, 0x03, 0x01, 0xAA, // mov x0, x1 (indirect setting)
+		0xFE, 0x03, 0x00, 0x94, // bl 0x402000
+	}
+
+	result, decodeFailures := resolver.FindWrapperCalls(code, baseAddr)
+	assert.Equal(t, 0, decodeFailures)
+
+	require.Len(t, result, 1)
+	assert.Equal(t, -1, result[0].SyscallNumber)
+	assert.False(t, result[0].Resolved)
+	assert.Equal(t, DeterminationMethodUnknownIndirectSetting, result[0].DeterminationMethod)
+}
+
+func TestARM64GoWrapperResolver_FindWrapperCalls_GlobalLoadFromDataSection(t *testing.T) {
+	resolver := newARM64GoWrapperResolver()
+
+	wrapperAddr := uint64(0x402000)
+	resolver.wrapperAddrs[wrapperAddr] = "syscall.RawSyscall"
+
+	baseAddr := uint64(0x401000)
+	code := []byte{
+		0x1b, 0x89, 0x19, 0x90, // adrp x27, .+0x33120000
+		0x60, 0xd7, 0x42, 0xf9, // ldr x0, [x27,#1448]
+		0xFE, 0x03, 0x00, 0x94, // bl 0x402000
+	}
+
+	adrpInst, err := resolver.decoder.Decode(code[:4], baseAddr)
+	require.NoError(t, err)
+	a := adrpInst.arch.(arm64asm.Inst)
+	rel, ok := a.Args[1].(arm64asm.PCRel)
+	require.True(t, ok)
+	loadAddr := uint64(int64(adrpInst.Offset&^uint64(0xfff))+int64(rel)) + 1448
+
+	blob := make([]byte, 16)
+	binary.LittleEndian.PutUint64(blob[:8], 25)
+	resolver.decoder.SetDataSections([]arm64DataSection{{Addr: loadAddr, Data: blob}})
+
+	result, decodeFailures := resolver.FindWrapperCalls(code, baseAddr)
+	assert.Equal(t, 0, decodeFailures)
+
+	require.Len(t, result, 1)
+	assert.Equal(t, 25, result[0].SyscallNumber)
+	assert.True(t, result[0].Resolved)
+	assert.Equal(t, DeterminationMethodGoWrapper, result[0].DeterminationMethod)
 }

--- a/internal/runner/security/elfanalyzer/go_wrapper_resolver.go
+++ b/internal/runner/security/elfanalyzer/go_wrapper_resolver.go
@@ -291,11 +291,6 @@ func (b *goWrapperBase) resolveSyscallArgument(recentInstructions []DecodedInstr
 		scanCount++
 		inst := recentInstructions[i]
 
-		// Stop at control flow boundary
-		if decoder.IsControlFlowInstruction(inst) {
-			return -1, DeterminationMethodUnknownControlFlowBoundary
-		}
-
 		// Check for immediate move to first argument register.
 		if value, ok := decoder.IsImmediateToFirstArgRegister(inst); ok {
 			// Validate immediate value is a plausible syscall number.
@@ -306,6 +301,26 @@ func (b *goWrapperBase) resolveSyscallArgument(recentInstructions []DecodedInstr
 			}
 			// Immediate value is out of valid range; treat as indirect setting
 			return -1, DeterminationMethodUnknownIndirectSetting
+		}
+
+		// Try resolving first argument from a global-data load pattern
+		// (e.g., ADRP+LDR on arm64).
+		if value, ok := decoder.TryResolveFirstArgFromGlobalLoad(recentInstructions, i); ok {
+			if value >= 0 && value <= maxValidSyscallNumber {
+				return int(value), DeterminationMethodGoWrapper
+			}
+			return -1, DeterminationMethodUnknownIndirectSetting
+		}
+
+		// Any non-immediate write to the first argument register means
+		// the value is set indirectly and cannot be resolved statically.
+		if decoder.ModifiesFirstArgRegister(inst) {
+			return -1, DeterminationMethodUnknownIndirectSetting
+		}
+
+		// Stop at control flow boundary.
+		if decoder.IsControlFlowInstruction(inst) {
+			return -1, DeterminationMethodUnknownControlFlowBoundary
 		}
 	}
 

--- a/internal/runner/security/elfanalyzer/syscall_analyzer_test.go
+++ b/internal/runner/security/elfanalyzer/syscall_analyzer_test.go
@@ -50,6 +50,14 @@ func (m *MockMachineCodeDecoder) IsImmediateToFirstArgRegister(_ DecodedInstruct
 	return 0, false
 }
 
+func (m *MockMachineCodeDecoder) ModifiesFirstArgRegister(_ DecodedInstruction) bool {
+	return false
+}
+
+func (m *MockMachineCodeDecoder) TryResolveFirstArgFromGlobalLoad(_ []DecodedInstruction, _ int) (int64, bool) {
+	return 0, false
+}
+
 func (m *MockMachineCodeDecoder) ModifiesThirdArgRegister(_ DecodedInstruction) bool {
 	return false
 }

--- a/internal/runner/security/elfanalyzer/syscall_decoder.go
+++ b/internal/runner/security/elfanalyzer/syscall_decoder.go
@@ -79,6 +79,18 @@ type MachineCodeDecoder interface {
 	// Returns (0, false) otherwise.
 	IsImmediateToFirstArgRegister(inst DecodedInstruction) (int64, bool)
 
+	// ModifiesFirstArgRegister returns true if the instruction writes to the
+	// first integer argument register.
+	// x86_64: eax/rax (same as syscall number register in Go ABI)
+	// arm64:  w0 or x0
+	ModifiesFirstArgRegister(inst DecodedInstruction) bool
+
+	// TryResolveFirstArgFromGlobalLoad tries to resolve the first argument value
+	// when it is loaded from memory, using nearby context in recentInstructions.
+	// idx is the index of the candidate load instruction in recentInstructions.
+	// Returns (value, true) if resolved, (0, false) otherwise.
+	TryResolveFirstArgFromGlobalLoad(recentInstructions []DecodedInstruction, idx int) (int64, bool)
+
 	// ModifiesThirdArgRegister returns true if the instruction writes to the
 	// third syscall argument register.
 	// x86_64: edx/rdx (any write including dl, dx, edx/rdx)

--- a/internal/runner/security/elfanalyzer/x86_decoder.go
+++ b/internal/runner/security/elfanalyzer/x86_decoder.go
@@ -261,6 +261,18 @@ func (d *X86Decoder) IsImmediateToFirstArgRegister(inst DecodedInstruction) (int
 	return val, ok
 }
 
+// ModifiesFirstArgRegister returns true if the instruction writes to the
+// first argument register in x86_64 Go ABI (RAX/EAX).
+func (d *X86Decoder) ModifiesFirstArgRegister(inst DecodedInstruction) bool {
+	return d.ModifiesSyscallNumberRegister(inst)
+}
+
+// TryResolveFirstArgFromGlobalLoad returns unresolved on x86_64.
+// The current Go wrapper resolution path only uses immediate assignments.
+func (d *X86Decoder) TryResolveFirstArgFromGlobalLoad(_ []DecodedInstruction, _ int) (int64, bool) {
+	return 0, false
+}
+
 // implicitlyWritesRDXEDX reports whether the instruction unconditionally writes
 // to RDX/EDX as an implicit (unlisted) destination.
 //

--- a/internal/runner/security/elfanalyzer/x86_decoder_test.go
+++ b/internal/runner/security/elfanalyzer/x86_decoder_test.go
@@ -597,3 +597,26 @@ func TestX86Decoder_IsImmediateToThirdArgRegister(t *testing.T) {
 		assert.False(t, ok)
 	})
 }
+
+func TestX86Decoder_ModifiesFirstArgRegister(t *testing.T) {
+	decoder := NewX86Decoder()
+
+	t.Run("mov imm to EAX returns true", func(t *testing.T) {
+		inst, err := decoder.Decode([]byte{0xb8, 0x2a, 0x00, 0x00, 0x00}, 0)
+		require.NoError(t, err)
+		assert.True(t, decoder.ModifiesFirstArgRegister(inst))
+	})
+
+	t.Run("mov imm to EDX returns false", func(t *testing.T) {
+		inst, err := decoder.Decode([]byte{0xba, 0x07, 0x00, 0x00, 0x00}, 0)
+		require.NoError(t, err)
+		assert.False(t, decoder.ModifiesFirstArgRegister(inst))
+	})
+}
+
+func TestX86Decoder_TryResolveFirstArgFromGlobalLoad(t *testing.T) {
+	decoder := NewX86Decoder()
+	value, ok := decoder.TryResolveFirstArgFromGlobalLoad(nil, 0)
+	assert.False(t, ok)
+	assert.Equal(t, int64(0), value)
+}


### PR DESCRIPTION
This pull request significantly improves the ARM64 syscall wrapper analysis by enabling static resolution of syscalls that use global data loads (such as ADRP+LDR patterns), and by adding robust detection of indirect argument settings. It introduces new decoder capabilities, updates the wrapper resolver logic, and expands test coverage for these patterns.

Key changes include:

**ARM64 Decoder Enhancements:**

* Added support for tracking read-only data sections in `ARM64Decoder` via a new `SetDataSections` method and the `arm64DataSection` type, enabling resolution of global-data-based register loads (e.g., ADRP+LDR patterns).
* Implemented logic to detect and resolve when the first syscall argument register (X0/W0) is set via a global load, including instruction decoding, address calculation, and memory reading from data sections. [[1]](diffhunk://#diff-4b59113cdddeba290e30e01ae43fbec55be48ead23820f6b9ec4f01319dfa092R251-R291) [[2]](diffhunk://#diff-4b59113cdddeba290e30e01ae43fbec55be48ead23820f6b9ec4f01319dfa092R343-R457)
* Added `ModifiesFirstArgRegister` to detect indirect modifications to the first argument register, improving the ability to distinguish between direct, indirect, and unresolved syscall number settings.

**Go Wrapper Resolver Improvements:**

* Updated `resolveSyscallArgument` to utilize the new decoder capabilities: it now attempts to resolve syscall numbers from global loads, handles indirect register modifications, and only stops at control flow boundaries after these checks. [[1]](diffhunk://#diff-f5fb17f735f638ad2200bd84283c9d045b7ca45bbc47c273dba943537abd93e6L294-L298) [[2]](diffhunk://#diff-f5fb17f735f638ad2200bd84283c9d045b7ca45bbc47c273dba943537abd93e6R305-R324)
* On initialization, the ARM64 wrapper resolver now loads relevant data sections from the ELF file and passes them to the decoder for use in argument resolution. [[1]](diffhunk://#diff-7ff079020988b63cc12f846f270f636a0f6cdf5150dbd6ac6f66c3d40924889fR36) [[2]](diffhunk://#diff-7ff079020988b63cc12f846f270f636a0f6cdf5150dbd6ac6f66c3d40924889fR59-R307)

**Testing and Validation:**

* Added comprehensive unit tests for the new decoder methods and for wrapper call detection involving global-data loads and indirect register settings, ensuring correctness and improved coverage. [[1]](diffhunk://#diff-119499ce037e85c926fdc082cf631449b3f3127c84efbf6e39ab38f1df995424R402-R475) [[2]](diffhunk://#diff-57a41b264559e5a3b86cf9b3ed491ac72f74bdcbc37691cf9de0a994c4dce1d7R185-R239)

These changes make the ARM64 syscall wrapper analysis more accurate and robust, especially for binaries that use global data for syscall numbers.