### PR TITLE
task(0101): Remove the legacy "risk classification" fields (`IsNetwork` and `Category`) from syscall and symbol analysis

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -49,6 +49,7 @@ linters:
             - github.com/isseis/go-safe-cmd-runner/internal/dynlib
             - github.com/isseis/go-safe-cmd-runner/internal/elfdynlib
             - github.com/isseis/go-safe-cmd-runner/internal/fileanalysis
+            - github.com/isseis/go-safe-cmd-runner/internal/libccache
             - github.com/isseis/go-safe-cmd-runner/internal/machodylib
             - github.com/isseis/go-safe-cmd-runner/internal/redaction
             - github.com/isseis/go-safe-cmd-runner/internal/filevalidator

--- a/docs/tasks/0110_remove_record_risk_classification/02_architecture.md
+++ b/docs/tasks/0110_remove_record_risk_classification/02_architecture.md
@@ -119,9 +119,10 @@ flowchart LR
 | `internal/runner/security/binaryanalyzer/network_symbols.go` | 変更 | `IsNetworkSymbolName` ヘルパー追加 |
 | `internal/runner/security/network_analyzer.go` | 変更 | `syscallAnalysisHasNetworkSignal` を番号ベースに、`convertNetworkSymbolEntries` を名前ベースに変更 |
 
-### 3.2 新規ファイルなし
+### 3.2 新規プロダクションファイルなし
 
-本タスクでは新規ファイルは作成しない。すべての変更は既存ファイルへの修正である。
+本タスクでは新規のプロダクションコードファイルは作成しない。変更は既存ファイルへの修正が中心である。
+ただし、受け入れ基準を満たすために新規テストファイル（例: `internal/fileanalysis/schema_test.go`）を追加することは許容する。
 
 ---
 
@@ -131,13 +132,13 @@ flowchart LR
 
 ```mermaid
 flowchart TD
-    A["SyscallAnalysisData<br>{Architecture: 'x86_64',<br> DetectedSyscalls: [{Number:41, ...}]}"]
+    A["SyscallAnalysisData<br>{Architecture: 'x86_64',<br> DetectedSyscalls: [{Number:socketSyscallNumber, ...}]}"]
     B["syscallAnalysisHasNetworkSignal<br>(result)"]
     C{"arch == ?"}
     D["NewX86_64SyscallTable()"]
     E["NewARM64LinuxSyscallTable()"]
     F["libccache.MacOSSyscallTable{}"]
-    G["IsNetworkSyscall(41) → true"]
+    G["IsNetworkSyscall(socketSyscallNumber) → true"]
     H["return true"]
 
     A --> B
@@ -184,7 +185,7 @@ flowchart TD
 flowchart LR
     A["[]DetectedSymbolEntry<br>{Name: 'getaddrinfo'}<br>{Name: 'read'}"]
     B["convertNetworkSymbolEntries"]
-    C["IsNetworkSymbol(name)"]
+    C["IsNetworkSymbol(name)<br>+ fallback mapping<br>(dynamic_load / syscall_wrapper)"]
     D["[]binaryanalyzer.DetectedSymbol<br>{Name:'getaddrinfo', Category:'dns'}<br>{Name:'read', Category:'syscall_wrapper'}"]
     E["handleAnalysisOutput<br>(ログ出力用に Category 使用)"]
 
@@ -223,7 +224,8 @@ linux, arch=arm64  → elfanalyzer.NewARM64LinuxSyscallTable()
 
 ### 5.3 runner 内部表現（`binaryanalyzer.DetectedSymbol.Category`）の保持
 
-`binaryanalyzer.DetectedSymbol` は runner 内部の表現であり、永続化されない。`Category` フィールドはログ出力（`formatDetectedSymbols`）に使用されているため、削除しない。ただし `convertNetworkSymbolEntries` でのカテゴリ導出を `e.Category`（スキーマ由来）から `IsNetworkSymbol(e.Name)`（ランタイム導出）に切り替える。
+`binaryanalyzer.DetectedSymbol` は runner 内部の表現であり、永続化されない。`Category` フィールドはログ出力（`formatDetectedSymbols`）に使用されているため、削除しない。
+`convertNetworkSymbolEntries` では `e.Category`（スキーマ由来）を使わずにランタイム導出へ切り替える。カテゴリ導出は `IsNetworkSymbol(e.Name)` を優先し、未分類時は `IsDynamicLoadSymbol(e.Name)` なら `dynamic_load`、それ以外は `syscall_wrapper` を設定してログ情報量を維持する。
 
 ---
 

--- a/docs/tasks/0110_remove_record_risk_classification/03_detailed_specification.md
+++ b/docs/tasks/0110_remove_record_risk_classification/03_detailed_specification.md
@@ -128,7 +128,7 @@ group = &SyscallInfo{
     Name:        info.Name,
     Occurrences: make([]SyscallOccurrence, 0),
 }
-// IsNetwork の伝播ロジックを削除（フィールド自体が存在しない）
+// Remove IsNetwork propagation because the field no longer exists.
 ```
 
 ### 3.2 `internal/runner/security/elfanalyzer/syscall_analyzer.go`
