### PR TITLE
refactor(elfanalyzer): shorten verbose symbol names

### DIFF
--- a/internal/runner/security/elfanalyzer/arm64_decoder.go
+++ b/internal/runner/security/elfanalyzer/arm64_decoder.go
@@ -139,9 +139,9 @@ func arm64OrrZeroRegImm(a arm64asm.Inst, regs ...arm64asm.Reg) (bool, int64) {
 	return ok, val
 }
 
-// ModifiesSyscallNumberRegister returns true if the instruction writes to
+// ModifiesSyscallReg returns true if the instruction writes to
 // the arm64 syscall number register (W8 or X8).
-func (d *ARM64Decoder) ModifiesSyscallNumberRegister(inst DecodedInstruction) bool {
+func (d *ARM64Decoder) ModifiesSyscallReg(inst DecodedInstruction) bool {
 	a, ok := inst.arch.(arm64asm.Inst)
 	if !ok {
 		return false
@@ -155,12 +155,12 @@ func (d *ARM64Decoder) ModifiesSyscallNumberRegister(inst DecodedInstruction) bo
 	return arm64MatchesReg(a.Args[0], arm64asm.W8) || arm64MatchesReg(a.Args[0], arm64asm.X8)
 }
 
-// IsImmediateToSyscallNumberRegister returns (true, value) if inst sets
+// IsSyscallNumImm returns (true, value) if inst sets
 // W8 or X8 to a known immediate value.
 // Handles two encodings:
 //   - MOV W8/X8, #imm  (arm64asm normalises MOVZ to MOV)
 //   - ORR W8/X8, WZR/XZR, #imm  (bitmask-immediate; functionally identical to MOV)
-func (d *ARM64Decoder) IsImmediateToSyscallNumberRegister(inst DecodedInstruction) (bool, int64) {
+func (d *ARM64Decoder) IsSyscallNumImm(inst DecodedInstruction) (bool, int64) {
 	a, ok := inst.arch.(arm64asm.Inst)
 	if !ok {
 		return false, 0
@@ -227,13 +227,13 @@ func (d *ARM64Decoder) GetCallTarget(inst DecodedInstruction, instAddr uint64) (
 	return uint64(target), true //nolint:gosec // G115: target non-negative validated above
 }
 
-// IsImmediateToFirstArgRegister returns (value, true) if inst sets the arm64
+// IsFirstArgImm returns (value, true) if inst sets the arm64
 // first argument register (X0 or W0) to an immediate.
 // arm64 Go ABI uses X0 for the first integer argument.
 // Handles two encodings:
 //   - MOV X0/W0, #imm  (arm64asm normalises MOVZ to MOV)
 //   - ORR X0/W0, XZR/WZR, #imm  (bitmask-immediate; functionally identical to MOV)
-func (d *ARM64Decoder) IsImmediateToFirstArgRegister(inst DecodedInstruction) (int64, bool) {
+func (d *ARM64Decoder) IsFirstArgImm(inst DecodedInstruction) (int64, bool) {
 	a, ok := inst.arch.(arm64asm.Inst)
 	if !ok {
 		return 0, false
@@ -252,9 +252,9 @@ func (d *ARM64Decoder) IsImmediateToFirstArgRegister(inst DecodedInstruction) (i
 	return val, ok2
 }
 
-// ModifiesFirstArgRegister returns true if the instruction writes to
+// ModifiesFirstArg returns true if the instruction writes to
 // the arm64 first syscall argument register (W0 or X0).
-func (d *ARM64Decoder) ModifiesFirstArgRegister(inst DecodedInstruction) bool {
+func (d *ARM64Decoder) ModifiesFirstArg(inst DecodedInstruction) bool {
 	a, ok := inst.arch.(arm64asm.Inst)
 	if !ok {
 		return false
@@ -268,11 +268,11 @@ func (d *ARM64Decoder) ModifiesFirstArgRegister(inst DecodedInstruction) bool {
 	return arm64MatchesReg(a.Args[0], arm64asm.W0) || arm64MatchesReg(a.Args[0], arm64asm.X0)
 }
 
-// TryResolveFirstArgFromGlobalLoad resolves X0/W0 value for the pattern:
+// ResolveFirstArgGlobal resolves X0/W0 value for the pattern:
 //
 //	ADRP Xn, <page>
 //	LDR  X0/W0, [Xn, #offset]
-func (d *ARM64Decoder) TryResolveFirstArgFromGlobalLoad(recentInstructions []DecodedInstruction, idx int) (int64, bool) {
+func (d *ARM64Decoder) ResolveFirstArgGlobal(recentInstructions []DecodedInstruction, idx int) (int64, bool) {
 	if idx < 0 || idx >= len(recentInstructions) {
 		return 0, false
 	}
@@ -293,9 +293,9 @@ func (d *ARM64Decoder) TryResolveFirstArgFromGlobalLoad(recentInstructions []Dec
 	return d.readResolvedFirstArg(addr, loadInfo.is64Bit)
 }
 
-// ModifiesThirdArgRegister returns true if the instruction writes to
+// ModifiesThirdArg returns true if the instruction writes to
 // the arm64 third syscall argument register (W2 or X2).
-func (d *ARM64Decoder) ModifiesThirdArgRegister(inst DecodedInstruction) bool {
+func (d *ARM64Decoder) ModifiesThirdArg(inst DecodedInstruction) bool {
 	a, ok := inst.arch.(arm64asm.Inst)
 	if !ok {
 		return false
@@ -309,12 +309,12 @@ func (d *ARM64Decoder) ModifiesThirdArgRegister(inst DecodedInstruction) bool {
 	return arm64MatchesReg(a.Args[0], arm64asm.W2) || arm64MatchesReg(a.Args[0], arm64asm.X2)
 }
 
-// IsImmediateToThirdArgRegister returns (true, value) if inst sets
+// IsThirdArgImm returns (true, value) if inst sets
 // W2 or X2 to a known immediate value.
 // Handles two encodings:
 //   - MOV W2/X2, #imm  (arm64asm normalises MOVZ to MOV)
 //   - ORR W2/X2, WZR/XZR, #imm  (bitmask-immediate; functionally identical to MOV)
-func (d *ARM64Decoder) IsImmediateToThirdArgRegister(inst DecodedInstruction) (bool, int64) {
+func (d *ARM64Decoder) IsThirdArgImm(inst DecodedInstruction) (bool, int64) {
 	a, ok := inst.arch.(arm64asm.Inst)
 	if !ok {
 		return false, 0
@@ -381,36 +381,36 @@ func (d *ARM64Decoder) readUintAtVA(addr uint64, size int) (uint64, bool) {
 	return 0, false
 }
 
-type arm64FirstArgLoadInfo struct {
+type arm64LoadInfo struct {
 	base    arm64asm.RegSP
 	offset  uint64
 	is64Bit bool
 }
 
-func (d *ARM64Decoder) decodeFirstArgGlobalLoad(inst DecodedInstruction) (arm64FirstArgLoadInfo, bool) {
+func (d *ARM64Decoder) decodeFirstArgGlobalLoad(inst DecodedInstruction) (arm64LoadInfo, bool) {
 	a, ok := inst.arch.(arm64asm.Inst)
 	if !ok || a.Op != arm64asm.LDR || a.Args[0] == nil || a.Args[1] == nil {
-		return arm64FirstArgLoadInfo{}, false
+		return arm64LoadInfo{}, false
 	}
 
 	isX0 := arm64MatchesReg(a.Args[0], arm64asm.X0)
 	isW0 := arm64MatchesReg(a.Args[0], arm64asm.W0)
 	if !isX0 && !isW0 {
-		return arm64FirstArgLoadInfo{}, false
+		return arm64LoadInfo{}, false
 	}
 
 	mem, ok := a.Args[1].(arm64asm.MemImmediate)
 	if !ok || mem.Mode != arm64asm.AddrOffset {
-		return arm64FirstArgLoadInfo{}, false
+		return arm64LoadInfo{}, false
 	}
 
 	loadEnc := binary.LittleEndian.Uint32(inst.Raw)
 	offset, ok := arm64UnsignedOffsetFromEnc(loadEnc, isX0)
 	if !ok {
-		return arm64FirstArgLoadInfo{}, false
+		return arm64LoadInfo{}, false
 	}
 
-	info := arm64FirstArgLoadInfo{base: mem.Base, offset: offset, is64Bit: isX0}
+	info := arm64LoadInfo{base: mem.Base, offset: offset, is64Bit: isX0}
 	return info, true
 }
 

--- a/internal/runner/security/elfanalyzer/arm64_decoder.go
+++ b/internal/runner/security/elfanalyzer/arm64_decoder.go
@@ -227,29 +227,29 @@ func (d *ARM64Decoder) GetCallTarget(inst DecodedInstruction, instAddr uint64) (
 	return uint64(target), true //nolint:gosec // G115: target non-negative validated above
 }
 
-// IsFirstArgImm returns (value, true) if inst sets the arm64
+// IsFirstArgImm returns (true, value) if inst sets the arm64
 // first argument register (X0 or W0) to an immediate.
 // arm64 Go ABI uses X0 for the first integer argument.
 // Handles two encodings:
 //   - MOV X0/W0, #imm  (arm64asm normalises MOVZ to MOV)
 //   - ORR X0/W0, XZR/WZR, #imm  (bitmask-immediate; functionally identical to MOV)
-func (d *ARM64Decoder) IsFirstArgImm(inst DecodedInstruction) (int64, bool) {
+func (d *ARM64Decoder) IsFirstArgImm(inst DecodedInstruction) (bool, int64) {
 	a, ok := inst.arch.(arm64asm.Inst)
 	if !ok {
-		return 0, false
+		return false, 0
 	}
 	if a.Op == arm64asm.MOV {
 		if a.Args[0] == nil || a.Args[1] == nil {
-			return 0, false
+			return false, 0
 		}
 		if !arm64MatchesReg(a.Args[0], arm64asm.X0) && !arm64MatchesReg(a.Args[0], arm64asm.W0) {
-			return 0, false
+			return false, 0
 		}
 		val, ok := arm64ImmValue(a.Args[1])
-		return val, ok
+		return ok, val
 	}
 	ok2, val := arm64OrrZeroRegImm(a, arm64asm.X0, arm64asm.W0)
-	return val, ok2
+	return ok2, val
 }
 
 // ModifiesFirstArg returns true if the instruction writes to
@@ -272,25 +272,26 @@ func (d *ARM64Decoder) ModifiesFirstArg(inst DecodedInstruction) bool {
 //
 //	ADRP Xn, <page>
 //	LDR  X0/W0, [Xn, #offset]
-func (d *ARM64Decoder) ResolveFirstArgGlobal(recentInstructions []DecodedInstruction, idx int) (int64, bool) {
+func (d *ARM64Decoder) ResolveFirstArgGlobal(recentInstructions []DecodedInstruction, idx int) (bool, int64) {
 	if idx < 0 || idx >= len(recentInstructions) {
-		return 0, false
+		return false, 0
 	}
 	if len(d.dataSections) == 0 {
-		return 0, false
+		return false, 0
 	}
 
 	loadInfo, ok := d.decodeFirstArgGlobalLoad(recentInstructions[idx])
 	if !ok {
-		return 0, false
+		return false, 0
 	}
 
 	addr, ok := d.resolveADRPBacktrackAddress(recentInstructions, idx, loadInfo.base, loadInfo.offset)
 	if !ok {
-		return 0, false
+		return false, 0
 	}
 
-	return d.readResolvedFirstArg(addr, loadInfo.is64Bit)
+	val, ok := d.readResolvedFirstArg(addr, loadInfo.is64Bit)
+	return ok, val
 }
 
 // ModifiesThirdArg returns true if the instruction writes to

--- a/internal/runner/security/elfanalyzer/arm64_decoder_test.go
+++ b/internal/runner/security/elfanalyzer/arm64_decoder_test.go
@@ -92,7 +92,7 @@ func TestARM64Decoder_IsSyscallInstruction(t *testing.T) {
 	}
 }
 
-func TestARM64Decoder_ModifiesSyscallNumberRegister(t *testing.T) {
+func TestARM64Decoder_ModifiesSyscallReg(t *testing.T) {
 	decoder := NewARM64Decoder()
 
 	tests := []struct {
@@ -125,12 +125,12 @@ func TestARM64Decoder_ModifiesSyscallNumberRegister(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			inst, err := decoder.Decode(tt.code, 0)
 			require.NoError(t, err)
-			assert.Equal(t, tt.want, decoder.ModifiesSyscallNumberRegister(inst))
+			assert.Equal(t, tt.want, decoder.ModifiesSyscallReg(inst))
 		})
 	}
 }
 
-func TestARM64Decoder_IsImmediateToSyscallNumberRegister(t *testing.T) {
+func TestARM64Decoder_IsSyscallNumImm(t *testing.T) {
 	decoder := NewARM64Decoder()
 
 	// Verified ORR-immediate encodings (little-endian, bitmask immediate):
@@ -166,7 +166,7 @@ func TestARM64Decoder_IsImmediateToSyscallNumberRegister(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			inst, err := decoder.Decode(tt.code, 0)
 			require.NoError(t, err)
-			gotImm, gotVal := decoder.IsImmediateToSyscallNumberRegister(inst)
+			gotImm, gotVal := decoder.IsSyscallNumImm(inst)
 			assert.Equal(t, tt.wantImm, gotImm)
 			if tt.wantImm {
 				assert.Equal(t, tt.wantVal, gotVal)
@@ -250,14 +250,14 @@ func TestARM64Decoder_GetCallTarget(t *testing.T) {
 	})
 }
 
-func TestARM64Decoder_IsImmediateToFirstArgRegister(t *testing.T) {
+func TestARM64Decoder_IsFirstArgImm(t *testing.T) {
 	decoder := NewARM64Decoder()
 
 	// In arm64 Go ABI, X0 is the first argument register.
 	t.Run("mov x0, #41 (first arg register)", func(t *testing.T) {
 		inst, err := decoder.Decode([]byte{0x20, 0x05, 0x80, 0xD2}, 0)
 		require.NoError(t, err)
-		imm, ok := decoder.IsImmediateToFirstArgRegister(inst)
+		imm, ok := decoder.IsFirstArgImm(inst)
 		assert.True(t, ok)
 		assert.Equal(t, int64(41), imm)
 	})
@@ -265,7 +265,7 @@ func TestARM64Decoder_IsImmediateToFirstArgRegister(t *testing.T) {
 	t.Run("mov w0, #198 (first arg register, 32-bit)", func(t *testing.T) {
 		inst, err := decoder.Decode([]byte{0xC0, 0x18, 0x80, 0x52}, 0)
 		require.NoError(t, err)
-		imm, ok := decoder.IsImmediateToFirstArgRegister(inst)
+		imm, ok := decoder.IsFirstArgImm(inst)
 		assert.True(t, ok)
 		assert.Equal(t, int64(198), imm)
 	})
@@ -273,14 +273,14 @@ func TestARM64Decoder_IsImmediateToFirstArgRegister(t *testing.T) {
 	t.Run("mov w8, #198 (syscall reg, not first arg)", func(t *testing.T) {
 		inst, err := decoder.Decode([]byte{0xC8, 0x18, 0x80, 0x52}, 0)
 		require.NoError(t, err)
-		_, ok := decoder.IsImmediateToFirstArgRegister(inst)
+		_, ok := decoder.IsFirstArgImm(inst)
 		assert.False(t, ok)
 	})
 
 	t.Run("nop returns false", func(t *testing.T) {
 		inst, err := decoder.Decode([]byte{0x1F, 0x20, 0x03, 0xD5}, 0)
 		require.NoError(t, err)
-		_, ok := decoder.IsImmediateToFirstArgRegister(inst)
+		_, ok := decoder.IsFirstArgImm(inst)
 		assert.False(t, ok)
 	})
 
@@ -290,7 +290,7 @@ func TestARM64Decoder_IsImmediateToFirstArgRegister(t *testing.T) {
 	t.Run("orr x0, xzr, #0x38 (bitmask imm, openat syscall number)", func(t *testing.T) {
 		inst, err := decoder.Decode([]byte{0xe0, 0x0b, 0x7d, 0xb2}, 0)
 		require.NoError(t, err)
-		imm, ok := decoder.IsImmediateToFirstArgRegister(inst)
+		imm, ok := decoder.IsFirstArgImm(inst)
 		assert.True(t, ok)
 		assert.Equal(t, int64(0x38), imm)
 	})
@@ -298,12 +298,12 @@ func TestARM64Decoder_IsImmediateToFirstArgRegister(t *testing.T) {
 	t.Run("orr x8, xzr, #0x38 (bitmask imm, wrong register)", func(t *testing.T) {
 		inst, err := decoder.Decode([]byte{0xe8, 0x0b, 0x7d, 0xb2}, 0)
 		require.NoError(t, err)
-		_, ok := decoder.IsImmediateToFirstArgRegister(inst)
+		_, ok := decoder.IsFirstArgImm(inst)
 		assert.False(t, ok)
 	})
 }
 
-func TestARM64Decoder_ModifiesThirdArgRegister(t *testing.T) {
+func TestARM64Decoder_ModifiesThirdArg(t *testing.T) {
 	decoder := NewARM64Decoder()
 
 	// arm64 third syscall argument register is X2 / W2.
@@ -316,31 +316,31 @@ func TestARM64Decoder_ModifiesThirdArgRegister(t *testing.T) {
 	t.Run("mov x2, #7 returns true", func(t *testing.T) {
 		inst, err := decoder.Decode([]byte{0xE2, 0x00, 0x80, 0xD2}, 0)
 		require.NoError(t, err)
-		assert.True(t, decoder.ModifiesThirdArgRegister(inst))
+		assert.True(t, decoder.ModifiesThirdArg(inst))
 	})
 
 	t.Run("mov w2, #3 returns true", func(t *testing.T) {
 		inst, err := decoder.Decode([]byte{0x62, 0x00, 0x80, 0x52}, 0)
 		require.NoError(t, err)
-		assert.True(t, decoder.ModifiesThirdArgRegister(inst))
+		assert.True(t, decoder.ModifiesThirdArg(inst))
 	})
 
 	t.Run("mov x2, x1 returns true (register move modifies x2)", func(t *testing.T) {
 		inst, err := decoder.Decode([]byte{0xE2, 0x03, 0x01, 0xAA}, 0)
 		require.NoError(t, err)
-		assert.True(t, decoder.ModifiesThirdArgRegister(inst))
+		assert.True(t, decoder.ModifiesThirdArg(inst))
 	})
 
 	t.Run("mov x8, #7 returns false (wrong register)", func(t *testing.T) {
 		inst, err := decoder.Decode([]byte{0xE8, 0x00, 0x80, 0xD2}, 0)
 		require.NoError(t, err)
-		assert.False(t, decoder.ModifiesThirdArgRegister(inst))
+		assert.False(t, decoder.ModifiesThirdArg(inst))
 	})
 
 	t.Run("nop returns false", func(t *testing.T) {
 		inst, err := decoder.Decode([]byte{0x1F, 0x20, 0x03, 0xD5}, 0)
 		require.NoError(t, err)
-		assert.False(t, decoder.ModifiesThirdArgRegister(inst))
+		assert.False(t, decoder.ModifiesThirdArg(inst))
 	})
 
 	// Read-only first operand: must not be mistaken for writes to X2/W2
@@ -348,31 +348,31 @@ func TestARM64Decoder_ModifiesThirdArgRegister(t *testing.T) {
 		// str x2, [x0] — 02 00 00 F9
 		inst, err := decoder.Decode([]byte{0x02, 0x00, 0x00, 0xF9}, 0)
 		require.NoError(t, err)
-		assert.False(t, decoder.ModifiesThirdArgRegister(inst))
+		assert.False(t, decoder.ModifiesThirdArg(inst))
 	})
 
 	t.Run("cmp x2, #5 returns false (sets flags only)", func(t *testing.T) {
 		// cmp x2, #5 (SUBS XZR, X2, #5) — 5F 14 00 F1
 		inst, err := decoder.Decode([]byte{0x5F, 0x14, 0x00, 0xF1}, 0)
 		require.NoError(t, err)
-		assert.False(t, decoder.ModifiesThirdArgRegister(inst))
+		assert.False(t, decoder.ModifiesThirdArg(inst))
 	})
 
 	t.Run("tst x2, x1 returns false (sets flags only)", func(t *testing.T) {
 		// tst x2, x1 (ANDS XZR, X2, X1) — 5F 00 01 EA
 		inst, err := decoder.Decode([]byte{0x5F, 0x00, 0x01, 0xEA}, 0)
 		require.NoError(t, err)
-		assert.False(t, decoder.ModifiesThirdArgRegister(inst))
+		assert.False(t, decoder.ModifiesThirdArg(inst))
 	})
 }
 
-func TestARM64Decoder_IsImmediateToThirdArgRegister(t *testing.T) {
+func TestARM64Decoder_IsThirdArgImm(t *testing.T) {
 	decoder := NewARM64Decoder()
 
 	t.Run("mov x2, #7 returns (true, 7)", func(t *testing.T) {
 		inst, err := decoder.Decode([]byte{0xE2, 0x00, 0x80, 0xD2}, 0)
 		require.NoError(t, err)
-		ok, val := decoder.IsImmediateToThirdArgRegister(inst)
+		ok, val := decoder.IsThirdArgImm(inst)
 		assert.True(t, ok)
 		assert.Equal(t, int64(7), val)
 	})
@@ -380,7 +380,7 @@ func TestARM64Decoder_IsImmediateToThirdArgRegister(t *testing.T) {
 	t.Run("mov w2, #3 returns (true, 3)", func(t *testing.T) {
 		inst, err := decoder.Decode([]byte{0x62, 0x00, 0x80, 0x52}, 0)
 		require.NoError(t, err)
-		ok, val := decoder.IsImmediateToThirdArgRegister(inst)
+		ok, val := decoder.IsThirdArgImm(inst)
 		assert.True(t, ok)
 		assert.Equal(t, int64(3), val)
 	})
@@ -388,48 +388,48 @@ func TestARM64Decoder_IsImmediateToThirdArgRegister(t *testing.T) {
 	t.Run("mov x2, x1 returns false (register move)", func(t *testing.T) {
 		inst, err := decoder.Decode([]byte{0xE2, 0x03, 0x01, 0xAA}, 0)
 		require.NoError(t, err)
-		ok, _ := decoder.IsImmediateToThirdArgRegister(inst)
+		ok, _ := decoder.IsThirdArgImm(inst)
 		assert.False(t, ok)
 	})
 
 	t.Run("mov x8, #7 returns false (wrong register)", func(t *testing.T) {
 		inst, err := decoder.Decode([]byte{0xE8, 0x00, 0x80, 0xD2}, 0)
 		require.NoError(t, err)
-		ok, _ := decoder.IsImmediateToThirdArgRegister(inst)
+		ok, _ := decoder.IsThirdArgImm(inst)
 		assert.False(t, ok)
 	})
 }
 
-func TestARM64Decoder_ModifiesFirstArgRegister(t *testing.T) {
+func TestARM64Decoder_ModifiesFirstArg(t *testing.T) {
 	decoder := NewARM64Decoder()
 
 	t.Run("mov x0, x1 returns true", func(t *testing.T) {
 		// mov x0, x1
 		inst, err := decoder.Decode([]byte{0xE0, 0x03, 0x01, 0xAA}, 0)
 		require.NoError(t, err)
-		assert.True(t, decoder.ModifiesFirstArgRegister(inst))
+		assert.True(t, decoder.ModifiesFirstArg(inst))
 	})
 
 	t.Run("mov w0, #198 returns true", func(t *testing.T) {
 		inst, err := decoder.Decode([]byte{0xC0, 0x18, 0x80, 0x52}, 0)
 		require.NoError(t, err)
-		assert.True(t, decoder.ModifiesFirstArgRegister(inst))
+		assert.True(t, decoder.ModifiesFirstArg(inst))
 	})
 
 	t.Run("mov x8, #198 returns false", func(t *testing.T) {
 		inst, err := decoder.Decode([]byte{0xC8, 0x18, 0x80, 0xD2}, 0)
 		require.NoError(t, err)
-		assert.False(t, decoder.ModifiesFirstArgRegister(inst))
+		assert.False(t, decoder.ModifiesFirstArg(inst))
 	})
 
 	t.Run("str x0, [x1] returns false", func(t *testing.T) {
 		inst, err := decoder.Decode([]byte{0x20, 0x00, 0x00, 0xF9}, 0)
 		require.NoError(t, err)
-		assert.False(t, decoder.ModifiesFirstArgRegister(inst))
+		assert.False(t, decoder.ModifiesFirstArg(inst))
 	})
 }
 
-func TestARM64Decoder_TryResolveFirstArgFromGlobalLoad(t *testing.T) {
+func TestARM64Decoder_ResolveFirstArgGlobal(t *testing.T) {
 	decoder := NewARM64Decoder()
 
 	adrpCode := []byte{0x1b, 0x89, 0x19, 0x90} // adrp x27, .+0x33120000
@@ -455,11 +455,11 @@ func TestARM64Decoder_TryResolveFirstArgFromGlobalLoad(t *testing.T) {
 	decoder.SetDataSections([]arm64DataSection{{Addr: loadAddr, Data: blob}})
 
 	insts := []DecodedInstruction{adrpInst, ldrInst, callInst}
-	value, ok := decoder.TryResolveFirstArgFromGlobalLoad(insts, 1)
+	value, ok := decoder.ResolveFirstArgGlobal(insts, 1)
 	assert.True(t, ok)
 	assert.Equal(t, int64(25), value)
 
-	value, ok = decoder.TryResolveFirstArgFromGlobalLoad(insts, 0)
+	value, ok = decoder.ResolveFirstArgGlobal(insts, 0)
 	assert.False(t, ok)
 	assert.Equal(t, int64(0), value)
 
@@ -468,7 +468,7 @@ func TestARM64Decoder_TryResolveFirstArgFromGlobalLoad(t *testing.T) {
 		require.NoError(t, err)
 
 		instsWithBranch := []DecodedInstruction{adrpInst, branchInst, ldrInst, callInst}
-		value, ok := decoder.TryResolveFirstArgFromGlobalLoad(instsWithBranch, 2)
+		value, ok := decoder.ResolveFirstArgGlobal(instsWithBranch, 2)
 		assert.False(t, ok)
 		assert.Equal(t, int64(0), value)
 	})

--- a/internal/runner/security/elfanalyzer/arm64_decoder_test.go
+++ b/internal/runner/security/elfanalyzer/arm64_decoder_test.go
@@ -257,7 +257,7 @@ func TestARM64Decoder_IsFirstArgImm(t *testing.T) {
 	t.Run("mov x0, #41 (first arg register)", func(t *testing.T) {
 		inst, err := decoder.Decode([]byte{0x20, 0x05, 0x80, 0xD2}, 0)
 		require.NoError(t, err)
-		imm, ok := decoder.IsFirstArgImm(inst)
+		ok, imm := decoder.IsFirstArgImm(inst)
 		assert.True(t, ok)
 		assert.Equal(t, int64(41), imm)
 	})
@@ -265,7 +265,7 @@ func TestARM64Decoder_IsFirstArgImm(t *testing.T) {
 	t.Run("mov w0, #198 (first arg register, 32-bit)", func(t *testing.T) {
 		inst, err := decoder.Decode([]byte{0xC0, 0x18, 0x80, 0x52}, 0)
 		require.NoError(t, err)
-		imm, ok := decoder.IsFirstArgImm(inst)
+		ok, imm := decoder.IsFirstArgImm(inst)
 		assert.True(t, ok)
 		assert.Equal(t, int64(198), imm)
 	})
@@ -273,14 +273,14 @@ func TestARM64Decoder_IsFirstArgImm(t *testing.T) {
 	t.Run("mov w8, #198 (syscall reg, not first arg)", func(t *testing.T) {
 		inst, err := decoder.Decode([]byte{0xC8, 0x18, 0x80, 0x52}, 0)
 		require.NoError(t, err)
-		_, ok := decoder.IsFirstArgImm(inst)
+		ok, _ := decoder.IsFirstArgImm(inst)
 		assert.False(t, ok)
 	})
 
 	t.Run("nop returns false", func(t *testing.T) {
 		inst, err := decoder.Decode([]byte{0x1F, 0x20, 0x03, 0xD5}, 0)
 		require.NoError(t, err)
-		_, ok := decoder.IsFirstArgImm(inst)
+		ok, _ := decoder.IsFirstArgImm(inst)
 		assert.False(t, ok)
 	})
 
@@ -290,7 +290,7 @@ func TestARM64Decoder_IsFirstArgImm(t *testing.T) {
 	t.Run("orr x0, xzr, #0x38 (bitmask imm, openat syscall number)", func(t *testing.T) {
 		inst, err := decoder.Decode([]byte{0xe0, 0x0b, 0x7d, 0xb2}, 0)
 		require.NoError(t, err)
-		imm, ok := decoder.IsFirstArgImm(inst)
+		ok, imm := decoder.IsFirstArgImm(inst)
 		assert.True(t, ok)
 		assert.Equal(t, int64(0x38), imm)
 	})
@@ -298,7 +298,7 @@ func TestARM64Decoder_IsFirstArgImm(t *testing.T) {
 	t.Run("orr x8, xzr, #0x38 (bitmask imm, wrong register)", func(t *testing.T) {
 		inst, err := decoder.Decode([]byte{0xe8, 0x0b, 0x7d, 0xb2}, 0)
 		require.NoError(t, err)
-		_, ok := decoder.IsFirstArgImm(inst)
+		ok, _ := decoder.IsFirstArgImm(inst)
 		assert.False(t, ok)
 	})
 }
@@ -455,11 +455,11 @@ func TestARM64Decoder_ResolveFirstArgGlobal(t *testing.T) {
 	decoder.SetDataSections([]arm64DataSection{{Addr: loadAddr, Data: blob}})
 
 	insts := []DecodedInstruction{adrpInst, ldrInst, callInst}
-	value, ok := decoder.ResolveFirstArgGlobal(insts, 1)
+	ok, value := decoder.ResolveFirstArgGlobal(insts, 1)
 	assert.True(t, ok)
 	assert.Equal(t, int64(25), value)
 
-	value, ok = decoder.ResolveFirstArgGlobal(insts, 0)
+	ok, value = decoder.ResolveFirstArgGlobal(insts, 0)
 	assert.False(t, ok)
 	assert.Equal(t, int64(0), value)
 
@@ -468,7 +468,7 @@ func TestARM64Decoder_ResolveFirstArgGlobal(t *testing.T) {
 		require.NoError(t, err)
 
 		instsWithBranch := []DecodedInstruction{adrpInst, branchInst, ldrInst, callInst}
-		value, ok := decoder.ResolveFirstArgGlobal(instsWithBranch, 2)
+		ok, value := decoder.ResolveFirstArgGlobal(instsWithBranch, 2)
 		assert.False(t, ok)
 		assert.Equal(t, int64(0), value)
 	})

--- a/internal/runner/security/elfanalyzer/go_wrapper_resolver.go
+++ b/internal/runner/security/elfanalyzer/go_wrapper_resolver.go
@@ -292,7 +292,7 @@ func (b *goWrapperBase) resolveSyscallArgument(recentInstructions []DecodedInstr
 		inst := recentInstructions[i]
 
 		// Check for immediate move to first argument register.
-		if value, ok := decoder.IsImmediateToFirstArgRegister(inst); ok {
+		if value, ok := decoder.IsFirstArgImm(inst); ok {
 			// Validate immediate value is a plausible syscall number.
 			// Reject negative immediates and out-of-range values to prevent
 			// incorrect marking of wrapper calls as resolved.
@@ -305,7 +305,7 @@ func (b *goWrapperBase) resolveSyscallArgument(recentInstructions []DecodedInstr
 
 		// Try resolving first argument from a global-data load pattern
 		// (e.g., ADRP+LDR on arm64).
-		if value, ok := decoder.TryResolveFirstArgFromGlobalLoad(recentInstructions, i); ok {
+		if value, ok := decoder.ResolveFirstArgGlobal(recentInstructions, i); ok {
 			if value >= 0 && value <= maxValidSyscallNumber {
 				return int(value), DeterminationMethodGoWrapper
 			}
@@ -314,7 +314,7 @@ func (b *goWrapperBase) resolveSyscallArgument(recentInstructions []DecodedInstr
 
 		// Any non-immediate write to the first argument register means
 		// the value is set indirectly and cannot be resolved statically.
-		if decoder.ModifiesFirstArgRegister(inst) {
+		if decoder.ModifiesFirstArg(inst) {
 			return -1, DeterminationMethodUnknownIndirectSetting
 		}
 

--- a/internal/runner/security/elfanalyzer/go_wrapper_resolver.go
+++ b/internal/runner/security/elfanalyzer/go_wrapper_resolver.go
@@ -292,7 +292,7 @@ func (b *goWrapperBase) resolveSyscallArgument(recentInstructions []DecodedInstr
 		inst := recentInstructions[i]
 
 		// Check for immediate move to first argument register.
-		if value, ok := decoder.IsFirstArgImm(inst); ok {
+		if ok, value := decoder.IsFirstArgImm(inst); ok {
 			// Validate immediate value is a plausible syscall number.
 			// Reject negative immediates and out-of-range values to prevent
 			// incorrect marking of wrapper calls as resolved.
@@ -305,7 +305,7 @@ func (b *goWrapperBase) resolveSyscallArgument(recentInstructions []DecodedInstr
 
 		// Try resolving first argument from a global-data load pattern
 		// (e.g., ADRP+LDR on arm64).
-		if value, ok := decoder.ResolveFirstArgGlobal(recentInstructions, i); ok {
+		if ok, value := decoder.ResolveFirstArgGlobal(recentInstructions, i); ok {
 			if value >= 0 && value <= maxValidSyscallNumber {
 				return int(value), DeterminationMethodGoWrapper
 			}

--- a/internal/runner/security/elfanalyzer/syscall_analyzer.go
+++ b/internal/runner/security/elfanalyzer/syscall_analyzer.go
@@ -384,7 +384,7 @@ const (
 // Each name is processed independently to produce at most one ArgEvalResult per name.
 var MprotectFamilyNames = []string{syscallNameMprotect, syscallNamePkeyMprotect}
 
-type mprotectFamilyEvalResult struct {
+type mprotectEvalResult struct {
 	Result   common.SyscallArgEvalResult
 	Location uint64
 }
@@ -400,8 +400,8 @@ func (a *SyscallAnalyzer) evaluateMprotectFamilyArgs(
 	baseAddr uint64,
 	decoder MachineCodeDecoder,
 	detectedSyscalls []common.SyscallInfo,
-) []mprotectFamilyEvalResult {
-	var results []mprotectFamilyEvalResult
+) []mprotectEvalResult {
+	var results []mprotectEvalResult
 
 	for _, syscallName := range MprotectFamilyNames {
 		// Collect entries for this syscall name.
@@ -435,7 +435,7 @@ func (a *SyscallAnalyzer) evaluateMprotectFamilyArgs(
 			}
 		}
 
-		results = append(results, mprotectFamilyEvalResult{
+		results = append(results, mprotectEvalResult{
 			Result:   bestResult,
 			Location: bestLocation,
 		})
@@ -466,8 +466,8 @@ func (a *SyscallAnalyzer) evalSingleMprotect(
 
 	value, method := a.backwardScanForRegister(
 		code, baseAddr, offset, decoder,
-		decoder.ModifiesThirdArgRegister,
-		decoder.IsImmediateToThirdArgRegister,
+		decoder.ModifiesThirdArg,
+		decoder.IsThirdArgImm,
 	)
 
 	if method == DeterminationMethodImmediate {
@@ -647,7 +647,7 @@ func (a *SyscallAnalyzer) backwardScanForRegister(
 		windowStart = 0
 	}
 
-	instructions, _ := a.decodeInstructionsInWindow(
+	instructions, _ := a.decodeWindow(
 		code, baseAddr, windowStart, syscallOffset, decoder,
 	)
 	if len(instructions) == 0 {
@@ -691,8 +691,8 @@ func (a *SyscallAnalyzer) backwardScanForRegister(
 func (a *SyscallAnalyzer) backwardScanForSyscallNumber(code []byte, baseAddr uint64, syscallOffset int, decoder MachineCodeDecoder) (int, string) {
 	value, method := a.backwardScanForRegister(
 		code, baseAddr, syscallOffset, decoder,
-		decoder.ModifiesSyscallNumberRegister,
-		decoder.IsImmediateToSyscallNumberRegister,
+		decoder.ModifiesSyscallReg,
+		decoder.IsSyscallNumImm,
 	)
 
 	if method == DeterminationMethodImmediate {
@@ -710,7 +710,7 @@ func (a *SyscallAnalyzer) backwardScanForSyscallNumber(code []byte, baseAddr uin
 	return int(value), method
 }
 
-// decodeInstructionsInWindow decodes instructions within a specified window [startOffset, endOffset).
+// decodeWindow decodes instructions within a specified window [startOffset, endOffset).
 // This method provides better performance by avoiding unnecessary decoding of the entire code section.
 // For large binaries with many syscall instructions, this reduces total decode overhead significantly.
 //
@@ -738,7 +738,7 @@ func (a *SyscallAnalyzer) backwardScanForSyscallNumber(code []byte, baseAddr uin
 // Performance comparison (example: 10MB .text, 100 syscalls):
 //   - Old approach: 100 * 5MB avg = ~500MB worth of redundant decoding
 //   - Window approach: 100 * (50 instructions * 15 bytes) = ~75KB of focused decoding
-func (a *SyscallAnalyzer) decodeInstructionsInWindow(code []byte, baseAddr uint64, startOffset, endOffset int, decoder MachineCodeDecoder) ([]DecodedInstruction, int) {
+func (a *SyscallAnalyzer) decodeWindow(code []byte, baseAddr uint64, startOffset, endOffset int, decoder MachineCodeDecoder) ([]DecodedInstruction, int) {
 	var instructions []DecodedInstruction
 	decodeFailures := 0
 	pos := startOffset

--- a/internal/runner/security/elfanalyzer/syscall_analyzer_test.go
+++ b/internal/runner/security/elfanalyzer/syscall_analyzer_test.go
@@ -46,16 +46,16 @@ func (m *MockMachineCodeDecoder) GetCallTarget(_ DecodedInstruction, _ uint64) (
 	return 0, false
 }
 
-func (m *MockMachineCodeDecoder) IsFirstArgImm(_ DecodedInstruction) (int64, bool) {
-	return 0, false
+func (m *MockMachineCodeDecoder) IsFirstArgImm(_ DecodedInstruction) (bool, int64) {
+	return false, 0
 }
 
 func (m *MockMachineCodeDecoder) ModifiesFirstArg(_ DecodedInstruction) bool {
 	return false
 }
 
-func (m *MockMachineCodeDecoder) ResolveFirstArgGlobal(_ []DecodedInstruction, _ int) (int64, bool) {
-	return 0, false
+func (m *MockMachineCodeDecoder) ResolveFirstArgGlobal(_ []DecodedInstruction, _ int) (bool, int64) {
+	return false, 0
 }
 
 func (m *MockMachineCodeDecoder) ModifiesThirdArg(_ DecodedInstruction) bool {

--- a/internal/runner/security/elfanalyzer/syscall_analyzer_test.go
+++ b/internal/runner/security/elfanalyzer/syscall_analyzer_test.go
@@ -22,11 +22,11 @@ func (m *MockMachineCodeDecoder) IsSyscallInstruction(_ DecodedInstruction) bool
 	return false
 }
 
-func (m *MockMachineCodeDecoder) ModifiesSyscallNumberRegister(_ DecodedInstruction) bool {
+func (m *MockMachineCodeDecoder) ModifiesSyscallReg(_ DecodedInstruction) bool {
 	return false
 }
 
-func (m *MockMachineCodeDecoder) IsImmediateToSyscallNumberRegister(_ DecodedInstruction) (bool, int64) {
+func (m *MockMachineCodeDecoder) IsSyscallNumImm(_ DecodedInstruction) (bool, int64) {
 	return false, 0
 }
 
@@ -46,23 +46,23 @@ func (m *MockMachineCodeDecoder) GetCallTarget(_ DecodedInstruction, _ uint64) (
 	return 0, false
 }
 
-func (m *MockMachineCodeDecoder) IsImmediateToFirstArgRegister(_ DecodedInstruction) (int64, bool) {
+func (m *MockMachineCodeDecoder) IsFirstArgImm(_ DecodedInstruction) (int64, bool) {
 	return 0, false
 }
 
-func (m *MockMachineCodeDecoder) ModifiesFirstArgRegister(_ DecodedInstruction) bool {
+func (m *MockMachineCodeDecoder) ModifiesFirstArg(_ DecodedInstruction) bool {
 	return false
 }
 
-func (m *MockMachineCodeDecoder) TryResolveFirstArgFromGlobalLoad(_ []DecodedInstruction, _ int) (int64, bool) {
+func (m *MockMachineCodeDecoder) ResolveFirstArgGlobal(_ []DecodedInstruction, _ int) (int64, bool) {
 	return 0, false
 }
 
-func (m *MockMachineCodeDecoder) ModifiesThirdArgRegister(_ DecodedInstruction) bool {
+func (m *MockMachineCodeDecoder) ModifiesThirdArg(_ DecodedInstruction) bool {
 	return false
 }
 
-func (m *MockMachineCodeDecoder) IsImmediateToThirdArgRegister(_ DecodedInstruction) (bool, int64) {
+func (m *MockMachineCodeDecoder) IsThirdArgImm(_ DecodedInstruction) (bool, int64) {
 	return false, 0
 }
 
@@ -423,7 +423,7 @@ func TestSyscallAnalyzer_DecodeInstructionsInWindow(t *testing.T) {
 
 	// Decode window [0, 6) - should decode "mov" and "nop" but not "syscall"
 	cfg := analyzer.archConfigs[elf.EM_X86_64]
-	instructions, decodeFailures := analyzer.decodeInstructionsInWindow(code, 0, 0, 6, cfg.decoder)
+	instructions, decodeFailures := analyzer.decodeWindow(code, 0, 0, 6, cfg.decoder)
 	require.Len(t, instructions, 2) // mov (5 bytes) + nop (1 byte)
 	assert.Equal(t, 0, decodeFailures)
 
@@ -527,7 +527,7 @@ func TestSyscallAnalyzer_WindowExhausted(t *testing.T) {
 }
 
 func TestSyscallAnalyzer_DecodeInstructionsInWindow_NonPositiveLength(t *testing.T) {
-	// Test that decodeInstructionsInWindow panics when decoder returns
+	// Test that decodeWindow panics when decoder returns
 	// non-positive instruction lengths, indicating a programming bug.
 	code := []byte{0x90, 0x90, 0x90} // 3 nop instructions
 
@@ -546,12 +546,12 @@ func TestSyscallAnalyzer_DecodeInstructionsInWindow_NonPositiveLength(t *testing
 
 	// This should panic because returning Len=0 without error is a programming bug.
 	assert.Panics(t, func() {
-		analyzer.decodeInstructionsInWindow(code, 0, 0, 3, analyzer.archConfigs[elf.EM_X86_64].decoder)
+		analyzer.decodeWindow(code, 0, 0, 3, analyzer.archConfigs[elf.EM_X86_64].decoder)
 	}, "expected panic when decoder returns non-positive instruction length")
 }
 
 func TestSyscallAnalyzer_DecodeInstructionsInWindow_NegativeLength(t *testing.T) {
-	// Test that decodeInstructionsInWindow panics when decoder returns negative lengths.
+	// Test that decodeWindow panics when decoder returns negative lengths.
 	code := []byte{0x90, 0x90, 0x90} // 3 nop instructions
 
 	// Create a mock decoder that returns negative lengths
@@ -569,7 +569,7 @@ func TestSyscallAnalyzer_DecodeInstructionsInWindow_NegativeLength(t *testing.T)
 
 	// This should panic because returning Len=-1 without error is a programming bug.
 	assert.Panics(t, func() {
-		analyzer.decodeInstructionsInWindow(code, 0, 0, 3, analyzer.archConfigs[elf.EM_X86_64].decoder)
+		analyzer.decodeWindow(code, 0, 0, 3, analyzer.archConfigs[elf.EM_X86_64].decoder)
 	}, "expected panic when decoder returns negative instruction length")
 }
 

--- a/internal/runner/security/elfanalyzer/syscall_decoder.go
+++ b/internal/runner/security/elfanalyzer/syscall_decoder.go
@@ -71,13 +71,13 @@ type MachineCodeDecoder interface {
 	// Returns (addr, true) on success, (0, false) otherwise.
 	GetCallTarget(inst DecodedInstruction, instAddr uint64) (uint64, bool)
 
-	// IsFirstArgImm returns (value, true) if the instruction
+	// IsFirstArgImm returns (true, value) if the instruction
 	// sets the first integer argument register to a known immediate.
 	// x86_64: MOV EAX/RAX, imm  (RAX is the first argument register in Go ABI)
 	// arm64:  MOV W0/X0, #imm   (X0 is the first argument register in Go ABI)
 	//         ORR X0/W0, XZR/WZR, #imm  (bitmask-immediate encoding)
-	// Returns (0, false) otherwise.
-	IsFirstArgImm(inst DecodedInstruction) (int64, bool)
+	// Returns (false, 0) otherwise.
+	IsFirstArgImm(inst DecodedInstruction) (bool, int64)
 
 	// ModifiesFirstArg returns true if the instruction writes to the
 	// first integer argument register.
@@ -88,8 +88,8 @@ type MachineCodeDecoder interface {
 	// ResolveFirstArgGlobal tries to resolve the first argument value
 	// when it is loaded from memory, using nearby context in recentInstructions.
 	// idx is the index of the candidate load instruction in recentInstructions.
-	// Returns (value, true) if resolved, (0, false) otherwise.
-	ResolveFirstArgGlobal(recentInstructions []DecodedInstruction, idx int) (int64, bool)
+	// Returns (true, value) if resolved, (false, 0) otherwise.
+	ResolveFirstArgGlobal(recentInstructions []DecodedInstruction, idx int) (bool, int64)
 
 	// ModifiesThirdArg returns true if the instruction writes to the
 	// third syscall argument register.

--- a/internal/runner/security/elfanalyzer/syscall_decoder.go
+++ b/internal/runner/security/elfanalyzer/syscall_decoder.go
@@ -35,18 +35,18 @@ type MachineCodeDecoder interface {
 	// arm64:  SVC #0 (D4000001)
 	IsSyscallInstruction(inst DecodedInstruction) bool
 
-	// ModifiesSyscallNumberRegister returns true if the instruction writes
+	// ModifiesSyscallReg returns true if the instruction writes
 	// to the architecture's syscall number register.
 	// x86_64: eax/rax (any write including al, ax, r/eax)
 	// arm64:  w8 or x8
-	ModifiesSyscallNumberRegister(inst DecodedInstruction) bool
+	ModifiesSyscallReg(inst DecodedInstruction) bool
 
-	// IsImmediateToSyscallNumberRegister returns (true, value) if the
+	// IsSyscallNumImm returns (true, value) if the
 	// instruction sets the syscall number register to a known immediate.
 	// x86_64: MOV EAX/RAX, imm  or  XOR EAX, EAX (zeroing idiom)
 	// arm64:  MOV W8/X8, #imm  (arm64asm normalizes MOVZ to MOV)
 	//         ORR W8/X8, WZR/XZR, #imm  (bitmask-immediate encoding)
-	IsImmediateToSyscallNumberRegister(inst DecodedInstruction) (bool, int64)
+	IsSyscallNumImm(inst DecodedInstruction) (bool, int64)
 
 	// IsControlFlowInstruction returns true if the instruction changes the
 	// instruction pointer in a way that may skip over the syscall number setup.
@@ -71,36 +71,36 @@ type MachineCodeDecoder interface {
 	// Returns (addr, true) on success, (0, false) otherwise.
 	GetCallTarget(inst DecodedInstruction, instAddr uint64) (uint64, bool)
 
-	// IsImmediateToFirstArgRegister returns (value, true) if the instruction
+	// IsFirstArgImm returns (value, true) if the instruction
 	// sets the first integer argument register to a known immediate.
 	// x86_64: MOV EAX/RAX, imm  (RAX is the first argument register in Go ABI)
 	// arm64:  MOV W0/X0, #imm   (X0 is the first argument register in Go ABI)
 	//         ORR X0/W0, XZR/WZR, #imm  (bitmask-immediate encoding)
 	// Returns (0, false) otherwise.
-	IsImmediateToFirstArgRegister(inst DecodedInstruction) (int64, bool)
+	IsFirstArgImm(inst DecodedInstruction) (int64, bool)
 
-	// ModifiesFirstArgRegister returns true if the instruction writes to the
+	// ModifiesFirstArg returns true if the instruction writes to the
 	// first integer argument register.
 	// x86_64: eax/rax (same as syscall number register in Go ABI)
 	// arm64:  w0 or x0
-	ModifiesFirstArgRegister(inst DecodedInstruction) bool
+	ModifiesFirstArg(inst DecodedInstruction) bool
 
-	// TryResolveFirstArgFromGlobalLoad tries to resolve the first argument value
+	// ResolveFirstArgGlobal tries to resolve the first argument value
 	// when it is loaded from memory, using nearby context in recentInstructions.
 	// idx is the index of the candidate load instruction in recentInstructions.
 	// Returns (value, true) if resolved, (0, false) otherwise.
-	TryResolveFirstArgFromGlobalLoad(recentInstructions []DecodedInstruction, idx int) (int64, bool)
+	ResolveFirstArgGlobal(recentInstructions []DecodedInstruction, idx int) (int64, bool)
 
-	// ModifiesThirdArgRegister returns true if the instruction writes to the
+	// ModifiesThirdArg returns true if the instruction writes to the
 	// third syscall argument register.
 	// x86_64: edx/rdx (any write including dl, dx, edx/rdx)
 	// arm64:  w2 or x2
-	ModifiesThirdArgRegister(inst DecodedInstruction) bool
+	ModifiesThirdArg(inst DecodedInstruction) bool
 
-	// IsImmediateToThirdArgRegister returns (true, value) if the instruction
+	// IsThirdArgImm returns (true, value) if the instruction
 	// sets the third argument register to a known immediate.
 	// x86_64: MOV EDX/RDX, imm  or  XOR EDX, EDX (zeroing idiom)
 	// arm64:  MOV W2/X2, #imm
 	//         ORR W2/X2, WZR/XZR, #imm  (bitmask-immediate encoding)
-	IsImmediateToThirdArgRegister(inst DecodedInstruction) (bool, int64)
+	IsThirdArgImm(inst DecodedInstruction) (bool, int64)
 }

--- a/internal/runner/security/elfanalyzer/x86_decoder.go
+++ b/internal/runner/security/elfanalyzer/x86_decoder.go
@@ -91,8 +91,8 @@ func implicitlyWritesRAXEAX(x86inst x86asm.Inst) bool {
 	return false
 }
 
-// ModifiesSyscallNumberRegister checks if the instruction modifies eax or rax.
-func (d *X86Decoder) ModifiesSyscallNumberRegister(inst DecodedInstruction) bool {
+// ModifiesSyscallReg checks if the instruction modifies eax or rax.
+func (d *X86Decoder) ModifiesSyscallReg(inst DecodedInstruction) bool {
 	x86inst, ok := inst.arch.(x86asm.Inst)
 	if !ok {
 		return false
@@ -126,11 +126,11 @@ func (d *X86Decoder) ModifiesSyscallNumberRegister(inst DecodedInstruction) bool
 	return false
 }
 
-// IsImmediateToSyscallNumberRegister checks if the instruction sets eax/rax to a known immediate value.
+// IsSyscallNumImm checks if the instruction sets eax/rax to a known immediate value.
 // This covers two common compiler patterns:
 //   - MOV EAX/RAX, <imm>  — direct immediate load
 //   - XOR EAX, EAX        — idiom for zeroing EAX (equivalent to MOV EAX, 0)
-func (d *X86Decoder) IsImmediateToSyscallNumberRegister(inst DecodedInstruction) (bool, int64) {
+func (d *X86Decoder) IsSyscallNumImm(inst DecodedInstruction) (bool, int64) {
 	return d.isImmediateToReg(inst, func(reg x86asm.Reg) bool {
 		return reg == x86asm.EAX || reg == x86asm.RAX
 	})
@@ -249,27 +249,27 @@ func (d *X86Decoder) GetCallTarget(inst DecodedInstruction, instAddr uint64) (ui
 	return uint64(displacement), true
 }
 
-// IsImmediateToFirstArgRegister returns (value, true) if the instruction
+// IsFirstArgImm returns (value, true) if the instruction
 // sets the first argument register (RAX/EAX for x86_64 Go ABI) to an immediate.
 // Returns (0, false) otherwise.
-// Note: same as IsImmediateToSyscallNumberRegister for x86_64 (RAX is both syscall
+// Note: same as IsSyscallNumImm for x86_64 (RAX is both syscall
 // number register and first argument register in Go's register-based ABI).
-func (d *X86Decoder) IsImmediateToFirstArgRegister(inst DecodedInstruction) (int64, bool) {
+func (d *X86Decoder) IsFirstArgImm(inst DecodedInstruction) (int64, bool) {
 	ok, val := d.isImmediateToReg(inst, func(reg x86asm.Reg) bool {
 		return reg == x86asm.RAX || reg == x86asm.EAX
 	})
 	return val, ok
 }
 
-// ModifiesFirstArgRegister returns true if the instruction writes to the
+// ModifiesFirstArg returns true if the instruction writes to the
 // first argument register in x86_64 Go ABI (RAX/EAX).
-func (d *X86Decoder) ModifiesFirstArgRegister(inst DecodedInstruction) bool {
-	return d.ModifiesSyscallNumberRegister(inst)
+func (d *X86Decoder) ModifiesFirstArg(inst DecodedInstruction) bool {
+	return d.ModifiesSyscallReg(inst)
 }
 
-// TryResolveFirstArgFromGlobalLoad returns unresolved on x86_64.
+// ResolveFirstArgGlobal returns unresolved on x86_64.
 // The current Go wrapper resolution path only uses immediate assignments.
-func (d *X86Decoder) TryResolveFirstArgFromGlobalLoad(_ []DecodedInstruction, _ int) (int64, bool) {
+func (d *X86Decoder) ResolveFirstArgGlobal(_ []DecodedInstruction, _ int) (int64, bool) {
 	return 0, false
 }
 
@@ -301,8 +301,8 @@ func implicitlyWritesRDXEDX(x86inst x86asm.Inst) bool {
 	return false
 }
 
-// ModifiesThirdArgRegister checks if the instruction modifies edx or rdx.
-func (d *X86Decoder) ModifiesThirdArgRegister(inst DecodedInstruction) bool {
+// ModifiesThirdArg checks if the instruction modifies edx or rdx.
+func (d *X86Decoder) ModifiesThirdArg(inst DecodedInstruction) bool {
 	x86inst, ok := inst.arch.(x86asm.Inst)
 	if !ok {
 		return false
@@ -337,9 +337,9 @@ func (d *X86Decoder) ModifiesThirdArgRegister(inst DecodedInstruction) bool {
 	return false
 }
 
-// IsImmediateToThirdArgRegister checks if the instruction sets edx/rdx to a known
+// IsThirdArgImm checks if the instruction sets edx/rdx to a known
 // immediate value. Covers MOV EDX/RDX, imm and XOR EDX, EDX (zeroing idiom).
-func (d *X86Decoder) IsImmediateToThirdArgRegister(inst DecodedInstruction) (bool, int64) {
+func (d *X86Decoder) IsThirdArgImm(inst DecodedInstruction) (bool, int64) {
 	return d.isImmediateToReg(inst, func(reg x86asm.Reg) bool {
 		return reg == x86asm.EDX || reg == x86asm.RDX
 	})

--- a/internal/runner/security/elfanalyzer/x86_decoder.go
+++ b/internal/runner/security/elfanalyzer/x86_decoder.go
@@ -254,11 +254,11 @@ func (d *X86Decoder) GetCallTarget(inst DecodedInstruction, instAddr uint64) (ui
 // Returns (0, false) otherwise.
 // Note: same as IsSyscallNumImm for x86_64 (RAX is both syscall
 // number register and first argument register in Go's register-based ABI).
-func (d *X86Decoder) IsFirstArgImm(inst DecodedInstruction) (int64, bool) {
+func (d *X86Decoder) IsFirstArgImm(inst DecodedInstruction) (bool, int64) {
 	ok, val := d.isImmediateToReg(inst, func(reg x86asm.Reg) bool {
 		return reg == x86asm.RAX || reg == x86asm.EAX
 	})
-	return val, ok
+	return ok, val
 }
 
 // ModifiesFirstArg returns true if the instruction writes to the
@@ -269,8 +269,8 @@ func (d *X86Decoder) ModifiesFirstArg(inst DecodedInstruction) bool {
 
 // ResolveFirstArgGlobal returns unresolved on x86_64.
 // The current Go wrapper resolution path only uses immediate assignments.
-func (d *X86Decoder) ResolveFirstArgGlobal(_ []DecodedInstruction, _ int) (int64, bool) {
-	return 0, false
+func (d *X86Decoder) ResolveFirstArgGlobal(_ []DecodedInstruction, _ int) (bool, int64) {
+	return false, 0
 }
 
 // implicitlyWritesRDXEDX reports whether the instruction unconditionally writes

--- a/internal/runner/security/elfanalyzer/x86_decoder_test.go
+++ b/internal/runner/security/elfanalyzer/x86_decoder_test.go
@@ -104,7 +104,7 @@ func TestX86Decoder_IsSyscallInstruction(t *testing.T) {
 	}
 }
 
-func TestX86Decoder_ModifiesSyscallNumberRegister(t *testing.T) {
+func TestX86Decoder_ModifiesSyscallReg(t *testing.T) {
 	decoder := NewX86Decoder()
 
 	tests := []struct {
@@ -209,12 +209,12 @@ func TestX86Decoder_ModifiesSyscallNumberRegister(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			inst, err := decoder.Decode(tt.code, 0)
 			require.NoError(t, err)
-			assert.Equal(t, tt.want, decoder.ModifiesSyscallNumberRegister(inst))
+			assert.Equal(t, tt.want, decoder.ModifiesSyscallReg(inst))
 		})
 	}
 }
 
-func TestX86Decoder_IsImmediateToSyscallNumberRegister(t *testing.T) {
+func TestX86Decoder_IsSyscallNumImm(t *testing.T) {
 	decoder := NewX86Decoder()
 
 	tests := []struct {
@@ -266,7 +266,7 @@ func TestX86Decoder_IsImmediateToSyscallNumberRegister(t *testing.T) {
 			inst, err := decoder.Decode(tt.code, 0)
 			require.NoError(t, err)
 
-			gotImm, gotVal := decoder.IsImmediateToSyscallNumberRegister(inst)
+			gotImm, gotVal := decoder.IsSyscallNumImm(inst)
 			assert.Equal(t, tt.wantImm, gotImm)
 			if tt.wantImm {
 				assert.Equal(t, tt.wantVal, gotVal)
@@ -345,7 +345,7 @@ func TestX86Decoder_GetCallTarget(t *testing.T) {
 	})
 }
 
-func TestX86Decoder_IsImmediateToFirstArgRegister(t *testing.T) {
+func TestX86Decoder_IsFirstArgImm(t *testing.T) {
 	decoder := NewX86Decoder()
 
 	// In Go's register-based ABI for amd64, the first argument register is AX/EAX.
@@ -356,7 +356,7 @@ func TestX86Decoder_IsImmediateToFirstArgRegister(t *testing.T) {
 		code := []byte{0xb8, 0x29, 0x00, 0x00, 0x00}
 		inst, err := decoder.Decode(code, 0)
 		require.NoError(t, err)
-		imm, ok := decoder.IsImmediateToFirstArgRegister(inst)
+		imm, ok := decoder.IsFirstArgImm(inst)
 		assert.True(t, ok)
 		assert.Equal(t, int64(0x29), imm)
 	})
@@ -366,7 +366,7 @@ func TestX86Decoder_IsImmediateToFirstArgRegister(t *testing.T) {
 		code := []byte{0x48, 0xc7, 0xc0, 0x29, 0x00, 0x00, 0x00}
 		inst, err := decoder.Decode(code, 0)
 		require.NoError(t, err)
-		imm, ok := decoder.IsImmediateToFirstArgRegister(inst)
+		imm, ok := decoder.IsFirstArgImm(inst)
 		assert.True(t, ok)
 		assert.Equal(t, int64(0x29), imm)
 	})
@@ -376,7 +376,7 @@ func TestX86Decoder_IsImmediateToFirstArgRegister(t *testing.T) {
 		code := []byte{0x48, 0xc7, 0xc7, 0x29, 0x00, 0x00, 0x00}
 		inst, err := decoder.Decode(code, 0)
 		require.NoError(t, err)
-		_, ok := decoder.IsImmediateToFirstArgRegister(inst)
+		_, ok := decoder.IsFirstArgImm(inst)
 		assert.False(t, ok)
 	})
 
@@ -384,12 +384,12 @@ func TestX86Decoder_IsImmediateToFirstArgRegister(t *testing.T) {
 		code := []byte{0x90} // nop
 		inst, err := decoder.Decode(code, 0)
 		require.NoError(t, err)
-		_, ok := decoder.IsImmediateToFirstArgRegister(inst)
+		_, ok := decoder.IsFirstArgImm(inst)
 		assert.False(t, ok)
 	})
 }
 
-func TestX86Decoder_ModifiesThirdArgRegister(t *testing.T) {
+func TestX86Decoder_ModifiesThirdArg(t *testing.T) {
 	decoder := NewX86Decoder()
 
 	t.Run("mov imm to EDX returns true", func(t *testing.T) {
@@ -397,7 +397,7 @@ func TestX86Decoder_ModifiesThirdArgRegister(t *testing.T) {
 		code := []byte{0xba, 0x07, 0x00, 0x00, 0x00}
 		inst, err := decoder.Decode(code, 0)
 		require.NoError(t, err)
-		assert.True(t, decoder.ModifiesThirdArgRegister(inst))
+		assert.True(t, decoder.ModifiesThirdArg(inst))
 	})
 
 	t.Run("mov imm to RDX returns true", func(t *testing.T) {
@@ -405,7 +405,7 @@ func TestX86Decoder_ModifiesThirdArgRegister(t *testing.T) {
 		code := []byte{0x48, 0xc7, 0xc2, 0x07, 0x00, 0x00, 0x00}
 		inst, err := decoder.Decode(code, 0)
 		require.NoError(t, err)
-		assert.True(t, decoder.ModifiesThirdArgRegister(inst))
+		assert.True(t, decoder.ModifiesThirdArg(inst))
 	})
 
 	t.Run("mov reg to RDX returns true", func(t *testing.T) {
@@ -413,7 +413,7 @@ func TestX86Decoder_ModifiesThirdArgRegister(t *testing.T) {
 		code := []byte{0x48, 0x89, 0xf2}
 		inst, err := decoder.Decode(code, 0)
 		require.NoError(t, err)
-		assert.True(t, decoder.ModifiesThirdArgRegister(inst))
+		assert.True(t, decoder.ModifiesThirdArg(inst))
 	})
 
 	t.Run("xor EDX EDX returns true", func(t *testing.T) {
@@ -421,7 +421,7 @@ func TestX86Decoder_ModifiesThirdArgRegister(t *testing.T) {
 		code := []byte{0x31, 0xd2}
 		inst, err := decoder.Decode(code, 0)
 		require.NoError(t, err)
-		assert.True(t, decoder.ModifiesThirdArgRegister(inst))
+		assert.True(t, decoder.ModifiesThirdArg(inst))
 	})
 
 	t.Run("mov imm to EAX returns false (wrong register)", func(t *testing.T) {
@@ -429,14 +429,14 @@ func TestX86Decoder_ModifiesThirdArgRegister(t *testing.T) {
 		code := []byte{0xb8, 0x07, 0x00, 0x00, 0x00}
 		inst, err := decoder.Decode(code, 0)
 		require.NoError(t, err)
-		assert.False(t, decoder.ModifiesThirdArgRegister(inst))
+		assert.False(t, decoder.ModifiesThirdArg(inst))
 	})
 
 	t.Run("nop returns false", func(t *testing.T) {
 		code := []byte{0x90}
 		inst, err := decoder.Decode(code, 0)
 		require.NoError(t, err)
-		assert.False(t, decoder.ModifiesThirdArgRegister(inst))
+		assert.False(t, decoder.ModifiesThirdArg(inst))
 	})
 
 	t.Run("push rdx returns false (reads rdx, not a write)", func(t *testing.T) {
@@ -444,7 +444,7 @@ func TestX86Decoder_ModifiesThirdArgRegister(t *testing.T) {
 		code := []byte{0x52}
 		inst, err := decoder.Decode(code, 0)
 		require.NoError(t, err)
-		assert.False(t, decoder.ModifiesThirdArgRegister(inst))
+		assert.False(t, decoder.ModifiesThirdArg(inst))
 	})
 
 	t.Run("cmp edx imm returns false (sets flags only)", func(t *testing.T) {
@@ -452,7 +452,7 @@ func TestX86Decoder_ModifiesThirdArgRegister(t *testing.T) {
 		code := []byte{0x83, 0xfa, 0x05}
 		inst, err := decoder.Decode(code, 0)
 		require.NoError(t, err)
-		assert.False(t, decoder.ModifiesThirdArgRegister(inst))
+		assert.False(t, decoder.ModifiesThirdArg(inst))
 	})
 
 	t.Run("test edx edx returns false (sets flags only)", func(t *testing.T) {
@@ -460,7 +460,7 @@ func TestX86Decoder_ModifiesThirdArgRegister(t *testing.T) {
 		code := []byte{0x85, 0xd2}
 		inst, err := decoder.Decode(code, 0)
 		require.NoError(t, err)
-		assert.False(t, decoder.ModifiesThirdArgRegister(inst))
+		assert.False(t, decoder.ModifiesThirdArg(inst))
 	})
 
 	t.Run("mul ecx returns true (implicit RDX write)", func(t *testing.T) {
@@ -468,7 +468,7 @@ func TestX86Decoder_ModifiesThirdArgRegister(t *testing.T) {
 		code := []byte{0xf7, 0xe1}
 		inst, err := decoder.Decode(code, 0)
 		require.NoError(t, err)
-		assert.True(t, decoder.ModifiesThirdArgRegister(inst))
+		assert.True(t, decoder.ModifiesThirdArg(inst))
 	})
 
 	t.Run("imul ecx one-operand returns true (implicit RDX write)", func(t *testing.T) {
@@ -476,7 +476,7 @@ func TestX86Decoder_ModifiesThirdArgRegister(t *testing.T) {
 		code := []byte{0xf7, 0xe9}
 		inst, err := decoder.Decode(code, 0)
 		require.NoError(t, err)
-		assert.True(t, decoder.ModifiesThirdArgRegister(inst))
+		assert.True(t, decoder.ModifiesThirdArg(inst))
 	})
 
 	t.Run("imul eax ecx two-operand returns false (result only in EAX)", func(t *testing.T) {
@@ -484,7 +484,7 @@ func TestX86Decoder_ModifiesThirdArgRegister(t *testing.T) {
 		code := []byte{0x0f, 0xaf, 0xc1}
 		inst, err := decoder.Decode(code, 0)
 		require.NoError(t, err)
-		assert.False(t, decoder.ModifiesThirdArgRegister(inst))
+		assert.False(t, decoder.ModifiesThirdArg(inst))
 	})
 
 	t.Run("div ecx returns true (remainder → EDX)", func(t *testing.T) {
@@ -492,7 +492,7 @@ func TestX86Decoder_ModifiesThirdArgRegister(t *testing.T) {
 		code := []byte{0xf7, 0xf1}
 		inst, err := decoder.Decode(code, 0)
 		require.NoError(t, err)
-		assert.True(t, decoder.ModifiesThirdArgRegister(inst))
+		assert.True(t, decoder.ModifiesThirdArg(inst))
 	})
 
 	t.Run("idiv ecx returns true (remainder → EDX)", func(t *testing.T) {
@@ -500,7 +500,7 @@ func TestX86Decoder_ModifiesThirdArgRegister(t *testing.T) {
 		code := []byte{0xf7, 0xf9}
 		inst, err := decoder.Decode(code, 0)
 		require.NoError(t, err)
-		assert.True(t, decoder.ModifiesThirdArgRegister(inst))
+		assert.True(t, decoder.ModifiesThirdArg(inst))
 	})
 
 	t.Run("cqo returns true (sign-extends RAX into RDX)", func(t *testing.T) {
@@ -508,7 +508,7 @@ func TestX86Decoder_ModifiesThirdArgRegister(t *testing.T) {
 		code := []byte{0x48, 0x99}
 		inst, err := decoder.Decode(code, 0)
 		require.NoError(t, err)
-		assert.True(t, decoder.ModifiesThirdArgRegister(inst))
+		assert.True(t, decoder.ModifiesThirdArg(inst))
 	})
 
 	t.Run("cdq returns true (sign-extends EAX into EDX)", func(t *testing.T) {
@@ -516,7 +516,7 @@ func TestX86Decoder_ModifiesThirdArgRegister(t *testing.T) {
 		code := []byte{0x99}
 		inst, err := decoder.Decode(code, 0)
 		require.NoError(t, err)
-		assert.True(t, decoder.ModifiesThirdArgRegister(inst))
+		assert.True(t, decoder.ModifiesThirdArg(inst))
 	})
 
 	t.Run("cwd returns true (sign-extends AX into DX)", func(t *testing.T) {
@@ -524,7 +524,7 @@ func TestX86Decoder_ModifiesThirdArgRegister(t *testing.T) {
 		code := []byte{0x66, 0x99}
 		inst, err := decoder.Decode(code, 0)
 		require.NoError(t, err)
-		assert.True(t, decoder.ModifiesThirdArgRegister(inst))
+		assert.True(t, decoder.ModifiesThirdArg(inst))
 	})
 
 	t.Run("mov imm to DH returns true (overlaps EDX/RDX)", func(t *testing.T) {
@@ -532,11 +532,11 @@ func TestX86Decoder_ModifiesThirdArgRegister(t *testing.T) {
 		code := []byte{0xb6, 0x01}
 		inst, err := decoder.Decode(code, 0)
 		require.NoError(t, err)
-		assert.True(t, decoder.ModifiesThirdArgRegister(inst))
+		assert.True(t, decoder.ModifiesThirdArg(inst))
 	})
 }
 
-func TestX86Decoder_IsImmediateToThirdArgRegister(t *testing.T) {
+func TestX86Decoder_IsThirdArgImm(t *testing.T) {
 	decoder := NewX86Decoder()
 
 	t.Run("mov imm to RDX (64bit) returns value", func(t *testing.T) {
@@ -544,7 +544,7 @@ func TestX86Decoder_IsImmediateToThirdArgRegister(t *testing.T) {
 		code := []byte{0x48, 0xc7, 0xc2, 0x07, 0x00, 0x00, 0x00}
 		inst, err := decoder.Decode(code, 0)
 		require.NoError(t, err)
-		ok, val := decoder.IsImmediateToThirdArgRegister(inst)
+		ok, val := decoder.IsThirdArgImm(inst)
 		assert.True(t, ok)
 		assert.Equal(t, int64(7), val)
 	})
@@ -554,7 +554,7 @@ func TestX86Decoder_IsImmediateToThirdArgRegister(t *testing.T) {
 		code := []byte{0xba, 0x04, 0x00, 0x00, 0x00}
 		inst, err := decoder.Decode(code, 0)
 		require.NoError(t, err)
-		ok, val := decoder.IsImmediateToThirdArgRegister(inst)
+		ok, val := decoder.IsThirdArgImm(inst)
 		assert.True(t, ok)
 		assert.Equal(t, int64(4), val)
 	})
@@ -564,7 +564,7 @@ func TestX86Decoder_IsImmediateToThirdArgRegister(t *testing.T) {
 		code := []byte{0xba, 0x03, 0x00, 0x00, 0x00}
 		inst, err := decoder.Decode(code, 0)
 		require.NoError(t, err)
-		ok, val := decoder.IsImmediateToThirdArgRegister(inst)
+		ok, val := decoder.IsThirdArgImm(inst)
 		assert.True(t, ok)
 		assert.Equal(t, int64(3), val)
 	})
@@ -574,7 +574,7 @@ func TestX86Decoder_IsImmediateToThirdArgRegister(t *testing.T) {
 		code := []byte{0x48, 0x89, 0xf2}
 		inst, err := decoder.Decode(code, 0)
 		require.NoError(t, err)
-		ok, _ := decoder.IsImmediateToThirdArgRegister(inst)
+		ok, _ := decoder.IsThirdArgImm(inst)
 		assert.False(t, ok)
 	})
 
@@ -583,7 +583,7 @@ func TestX86Decoder_IsImmediateToThirdArgRegister(t *testing.T) {
 		code := []byte{0x31, 0xd2}
 		inst, err := decoder.Decode(code, 0)
 		require.NoError(t, err)
-		ok, val := decoder.IsImmediateToThirdArgRegister(inst)
+		ok, val := decoder.IsThirdArgImm(inst)
 		assert.True(t, ok)
 		assert.Equal(t, int64(0), val)
 	})
@@ -593,30 +593,30 @@ func TestX86Decoder_IsImmediateToThirdArgRegister(t *testing.T) {
 		code := []byte{0xb8, 0x07, 0x00, 0x00, 0x00}
 		inst, err := decoder.Decode(code, 0)
 		require.NoError(t, err)
-		ok, _ := decoder.IsImmediateToThirdArgRegister(inst)
+		ok, _ := decoder.IsThirdArgImm(inst)
 		assert.False(t, ok)
 	})
 }
 
-func TestX86Decoder_ModifiesFirstArgRegister(t *testing.T) {
+func TestX86Decoder_ModifiesFirstArg(t *testing.T) {
 	decoder := NewX86Decoder()
 
 	t.Run("mov imm to EAX returns true", func(t *testing.T) {
 		inst, err := decoder.Decode([]byte{0xb8, 0x2a, 0x00, 0x00, 0x00}, 0)
 		require.NoError(t, err)
-		assert.True(t, decoder.ModifiesFirstArgRegister(inst))
+		assert.True(t, decoder.ModifiesFirstArg(inst))
 	})
 
 	t.Run("mov imm to EDX returns false", func(t *testing.T) {
 		inst, err := decoder.Decode([]byte{0xba, 0x07, 0x00, 0x00, 0x00}, 0)
 		require.NoError(t, err)
-		assert.False(t, decoder.ModifiesFirstArgRegister(inst))
+		assert.False(t, decoder.ModifiesFirstArg(inst))
 	})
 }
 
-func TestX86Decoder_TryResolveFirstArgFromGlobalLoad(t *testing.T) {
+func TestX86Decoder_ResolveFirstArgGlobal(t *testing.T) {
 	decoder := NewX86Decoder()
-	value, ok := decoder.TryResolveFirstArgFromGlobalLoad(nil, 0)
+	value, ok := decoder.ResolveFirstArgGlobal(nil, 0)
 	assert.False(t, ok)
 	assert.Equal(t, int64(0), value)
 }

--- a/internal/runner/security/elfanalyzer/x86_decoder_test.go
+++ b/internal/runner/security/elfanalyzer/x86_decoder_test.go
@@ -356,7 +356,7 @@ func TestX86Decoder_IsFirstArgImm(t *testing.T) {
 		code := []byte{0xb8, 0x29, 0x00, 0x00, 0x00}
 		inst, err := decoder.Decode(code, 0)
 		require.NoError(t, err)
-		imm, ok := decoder.IsFirstArgImm(inst)
+		ok, imm := decoder.IsFirstArgImm(inst)
 		assert.True(t, ok)
 		assert.Equal(t, int64(0x29), imm)
 	})
@@ -366,7 +366,7 @@ func TestX86Decoder_IsFirstArgImm(t *testing.T) {
 		code := []byte{0x48, 0xc7, 0xc0, 0x29, 0x00, 0x00, 0x00}
 		inst, err := decoder.Decode(code, 0)
 		require.NoError(t, err)
-		imm, ok := decoder.IsFirstArgImm(inst)
+		ok, imm := decoder.IsFirstArgImm(inst)
 		assert.True(t, ok)
 		assert.Equal(t, int64(0x29), imm)
 	})
@@ -376,7 +376,7 @@ func TestX86Decoder_IsFirstArgImm(t *testing.T) {
 		code := []byte{0x48, 0xc7, 0xc7, 0x29, 0x00, 0x00, 0x00}
 		inst, err := decoder.Decode(code, 0)
 		require.NoError(t, err)
-		_, ok := decoder.IsFirstArgImm(inst)
+		ok, _ := decoder.IsFirstArgImm(inst)
 		assert.False(t, ok)
 	})
 
@@ -384,7 +384,7 @@ func TestX86Decoder_IsFirstArgImm(t *testing.T) {
 		code := []byte{0x90} // nop
 		inst, err := decoder.Decode(code, 0)
 		require.NoError(t, err)
-		_, ok := decoder.IsFirstArgImm(inst)
+		ok, _ := decoder.IsFirstArgImm(inst)
 		assert.False(t, ok)
 	})
 }
@@ -616,7 +616,7 @@ func TestX86Decoder_ModifiesFirstArg(t *testing.T) {
 
 func TestX86Decoder_ResolveFirstArgGlobal(t *testing.T) {
 	decoder := NewX86Decoder()
-	value, ok := decoder.ResolveFirstArgGlobal(nil, 0)
+	ok, value := decoder.ResolveFirstArgGlobal(nil, 0)
 	assert.False(t, ok)
 	assert.Equal(t, int64(0), value)
 }


### PR DESCRIPTION
MachineCodeDecoder interface: drop redundant "Register" suffix, abbreviate "Immediate" to "Imm", remove "Try" prefix (bool return already signals failure), e.g. IsImmediateToSyscallNumberRegister → IsSyscallNumImm.

Internal names: arm64FirstArgLoadInfo → arm64LoadInfo, mprotectFamilyEvalResult → mprotectEvalResult,
decodeInstructionsInWindow → decodeWindow.