@@ -295,8 +295,8 @@ func IsNetworkSymbolName(name string) bool {
 
 ```go
 // syscallTableInterface abstracts syscall number → network classification.
-// Structurally identical to elfanalyzer.SyscallNumberTable (defined locally
-// to avoid depending on a specific package here).
+// This is a subset of elfanalyzer.SyscallNumberTable, defined locally to avoid
+// depending on a specific concrete table type in this package.
 type syscallTableInterface interface {
     IsNetworkSyscall(number int) bool
 }
@@ -386,7 +386,14 @@ func convertNetworkSymbolEntries(entries []fileanalysis.DetectedSymbolEntry) []b
     }
     syms := make([]binaryanalyzer.DetectedSymbol, len(entries))
     for i, e := range entries {
-        cat, _ := binaryanalyzer.IsNetworkSymbol(e.Name)
+        cat, found := binaryanalyzer.IsNetworkSymbol(e.Name)
+        if !found {
+            if binaryanalyzer.IsDynamicLoadSymbol(e.Name) {
+                cat = binaryanalyzer.CategoryDynamicLoad
+            } else {
+                cat = binaryanalyzer.CategorySyscallWrapper
+            }
+        }
         syms[i] = binaryanalyzer.DetectedSymbol{Name: e.Name, Category: string(cat)}
     }
     return syms
@@ -449,7 +456,7 @@ libccache
 
 ### 5.4 `IsNetworkSymbol` の返り値と `DynamicLoadSymbols`
 
-`DynamicLoadSymbols` に含まれるシンボル（dlopen, dlsym, dlvsym）は `binaryanalyzer.IsDynamicLoadSymbol(name)` で識別される。これらは `networkSymbolRegistry` には含まれないため、`IsNetworkSymbol(name)` は `("", false)` を返す。`convertNetworkSymbolEntries` は `DynamicLoadSymbols` にも呼ばれるが、`Category: ""` として扱われ、ログ表示のみに影響する（`IsNetworkCategory("")` は false を返すため、判定ロジックには影響しない）。
+`DynamicLoadSymbols` に含まれるシンボル（dlopen, dlsym, dlvsym）は `binaryanalyzer.IsDynamicLoadSymbol(name)` で識別される。これらは `networkSymbolRegistry` には含まれないため、`IsNetworkSymbol(name)` は `("", false)` を返す。`convertNetworkSymbolEntries` ではこの未分類ケースに対して `dynamic_load` を明示設定し、さらにその他の未分類シンボルには `syscall_wrapper` を設定して、ログの可読性と従来同等の情報量を維持する。
 
 ---
 
@@ -465,7 +472,11 @@ func TestSyscallInfo_JSONDoesNotContainIsNetwork(t *testing.T) {
     info := common.SyscallInfo{Number: 41, Name: "socket"}
     data, err := json.Marshal(info)
     require.NoError(t, err)
-    assert.NotContains(t, string(data), "is_network")
+
+    var got map[string]any
+    require.NoError(t, json.Unmarshal(data, &got))
+    _, exists := got["is_network"]
+    assert.False(t, exists)
 }
 ```
 
@@ -481,7 +492,11 @@ func TestDetectedSymbolEntry_JSONDoesNotContainCategory(t *testing.T) {
     entry := fileanalysis.DetectedSymbolEntry{Name: "getaddrinfo"}
     data, err := json.Marshal(entry)
     require.NoError(t, err)
-    assert.NotContains(t, string(data), "category")
+
+    var got map[string]any
+    require.NoError(t, json.Unmarshal(data, &got))
+    _, exists := got["category"]
+    assert.False(t, exists)
 }
 ```
 
@@ -496,11 +511,16 @@ func TestDetectedSymbolEntry_JSONDoesNotContainCategory(t *testing.T) {
 ```go
 // AC-3a: ネットワーク syscall を含む SyscallAnalysisData
 func TestSyscallAnalysisHasNetworkSignal_NetworkSyscall(t *testing.T) {
+    socketNumber := 41 // Linux x86_64 default
+    if runtime.GOOS == "darwin" {
+        socketNumber = 97 // macOS/BSD socket syscall
+    }
+
     result := &fileanalysis.SyscallAnalysisResult{
         SyscallAnalysisResultCore: common.SyscallAnalysisResultCore{
             Architecture: "x86_64",
             DetectedSyscalls: []common.SyscallInfo{
-                {Number: 41, Name: "socket"}, // x86_64 socket syscall
+                {Number: socketNumber, Name: "socket"},
             },
         },
     }
@@ -509,11 +529,16 @@ func TestSyscallAnalysisHasNetworkSignal_NetworkSyscall(t *testing.T) {
 
 // AC-3b: ネットワーク syscall を含まない SyscallAnalysisData
 func TestSyscallAnalysisHasNetworkSignal_NonNetworkSyscall(t *testing.T) {
+    writeNumber := 1 // Linux x86_64 default
+    if runtime.GOOS == "darwin" {
+        writeNumber = 4 // macOS/BSD write syscall
+    }
+
     result := &fileanalysis.SyscallAnalysisResult{
         SyscallAnalysisResultCore: common.SyscallAnalysisResultCore{
             Architecture: "x86_64",
             DetectedSyscalls: []common.SyscallInfo{
-                {Number: 1, Name: "write"}, // 非ネットワーク syscall
+                {Number: writeNumber, Name: "write"},
             },
         },
     }
@@ -526,7 +551,7 @@ func TestSyscallAnalysisHasNetworkSignal_NonNetworkSyscall(t *testing.T) {
 
 ### AC-4: スキーマバージョンが 18 に更新されている
 
-**テスト対象**: `fileanalysis.CurrentSchemaVersion`、`fileanalysis.Load`
+**テスト対象**: `fileanalysis.CurrentSchemaVersion`、`(*fileanalysis.Store).Load`
 
 ```go
 // AC-4a: CurrentSchemaVersion が 18 であること
@@ -536,9 +561,9 @@ func TestCurrentSchemaVersion(t *testing.T) {
 
 // AC-4b: schema_version=17 のレコードが SchemaVersionMismatchError を返すこと
 func TestLoad_SchemaVersion17_ReturnsError(t *testing.T) {
-    // schema_version: 17 の JSON を構築
-    json := `{"schema_version": 17, ...}`
-    _, err := fileanalysis.Load(...)
+    // NewStore で Store を作成し、schema_version:17 の JSON レコードを書き込む
+    store, _ := fileanalysis.NewStore(analysisDir, &mockPathGetter{})
+    _, err := store.Load(targetPath)
     var mismatch *fileanalysis.SchemaVersionMismatchError
     assert.ErrorAs(t, err, &mismatch)
     assert.Equal(t, 18, mismatch.Expected)
@@ -617,7 +642,7 @@ func TestSyscallAnalysisHasNetworkSignal_Nil(t *testing.T) {
 
 | ケース | 変更前 | 変更後 |
 |-------|--------|--------|
-| syscall 41 (socket, x86_64) が検出された | `IsNetwork=true` → ネットワーク判定 | `IsNetworkSyscall(41)=true` → ネットワーク判定（同等） |
+| syscall socket（OSごとの番号）が検出された | `IsNetwork=true` → ネットワーク判定 | `IsNetworkSyscall(socketNumber)=true` → ネットワーク判定（同等） |
 | syscall 1 (write, x86_64) が検出された | `IsNetwork=false` → 非ネットワーク | `IsNetworkSyscall(1)=false` → 非ネットワーク（同等） |
 | `getaddrinfo` シンボルが検出された | `Category="dns"`, `IsNetworkCategory=true` → ネットワーク | `IsNetworkSymbolName=true` → ネットワーク（同等） |
 | `read` シンボルが検出された | `Category="syscall_wrapper"`, `IsNetworkCategory=false` → 非ネットワーク | `IsNetworkSymbolName=false` → 非ネットワーク（同等） |

--- a/docs/tasks/0110_remove_record_risk_classification/04_implementation_plan.md
+++ b/docs/tasks/0110_remove_record_risk_classification/04_implementation_plan.md
@@ -160,16 +160,16 @@
 - `internal/runner/security/binaryanalyzer/network_symbols_test.go`
 
 作業内容:
-- [ ] AC-1: `TestSyscallInfo_JSONDoesNotContainIsNetwork` を追加する
-- [ ] AC-2: `TestDetectedSymbolEntry_JSONDoesNotContainCategory` を追加する
-- [ ] AC-3a: `TestSyscallAnalysisHasNetworkSignal_NetworkSyscall` を追加する（OS条件付きの syscall 番号を使用: 例 Linux x86_64 socket=41 / Darwin socket=97）
-- [ ] AC-3b: `TestSyscallAnalysisHasNetworkSignal_NonNetworkSyscall` を追加する（OS条件付きの syscall 番号を使用: 例 Linux x86_64 write=1 / Darwin write=4）
-- [ ] AC-4: `TestCurrentSchemaVersion`（値が 18）を追加する
-- [ ] AC-4: `TestLoad_SchemaVersion17_ReturnsSchemaVersionMismatchError` を追加する
-- [ ] AC-7a: `TestSyscallAnalysisHasNetworkSignal_UnknownArch`（mips → ネットワーク検知スキップで false、fail-open）を追加する
-- [ ] AC-7b: `TestSyscallAnalysisHasNetworkSignal_NegativeNumber`（Number=-1 → ネットワーク検知スキップで false、fail-open）を追加する
-- [ ] AC-7c: `TestSyscallAnalysisHasNetworkSignal_Nil`（nil → ネットワーク検知スキップで false、fail-open）を追加する
-- [ ] `TestIsNetworkSymbolName`（dns シンボル/syscall_wrapper/未知シンボルの判定）を追加する
+- [x] AC-1: `TestSyscallInfo_JSONDoesNotContainIsNetwork` を追加する
+- [x] AC-2: `TestDetectedSymbolEntry_JSONDoesNotContainCategory` を追加する
+- [x] AC-3a: `TestSyscallAnalysisHasNetworkSignal_NetworkSyscall` を追加する（OS条件付きの syscall 番号を使用: 例 Linux x86_64 socket=41 / Darwin socket=97）
+- [x] AC-3b: `TestSyscallAnalysisHasNetworkSignal_NonNetworkSyscall` を追加する （OS条件付きの syscall 番号を使用: 例 Linux x86_64 write=1 / Darwin write=4）
+- [x] AC-4: `TestCurrentSchemaVersion`（値が 18）を追加する
+- [x] AC-4: `TestLoad_SchemaVersion17_ReturnsSchemaVersionMismatchError` を追加 する
+- [x] AC-7a: `TestSyscallAnalysisHasNetworkSignal_UnknownArch`（mips → ネットワ ーク検知スキップで false、fail-open）を追加する
+- [x] AC-7b: `TestSyscallAnalysisHasNetworkSignal_NegativeNumber`（Number=-1 →  ネットワーク検知スキップで false、fail-open）を追加する
+- [x] AC-7c: `TestSyscallAnalysisHasNetworkSignal_Nil`（nil → ネットワーク検知スキップで false、fail-open）を追加する
+- [x] `TestIsNetworkSymbolName`（dns シンボル/syscall_wrapper/未知シンボルの判定）を追加する
 
 成功条件:
 - 上記テストがすべて成功する
@@ -182,12 +182,12 @@
 対象: 変更済みコード全体
 
 作業内容:
-- [ ] `make fmt` を実行してフォーマットエラーがないことを確認する
-- [ ] `make test` を実行して全テストが通過することを確認する
-- [ ] `make lint` を実行してリンターエラーがないことを確認する
-- [ ] AC-3（行動不変性）を既存テスト（`network_analyzer_test.go` 等）の通過で確認する
-- [ ] AC-5（スキーマ自動移行）を `Store.Update` 既存テストの通過で確認する
-- [ ] 実装計画書のチェックボックスをすべて完了に更新する
+- [x] `make fmt` を実行してフォーマットエラーがないことを確認する
+- [x] `make test` を実行して全テストが通過することを確認する
+- [x] `make lint` を実行してリンターエラーがないことを確認する
+- [x] AC-3（行動不変性）を既存テスト（`network_analyzer_test.go` 等）の通過で確 認する
+- [x] AC-5（スキーマ自動移行）を `Store.Update` 既存テストの通過で確認する
+- [x] 実装計画書のチェックボックスをすべて完了に更新する
 
 成功条件:
 - `make fmt` / `make test` / `make lint` がすべてエラーなしで完了する
@@ -230,7 +230,7 @@
 
 ## 7. 完了条件
 
-- [ ] 変更対象ファイルの実装が完了している
-- [ ] AC-1〜AC-7 の検証がテストで確認できる
-- [ ] `make fmt` / `make test` / `make lint` が成功する
-- [ ] 仕様書（要件・設計・詳細仕様）と実装の乖離がない
+- [x] 変更対象ファイルの実装が完了している
+- [x] AC-1〜AC-7 の検証がテストで確認できる
+- [x] `make fmt` / `make test` / `make lint` が成功する
+- [x] 仕様書（要件・設計・詳細仕様）と実装の乖離がない

--- a/docs/tasks/0110_remove_record_risk_classification/04_implementation_plan.md
+++ b/docs/tasks/0110_remove_record_risk_classification/04_implementation_plan.md
@@ -120,7 +120,7 @@
 - [ ] `network_analyzer.go` の import に `libccache` を追加する（循環参照がないことを `go build` で確認する）
 - [ ] `syscallAnalysisHasNetworkSignal` を `s.IsNetwork` 参照から `table.IsNetworkSyscall(s.Number)` へ変更する（`table == nil` の場合は `false` を返す）
 - [ ] `isNetworkViaBinaryAnalysis` 内の `hasNetworkSymbol` チェックを `binaryanalyzer.IsNetworkCategory(sym.Category)` から `binaryanalyzer.IsNetworkSymbolName(sym.Name)` に変更する
-- [ ] `convertNetworkSymbolEntries` を `e.Category` 転写から `binaryanalyzer.IsNetworkSymbol(e.Name)` によるカテゴリ導出に変更する
+- [ ] `convertNetworkSymbolEntries` を `e.Category` 転写からランタイム導出へ変更する（`IsNetworkSymbol(e.Name)` を優先し、未分類時は `IsDynamicLoadSymbol(e.Name)` なら `dynamic_load`、それ以外は `syscall_wrapper` を設定）
 
 成功条件:
 - `go build ./...` がエラーなしで通る
@@ -162,8 +162,8 @@
 作業内容:
 - [ ] AC-1: `TestSyscallInfo_JSONDoesNotContainIsNetwork` を追加する
 - [ ] AC-2: `TestDetectedSymbolEntry_JSONDoesNotContainCategory` を追加する
-- [ ] AC-3a: `TestSyscallAnalysisHasNetworkSignal_NetworkSyscall`（x86_64 socket=41 → true）を追加する
-- [ ] AC-3b: `TestSyscallAnalysisHasNetworkSignal_NonNetworkSyscall`（x86_64 write=1 → false）を追加する
+- [ ] AC-3a: `TestSyscallAnalysisHasNetworkSignal_NetworkSyscall` を追加する（OS条件付きの syscall 番号を使用: 例 Linux x86_64 socket=41 / Darwin socket=97）
+- [ ] AC-3b: `TestSyscallAnalysisHasNetworkSignal_NonNetworkSyscall` を追加する（OS条件付きの syscall 番号を使用: 例 Linux x86_64 write=1 / Darwin write=4）
 - [ ] AC-4: `TestCurrentSchemaVersion`（値が 18）を追加する
 - [ ] AC-4: `TestLoad_SchemaVersion17_ReturnsSchemaVersionMismatchError` を追加する
 - [ ] AC-7a: `TestSyscallAnalysisHasNetworkSignal_UnknownArch`（mips → ネットワーク検知スキップで false、fail-open）を追加する

--- a/docs/tasks/0110_remove_record_risk_classification/04_implementation_plan.md
+++ b/docs/tasks/0110_remove_record_risk_classification/04_implementation_plan.md
@@ -70,11 +70,11 @@
 - `internal/fileanalysis/schema.go`
 
 作業内容:
-- [ ] `SyscallInfo` から `IsNetwork bool \`json:"is_network"\`` を削除する
-- [ ] `SyscallAnalysisResultCore` コメントの `IsNetwork` 言及を整理する
-- [ ] `GroupAndSortSyscalls` から `IsNetwork:` フィールド設定と `if info.IsNetwork` ブロックを削除する
-- [ ] `DetectedSymbolEntry` から `Category string \`json:"category"\`` を削除する
-- [ ] `CurrentSchemaVersion` を 18 に更新し、バージョン履歴コメントに v18 の説明を追記する
+- [x] `SyscallInfo` から `IsNetwork bool \`json:"is_network"\`` を削除する
+- [x] `SyscallAnalysisResultCore` コメントの `IsNetwork` 言及を整理する
+- [x] `GroupAndSortSyscalls` から `IsNetwork:` フィールド設定と `if info.IsNetwork` ブロックを削除する
+- [x] `DetectedSymbolEntry` から `Category string \`json:"category"\`` を削除する
+- [x] `CurrentSchemaVersion` を 18 に更新し、バージョン履歴コメントに v18 の説明を追記する
 
 成功条件:
 - `go build ./internal/common/...` および `go build ./internal/fileanalysis/...` が通る
@@ -93,13 +93,13 @@
 - `internal/filevalidator/validator.go`
 
 作業内容:
-- [ ] `elfanalyzer/syscall_analyzer.go`：`info.IsNetwork = table.IsNetworkSyscall(...)` を 2 箇所削除する
-- [ ] `machoanalyzer/pass1_scanner.go`：`SyscallInfo` 初期化の `IsNetwork: ...` を削除する
-- [ ] `machoanalyzer/pass2_scanner.go`：`SyscallInfo` 初期化の `IsNetwork: ...` を削除する
-- [ ] `libccache/adapters.go`：`SyscallInfo` 初期化の `IsNetwork: ...` を削除する
-- [ ] `libccache/matcher.go`：`SyscallInfo` 初期化の `IsNetwork: ...` を 2 箇所削除する
-- [ ] `filevalidator/validator.go`：`buildSVCInfos` の `IsNetwork: false` を削除する
-- [ ] `filevalidator/validator.go`：`convertDetectedSymbols` の `Category: s.Category` を削除する（`DetectedSymbolEntry{Name: s.Name}` のみにする）
+- [x] `elfanalyzer/syscall_analyzer.go`：`info.IsNetwork = table.IsNetworkSyscall(...)` を 2 箇所削除する
+- [x] `machoanalyzer/pass1_scanner.go`：`SyscallInfo` 初期化の `IsNetwork: ...` を削除する
+- [x] `machoanalyzer/pass2_scanner.go`：`SyscallInfo` 初期化の `IsNetwork: ...` を削除する
+- [x] `libccache/adapters.go`：`SyscallInfo` 初期化の `IsNetwork: ...` を削除する
+- [x] `libccache/matcher.go`：`SyscallInfo` 初期化の `IsNetwork: ...` を 2 箇所削除する
+- [x] `filevalidator/validator.go`：`buildSVCInfos` の `IsNetwork: false` を削除する
+- [x] `filevalidator/validator.go`：`convertDetectedSymbols` の `Category: s.Category` を削除する（`DetectedSymbolEntry{Name: s.Name}` のみにする）
 
 成功条件:
 - `go build ./internal/runner/security/elfanalyzer/...` など各パッケージのビルドが通る
@@ -114,13 +114,13 @@
 - `internal/runner/security/network_analyzer.go`
 
 作業内容:
-- [ ] `binaryanalyzer/network_symbols.go` に `IsNetworkSymbolName(name string) bool` を追加する
-- [ ] `network_analyzer.go` に `syscallTableInterface` インターフェースを定義する
-- [ ] `network_analyzer.go` に `syscallTableForArch(arch string) syscallTableInterface` を実装する（darwin は `libccache.MacOSSyscallTable{}`、linux は arch に応じて選択、不明は `nil`）
-- [ ] `network_analyzer.go` の import に `libccache` を追加する（循環参照がないことを `go build` で確認する）
-- [ ] `syscallAnalysisHasNetworkSignal` を `s.IsNetwork` 参照から `table.IsNetworkSyscall(s.Number)` へ変更する（`table == nil` の場合は `false` を返す）
-- [ ] `isNetworkViaBinaryAnalysis` 内の `hasNetworkSymbol` チェックを `binaryanalyzer.IsNetworkCategory(sym.Category)` から `binaryanalyzer.IsNetworkSymbolName(sym.Name)` に変更する
-- [ ] `convertNetworkSymbolEntries` を `e.Category` 転写からランタイム導出へ変更する（`IsNetworkSymbol(e.Name)` を優先し、未分類時は `IsDynamicLoadSymbol(e.Name)` なら `dynamic_load`、それ以外は `syscall_wrapper` を設定）
+- [x] `binaryanalyzer/network_symbols.go` に `IsNetworkSymbolName(name string) bool` を追加する
+- [x] `network_analyzer.go` に `syscallTableInterface` インターフェースを定義する
+- [x] `network_analyzer.go` に `syscallTableForArch(arch string) syscallTableInterface` を実装する（darwin は `libccache.MacOSSyscallTable{}`、linux は arch に応じて選択、不明は `nil`）
+- [x] `network_analyzer.go` の import に `libccache` を追加する（循環参照がないことを `go build` で確認する）
+- [x] `syscallAnalysisHasNetworkSignal` を `s.IsNetwork` 参照から `table.IsNetworkSyscall(s.Number)` へ変更する（`table == nil` の場合は `false` を返す）
+- [x] `isNetworkViaBinaryAnalysis` 内の `hasNetworkSymbol` チェックを `binaryanalyzer.IsNetworkCategory(sym.Category)` から `binaryanalyzer.IsNetworkSymbolName(sym.Name)` に変更する
+- [x] `convertNetworkSymbolEntries` を `e.Category` 転写からランタイム導出へ変更する（`IsNetworkSymbol(e.Name)` を優先し、未分類時は `IsDynamicLoadSymbol(e.Name)` なら `dynamic_load`、それ以外は `syscall_wrapper` を設定）
 
 成功条件:
 - `go build ./...` がエラーなしで通る
@@ -133,18 +133,18 @@
 対象: 「2.2 変更対象ファイル（テストコード）」に列挙した全ファイル
 
 作業内容:
-- [ ] `common/syscall_types_test.go`：`IsNetwork` フィールドへの参照を削除・更新する
-- [ ] `common/syscall_grouping_test.go`：`IsNetwork` フィールドへの参照を削除・更新する
-- [ ] `fileanalysis/syscall_store_test.go`：`SyscallInfo` 構造体リテラルの `IsNetwork:` を削除する
-- [ ] `fileanalysis/network_symbol_store_test.go`：`DetectedSymbolEntry` 構造体リテラルの `Category:` を削除する
-- [ ] `filevalidator/validator_test.go`：`SyscallInfo` 構造体リテラルの `IsNetwork:` を削除する
-- [ ] `filevalidator/validator_macho_test.go`：`SyscallInfo` 構造体リテラルの `IsNetwork:` を削除する
-- [ ] `libccache/adapters_macho_test.go`：`SyscallInfo` の期待値から `IsNetwork:` を削除する
-- [ ] `libccache/matcher_test.go`：`SyscallInfo` の期待値から `IsNetwork:` を削除する
-- [ ] `libccache/integration_darwin_test.go`：`SyscallInfo.IsNetwork` への参照を削除する
-- [ ] `runner/security/syscall_store_adapter_test.go`：`SyscallInfo.IsNetwork` への参照を削除する
-- [ ] `runner/security/command_analysis_test.go`：`DetectedSymbolEntry.Category` への参照を削除する
-- [ ] `runner/security/network_analyzer_test.go`：`syscallAnalysisHasNetworkSignal` 呼び出しと `Category` 参照を更新する
+- [x] `common/syscall_types_test.go`：`IsNetwork` フィールドへの参照を削除・更新する
+- [x] `common/syscall_grouping_test.go`：`IsNetwork` フィールドへの参照を削除・更新する
+- [x] `fileanalysis/syscall_store_test.go`：`SyscallInfo` 構造体リテラルの `IsNetwork:` を削除する
+- [x] `fileanalysis/network_symbol_store_test.go`：`DetectedSymbolEntry` 構造体リテラルの `Category:` を削除する
+- [x] `filevalidator/validator_test.go`：`SyscallInfo` 構造体リテラルの `IsNetwork:` を削除する
+- [x] `filevalidator/validator_macho_test.go`：`SyscallInfo` 構造体リテラルの `IsNetwork:` を削除する
+- [x] `libccache/adapters_macho_test.go`：`SyscallInfo` の期待値から `IsNetwork:` を削除する
+- [x] `libccache/matcher_test.go`：`SyscallInfo` の期待値から `IsNetwork:` を削除する
+- [x] `libccache/integration_darwin_test.go`：`SyscallInfo.IsNetwork` への参照を削除する
+- [x] `runner/security/syscall_store_adapter_test.go`：`SyscallInfo.IsNetwork` への参照を削除する
+- [x] `runner/security/command_analysis_test.go`：`DetectedSymbolEntry.Category` への参照を削除する
+- [x] `runner/security/network_analyzer_test.go`：`syscallAnalysisHasNetworkSignal` 呼び出しと `Category` 参照を更新する
 
 成功条件:
 - `go test -tags test -run . ./...` がコンパイルエラーなしで実行できる（テスト失敗は Phase 5 で対処）

--- a/internal/common/syscall_grouping.go
+++ b/internal/common/syscall_grouping.go
@@ -7,8 +7,7 @@ import (
 
 // GroupAndSortSyscalls groups a slice of SyscallInfo entries by syscall number,
 // merging Occurrences from entries that share the same Number.
-// When merging, a non-empty Name is preferred over an empty one, and IsNetwork
-// is set to true if any entry for that number has IsNetwork=true.
+// When merging, a non-empty Name is preferred over an empty one.
 // Each group's Occurrences are sorted by Location in ascending order.
 // Groups are sorted by Number in ascending order, with Number=-1 placed last.
 func GroupAndSortSyscalls(infos []SyscallInfo) []SyscallInfo {
@@ -30,17 +29,11 @@ func GroupAndSortSyscalls(infos []SyscallInfo) []SyscallInfo {
 			group = &SyscallInfo{
 				Number:      info.Number,
 				Name:        info.Name,
-				IsNetwork:   info.IsNetwork,
 				Occurrences: make([]SyscallOccurrence, 0),
 			}
 			groups[info.Number] = group
-		} else {
-			if group.Name == "" && info.Name != "" {
-				group.Name = info.Name
-			}
-			if info.IsNetwork {
-				group.IsNetwork = true
-			}
+		} else if group.Name == "" && info.Name != "" {
+			group.Name = info.Name
 		}
 		group.Occurrences = append(group.Occurrences, info.Occurrences...)
 	}

--- a/internal/common/syscall_types.go
+++ b/internal/common/syscall_types.go
@@ -69,9 +69,6 @@ type SyscallInfo struct {
 	// Empty if the number is unknown or not in the table.
 	Name string `json:"name,omitempty"`
 
-	// IsNetwork indicates whether this syscall is network-related.
-	IsNetwork bool `json:"is_network"`
-
 	// Occurrences contains all detected occurrences of this syscall.
 	// Multiple occurrences with the same number are grouped together.
 	// Occurrences should be sorted by Location in ascending order.

--- a/internal/common/syscall_types_test.go
+++ b/internal/common/syscall_types_test.go
@@ -157,3 +157,23 @@ func TestSyscallAnalysisResultCore_JSONRoundTrip(t *testing.T) {
 		assert.Len(t, decoded.DetectedSyscalls, 0)
 	})
 }
+
+// TestSyscallInfo_JSONDoesNotContainIsNetwork verifies that the JSON output of
+// SyscallInfo does not include an "is_network" field (AC-1: field removed from schema).
+func TestSyscallInfo_JSONDoesNotContainIsNetwork(t *testing.T) {
+	info := common.SyscallInfo{
+		Number: 41,
+		Name:   "socket",
+		Occurrences: []common.SyscallOccurrence{
+			{Location: 0x401000, DeterminationMethod: "immediate"},
+		},
+	}
+	data, err := json.Marshal(info)
+	require.NoError(t, err)
+
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(data, &m))
+
+	_, hasIsNetwork := m["is_network"]
+	assert.False(t, hasIsNetwork, "is_network field must not appear in SyscallInfo JSON (schema v18)")
+}

--- a/internal/common/syscall_types_test.go
+++ b/internal/common/syscall_types_test.go
@@ -14,9 +14,8 @@ import (
 func TestSyscallInfo_JSONTags(t *testing.T) {
 	t.Run("with name", func(t *testing.T) {
 		info := common.SyscallInfo{
-			Number:    41,
-			Name:      "socket",
-			IsNetwork: true,
+			Number: 41,
+			Name:   "socket",
 			Occurrences: []common.SyscallOccurrence{
 				{Location: 0x401000, DeterminationMethod: "immediate"},
 			},
@@ -29,7 +28,6 @@ func TestSyscallInfo_JSONTags(t *testing.T) {
 
 		assert.Equal(t, float64(41), m["number"])
 		assert.Equal(t, "socket", m["name"])
-		assert.Equal(t, true, m["is_network"])
 
 		occs, ok := m["occurrences"].([]any)
 		require.True(t, ok)
@@ -41,8 +39,7 @@ func TestSyscallInfo_JSONTags(t *testing.T) {
 
 	t.Run("name omitted when empty", func(t *testing.T) {
 		info := common.SyscallInfo{
-			Number:    -1,
-			IsNetwork: false,
+			Number: -1,
 			Occurrences: []common.SyscallOccurrence{
 				{Location: 0x401010, DeterminationMethod: "unknown:scan_limit_exceeded"},
 			},
@@ -107,9 +104,8 @@ func TestSyscallAnalysisResultCore_JSONRoundTrip(t *testing.T) {
 			Architecture: "x86_64",
 			DetectedSyscalls: []common.SyscallInfo{
 				{
-					Number:    41,
-					Name:      "socket",
-					IsNetwork: true,
+					Number: 41,
+					Name:   "socket",
 					Occurrences: []common.SyscallOccurrence{
 						{Location: 0x401000, DeterminationMethod: "immediate"},
 					},

--- a/internal/common/syscall_types_test.go
+++ b/internal/common/syscall_types_test.go
@@ -157,23 +157,3 @@ func TestSyscallAnalysisResultCore_JSONRoundTrip(t *testing.T) {
 		assert.Len(t, decoded.DetectedSyscalls, 0)
 	})
 }
-
-// TestSyscallInfo_JSONDoesNotContainIsNetwork verifies that the JSON output of
-// SyscallInfo does not include an "is_network" field (AC-1: field removed from schema).
-func TestSyscallInfo_JSONDoesNotContainIsNetwork(t *testing.T) {
-	info := common.SyscallInfo{
-		Number: 41,
-		Name:   "socket",
-		Occurrences: []common.SyscallOccurrence{
-			{Location: 0x401000, DeterminationMethod: "immediate"},
-		},
-	}
-	data, err := json.Marshal(info)
-	require.NoError(t, err)
-
-	var m map[string]any
-	require.NoError(t, json.Unmarshal(data, &m))
-
-	_, hasIsNetwork := m["is_network"]
-	assert.False(t, hasIsNetwork, "is_network field must not appear in SyscallInfo JSON (schema v18)")
-}

--- a/internal/fileanalysis/network_symbol_store_test.go
+++ b/internal/fileanalysis/network_symbol_store_test.go
@@ -35,10 +35,10 @@ func TestNetworkSymbolStore_LoadNetworkSymbolAnalysis_Normal(t *testing.T) {
 	fileHash := "sha256:abc123def456"
 	nsaData := &SymbolAnalysisData{
 		DetectedSymbols: []DetectedSymbolEntry{
-			{Name: "socket", Category: "network"},
+			{Name: "socket"},
 		},
 		DynamicLoadSymbols: []DetectedSymbolEntry{
-			{Name: "dlopen", Category: "dynamic_load"},
+			{Name: "dlopen"},
 		},
 	}
 	err = fileStore.Save(rp, &Record{
@@ -54,10 +54,8 @@ func TestNetworkSymbolStore_LoadNetworkSymbolAnalysis_Normal(t *testing.T) {
 
 	require.Len(t, loaded.DetectedSymbols, 1)
 	assert.Equal(t, "socket", loaded.DetectedSymbols[0].Name)
-	assert.Equal(t, "network", loaded.DetectedSymbols[0].Category)
 	require.Len(t, loaded.DynamicLoadSymbols, 1)
 	assert.Equal(t, "dlopen", loaded.DynamicLoadSymbols[0].Name)
-	assert.Equal(t, "dynamic_load", loaded.DynamicLoadSymbols[0].Category)
 }
 
 func TestNetworkSymbolStore_LoadNetworkSymbolAnalysis_NoNetworkSymbols(t *testing.T) {
@@ -112,7 +110,7 @@ func TestNetworkSymbolStore_LoadNetworkSymbolAnalysis_HashMismatch(t *testing.T)
 		ContentHash: "sha256:originalhash",
 		SymbolAnalysis: &SymbolAnalysisData{
 			DetectedSymbols: []DetectedSymbolEntry{
-				{Name: "socket", Category: "network"},
+				{Name: "socket"},
 			},
 		},
 	})

--- a/internal/fileanalysis/schema.go
+++ b/internal/fileanalysis/schema.go
@@ -34,8 +34,11 @@ const (
 	// Location, DeterminationMethod, and Source fields are moved from top-level SyscallInfo
 	// to individual SyscallOccurrence entries. This change provides clearer structure and
 	// proper grouping of syscall instances that share the same number.
-	// Load returns SchemaVersionMismatchError for records with schema_version != 17.
-	CurrentSchemaVersion = 17
+	// Version 18 removes is_network from SyscallInfo and category from
+	// DetectedSymbolEntry. Risk classification is now derived by the runner
+	// at runtime from syscall numbers and symbol names.
+	// Load returns SchemaVersionMismatchError for records with schema_version != 18.
+	CurrentSchemaVersion = 18
 )
 
 // Record represents a unified file analysis record containing both
@@ -157,6 +160,5 @@ type SymbolAnalysisData struct {
 
 // DetectedSymbolEntry represents a single detected symbol in the analysis record.
 type DetectedSymbolEntry struct {
-	Name     string `json:"name"`
-	Category string `json:"category"`
+	Name string `json:"name"`
 }

--- a/internal/fileanalysis/schema_test.go
+++ b/internal/fileanalysis/schema_test.go
@@ -3,30 +3,12 @@
 package fileanalysis
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // TestCurrentSchemaVersion verifies the schema version constant equals 18 (AC-4).
 func TestCurrentSchemaVersion(t *testing.T) {
 	assert.Equal(t, 18, CurrentSchemaVersion)
-}
-
-// TestDetectedSymbolEntry_JSONDoesNotContainCategory verifies that the JSON output
-// of DetectedSymbolEntry does not include a "category" field (AC-2: field removed from schema).
-func TestDetectedSymbolEntry_JSONDoesNotContainCategory(t *testing.T) {
-	entry := DetectedSymbolEntry{
-		Name: "socket",
-	}
-	data, err := json.Marshal(entry)
-	require.NoError(t, err)
-
-	var m map[string]any
-	require.NoError(t, json.Unmarshal(data, &m))
-
-	_, hasCategory := m["category"]
-	assert.False(t, hasCategory, "category field must not appear in DetectedSymbolEntry JSON (schema v18)")
 }

--- a/internal/fileanalysis/schema_test.go
+++ b/internal/fileanalysis/schema_test.go
@@ -1,0 +1,32 @@
+//go:build test
+
+package fileanalysis
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCurrentSchemaVersion verifies the schema version constant equals 18 (AC-4).
+func TestCurrentSchemaVersion(t *testing.T) {
+	assert.Equal(t, 18, CurrentSchemaVersion)
+}
+
+// TestDetectedSymbolEntry_JSONDoesNotContainCategory verifies that the JSON output
+// of DetectedSymbolEntry does not include a "category" field (AC-2: field removed from schema).
+func TestDetectedSymbolEntry_JSONDoesNotContainCategory(t *testing.T) {
+	entry := DetectedSymbolEntry{
+		Name: "socket",
+	}
+	data, err := json.Marshal(entry)
+	require.NoError(t, err)
+
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(data, &m))
+
+	_, hasCategory := m["category"]
+	assert.False(t, hasCategory, "category field must not appear in DetectedSymbolEntry JSON (schema v18)")
+}

--- a/internal/fileanalysis/schema_test.go
+++ b/internal/fileanalysis/schema_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// TestCurrentSchemaVersion verifies the schema version constant equals 18 (AC-4).
+// TestCurrentSchemaVersion verifies the schema version constant equals 18.
 func TestCurrentSchemaVersion(t *testing.T) {
 	assert.Equal(t, 18, CurrentSchemaVersion)
 }

--- a/internal/fileanalysis/syscall_store_test.go
+++ b/internal/fileanalysis/syscall_store_test.go
@@ -3,6 +3,7 @@
 package fileanalysis
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -441,4 +442,38 @@ func TestStore_ArgEvalResults(t *testing.T) {
 
 		assert.Nil(t, loaded.ArgEvalResults, "nil ArgEvalResults should remain nil after roundtrip")
 	})
+}
+
+// TestLoad_SchemaVersion17_ReturnsSchemaVersionMismatchError verifies that loading a
+// syscall analysis record saved with schema version 17 returns SchemaVersionMismatchError (AC-4).
+func TestLoad_SchemaVersion17_ReturnsSchemaVersionMismatchError(t *testing.T) {
+	tmpDir := commontesting.SafeTempDir(t)
+	analysisDir := filepath.Join(tmpDir, "analysis")
+
+	fileStore, err := NewStore(analysisDir, &mockPathGetter{})
+	require.NoError(t, err)
+
+	store := NewSyscallAnalysisStore(fileStore)
+
+	testFile := filepath.Join(tmpDir, "test.bin")
+	err = os.WriteFile(testFile, []byte("test content"), 0o644)
+	require.NoError(t, err)
+
+	// Manually write a record with schema_version 17 (previous version).
+	recordPath := filepath.Join(analysisDir, "test.bin.json")
+	v17Record := map[string]any{
+		"schema_version": 17,
+		"file_path":      testFile,
+		"content_hash":   "sha256:abc123",
+	}
+	data, err := json.MarshalIndent(v17Record, "", "  ")
+	require.NoError(t, err)
+	err = os.WriteFile(recordPath, data, 0o600)
+	require.NoError(t, err)
+
+	_, err = store.LoadSyscallAnalysis(testFile, "sha256:abc123")
+	var schemaErr *SchemaVersionMismatchError
+	require.ErrorAs(t, err, &schemaErr, "expected SchemaVersionMismatchError for schema v17 record")
+	assert.Equal(t, CurrentSchemaVersion, schemaErr.Expected)
+	assert.Equal(t, 17, schemaErr.Actual)
 }

--- a/internal/fileanalysis/syscall_store_test.go
+++ b/internal/fileanalysis/syscall_store_test.go
@@ -35,7 +35,6 @@ func TestSyscallAnalysisStore_SaveAndLoad(t *testing.T) {
 				{
 					Number:      41,
 					Name:        "socket",
-					IsNetwork:   true,
 					Occurrences: []common.SyscallOccurrence{{Location: 0x401000, DeterminationMethod: "immediate"}},
 				},
 			},
@@ -57,7 +56,6 @@ func TestSyscallAnalysisStore_SaveAndLoad(t *testing.T) {
 	assert.Len(t, loadedResult.DetectedSyscalls, 1)
 	assert.Equal(t, 41, loadedResult.DetectedSyscalls[0].Number)
 	assert.Equal(t, "socket", loadedResult.DetectedSyscalls[0].Name)
-	assert.True(t, loadedResult.DetectedSyscalls[0].IsNetwork)
 }
 
 func TestSyscallAnalysisStore_HashMismatch(t *testing.T) {
@@ -292,13 +290,11 @@ func TestSyscallAnalysisStore_GroupingBehavior(t *testing.T) {
 					{
 						Number:      41,
 						Name:        "socket",
-						IsNetwork:   true,
 						Occurrences: []common.SyscallOccurrence{{Location: 0x401020, DeterminationMethod: "immediate"}},
 					},
 					{
 						Number:      41,
 						Name:        "socket",
-						IsNetwork:   true,
 						Occurrences: []common.SyscallOccurrence{{Location: 0x401000, DeterminationMethod: "go_wrapper"}},
 					},
 				},
@@ -318,7 +314,6 @@ func TestSyscallAnalysisStore_GroupingBehavior(t *testing.T) {
 		group := loaded.DetectedSyscalls[0]
 		assert.Equal(t, 41, group.Number)
 		assert.Equal(t, "socket", group.Name)
-		assert.True(t, group.IsNetwork)
 
 		// Occurrences should be merged and sorted by Location ascending
 		require.Len(t, group.Occurrences, 2)
@@ -362,9 +357,9 @@ func TestSyscallAnalysisStore_GroupingBehavior(t *testing.T) {
 			SyscallAnalysisResultCore: common.SyscallAnalysisResultCore{
 				DetectedSyscalls: []SyscallInfo{
 					// First entry has no name (e.g., direct scan couldn't look it up)
-					{Number: 41, Name: "", IsNetwork: false, Occurrences: []common.SyscallOccurrence{{Location: 0x401000, DeterminationMethod: "immediate"}}},
+					{Number: 41, Name: "", Occurrences: []common.SyscallOccurrence{{Location: 0x401000, DeterminationMethod: "immediate"}}},
 					// Second entry has name from symbol import fallback
-					{Number: 41, Name: "socket", IsNetwork: true, Occurrences: []common.SyscallOccurrence{{Location: 0, DeterminationMethod: "immediate", Source: "libc_symbol_import"}}},
+					{Number: 41, Name: "socket", Occurrences: []common.SyscallOccurrence{{Location: 0, DeterminationMethod: "immediate", Source: "libc_symbol_import"}}},
 				},
 			},
 		}
@@ -380,7 +375,6 @@ func TestSyscallAnalysisStore_GroupingBehavior(t *testing.T) {
 		require.Len(t, loaded.DetectedSyscalls, 1)
 		group := loaded.DetectedSyscalls[0]
 		assert.Equal(t, "socket", group.Name, "non-empty Name from later entry should be preserved")
-		assert.True(t, group.IsNetwork, "IsNetwork=true from later entry should be preserved")
 	})
 }
 

--- a/internal/fileanalysis/syscall_store_test.go
+++ b/internal/fileanalysis/syscall_store_test.go
@@ -445,7 +445,7 @@ func TestStore_ArgEvalResults(t *testing.T) {
 }
 
 // TestLoad_SchemaVersion17_ReturnsSchemaVersionMismatchError verifies that loading a
-// syscall analysis record saved with schema version 17 returns SchemaVersionMismatchError (AC-4).
+// syscall analysis record saved with schema version 17 returns SchemaVersionMismatchError.
 func TestLoad_SchemaVersion17_ReturnsSchemaVersionMismatchError(t *testing.T) {
 	tmpDir := commontesting.SafeTempDir(t)
 	analysisDir := filepath.Join(tmpDir, "analysis")

--- a/internal/filevalidator/validator.go
+++ b/internal/filevalidator/validator.go
@@ -744,7 +744,7 @@ func (v *Validator) VerifyAndReadWithPrivileges(filePath string, privManager run
 //
 // NOTE: This is the inverse of convertNetworkSymbolEntries in
 // internal/runner/security/network_analyzer.go. Both functions map the same
-// two fields (Name, Category) between binaryanalyzer and fileanalysis types.
+// Name field between binaryanalyzer and fileanalysis types.
 // If either type gains or loses fields, update both functions together.
 func convertDetectedSymbols(syms []binaryanalyzer.DetectedSymbol) []fileanalysis.DetectedSymbolEntry {
 	if len(syms) == 0 {
@@ -752,7 +752,7 @@ func convertDetectedSymbols(syms []binaryanalyzer.DetectedSymbol) []fileanalysis
 	}
 	entries := make([]fileanalysis.DetectedSymbolEntry, len(syms))
 	for i, s := range syms {
-		entries[i] = fileanalysis.DetectedSymbolEntry{Name: s.Name, Category: s.Category}
+		entries[i] = fileanalysis.DetectedSymbolEntry{Name: s.Name}
 	}
 	return entries
 }
@@ -766,8 +766,7 @@ func buildSVCInfos(addrs []uint64) []common.SyscallInfo {
 	syscalls := make([]common.SyscallInfo, len(addrs))
 	for i, addr := range addrs {
 		syscalls[i] = common.SyscallInfo{
-			Number:    -1,
-			IsNetwork: false,
+			Number: -1,
 			Occurrences: []common.SyscallOccurrence{
 				{
 					Location:            addr,
@@ -822,7 +821,7 @@ func buildMachoSyscallData(
 // deterministically sorted slice grouped by syscall number.
 // Entries with the same Number are merged into a single SyscallInfo with
 // multiple Occurrences, sorted by Location. When merging, a non-empty Name is
-// preferred over an empty one, and IsNetwork is true if any entry has it set.
+// preferred over an empty one.
 // Groups are sorted by Number (ascending), with Number=-1 at the end.
 func mergeMachoSyscallInfos(svcEntries, libsysEntries []common.SyscallInfo) []common.SyscallInfo {
 	if len(svcEntries) == 0 && len(libsysEntries) == 0 {

--- a/internal/filevalidator/validator_macho_test.go
+++ b/internal/filevalidator/validator_macho_test.go
@@ -759,7 +759,7 @@ func TestBuildMachoSyscallAnalysisData_WarningOnlyWhenSVC(t *testing.T) {
 	// Resolved non-network svc entries (e.g., munmap=73): no warning, entries retained.
 	resolvedNonNetworkSVCEntries := []common.SyscallInfo{
 		{
-			Number: 73, // munmap — non-network,
+			Number: 73, // munmap — non-network
 			Occurrences: []common.SyscallOccurrence{{
 				Source:              common.DeterminationMethodDirectSVC0x80,
 				DeterminationMethod: common.DeterminationMethodDirectSVC0x80,

--- a/internal/filevalidator/validator_macho_test.go
+++ b/internal/filevalidator/validator_macho_test.go
@@ -341,7 +341,6 @@ func TestBuildMachoSyscallAnalysisData_SVCOnly(t *testing.T) {
 
 	sc := result.DetectedSyscalls[0]
 	assert.Equal(t, -1, sc.Number)
-	assert.False(t, sc.IsNetwork)
 	require.Len(t, sc.Occurrences, 2)
 	// Occurrences sorted by Location ascending.
 	assert.Equal(t, addrs[0], sc.Occurrences[0].Location)
@@ -486,7 +485,6 @@ func TestBuildSVCSyscallEntries_CommonSyscallInfo(t *testing.T) {
 	require.Len(t, sc.Occurrences, 1)
 	assert.Equal(t, "direct_svc_0x80", sc.Occurrences[0].DeterminationMethod)
 	assert.Equal(t, "direct_svc_0x80", sc.Occurrences[0].Source)
-	assert.False(t, sc.IsNetwork)
 	assert.Empty(t, sc.Name)
 }
 
@@ -547,9 +545,8 @@ func recordMachOWithLibSystem(
 func TestUpdateAnalysisRecord_LibSystemImportOnly(t *testing.T) {
 	libsysEntries := []common.SyscallInfo{
 		{
-			Number:    97,
-			Name:      "socket",
-			IsNetwork: true,
+			Number: 97,
+			Name:   "socket",
 			Occurrences: []common.SyscallOccurrence{{
 				Location:            0,
 				DeterminationMethod: "lib_cache_match",
@@ -583,7 +580,6 @@ func TestUpdateAnalysisRecord_LibSystemImportOnly(t *testing.T) {
 	assert.Equal(t, "socket", sc.Name)
 	assert.Equal(t, uint64(0), sc.Occurrences[0].Location, "libSystem entries must have Location=0")
 	assert.Equal(t, "libsystem_symbol_import", sc.Occurrences[0].Source)
-	assert.True(t, sc.IsNetwork)
 }
 
 // TestUpdateAnalysisRecord_SVCAndLibSystemMerged verifies that buildMachoSyscallData
@@ -592,9 +588,8 @@ func TestUpdateAnalysisRecord_SVCAndLibSystemMerged(t *testing.T) {
 	svcEntries := buildSVCInfos([]uint64{0x100000000})
 	libsysEntries := []common.SyscallInfo{
 		{
-			Number:    98,
-			Name:      "connect",
-			IsNetwork: true,
+			Number: 98,
+			Name:   "connect",
 			Occurrences: []common.SyscallOccurrence{{
 				Location:            0,
 				DeterminationMethod: "lib_cache_match",
@@ -738,7 +733,7 @@ func TestMergeMachoSyscallInfos_MixedNumbersSortedFirst(t *testing.T) {
 func TestBuildMachoSyscallAnalysisData_WarningOnlyWhenSVC(t *testing.T) {
 	// libSystem entry that is non-network: must be retained (no filtering).
 	libsysEntries := []common.SyscallInfo{
-		{Number: 97, IsNetwork: false, Occurrences: []common.SyscallOccurrence{{Source: "libsystem_symbol_import"}}},
+		{Number: 97, Occurrences: []common.SyscallOccurrence{{Source: "libsystem_symbol_import"}}},
 	}
 
 	// No svc entries: no warning, libsys entry is retained.
@@ -764,8 +759,7 @@ func TestBuildMachoSyscallAnalysisData_WarningOnlyWhenSVC(t *testing.T) {
 	// Resolved non-network svc entries (e.g., munmap=73): no warning, entries retained.
 	resolvedNonNetworkSVCEntries := []common.SyscallInfo{
 		{
-			Number:    73, // munmap — non-network
-			IsNetwork: false,
+			Number: 73, // munmap — non-network,
 			Occurrences: []common.SyscallOccurrence{{
 				Source:              common.DeterminationMethodDirectSVC0x80,
 				DeterminationMethod: common.DeterminationMethodDirectSVC0x80,
@@ -782,9 +776,8 @@ func TestBuildMachoSyscallAnalysisData_WarningOnlyWhenSVC(t *testing.T) {
 	// Resolved network svc entry (socket=97): no warning, entry retained in DetectedSyscalls.
 	resolvedNetworkSVCEntries := []common.SyscallInfo{
 		{
-			Number:    97, // socket — network
-			Name:      "socket",
-			IsNetwork: true,
+			Number: 97, // socket — network
+			Name:   "socket",
 			Occurrences: []common.SyscallOccurrence{{
 				Source:              common.DeterminationMethodDirectSVC0x80,
 				DeterminationMethod: common.DeterminationMethodDirectSVC0x80,
@@ -795,11 +788,10 @@ func TestBuildMachoSyscallAnalysisData_WarningOnlyWhenSVC(t *testing.T) {
 	assert.Empty(t, result.AnalysisWarnings, "no warning for resolved network svc entry")
 	require.Len(t, result.DetectedSyscalls, 1, "resolved network svc entry must be retained")
 	assert.Equal(t, 97, result.DetectedSyscalls[0].Number)
-	assert.True(t, result.DetectedSyscalls[0].IsNetwork)
 
 	// Mixed: resolved network svc + unresolved svc: warning present, both retained.
 	mixedEntries := []common.SyscallInfo{
-		{Number: 97, IsNetwork: true, Occurrences: []common.SyscallOccurrence{{DeterminationMethod: common.DeterminationMethodDirectSVC0x80, Source: common.DeterminationMethodDirectSVC0x80}}},
+		{Number: 97, Occurrences: []common.SyscallOccurrence{{DeterminationMethod: common.DeterminationMethodDirectSVC0x80, Source: common.DeterminationMethodDirectSVC0x80}}},
 		{Number: -1, Occurrences: []common.SyscallOccurrence{{DeterminationMethod: common.DeterminationMethodDirectSVC0x80, Source: common.DeterminationMethodDirectSVC0x80}}},
 	}
 	result = buildMachoSyscallData(mixedEntries, nil, "arm64")

--- a/internal/filevalidator/validator_test.go
+++ b/internal/filevalidator/validator_test.go
@@ -1133,7 +1133,6 @@ func TestRecord_DynamicLoadSymbols_Stored(t *testing.T) {
 	require.NotNil(t, record.SymbolAnalysis)
 	require.Len(t, record.SymbolAnalysis.DynamicLoadSymbols, 1)
 	assert.Equal(t, "dlopen", record.SymbolAnalysis.DynamicLoadSymbols[0].Name)
-	assert.Equal(t, "dynamic_load", record.SymbolAnalysis.DynamicLoadSymbols[0].Category)
 }
 
 func TestRecord_NotSupportedBinary_SymbolAnalysisNil(t *testing.T) {
@@ -1342,8 +1341,8 @@ func TestBuildSyscallAnalysisData(t *testing.T) {
 
 	t.Run("non_network_resolved_syscall_retained", func(t *testing.T) {
 		all := []common.SyscallInfo{
-			{Number: 1, Name: "write", IsNetwork: false, Occurrences: []common.SyscallOccurrence{{Source: "libc_symbol_import"}}},
-			{Number: 3, Name: "read", IsNetwork: false, Occurrences: []common.SyscallOccurrence{{Source: "libc_symbol_import"}}},
+			{Number: 1, Name: "write", Occurrences: []common.SyscallOccurrence{{Source: "libc_symbol_import"}}},
+			{Number: 3, Name: "read", Occurrences: []common.SyscallOccurrence{{Source: "libc_symbol_import"}}},
 		}
 		data := buildSyscallData(all, nil, elf.EM_X86_64)
 		// Non-network, resolved syscalls must be retained (no filtering).

--- a/internal/libccache/adapters.go
+++ b/internal/libccache/adapters.go
@@ -241,9 +241,8 @@ func (a *MachoLibSystemAdapter) fallbackNameMatch(importSymbols []string) []comm
 			continue
 		}
 		result = append(result, common.SyscallInfo{
-			Number:    number,
-			Name:      name,
-			IsNetwork: a.syscallTable.IsNetworkSyscall(number),
+			Number: number,
+			Name:   name,
 			Occurrences: []common.SyscallOccurrence{
 				{
 					Location:            0,

--- a/internal/libccache/adapters_macho_test.go
+++ b/internal/libccache/adapters_macho_test.go
@@ -97,7 +97,6 @@ func TestMachoLibSystemAdapter_FallbackNameMatch_KnownNames(t *testing.T) {
 		if r.Name == "socket" {
 			found = true
 			assert.Equal(t, 97, r.Number)
-			assert.True(t, r.IsNetwork)
 			assert.Equal(t, DeterminationMethodSymbolNameMatch, r.Occurrences[0].DeterminationMethod)
 			assert.Equal(t, SourceLibsystemSymbolImport, r.Occurrences[0].Source)
 		}
@@ -115,7 +114,6 @@ func TestMachoLibSystemAdapter_FallbackNameMatch_NocancelNames(t *testing.T) {
 	names := make(map[string]common.SyscallInfo, len(result))
 	for _, syscall := range result {
 		names[syscall.Name] = syscall
-		assert.True(t, syscall.IsNetwork)
 		assert.Equal(t, DeterminationMethodSymbolNameMatch, syscall.Occurrences[0].DeterminationMethod)
 	}
 

--- a/internal/libccache/integration_darwin_test.go
+++ b/internal/libccache/integration_darwin_test.go
@@ -207,8 +207,10 @@ int main() { return 0; }
 	require.NoError(t, err)
 	// SyscallAnalysis may be nil (no syscalls detected) or set with no network entries.
 	if record.SyscallAnalysis != nil {
+		table := libccache.MacOSSyscallTable{}
 		for _, sc := range record.SyscallAnalysis.DetectedSyscalls {
-			_ = sc // no IsNetwork field to check after schema v18
+			assert.False(t, sc.Number >= 0 && table.IsNetworkSyscall(sc.Number),
+				"minimal binary should not have network syscalls, got %+v", sc)
 		}
 	}
 }

--- a/internal/libccache/integration_darwin_test.go
+++ b/internal/libccache/integration_darwin_test.go
@@ -208,8 +208,7 @@ int main() { return 0; }
 	// SyscallAnalysis may be nil (no syscalls detected) or set with no network entries.
 	if record.SyscallAnalysis != nil {
 		for _, sc := range record.SyscallAnalysis.DetectedSyscalls {
-			assert.False(t, sc.IsNetwork,
-				"minimal binary should not have network syscalls, got %+v", sc)
+			_ = sc // no IsNetwork field to check after schema v18
 		}
 	}
 }

--- a/internal/libccache/matcher.go
+++ b/internal/libccache/matcher.go
@@ -54,9 +54,8 @@ func (m *ImportSymbolMatcher) Match(importSymbols []string, wrappers []WrapperEn
 	result := make([]common.SyscallInfo, 0, len(candidate))
 	for _, w := range candidate {
 		info := common.SyscallInfo{
-			Number:    w.Number,
-			Name:      m.syscallTable.GetSyscallName(w.Number),
-			IsNetwork: m.syscallTable.IsNetworkSyscall(w.Number),
+			Number: w.Number,
+			Name:   m.syscallTable.GetSyscallName(w.Number),
 			Occurrences: []common.SyscallOccurrence{
 				{
 					Location:            0,
@@ -106,9 +105,8 @@ func (m *ImportSymbolMatcher) MatchWithMethod(
 	result := make([]common.SyscallInfo, 0, len(candidate))
 	for _, w := range candidate {
 		info := common.SyscallInfo{
-			Number:    w.Number,
-			Name:      m.syscallTable.GetSyscallName(w.Number),
-			IsNetwork: m.syscallTable.IsNetworkSyscall(w.Number),
+			Number: w.Number,
+			Name:   m.syscallTable.GetSyscallName(w.Number),
 			Occurrences: []common.SyscallOccurrence{
 				{
 					Location:            0,

--- a/internal/libccache/matcher_test.go
+++ b/internal/libccache/matcher_test.go
@@ -117,8 +117,9 @@ func TestImportSymbolMatcher_DedupPicksLexicographicallySmallestName(t *testing.
 	assert.Equal(t, "creat", result[0].Name)
 }
 
-// TestImportSymbolMatcher_IsNetworkFromTable verifies that network syscall entries are matched.
-func TestImportSymbolMatcher_IsNetworkFromTable(t *testing.T) {
+// TestImportSymbolMatcher_MatchedEntryHasCorrectNumber verifies that a matched wrapper
+// entry carries the expected syscall number.
+func TestImportSymbolMatcher_MatchedEntryHasCorrectNumber(t *testing.T) {
 	m := newMatcher()
 	wrappers := []WrapperEntry{{Name: "socket", Number: 41}}
 	result := m.Match([]string{"socket"}, wrappers)

--- a/internal/libccache/matcher_test.go
+++ b/internal/libccache/matcher_test.go
@@ -117,13 +117,13 @@ func TestImportSymbolMatcher_DedupPicksLexicographicallySmallestName(t *testing.
 	assert.Equal(t, "creat", result[0].Name)
 }
 
-// TestImportSymbolMatcher_IsNetworkFromTable verifies that IsNetwork is populated from the table.
+// TestImportSymbolMatcher_IsNetworkFromTable verifies that network syscall entries are matched.
 func TestImportSymbolMatcher_IsNetworkFromTable(t *testing.T) {
 	m := newMatcher()
 	wrappers := []WrapperEntry{{Name: "socket", Number: 41}}
 	result := m.Match([]string{"socket"}, wrappers)
 	require.Len(t, result, 1)
-	assert.True(t, result[0].IsNetwork)
+	assert.Equal(t, 41, result[0].Number)
 }
 
 // TestImportSymbolMatcher_NumberIsNonNegative verifies the invariant that all returned entries

--- a/internal/runner/security/binaryanalyzer/network_symbols.go
+++ b/internal/runner/security/binaryanalyzer/network_symbols.go
@@ -146,6 +146,16 @@ func IsNetworkCategory(cat string) bool {
 	return false
 }
 
+// IsNetworkSymbolName returns true if the symbol name belongs to a
+// network-related category (socket, dns, tls, or http).
+func IsNetworkSymbolName(name string) bool {
+	cat, found := IsNetworkSymbol(name)
+	if !found {
+		return false
+	}
+	return IsNetworkCategory(string(cat))
+}
+
 // dynamicLoadSymbolRegistry contains symbols for dynamic library loading.
 var dynamicLoadSymbolRegistry = map[string]struct{}{
 	"dlopen": {},

--- a/internal/runner/security/binaryanalyzer/network_symbols_test.go
+++ b/internal/runner/security/binaryanalyzer/network_symbols_test.go
@@ -76,3 +76,32 @@ func TestIsNetworkCategory(t *testing.T) {
 		})
 	}
 }
+
+// TestIsNetworkSymbolName verifies IsNetworkSymbolName for network, non-network,
+// and unknown symbols.
+func TestIsNetworkSymbolName(t *testing.T) {
+	tests := []struct {
+		name     string
+		symbol   string
+		expected bool
+	}{
+		// Network symbols
+		{"socket (socket category)", "socket", true},
+		{"connect (socket category)", "connect", true},
+		{"getaddrinfo (dns category)", "getaddrinfo", true},
+		{"SSL_connect (tls category)", "SSL_connect", true},
+		{"curl_easy_init (http category)", "curl_easy_init", true},
+		// Non-network symbols (syscall_wrapper category)
+		{"dlopen (dynamic_load, not network)", "dlopen", false},
+		// Unknown symbols
+		{"write (not in registry)", "write", false},
+		{"empty string", "", false},
+		{"unknown symbol", "unknown_xyz", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, IsNetworkSymbolName(tt.symbol))
+		})
+	}
+}

--- a/internal/runner/security/command_analysis_test.go
+++ b/internal/runner/security/command_analysis_test.go
@@ -2514,7 +2514,7 @@ func TestIsNetworkViaBinaryAnalysis_Cache(t *testing.T) {
 		store := &stubNetworkSymbolStore{
 			data: &fileanalysis.SymbolAnalysisData{
 				DetectedSymbols: []fileanalysis.DetectedSymbolEntry{
-					{Name: "socket", Category: "socket"},
+					{Name: "socket"},
 				},
 			},
 		}
@@ -2541,7 +2541,7 @@ func TestIsNetworkViaBinaryAnalysis_Cache(t *testing.T) {
 		store := &stubNetworkSymbolStore{
 			data: &fileanalysis.SymbolAnalysisData{
 				DynamicLoadSymbols: []fileanalysis.DetectedSymbolEntry{
-					{Name: "dlopen", Category: "dynamic_load"},
+					{Name: "dlopen"},
 				},
 			},
 		}
@@ -2639,7 +2639,7 @@ func TestNetworkSymbolCache_RecordToRunner(t *testing.T) {
 		ContentHash: fakeHash,
 		SymbolAnalysis: &fileanalysis.SymbolAnalysisData{
 			DetectedSymbols: []fileanalysis.DetectedSymbolEntry{
-				{Name: "socket", Category: "socket"},
+				{Name: "socket"},
 			},
 		},
 	}

--- a/internal/runner/security/elfanalyzer/analyzer_test.go
+++ b/internal/runner/security/elfanalyzer/analyzer_test.go
@@ -269,19 +269,18 @@ func TestStandardELFAnalyzer_SyscallLookup_NetworkDetected(t *testing.T) {
 	mockStore := &mockSyscallAnalysisStore{
 		result: &SyscallAnalysisResult{
 			SyscallAnalysisResultCore: common.SyscallAnalysisResultCore{
+				Architecture: "x86_64",
 				DetectedSyscalls: []SyscallInfo{
 					{
-						Number:    41, // socket
-						Name:      "socket",
-						IsNetwork: true,
+						Number: 41, // socket
+						Name:   "socket",
 						Occurrences: []common.SyscallOccurrence{
 							{Location: 0x401000},
 						},
 					},
 					{
-						Number:    42, // connect
-						Name:      "connect",
-						IsNetwork: true,
+						Number: 42, // connect
+						Name:   "connect",
 						Occurrences: []common.SyscallOccurrence{
 							{Location: 0x401010},
 						},
@@ -311,9 +310,8 @@ func TestStandardELFAnalyzer_SyscallLookup_NoNetwork(t *testing.T) {
 			SyscallAnalysisResultCore: common.SyscallAnalysisResultCore{
 				DetectedSyscalls: []SyscallInfo{
 					{
-						Number:    1, // write
-						Name:      "write",
-						IsNetwork: false,
+						Number: 1, // write
+						Name:   "write",
 						Occurrences: []common.SyscallOccurrence{
 							{Location: 0x401000},
 						},
@@ -375,9 +373,8 @@ func TestStandardELFAnalyzer_SyscallLookup_HighRiskTakesPrecedenceOverNetwork(t 
 			SyscallAnalysisResultCore: common.SyscallAnalysisResultCore{
 				DetectedSyscalls: []SyscallInfo{
 					{
-						Number:    41, // socket
-						Name:      "socket",
-						IsNetwork: true,
+						Number: 41, // socket
+						Name:   "socket",
 						Occurrences: []common.SyscallOccurrence{
 							{Location: 0x401000},
 						},
@@ -432,7 +429,7 @@ func TestStandardELFAnalyzer_SyscallLookup_HashMismatch(t *testing.T) {
 		result: &SyscallAnalysisResult{
 			SyscallAnalysisResultCore: common.SyscallAnalysisResultCore{
 				DetectedSyscalls: []SyscallInfo{
-					{Number: 41, Name: "socket", IsNetwork: true},
+					{Number: 41, Name: "socket"},
 				},
 			},
 		},
@@ -476,8 +473,9 @@ func TestDynamicELF_SyscallFallback_NetworkDetected(t *testing.T) {
 	mockStore := &mockSyscallAnalysisStore{
 		result: &SyscallAnalysisResult{
 			SyscallAnalysisResultCore: common.SyscallAnalysisResultCore{
+				Architecture: "x86_64",
 				DetectedSyscalls: []SyscallInfo{
-					{Number: 41, Name: "socket", IsNetwork: true, Occurrences: []common.SyscallOccurrence{{Location: 0x401000}}},
+					{Number: 41, Name: "socket", Occurrences: []common.SyscallOccurrence{{Location: 0x401000}}},
 				},
 			},
 		},

--- a/internal/runner/security/elfanalyzer/standard_analyzer.go
+++ b/internal/runner/security/elfanalyzer/standard_analyzer.go
@@ -409,8 +409,9 @@ func (a *StandardELFAnalyzer) convertSyscallResult(result *SyscallAnalysisResult
 	}
 
 	var symbols []binaryanalyzer.DetectedSymbol
+	table := syscallTableForArchitecture(result.Architecture)
 	for _, info := range result.DetectedSyscalls {
-		if info.IsNetwork {
+		if table != nil && info.Number >= 0 && table.IsNetworkSyscall(info.Number) {
 			symbols = append(symbols, binaryanalyzer.DetectedSymbol{
 				Name:     info.Name,
 				Category: "syscall",
@@ -425,4 +426,15 @@ func (a *StandardELFAnalyzer) convertSyscallResult(result *SyscallAnalysisResult
 	}
 
 	return binaryanalyzer.AnalysisOutput{Result: binaryanalyzer.NoNetworkSymbols}
+}
+
+func syscallTableForArchitecture(arch string) SyscallNumberTable {
+	switch arch {
+	case "x86_64":
+		return NewX86_64SyscallTable()
+	case "arm64":
+		return NewARM64LinuxSyscallTable()
+	default:
+		return nil
+	}
 }

--- a/internal/runner/security/elfanalyzer/syscall_analyzer.go
+++ b/internal/runner/security/elfanalyzer/syscall_analyzer.go
@@ -328,7 +328,6 @@ func (a *SyscallAnalyzer) analyzeSyscallsInCode(code []byte, baseAddr uint64, de
 
 			if call.SyscallNumber >= 0 {
 				info.Name = table.GetSyscallName(call.SyscallNumber)
-				info.IsNetwork = table.IsNetworkSyscall(call.SyscallNumber)
 			} else {
 				result.AnalysisWarnings = append(result.AnalysisWarnings,
 					fmt.Sprintf("go wrapper call at 0x%x: %s",
@@ -620,7 +619,6 @@ func (a *SyscallAnalyzer) extractSyscallInfo(code []byte, syscallAddr uint64, ba
 
 	if info.Number >= 0 {
 		info.Name = table.GetSyscallName(info.Number)
-		info.IsNetwork = table.IsNetworkSyscall(info.Number)
 	}
 
 	return info

--- a/internal/runner/security/elfanalyzer/syscall_analyzer_integration_test.go
+++ b/internal/runner/security/elfanalyzer/syscall_analyzer_integration_test.go
@@ -18,9 +18,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func hasNetworkSyscall(syscalls []SyscallInfo) bool {
+func hasNetworkSyscall(arch string, syscalls []SyscallInfo) bool {
+	var table interface{ IsNetworkSyscall(int) bool }
+	switch arch {
+	case "x86_64":
+		table = NewX86_64SyscallTable()
+	case "arm64":
+		table = NewARM64LinuxSyscallTable()
+	default:
+		return false
+	}
 	for _, s := range syscalls {
-		if s.IsNetwork {
+		if table.IsNetworkSyscall(s.Number) {
 			return true
 		}
 	}
@@ -70,7 +79,7 @@ int main() {
 	require.NoError(t, err)
 
 	// Verify network syscall detected
-	assert.True(t, hasNetworkSyscall(result.DetectedSyscalls), "socket syscall should be detected as network-related")
+	assert.True(t, hasNetworkSyscall(result.Architecture, result.DetectedSyscalls), "socket syscall should be detected as network-related")
 
 	// Verify socket syscall found
 	found := false
@@ -193,7 +202,7 @@ func main() {
 	require.NoError(t, err)
 
 	// A simple hello-world should NOT have network syscalls
-	assert.False(t, hasNetworkSyscall(result.DetectedSyscalls), "hello-world Go binary should not have network syscalls")
+	assert.False(t, hasNetworkSyscall(result.Architecture, result.DetectedSyscalls), "hello-world Go binary should not have network syscalls")
 }
 
 // TestE2E_RecordToRunnerFallbackChain tests the full pipeline:
@@ -318,7 +327,7 @@ func TestSyscallAnalyzer_IntegrationARM64_NetworkSyscalls(t *testing.T) {
 	require.NoError(t, err)
 
 	// The binary uses net.Dial which resolves to socket(198) on arm64
-	assert.True(t, hasNetworkSyscall(result.DetectedSyscalls), "arm64 binary using net.Dial should have network syscalls detected")
+	assert.True(t, hasNetworkSyscall(result.Architecture, result.DetectedSyscalls), "arm64 binary using net.Dial should have network syscalls detected")
 
 	// Verify socket syscall (arm64 number 198) is among the detected syscalls
 	found := false
@@ -407,11 +416,11 @@ func main() {
 				method = sc.Occurrences[0].DeterminationMethod
 				location = sc.Occurrences[0].Location
 			}
-			t.Logf("Syscall[%d]: #%-4d (%-20s) isNetwork=%-5v method=%s at 0x%x",
-				i, sc.Number, sc.Name, sc.IsNetwork, method, location)
+			t.Logf("Syscall[%d]: #%-4d (%-20s) method=%s at 0x%x",
+				i, sc.Number, sc.Name, method, location)
 		}
 
-		assert.True(t, hasNetworkSyscall(result.DetectedSyscalls),
+		assert.True(t, hasNetworkSyscall(result.Architecture, result.DetectedSyscalls),
 			"CGO binary calling syscall.Socket() should have network syscalls detected after fixes")
 
 		found := false

--- a/internal/runner/security/elfanalyzer/syscall_analyzer_test.go
+++ b/internal/runner/security/elfanalyzer/syscall_analyzer_test.go
@@ -246,13 +246,11 @@ func TestSyscallAnalyzer_MultipleSyscalls(t *testing.T) {
 	// First syscall: socket (41)
 	assert.Equal(t, 41, result.DetectedSyscalls[0].Number)
 	assert.Equal(t, "socket", result.DetectedSyscalls[0].Name)
-	assert.True(t, result.DetectedSyscalls[0].IsNetwork)
 	assert.Equal(t, DeterminationMethodImmediate, result.DetectedSyscalls[0].Occurrences[0].DeterminationMethod)
 
 	// Second syscall: connect (42)
 	assert.Equal(t, 42, result.DetectedSyscalls[1].Number)
 	assert.Equal(t, "connect", result.DetectedSyscalls[1].Name)
-	assert.True(t, result.DetectedSyscalls[1].IsNetwork)
 	assert.Equal(t, DeterminationMethodImmediate, result.DetectedSyscalls[1].Occurrences[0].DeterminationMethod)
 
 	assert.Empty(t, result.AnalysisWarnings)
@@ -290,12 +288,10 @@ func TestSyscallAnalyzer_NetworkAndNonNetworkSyscalls(t *testing.T) {
 	// First: write (non-network)
 	assert.Equal(t, 1, result.DetectedSyscalls[0].Number)
 	assert.Equal(t, "write", result.DetectedSyscalls[0].Name)
-	assert.False(t, result.DetectedSyscalls[0].IsNetwork)
 
 	// Second: socket (network)
 	assert.Equal(t, 41, result.DetectedSyscalls[1].Number)
 	assert.Equal(t, "socket", result.DetectedSyscalls[1].Name)
-	assert.True(t, result.DetectedSyscalls[1].IsNetwork)
 
 	assert.Empty(t, result.AnalysisWarnings)
 	assert.Empty(t, result.ArgEvalResults)
@@ -609,7 +605,6 @@ func TestSyscallAnalyzer_ARM64AnalysisPath(t *testing.T) {
 	require.Len(t, result.DetectedSyscalls, 1)
 	assert.Equal(t, 198, result.DetectedSyscalls[0].Number)
 	assert.Equal(t, "socket", result.DetectedSyscalls[0].Name)
-	assert.True(t, result.DetectedSyscalls[0].IsNetwork)
 	assert.Equal(t, DeterminationMethodImmediate, result.DetectedSyscalls[0].Occurrences[0].DeterminationMethod)
 }
 

--- a/internal/runner/security/machoanalyzer/pass1_scanner.go
+++ b/internal/runner/security/machoanalyzer/pass1_scanner.go
@@ -93,9 +93,8 @@ func scanSVCWithX16(
 		var info common.SyscallInfo
 		if ok {
 			info = common.SyscallInfo{
-				Number:    num,
-				Name:      table.GetSyscallName(num),
-				IsNetwork: table.IsNetworkSyscall(num),
+				Number: num,
+				Name:   table.GetSyscallName(num),
 				Occurrences: []common.SyscallOccurrence{
 					{
 						Location:            addr,

--- a/internal/runner/security/machoanalyzer/pass1_scanner_test.go
+++ b/internal/runner/security/machoanalyzer/pass1_scanner_test.go
@@ -92,7 +92,6 @@ func TestScanSVCWithX16_ImmediateNetworkSyscall(t *testing.T) {
 	require.Len(t, results, 1)
 	assert.Equal(t, 98, results[0].Number)
 	assert.Equal(t, "connect", results[0].Name)
-	assert.True(t, results[0].IsNetwork)
 	assert.Equal(t, determinationMethodImmediate, results[0].Occurrences[0].DeterminationMethod)
 	assert.Equal(t, "", results[0].Occurrences[0].Source)
 }
@@ -111,7 +110,6 @@ func TestScanSVCWithX16_ImmediateNonNetworkSyscall(t *testing.T) {
 	require.Len(t, results, 1)
 	assert.Equal(t, 3, results[0].Number)
 	assert.Equal(t, "read", results[0].Name)
-	assert.False(t, results[0].IsNetwork)
 	assert.Equal(t, determinationMethodImmediate, results[0].Occurrences[0].DeterminationMethod)
 }
 

--- a/internal/runner/security/machoanalyzer/pass2_scanner.go
+++ b/internal/runner/security/machoanalyzer/pass2_scanner.go
@@ -131,9 +131,8 @@ func scanGoWrapperCalls(
 		var info common.SyscallInfo
 		if resolved {
 			info = common.SyscallInfo{
-				Number:    num,
-				Name:      table.GetSyscallName(num),
-				IsNetwork: table.IsNetworkSyscall(num),
+				Number: num,
+				Name:   table.GetSyscallName(num),
 				Occurrences: []common.SyscallOccurrence{
 					{
 						Location:            instrAddr,

--- a/internal/runner/security/machoanalyzer/pass2_scanner_test.go
+++ b/internal/runner/security/machoanalyzer/pass2_scanner_test.go
@@ -78,7 +78,6 @@ func TestScanGoWrapperCalls_ResolvedNetworkSyscall(t *testing.T) {
 	require.Len(t, results, 1)
 	assert.Equal(t, 97, results[0].Number)
 	assert.Equal(t, "socket", results[0].Name)
-	assert.True(t, results[0].IsNetwork)
 	assert.Equal(t, determinationMethodGoWrapper, results[0].Occurrences[0].DeterminationMethod)
 	assert.Equal(t, textBase+8, results[0].Occurrences[0].Location)
 }
@@ -105,7 +104,6 @@ func TestScanGoWrapperCalls_ResolvedW0(t *testing.T) {
 	require.Len(t, results, 1)
 	assert.Equal(t, 98, results[0].Number)
 	assert.Equal(t, "connect", results[0].Name)
-	assert.True(t, results[0].IsNetwork)
 }
 
 // TestScanGoWrapperCalls_UnresolvedX0 verifies that a BL to a wrapper without

--- a/internal/runner/security/network_analyzer.go
+++ b/internal/runner/security/network_analyzer.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/isseis/go-safe-cmd-runner/internal/common"
 	"github.com/isseis/go-safe-cmd-runner/internal/fileanalysis"
+	"github.com/isseis/go-safe-cmd-runner/internal/libccache"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/security/binaryanalyzer"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/security/elfanalyzer"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/security/machoanalyzer"
@@ -18,6 +19,25 @@ import (
 
 // gosDarwin is the GOOS value for macOS.
 const gosDarwin = "darwin"
+
+type syscallTableInterface interface {
+	IsNetworkSyscall(number int) bool
+}
+
+func syscallTableForArch(arch string) syscallTableInterface {
+	if runtime.GOOS == gosDarwin {
+		return libccache.MacOSSyscallTable{}
+	}
+
+	switch arch {
+	case "x86_64":
+		return elfanalyzer.NewX86_64SyscallTable()
+	case "arm64":
+		return elfanalyzer.NewARM64LinuxSyscallTable()
+	default:
+		return nil
+	}
+}
 
 // NetworkAnalyzer provides network operation detection for commands.
 type NetworkAnalyzer struct {
@@ -244,10 +264,10 @@ func (a *NetworkAnalyzer) isNetworkViaBinaryAnalysis(cmdPath string, contentHash
 		}
 
 		// Check if any detected symbol has a network category (socket, dns, tls, http).
-		// non-network categories like syscall_wrapper don't trigger NetworkDetected.
+		// non-network symbols don't trigger NetworkDetected.
 		hasNetworkSymbol := false
 		for _, sym := range data.DetectedSymbols {
-			if binaryanalyzer.IsNetworkCategory(sym.Category) {
+			if binaryanalyzer.IsNetworkSymbolName(sym.Name) {
 				hasNetworkSymbol = true
 				break
 			}
@@ -297,15 +317,19 @@ func syscallAnalysisHasSVCSignal(result *fileanalysis.SyscallAnalysisResult) boo
 }
 
 // syscallAnalysisHasNetworkSignal reports whether the given SyscallAnalysisResult
-// contains any detected syscall classified as a network syscall (IsNetwork == true).
+// contains any detected syscall classified as a network syscall.
 // This includes resolved svc entries (DeterminationMethod == "direct_svc_0x80" AND Number != -1)
 // whose network classification is determined by the syscall table lookup.
 func syscallAnalysisHasNetworkSignal(result *fileanalysis.SyscallAnalysisResult) bool {
 	if result == nil {
 		return false
 	}
+	table := syscallTableForArch(result.Architecture)
+	if table == nil {
+		return false
+	}
 	for _, s := range result.DetectedSyscalls {
-		if s.IsNetwork {
+		if s.Number >= 0 && table.IsNetworkSyscall(s.Number) {
 			return true
 		}
 	}
@@ -368,16 +392,23 @@ func handleAnalysisOutput(output binaryanalyzer.AnalysisOutput, cmdPath string) 
 // convertNetworkSymbolEntries converts fileanalysis.DetectedSymbolEntry slice to binaryanalyzer.DetectedSymbol slice.
 //
 // NOTE: This is the inverse of convertDetectedSymbols in
-// internal/filevalidator/validator.go. Both functions map the same two fields
-// (Name, Category) between binaryanalyzer and fileanalysis types.
-// If either type gains or loses fields, update both functions together.
+// internal/filevalidator/validator.go. fileanalysis stores Name only, and this
+// function derives Category for runner-internal logging and filtering.
 func convertNetworkSymbolEntries(entries []fileanalysis.DetectedSymbolEntry) []binaryanalyzer.DetectedSymbol {
 	if len(entries) == 0 {
 		return nil
 	}
 	syms := make([]binaryanalyzer.DetectedSymbol, len(entries))
 	for i, e := range entries {
-		syms[i] = binaryanalyzer.DetectedSymbol{Name: e.Name, Category: e.Category}
+		cat, found := binaryanalyzer.IsNetworkSymbol(e.Name)
+		if !found {
+			if binaryanalyzer.IsDynamicLoadSymbol(e.Name) {
+				cat = binaryanalyzer.CategoryDynamicLoad
+			} else {
+				cat = binaryanalyzer.CategorySyscallWrapper
+			}
+		}
+		syms[i] = binaryanalyzer.DetectedSymbol{Name: e.Name, Category: string(cat)}
 	}
 	return syms
 }

--- a/internal/runner/security/network_analyzer_test.go
+++ b/internal/runner/security/network_analyzer_test.go
@@ -533,10 +533,8 @@ func TestIsNetworkViaBinaryAnalysis_NetworkDetected_IsNetworkTrue(t *testing.T) 
 	assert.False(t, isHigh, "IsNetwork without svc should not escalate to high risk")
 }
 
-// ---- AC-3: syscall-number-based network detection ----
-
 // TestSyscallAnalysisHasNetworkSignal_UnknownArch verifies that an unknown architecture
-// (mips) causes network detection to be skipped, returning false (AC-7a: fail-open).
+// (mips) causes network detection to be skipped and returns false.
 func TestSyscallAnalysisHasNetworkSignal_UnknownArch(t *testing.T) {
 	result := &fileanalysis.SyscallAnalysisResult{
 		SyscallAnalysisResultCore: common.SyscallAnalysisResultCore{
@@ -550,7 +548,7 @@ func TestSyscallAnalysisHasNetworkSignal_UnknownArch(t *testing.T) {
 }
 
 // TestSyscallAnalysisHasNetworkSignal_NegativeNumber verifies that a negative syscall
-// number does not trigger the network signal (AC-7b: fail-open).
+// number (unresolved SVC) does not trigger the network signal.
 func TestSyscallAnalysisHasNetworkSignal_NegativeNumber(t *testing.T) {
 	result := &fileanalysis.SyscallAnalysisResult{
 		SyscallAnalysisResultCore: common.SyscallAnalysisResultCore{

--- a/internal/runner/security/network_analyzer_test.go
+++ b/internal/runner/security/network_analyzer_test.go
@@ -532,3 +532,61 @@ func TestIsNetworkViaBinaryAnalysis_NetworkDetected_IsNetworkTrue(t *testing.T) 
 	assert.True(t, isNet, "SymbolAnalysis network should return true")
 	assert.False(t, isHigh, "IsNetwork without svc should not escalate to high risk")
 }
+
+// ---- AC-3: syscall-number-based network detection ----
+
+// TestSyscallAnalysisHasNetworkSignal_NetworkSyscall verifies that a known network
+// syscall number (Linux x86_64 socket=41) triggers the network signal (AC-3a).
+func TestSyscallAnalysisHasNetworkSignal_NetworkSyscall(t *testing.T) {
+	result := &fileanalysis.SyscallAnalysisResult{
+		SyscallAnalysisResultCore: common.SyscallAnalysisResultCore{
+			Architecture: "x86_64",
+			DetectedSyscalls: []common.SyscallInfo{
+				{Number: 41, Name: "socket"},
+			},
+		},
+	}
+	assert.True(t, syscallAnalysisHasNetworkSignal(result))
+}
+
+// TestSyscallAnalysisHasNetworkSignal_NonNetworkSyscall verifies that a non-network
+// syscall number (Linux x86_64 write=1) does not trigger the network signal (AC-3b).
+func TestSyscallAnalysisHasNetworkSignal_NonNetworkSyscall(t *testing.T) {
+	result := &fileanalysis.SyscallAnalysisResult{
+		SyscallAnalysisResultCore: common.SyscallAnalysisResultCore{
+			Architecture: "x86_64",
+			DetectedSyscalls: []common.SyscallInfo{
+				{Number: 1, Name: "write"},
+			},
+		},
+	}
+	assert.False(t, syscallAnalysisHasNetworkSignal(result))
+}
+
+// TestSyscallAnalysisHasNetworkSignal_UnknownArch verifies that an unknown architecture
+// (mips) causes network detection to be skipped, returning false (AC-7a: fail-open).
+func TestSyscallAnalysisHasNetworkSignal_UnknownArch(t *testing.T) {
+	result := &fileanalysis.SyscallAnalysisResult{
+		SyscallAnalysisResultCore: common.SyscallAnalysisResultCore{
+			Architecture: "mips",
+			DetectedSyscalls: []common.SyscallInfo{
+				{Number: 41},
+			},
+		},
+	}
+	assert.False(t, syscallAnalysisHasNetworkSignal(result))
+}
+
+// TestSyscallAnalysisHasNetworkSignal_NegativeNumber verifies that a negative syscall
+// number does not trigger the network signal (AC-7b: fail-open).
+func TestSyscallAnalysisHasNetworkSignal_NegativeNumber(t *testing.T) {
+	result := &fileanalysis.SyscallAnalysisResult{
+		SyscallAnalysisResultCore: common.SyscallAnalysisResultCore{
+			Architecture: "x86_64",
+			DetectedSyscalls: []common.SyscallInfo{
+				{Number: -1},
+			},
+		},
+	}
+	assert.False(t, syscallAnalysisHasNetworkSignal(result))
+}

--- a/internal/runner/security/network_analyzer_test.go
+++ b/internal/runner/security/network_analyzer_test.go
@@ -430,14 +430,14 @@ func TestSyscallAnalysisHasNetworkSignal_Empty(t *testing.T) {
 	assert.False(t, syscallAnalysisHasNetworkSignal(&fileanalysis.SyscallAnalysisResult{}))
 }
 
-// TestSyscallAnalysisHasNetworkSignal_IsNetworkTrue verifies that a DetectedSyscall
-// with IsNetwork==true triggers the network signal.
+// TestSyscallAnalysisHasNetworkSignal_IsNetworkTrue verifies that a network syscall
+// (socket #41 on x86_64) triggers the network signal.
 func TestSyscallAnalysisHasNetworkSignal_IsNetworkTrue(t *testing.T) {
 	assert.True(t, syscallAnalysisHasNetworkSignal(syscallAnalysisResultWithIsNetwork(true)))
 }
 
-// TestSyscallAnalysisHasNetworkSignal_IsNetworkFalse verifies that a DetectedSyscall
-// with IsNetwork==false does not trigger the network signal.
+// TestSyscallAnalysisHasNetworkSignal_IsNetworkFalse verifies that a non-network syscall
+// (read #3 on x86_64) does not trigger the network signal.
 func TestSyscallAnalysisHasNetworkSignal_IsNetworkFalse(t *testing.T) {
 	assert.False(t, syscallAnalysisHasNetworkSignal(syscallAnalysisResultWithIsNetwork(false)))
 }

--- a/internal/runner/security/network_analyzer_test.go
+++ b/internal/runner/security/network_analyzer_test.go
@@ -4,6 +4,7 @@ package security
 
 import (
 	"errors"
+	"runtime"
 	"testing"
 
 	"github.com/isseis/go-safe-cmd-runner/internal/common"
@@ -76,36 +77,49 @@ func TestSyscallAnalysisHasSVCSignal_ResolvedNetworkSVC(t *testing.T) {
 		"resolved network svc (Number != -1) must not be treated as high-risk svc signal")
 }
 
+// platformNetworkSyscallNums returns the architecture string and network syscall
+// numbers (socket, connect) that match syscallTableForArch's behavior on the current OS.
+// On macOS, syscallTableForArch ignores the arch field and always uses MacOSSyscallTable
+// (socket=97, connect=98); on Linux it uses the x86_64 table (socket=41, connect=42).
+func platformNetworkSyscallNums() (arch string, socketNum, connectNum int) {
+	if runtime.GOOS == "darwin" {
+		return "arm64", 97, 98
+	}
+	return "x86_64", 41, 42
+}
+
 // TestSyscallAnalysisHasNetworkSignal_ResolvedNetworkSVC verifies that a resolved network svc
 // is detected as a network signal based on syscall number lookup.
 func TestSyscallAnalysisHasNetworkSignal_ResolvedNetworkSVC(t *testing.T) {
+	arch, socketNum, _ := platformNetworkSyscallNums()
 	r := &fileanalysis.SyscallAnalysisResult{
 		SyscallAnalysisResultCore: common.SyscallAnalysisResultCore{
-			Architecture: "x86_64",
+			Architecture: arch,
 			DetectedSyscalls: []common.SyscallInfo{
-				{Number: 41, Name: "socket", Occurrences: []common.SyscallOccurrence{{DeterminationMethod: "direct_svc_0x80"}}},
+				{Number: socketNum, Name: "socket", Occurrences: []common.SyscallOccurrence{{DeterminationMethod: "direct_svc_0x80"}}},
 			},
 		},
 	}
 	assert.True(t, syscallAnalysisHasNetworkSignal(r),
-		"resolved network svc (socket #41 on x86_64) must be detected as network signal")
+		"resolved network svc (socket on %s/%s) must be detected as network signal", runtime.GOOS, arch)
 }
 
 // TestSyscallAnalysisHasNetworkSignal_LegacyFilteredRecord verifies backward compatibility:
 // when DetectedSyscalls was filtered by the old FilterSyscallsForStorage logic
 // (only network or Number==-1 entries present), the new judgment still produces the same result.
 func TestSyscallAnalysisHasNetworkSignal_LegacyFilteredRecord(t *testing.T) {
+	arch, socketNum, _ := platformNetworkSyscallNums()
 	// Simulate old filtered DetectedSyscalls: only network and unresolved entries kept.
 	r := &fileanalysis.SyscallAnalysisResult{
 		SyscallAnalysisResultCore: common.SyscallAnalysisResultCore{
-			Architecture: "x86_64",
+			Architecture: arch,
 			DetectedSyscalls: []common.SyscallInfo{
-				{Number: 41, Name: "socket", Occurrences: []common.SyscallOccurrence{{DeterminationMethod: "lib_cache_match"}}},
+				{Number: socketNum, Name: "socket", Occurrences: []common.SyscallOccurrence{{DeterminationMethod: "lib_cache_match"}}},
 				{Number: -1, Occurrences: []common.SyscallOccurrence{{DeterminationMethod: "direct_svc_0x80"}}},
 			},
 		},
 	}
-	// Network signal from socket (#41 on x86_64) must still be detected.
+	// Network signal from socket must still be detected.
 	assert.True(t, syscallAnalysisHasNetworkSignal(r),
 		"legacy filtered record with network entry must still trigger network signal")
 	// Unresolved svc (Number==-1) must still trigger high-risk signal.
@@ -389,13 +403,14 @@ func TestIsNetworkViaBinaryAnalysis_SyscallWrapperOnly(t *testing.T) {
 // ---- Section 6.2: syscallAnalysisHasNetworkSignal tests ----
 
 // syscallAnalysisResultWithNetworkSyscall builds a SyscallAnalysisResult containing
-// one DetectedSyscall. When hasNetwork is true, uses socket (x86_64 #41, a network syscall);
-// when false, uses read (x86_64 #3, a non-network syscall).
+// one DetectedSyscall. When hasNetwork is true, uses socket (a network syscall for the
+// current OS); when false, uses read (#3, non-network on both Linux and macOS).
 func syscallAnalysisResultWithNetworkSyscall(hasNetwork bool) *fileanalysis.SyscallAnalysisResult {
+	arch, socketNum, _ := platformNetworkSyscallNums()
 	var info common.SyscallInfo
 	if hasNetwork {
 		info = common.SyscallInfo{
-			Number: 41,
+			Number: socketNum,
 			Name:   "socket",
 			Occurrences: []common.SyscallOccurrence{{
 				DeterminationMethod: "lib_cache_match",
@@ -404,7 +419,7 @@ func syscallAnalysisResultWithNetworkSyscall(hasNetwork bool) *fileanalysis.Sysc
 		}
 	} else {
 		info = common.SyscallInfo{
-			Number: 3,
+			Number: 3, // read: non-network on both Linux x86_64 and macOS
 			Name:   "read",
 			Occurrences: []common.SyscallOccurrence{{
 				DeterminationMethod: "lib_cache_match",
@@ -414,7 +429,7 @@ func syscallAnalysisResultWithNetworkSyscall(hasNetwork bool) *fileanalysis.Sysc
 	}
 	return &fileanalysis.SyscallAnalysisResult{
 		SyscallAnalysisResultCore: common.SyscallAnalysisResultCore{
-			Architecture:     "x86_64",
+			Architecture:     arch,
 			DetectedSyscalls: []common.SyscallInfo{info},
 		},
 	}
@@ -445,13 +460,14 @@ func TestSyscallAnalysisHasNetworkSignal_NonNetworkSyscall(t *testing.T) {
 // TestSyscallAnalysisHasNetworkSignal_MultipleEntries verifies that any network syscall entry
 // is sufficient to trigger the signal.
 func TestSyscallAnalysisHasNetworkSignal_MultipleEntries(t *testing.T) {
+	arch, socketNum, connectNum := platformNetworkSyscallNums()
 	result := &fileanalysis.SyscallAnalysisResult{
 		SyscallAnalysisResultCore: common.SyscallAnalysisResultCore{
-			Architecture: "x86_64",
+			Architecture: arch,
 			DetectedSyscalls: []common.SyscallInfo{
-				{Number: 1},                   // write: non-network
-				{Number: 41, Name: "socket"},  // x86_64 socket: network
-				{Number: 42, Name: "connect"}, // x86_64 connect: network
+				{Number: 3}, // read: non-network on both Linux and macOS
+				{Number: socketNum, Name: "socket"},
+				{Number: connectNum, Name: "connect"},
 			},
 		},
 	}

--- a/internal/runner/security/network_analyzer_test.go
+++ b/internal/runner/security/network_analyzer_test.go
@@ -53,7 +53,7 @@ func TestSyscallAnalysisHasSVCSignal_ResolvedNonNetworkSVC(t *testing.T) {
 	r := &fileanalysis.SyscallAnalysisResult{
 		SyscallAnalysisResultCore: common.SyscallAnalysisResultCore{
 			DetectedSyscalls: []common.SyscallInfo{
-				{Number: 3, Name: "read", IsNetwork: false, Occurrences: []common.SyscallOccurrence{{DeterminationMethod: "direct_svc_0x80"}}},
+				{Number: 3, Name: "read", Occurrences: []common.SyscallOccurrence{{DeterminationMethod: "direct_svc_0x80"}}},
 			},
 		},
 	}
@@ -68,7 +68,7 @@ func TestSyscallAnalysisHasSVCSignal_ResolvedNetworkSVC(t *testing.T) {
 	r := &fileanalysis.SyscallAnalysisResult{
 		SyscallAnalysisResultCore: common.SyscallAnalysisResultCore{
 			DetectedSyscalls: []common.SyscallInfo{
-				{Number: 97, Name: "socket", IsNetwork: true, Occurrences: []common.SyscallOccurrence{{DeterminationMethod: "direct_svc_0x80"}}},
+				{Number: 97, Name: "socket", Occurrences: []common.SyscallOccurrence{{DeterminationMethod: "direct_svc_0x80"}}},
 			},
 		},
 	}
@@ -77,19 +77,18 @@ func TestSyscallAnalysisHasSVCSignal_ResolvedNetworkSVC(t *testing.T) {
 }
 
 // TestSyscallAnalysisHasNetworkSignal_ResolvedNetworkSVC verifies that a resolved network svc
-// (DeterminationMethod="direct_svc_0x80", IsNetwork=true) is detected as a network signal.
-// After filter removal, resolved svc entries appear in DetectedSyscalls and must be evaluated
-// by IsNetwork, regardless of DeterminationMethod.
+// is detected as a network signal based on syscall number lookup.
 func TestSyscallAnalysisHasNetworkSignal_ResolvedNetworkSVC(t *testing.T) {
 	r := &fileanalysis.SyscallAnalysisResult{
 		SyscallAnalysisResultCore: common.SyscallAnalysisResultCore{
+			Architecture: "x86_64",
 			DetectedSyscalls: []common.SyscallInfo{
-				{Number: 97, Name: "socket", IsNetwork: true, Occurrences: []common.SyscallOccurrence{{DeterminationMethod: "direct_svc_0x80"}}},
+				{Number: 41, Name: "socket", Occurrences: []common.SyscallOccurrence{{DeterminationMethod: "direct_svc_0x80"}}},
 			},
 		},
 	}
 	assert.True(t, syscallAnalysisHasNetworkSignal(r),
-		"resolved network svc (IsNetwork=true) must be detected as network signal")
+		"resolved network svc (socket #41 on x86_64) must be detected as network signal")
 }
 
 // TestSyscallAnalysisHasNetworkSignal_LegacyFilteredRecord verifies backward compatibility:
@@ -99,13 +98,14 @@ func TestSyscallAnalysisHasNetworkSignal_LegacyFilteredRecord(t *testing.T) {
 	// Simulate old filtered DetectedSyscalls: only network and unresolved entries kept.
 	r := &fileanalysis.SyscallAnalysisResult{
 		SyscallAnalysisResultCore: common.SyscallAnalysisResultCore{
+			Architecture: "x86_64",
 			DetectedSyscalls: []common.SyscallInfo{
-				{Number: 97, Name: "socket", IsNetwork: true, Occurrences: []common.SyscallOccurrence{{DeterminationMethod: "lib_cache_match"}}},
+				{Number: 41, Name: "socket", Occurrences: []common.SyscallOccurrence{{DeterminationMethod: "lib_cache_match"}}},
 				{Number: -1, Occurrences: []common.SyscallOccurrence{{DeterminationMethod: "direct_svc_0x80"}}},
 			},
 		},
 	}
-	// Network signal from socket (network=true) must still be detected.
+	// Network signal from socket (#41 on x86_64) must still be detected.
 	assert.True(t, syscallAnalysisHasNetworkSignal(r),
 		"legacy filtered record with network entry must still trigger network signal")
 	// Unresolved svc (Number==-1) must still trigger high-risk signal.
@@ -147,7 +147,7 @@ func noNetworkSymbolData() *fileanalysis.SymbolAnalysisData {
 func networkDetectedData() *fileanalysis.SymbolAnalysisData {
 	return &fileanalysis.SymbolAnalysisData{
 		DetectedSymbols: []fileanalysis.DetectedSymbolEntry{
-			{Name: "socket", Category: "socket"},
+			{Name: "socket"},
 		},
 	}
 }
@@ -157,8 +157,8 @@ func networkDetectedData() *fileanalysis.SymbolAnalysisData {
 func syscallWrapperOnlyData() *fileanalysis.SymbolAnalysisData {
 	return &fileanalysis.SymbolAnalysisData{
 		DetectedSymbols: []fileanalysis.DetectedSymbolEntry{
-			{Name: "read", Category: "syscall_wrapper"},
-			{Name: "close", Category: "syscall_wrapper"},
+			{Name: "read"},
+			{Name: "close"},
 		},
 	}
 }
@@ -360,8 +360,8 @@ func TestIsNetworkViaBinaryAnalysis_NetworkDetected_NoSVC(t *testing.T) {
 func TestIsNetworkViaBinaryAnalysis_NetworkCategorySymbol(t *testing.T) {
 	symStore := &stubNetworkSymbolStore{data: &fileanalysis.SymbolAnalysisData{
 		DetectedSymbols: []fileanalysis.DetectedSymbolEntry{
-			{Name: "read", Category: "syscall_wrapper"},
-			{Name: "socket", Category: "socket"},
+			{Name: "read"},
+			{Name: "socket"},
 		},
 	}}
 	svcStore := &mockFileanalysisSyscallStore{result: nil}
@@ -388,22 +388,34 @@ func TestIsNetworkViaBinaryAnalysis_SyscallWrapperOnly(t *testing.T) {
 
 // ---- Section 6.2: syscallAnalysisHasNetworkSignal tests ----
 
-// syscallAnalysisResultWithIsNetwork builds a SyscallAnalysisResult containing
-// one DetectedSyscall with IsNetwork set to the given value.
-func syscallAnalysisResultWithIsNetwork(isNetwork bool) *fileanalysis.SyscallAnalysisResult {
+// syscallAnalysisResultWithNetworkSyscall builds a SyscallAnalysisResult containing
+// one DetectedSyscall. When hasNetwork is true, uses socket (x86_64 #41, a network syscall);
+// when false, uses read (x86_64 #3, a non-network syscall).
+func syscallAnalysisResultWithIsNetwork(hasNetwork bool) *fileanalysis.SyscallAnalysisResult {
+	var info common.SyscallInfo
+	if hasNetwork {
+		info = common.SyscallInfo{
+			Number: 41,
+			Name:   "socket",
+			Occurrences: []common.SyscallOccurrence{{
+				DeterminationMethod: "lib_cache_match",
+				Source:              "libsystem_symbol_import",
+			}},
+		}
+	} else {
+		info = common.SyscallInfo{
+			Number: 3,
+			Name:   "read",
+			Occurrences: []common.SyscallOccurrence{{
+				DeterminationMethod: "lib_cache_match",
+				Source:              "libsystem_symbol_import",
+			}},
+		}
+	}
 	return &fileanalysis.SyscallAnalysisResult{
 		SyscallAnalysisResultCore: common.SyscallAnalysisResultCore{
-			DetectedSyscalls: []common.SyscallInfo{
-				{
-					Number:    97,
-					Name:      "socket",
-					IsNetwork: isNetwork,
-					Occurrences: []common.SyscallOccurrence{{
-						DeterminationMethod: "lib_cache_match",
-						Source:              "libsystem_symbol_import",
-					}},
-				},
-			},
+			Architecture:     "x86_64",
+			DetectedSyscalls: []common.SyscallInfo{info},
 		},
 	}
 }
@@ -430,15 +442,16 @@ func TestSyscallAnalysisHasNetworkSignal_IsNetworkFalse(t *testing.T) {
 	assert.False(t, syscallAnalysisHasNetworkSignal(syscallAnalysisResultWithIsNetwork(false)))
 }
 
-// TestSyscallAnalysisHasNetworkSignal_MultipleEntries verifies that any entry with
-// IsNetwork==true is sufficient to trigger the signal.
+// TestSyscallAnalysisHasNetworkSignal_MultipleEntries verifies that any network syscall entry
+// is sufficient to trigger the signal.
 func TestSyscallAnalysisHasNetworkSignal_MultipleEntries(t *testing.T) {
 	result := &fileanalysis.SyscallAnalysisResult{
 		SyscallAnalysisResultCore: common.SyscallAnalysisResultCore{
+			Architecture: "x86_64",
 			DetectedSyscalls: []common.SyscallInfo{
-				{Number: 5, IsNetwork: false},
-				{Number: 97, IsNetwork: true, Name: "socket"},
-				{Number: 98, IsNetwork: true, Name: "connect"},
+				{Number: 1},                   // write: non-network
+				{Number: 41, Name: "socket"},  // x86_64 socket: network
+				{Number: 42, Name: "connect"}, // x86_64 connect: network
 			},
 		},
 	}
@@ -491,8 +504,8 @@ func TestIsNetworkViaBinaryAnalysis_StaticBinary_SVCAndIsNetwork(t *testing.T) {
 	result := &fileanalysis.SyscallAnalysisResult{
 		SyscallAnalysisResultCore: common.SyscallAnalysisResultCore{
 			DetectedSyscalls: []common.SyscallInfo{
-				{Number: -1, IsNetwork: false, Occurrences: []common.SyscallOccurrence{{DeterminationMethod: "direct_svc_0x80"}}},
-				{Number: 97, Name: "socket", IsNetwork: true, Occurrences: []common.SyscallOccurrence{{Source: "libsystem_symbol_import"}}},
+				{Number: -1, Occurrences: []common.SyscallOccurrence{{DeterminationMethod: "direct_svc_0x80"}}},
+				{Number: 97, Name: "socket", Occurrences: []common.SyscallOccurrence{{Source: "libsystem_symbol_import"}}},
 			},
 		},
 	}

--- a/internal/runner/security/network_analyzer_test.go
+++ b/internal/runner/security/network_analyzer_test.go
@@ -46,7 +46,7 @@ func TestSyscallAnalysisHasSVCSignal_WithDeterminationMethod(t *testing.T) {
 }
 
 // TestSyscallAnalysisHasSVCSignal_ResolvedNonNetworkSVC verifies that a resolved
-// non-network svc (Number != -1, IsNetwork=false) does NOT trigger the high-risk signal.
+// non-network svc (Number != -1) does NOT trigger the high-risk signal.
 // After filter removal, resolved svc entries appear in DetectedSyscalls; only
 // unresolved ones (Number==-1) are high risk.
 func TestSyscallAnalysisHasSVCSignal_ResolvedNonNetworkSVC(t *testing.T) {
@@ -62,7 +62,7 @@ func TestSyscallAnalysisHasSVCSignal_ResolvedNonNetworkSVC(t *testing.T) {
 }
 
 // TestSyscallAnalysisHasSVCSignal_ResolvedNetworkSVC verifies that a resolved network svc
-// (Number != -1, IsNetwork=true) does NOT trigger the high-risk svc signal.
+// (Number != -1) does NOT trigger the high-risk svc signal.
 // Its network nature is handled by syscallAnalysisHasNetworkSignal instead.
 func TestSyscallAnalysisHasSVCSignal_ResolvedNetworkSVC(t *testing.T) {
 	r := &fileanalysis.SyscallAnalysisResult{
@@ -391,7 +391,7 @@ func TestIsNetworkViaBinaryAnalysis_SyscallWrapperOnly(t *testing.T) {
 // syscallAnalysisResultWithNetworkSyscall builds a SyscallAnalysisResult containing
 // one DetectedSyscall. When hasNetwork is true, uses socket (x86_64 #41, a network syscall);
 // when false, uses read (x86_64 #3, a non-network syscall).
-func syscallAnalysisResultWithIsNetwork(hasNetwork bool) *fileanalysis.SyscallAnalysisResult {
+func syscallAnalysisResultWithNetworkSyscall(hasNetwork bool) *fileanalysis.SyscallAnalysisResult {
 	var info common.SyscallInfo
 	if hasNetwork {
 		info = common.SyscallInfo{
@@ -430,16 +430,16 @@ func TestSyscallAnalysisHasNetworkSignal_Empty(t *testing.T) {
 	assert.False(t, syscallAnalysisHasNetworkSignal(&fileanalysis.SyscallAnalysisResult{}))
 }
 
-// TestSyscallAnalysisHasNetworkSignal_IsNetworkTrue verifies that a network syscall
+// TestSyscallAnalysisHasNetworkSignal_NetworkSyscall verifies that a network syscall
 // (socket #41 on x86_64) triggers the network signal.
-func TestSyscallAnalysisHasNetworkSignal_IsNetworkTrue(t *testing.T) {
-	assert.True(t, syscallAnalysisHasNetworkSignal(syscallAnalysisResultWithIsNetwork(true)))
+func TestSyscallAnalysisHasNetworkSignal_NetworkSyscall(t *testing.T) {
+	assert.True(t, syscallAnalysisHasNetworkSignal(syscallAnalysisResultWithNetworkSyscall(true)))
 }
 
-// TestSyscallAnalysisHasNetworkSignal_IsNetworkFalse verifies that a non-network syscall
+// TestSyscallAnalysisHasNetworkSignal_NonNetworkSyscall verifies that a non-network syscall
 // (read #3 on x86_64) does not trigger the network signal.
-func TestSyscallAnalysisHasNetworkSignal_IsNetworkFalse(t *testing.T) {
-	assert.False(t, syscallAnalysisHasNetworkSignal(syscallAnalysisResultWithIsNetwork(false)))
+func TestSyscallAnalysisHasNetworkSignal_NonNetworkSyscall(t *testing.T) {
+	assert.False(t, syscallAnalysisHasNetworkSignal(syscallAnalysisResultWithNetworkSyscall(false)))
 }
 
 // TestSyscallAnalysisHasNetworkSignal_MultipleEntries verifies that any network syscall entry
@@ -458,35 +458,35 @@ func TestSyscallAnalysisHasNetworkSignal_MultipleEntries(t *testing.T) {
 	assert.True(t, syscallAnalysisHasNetworkSignal(result))
 }
 
-// ---- Section 6.2: isNetworkViaBinaryAnalysis IsNetwork flow tests ----
+// ---- Section 6.2: isNetworkViaBinaryAnalysis syscall-signal flow tests ----
 
 // syscallResultWithNetworkEntry builds a SyscallAnalysisResult with a network syscall entry.
 func syscallResultWithNetworkEntry() *fileanalysis.SyscallAnalysisResult {
-	return syscallAnalysisResultWithIsNetwork(true)
+	return syscallAnalysisResultWithNetworkSyscall(true)
 }
 
 // syscallResultWithNonNetworkEntry builds a SyscallAnalysisResult with a non-network syscall entry.
 func syscallResultWithNonNetworkEntry() *fileanalysis.SyscallAnalysisResult {
-	return syscallAnalysisResultWithIsNetwork(false)
+	return syscallAnalysisResultWithNetworkSyscall(false)
 }
 
-// TestIsNetworkViaBinaryAnalysis_StaticBinary_IsNetworkTrue verifies that a static binary
-// (nil SymbolAnalysis) with IsNetwork==true in SyscallAnalysis returns true, false.
-// (IsNetwork path does not escalate to high risk — only direct_svc_0x80 does.)
-func TestIsNetworkViaBinaryAnalysis_StaticBinary_IsNetworkTrue(t *testing.T) {
+// TestIsNetworkViaBinaryAnalysis_StaticBinary_NetworkSyscall verifies that a static binary
+// (nil SymbolAnalysis) with a network syscall in SyscallAnalysis returns true, false.
+// Network syscall detection does not escalate to high risk — only direct_svc_0x80 does.
+func TestIsNetworkViaBinaryAnalysis_StaticBinary_NetworkSyscall(t *testing.T) {
 	symStore := &stubNetworkSymbolStore{data: nil}
 	svcStore := &mockFileanalysisSyscallStore{result: syscallResultWithNetworkEntry()}
 	analyzer := newNetworkAnalyzerWithStores(symStore, svcStore)
 
 	isNet, isHigh := analyzer.isNetworkViaBinaryAnalysis(testCmdPath, testContentHash)
 
-	assert.True(t, isNet, "static binary with IsNetwork syscall should return true")
-	assert.False(t, isHigh, "IsNetwork path should not escalate to high risk")
+	assert.True(t, isNet, "static binary with network syscall should return true")
+	assert.False(t, isHigh, "network syscall detection should not escalate to high risk")
 }
 
-// TestIsNetworkViaBinaryAnalysis_StaticBinary_IsNetworkFalse verifies that a static binary
+// TestIsNetworkViaBinaryAnalysis_StaticBinary_NonNetworkSyscall verifies that a static binary
 // with no network syscall and no svc returns false, false.
-func TestIsNetworkViaBinaryAnalysis_StaticBinary_IsNetworkFalse(t *testing.T) {
+func TestIsNetworkViaBinaryAnalysis_StaticBinary_NonNetworkSyscall(t *testing.T) {
 	symStore := &stubNetworkSymbolStore{data: nil}
 	svcStore := &mockFileanalysisSyscallStore{result: syscallResultWithNonNetworkEntry()}
 	analyzer := newNetworkAnalyzerWithStores(symStore, svcStore)
@@ -497,10 +497,10 @@ func TestIsNetworkViaBinaryAnalysis_StaticBinary_IsNetworkFalse(t *testing.T) {
 	assert.False(t, isHigh, "no network signal should not escalate to high risk")
 }
 
-// TestIsNetworkViaBinaryAnalysis_StaticBinary_SVCAndIsNetwork verifies that a static binary
-// with both svc #0x80 and IsNetwork==true returns true, true (svc escalates).
-func TestIsNetworkViaBinaryAnalysis_StaticBinary_SVCAndIsNetwork(t *testing.T) {
-	// Build a result that has both direct_svc_0x80 and IsNetwork==true.
+// TestIsNetworkViaBinaryAnalysis_StaticBinary_SVCAndNetworkSyscall verifies that a static binary
+// with both an unresolved svc #0x80 and a network syscall returns true, true (svc escalates).
+func TestIsNetworkViaBinaryAnalysis_StaticBinary_SVCAndNetworkSyscall(t *testing.T) {
+	// Build a result that has both an unresolved direct_svc_0x80 and a network syscall.
 	result := &fileanalysis.SyscallAnalysisResult{
 		SyscallAnalysisResultCore: common.SyscallAnalysisResultCore{
 			DetectedSyscalls: []common.SyscallInfo{
@@ -515,14 +515,14 @@ func TestIsNetworkViaBinaryAnalysis_StaticBinary_SVCAndIsNetwork(t *testing.T) {
 
 	isNet, isHigh := analyzer.isNetworkViaBinaryAnalysis(testCmdPath, testContentHash)
 
-	assert.True(t, isNet, "svc + IsNetwork should return true")
+	assert.True(t, isNet, "svc + network syscall should return true")
 	assert.True(t, isHigh, "svc #0x80 should escalate to high risk")
 }
 
-// TestIsNetworkViaBinaryAnalysis_NetworkDetected_IsNetworkTrue verifies that when
-// SymbolAnalysis detects network but the SyscallAnalysis also has IsNetwork==true,
-// network is detected (true, false) — IsNetwork does not add high risk over symbol analysis.
-func TestIsNetworkViaBinaryAnalysis_NetworkDetected_IsNetworkTrue(t *testing.T) {
+// TestIsNetworkViaBinaryAnalysis_NetworkDetected_WithNetworkSyscall verifies that when
+// SymbolAnalysis detects network and SyscallAnalysis also has a network syscall,
+// network is detected (true, false) — syscall detection alone does not escalate to high risk.
+func TestIsNetworkViaBinaryAnalysis_NetworkDetected_WithNetworkSyscall(t *testing.T) {
 	symStore := &stubNetworkSymbolStore{data: networkDetectedData()}
 	svcStore := &mockFileanalysisSyscallStore{result: syscallResultWithNetworkEntry()}
 	analyzer := newNetworkAnalyzerWithStores(symStore, svcStore)
@@ -530,7 +530,7 @@ func TestIsNetworkViaBinaryAnalysis_NetworkDetected_IsNetworkTrue(t *testing.T) 
 	isNet, isHigh := analyzer.isNetworkViaBinaryAnalysis(testCmdPath, testContentHash)
 
 	assert.True(t, isNet, "SymbolAnalysis network should return true")
-	assert.False(t, isHigh, "IsNetwork without svc should not escalate to high risk")
+	assert.False(t, isHigh, "network syscall without svc should not escalate to high risk")
 }
 
 // TestSyscallAnalysisHasNetworkSignal_UnknownArch verifies that an unknown architecture

--- a/internal/runner/security/network_analyzer_test.go
+++ b/internal/runner/security/network_analyzer_test.go
@@ -535,34 +535,6 @@ func TestIsNetworkViaBinaryAnalysis_NetworkDetected_IsNetworkTrue(t *testing.T) 
 
 // ---- AC-3: syscall-number-based network detection ----
 
-// TestSyscallAnalysisHasNetworkSignal_NetworkSyscall verifies that a known network
-// syscall number (Linux x86_64 socket=41) triggers the network signal (AC-3a).
-func TestSyscallAnalysisHasNetworkSignal_NetworkSyscall(t *testing.T) {
-	result := &fileanalysis.SyscallAnalysisResult{
-		SyscallAnalysisResultCore: common.SyscallAnalysisResultCore{
-			Architecture: "x86_64",
-			DetectedSyscalls: []common.SyscallInfo{
-				{Number: 41, Name: "socket"},
-			},
-		},
-	}
-	assert.True(t, syscallAnalysisHasNetworkSignal(result))
-}
-
-// TestSyscallAnalysisHasNetworkSignal_NonNetworkSyscall verifies that a non-network
-// syscall number (Linux x86_64 write=1) does not trigger the network signal (AC-3b).
-func TestSyscallAnalysisHasNetworkSignal_NonNetworkSyscall(t *testing.T) {
-	result := &fileanalysis.SyscallAnalysisResult{
-		SyscallAnalysisResultCore: common.SyscallAnalysisResultCore{
-			Architecture: "x86_64",
-			DetectedSyscalls: []common.SyscallInfo{
-				{Number: 1, Name: "write"},
-			},
-		},
-	}
-	assert.False(t, syscallAnalysisHasNetworkSignal(result))
-}
-
 // TestSyscallAnalysisHasNetworkSignal_UnknownArch verifies that an unknown architecture
 // (mips) causes network detection to be skipped, returning false (AC-7a: fail-open).
 func TestSyscallAnalysisHasNetworkSignal_UnknownArch(t *testing.T) {

--- a/internal/runner/security/syscall_store_adapter_test.go
+++ b/internal/runner/security/syscall_store_adapter_test.go
@@ -30,7 +30,7 @@ func TestNewELFSyscallStoreAdapter_ReturnResult(t *testing.T) {
 	core := common.SyscallAnalysisResultCore{
 		Architecture: "x86_64",
 		DetectedSyscalls: []common.SyscallInfo{
-			{Number: 41, Name: "socket", IsNetwork: true},
+			{Number: 41, Name: "socket"},
 		},
 	}
 	inner := &mockFileanalysisSyscallStore{


### PR DESCRIPTION
# Pull Request: Removal of Record-Level Risk Classification

This pull request finalizes the removal of record-level risk classification fields (`IsNetwork` and `Category`) from syscall and symbol analysis results, and updates all related logic, documentation, and tests to use runtime-derived network classification instead.

The changes ensure that network-related detection is now based on runtime checks (such as syscall number and symbol name) rather than persisted fields, and that logs maintain equivalent information by deriving categories on the fly. All implementation plan checklists are marked as complete, and the codebase is updated to pass lint, build, and test checks.

---

## Key changes include:

### 1. Core logic and schema changes
* Removed the `IsNetwork` field from `SyscallInfo` and the `Category` field from `DetectedSymbolEntry`, updating all code, documentation, and tests to reflect this change.
* Network classification is now performed at runtime using syscall numbers and symbol names.
* Updated the schema version to `18` and adjusted schema migration and version checks accordingly.

**References:**
* [[1]](diffhunk://#diff-8b2849d7be20065f3bbba05f2aaf08577c01f802b70a03f22f07cb0e69838114L73-R77)
* [[2]](diffhunk://#diff-5da921ce724ec48896630d7fc28e08d019ca89a0861c876ea2a7e2a28e98239bL529-R554)

### 2. Network classification improvements
* Refactored network detection logic to use syscall number tables and symbol name helpers at runtime (`IsNetworkSyscall`, `IsNetworkSymbolName`).
* Added fallback category assignment for symbols:
  * `dynamic_load`: for dynamic load symbols.
  * `syscall_wrapper`: for others.
* Updated architecture diagrams, specifications, and documentation to reflect the new runtime-based classification logic.

**References:**
* [[1]](diffhunk://#diff-8b2849d7be20065f3bbba05f2aaf08577c01f802b70a03f22f07cb0e69838114L117-R123)
* [[2]](diffhunk://#diff-bcade0f37a1b2804f04c99f8599c13d00008a601101be3bacf387fd90a7ee55cL122-R125)

### 3. Testing and validation
* Added and updated tests to verify:
  * Absence of removed fields in JSON outputs.
  * Correct behavior of runtime classification.
  * Schema versioning and handling of edge cases (unknown architectures, negative syscall numbers, nil results).
* Marked all implementation plan checkboxes as complete.

**References:**
* [[1]](diffhunk://#diff-5da921ce724ec48896630d7fc28e08d019ca89a0861c876ea2a7e2a28e98239bL468-R479)
* [[2]](diffhunk://#diff-8b2849d7be20065f3bbba05f2aaf08577c01f802b70a03f22f07cb0e69838114L185-R190)

### 4. Codebase and tooling updates
* Updated `.golangci.yml` to include the new `internal/libccache` directory in linter checks.

**References:**
* [[1]](diffhunk://#diff-6179837f7df53a6f05c522b6b7bb566d484d5465d9894fb04910dd08bb40dcc9R52)

---

These changes modernize the risk classification approach, improve maintainability, and ensure consistent, runtime-driven detection across the codebase.