### PR TITLE
perf: cache syscall tables as package-level vars to avoid redundant allocations

### DIFF
--- a/internal/runner/security/elfanalyzer/standard_analyzer.go
+++ b/internal/runner/security/elfanalyzer/standard_analyzer.go
@@ -428,12 +428,17 @@ func (a *StandardELFAnalyzer) convertSyscallResult(result *SyscallAnalysisResult
 	return binaryanalyzer.AnalysisOutput{Result: binaryanalyzer.NoNetworkSymbols}
 }
 
+var (
+	cachedX86SyscallTable   = NewX86_64SyscallTable()
+	cachedArm64SyscallTable = NewARM64LinuxSyscallTable()
+)
+
 func syscallTableForArchitecture(arch string) SyscallNumberTable {
 	switch arch {
 	case "x86_64":
-		return NewX86_64SyscallTable()
+		return cachedX86SyscallTable
 	case "arm64":
-		return NewARM64LinuxSyscallTable()
+		return cachedArm64SyscallTable
 	default:
 		return nil
 	}

--- a/internal/runner/security/elfanalyzer/standard_analyzer.go
+++ b/internal/runner/security/elfanalyzer/standard_analyzer.go
@@ -409,7 +409,7 @@ func (a *StandardELFAnalyzer) convertSyscallResult(result *SyscallAnalysisResult
 	}
 
 	var symbols []binaryanalyzer.DetectedSymbol
-	table := syscallTableForArchitecture(result.Architecture)
+	table := SyscallTableForArchitecture(result.Architecture)
 	for _, info := range result.DetectedSyscalls {
 		if table != nil && info.Number >= 0 && table.IsNetworkSyscall(info.Number) {
 			symbols = append(symbols, binaryanalyzer.DetectedSymbol{
@@ -433,7 +433,9 @@ var (
 	cachedArm64SyscallTable = NewARM64LinuxSyscallTable()
 )
 
-func syscallTableForArchitecture(arch string) SyscallNumberTable {
+// SyscallTableForArchitecture returns the shared cached SyscallNumberTable for the given Linux architecture.
+// Returns nil for unrecognized architectures.
+func SyscallTableForArchitecture(arch string) SyscallNumberTable {
 	switch arch {
 	case "x86_64":
 		return cachedX86SyscallTable

--- a/internal/runner/security/network_analyzer.go
+++ b/internal/runner/security/network_analyzer.go
@@ -24,25 +24,11 @@ type syscallTableInterface interface {
 	IsNetworkSyscall(number int) bool
 }
 
-var (
-	cachedX86Table   = elfanalyzer.NewX86_64SyscallTable()
-	cachedArm64Table = elfanalyzer.NewARM64LinuxSyscallTable()
-	cachedMacOSTable = libccache.MacOSSyscallTable{}
-)
-
-func syscallTableForArch(arch string) syscallTableInterface {
-	if runtime.GOOS == gosDarwin {
-		return cachedMacOSTable
+func syscallTableForArch(goos, arch string) syscallTableInterface {
+	if goos == gosDarwin {
+		return libccache.MacOSSyscallTable{}
 	}
-
-	switch arch {
-	case "x86_64":
-		return cachedX86Table
-	case "arm64":
-		return cachedArm64Table
-	default:
-		return nil
-	}
+	return elfanalyzer.SyscallTableForArchitecture(arch)
 }
 
 // NetworkAnalyzer provides network operation detection for commands.
@@ -233,7 +219,7 @@ func (a *NetworkAnalyzer) isNetworkViaBinaryAnalysis(cmdPath string, contentHash
 					return true, true
 				}
 				// Check whether any non-svc detected syscall is a network syscall.
-				if syscallAnalysisHasNetworkSignal(svcResult) {
+				if syscallAnalysisHasNetworkSignal(svcResult, runtime.GOOS) {
 					slog.Info("SyscallAnalysis cache indicates network syscall",
 						"path", cmdPath)
 					return true, false
@@ -326,14 +312,14 @@ func syscallAnalysisHasSVCSignal(result *fileanalysis.SyscallAnalysisResult) boo
 // contains any detected syscall classified as a network syscall.
 // This includes resolved svc entries (DeterminationMethod == "direct_svc_0x80" AND Number != -1)
 // whose network classification is determined by the syscall table lookup.
-func syscallAnalysisHasNetworkSignal(result *fileanalysis.SyscallAnalysisResult) bool {
+func syscallAnalysisHasNetworkSignal(result *fileanalysis.SyscallAnalysisResult, goos string) bool { //nolint:unparam // goos varies by platform (darwin vs linux)
 	if result == nil {
 		return false
 	}
 	if len(result.DetectedSyscalls) == 0 {
 		return false
 	}
-	table := syscallTableForArch(result.Architecture)
+	table := syscallTableForArch(goos, result.Architecture)
 	if table == nil {
 		return false
 	}

--- a/internal/runner/security/network_analyzer.go
+++ b/internal/runner/security/network_analyzer.go
@@ -24,16 +24,22 @@ type syscallTableInterface interface {
 	IsNetworkSyscall(number int) bool
 }
 
+var (
+	cachedX86Table   = elfanalyzer.NewX86_64SyscallTable()
+	cachedArm64Table = elfanalyzer.NewARM64LinuxSyscallTable()
+	cachedMacOSTable = libccache.MacOSSyscallTable{}
+)
+
 func syscallTableForArch(arch string) syscallTableInterface {
 	if runtime.GOOS == gosDarwin {
-		return libccache.MacOSSyscallTable{}
+		return cachedMacOSTable
 	}
 
 	switch arch {
 	case "x86_64":
-		return elfanalyzer.NewX86_64SyscallTable()
+		return cachedX86Table
 	case "arm64":
-		return elfanalyzer.NewARM64LinuxSyscallTable()
+		return cachedArm64Table
 	default:
 		return nil
 	}
@@ -322,6 +328,9 @@ func syscallAnalysisHasSVCSignal(result *fileanalysis.SyscallAnalysisResult) boo
 // whose network classification is determined by the syscall table lookup.
 func syscallAnalysisHasNetworkSignal(result *fileanalysis.SyscallAnalysisResult) bool {
 	if result == nil {
+		return false
+	}
+	if len(result.DetectedSyscalls) == 0 {
 		return false
 	}
 	table := syscallTableForArch(result.Architecture)

--- a/internal/runner/security/network_analyzer_test.go
+++ b/internal/runner/security/network_analyzer_test.go
@@ -100,7 +100,7 @@ func TestSyscallAnalysisHasNetworkSignal_ResolvedNetworkSVC(t *testing.T) {
 			},
 		},
 	}
-	assert.True(t, syscallAnalysisHasNetworkSignal(r),
+	assert.True(t, syscallAnalysisHasNetworkSignal(r, runtime.GOOS),
 		"resolved network svc (socket on %s/%s) must be detected as network signal", runtime.GOOS, arch)
 }
 
@@ -120,7 +120,7 @@ func TestSyscallAnalysisHasNetworkSignal_LegacyFilteredRecord(t *testing.T) {
 		},
 	}
 	// Network signal from socket must still be detected.
-	assert.True(t, syscallAnalysisHasNetworkSignal(r),
+	assert.True(t, syscallAnalysisHasNetworkSignal(r, runtime.GOOS),
 		"legacy filtered record with network entry must still trigger network signal")
 	// Unresolved svc (Number==-1) must still trigger high-risk signal.
 	assert.True(t, syscallAnalysisHasSVCSignal(r),
@@ -437,24 +437,24 @@ func syscallAnalysisResultWithNetworkSyscall(hasNetwork bool) *fileanalysis.Sysc
 
 // TestSyscallAnalysisHasNetworkSignal_Nil verifies nil returns false.
 func TestSyscallAnalysisHasNetworkSignal_Nil(t *testing.T) {
-	assert.False(t, syscallAnalysisHasNetworkSignal(nil))
+	assert.False(t, syscallAnalysisHasNetworkSignal(nil, runtime.GOOS))
 }
 
 // TestSyscallAnalysisHasNetworkSignal_Empty verifies empty result returns false.
 func TestSyscallAnalysisHasNetworkSignal_Empty(t *testing.T) {
-	assert.False(t, syscallAnalysisHasNetworkSignal(&fileanalysis.SyscallAnalysisResult{}))
+	assert.False(t, syscallAnalysisHasNetworkSignal(&fileanalysis.SyscallAnalysisResult{}, runtime.GOOS))
 }
 
 // TestSyscallAnalysisHasNetworkSignal_NetworkSyscall verifies that a network syscall
 // (socket #41 on x86_64) triggers the network signal.
 func TestSyscallAnalysisHasNetworkSignal_NetworkSyscall(t *testing.T) {
-	assert.True(t, syscallAnalysisHasNetworkSignal(syscallAnalysisResultWithNetworkSyscall(true)))
+	assert.True(t, syscallAnalysisHasNetworkSignal(syscallAnalysisResultWithNetworkSyscall(true), runtime.GOOS))
 }
 
 // TestSyscallAnalysisHasNetworkSignal_NonNetworkSyscall verifies that a non-network syscall
 // (read #3 on x86_64) does not trigger the network signal.
 func TestSyscallAnalysisHasNetworkSignal_NonNetworkSyscall(t *testing.T) {
-	assert.False(t, syscallAnalysisHasNetworkSignal(syscallAnalysisResultWithNetworkSyscall(false)))
+	assert.False(t, syscallAnalysisHasNetworkSignal(syscallAnalysisResultWithNetworkSyscall(false), runtime.GOOS))
 }
 
 // TestSyscallAnalysisHasNetworkSignal_MultipleEntries verifies that any network syscall entry
@@ -471,7 +471,7 @@ func TestSyscallAnalysisHasNetworkSignal_MultipleEntries(t *testing.T) {
 			},
 		},
 	}
-	assert.True(t, syscallAnalysisHasNetworkSignal(result))
+	assert.True(t, syscallAnalysisHasNetworkSignal(result, runtime.GOOS))
 }
 
 // ---- Section 6.2: isNetworkViaBinaryAnalysis syscall-signal flow tests ----
@@ -560,7 +560,7 @@ func TestSyscallAnalysisHasNetworkSignal_UnknownArch(t *testing.T) {
 			},
 		},
 	}
-	assert.False(t, syscallAnalysisHasNetworkSignal(result))
+	assert.False(t, syscallAnalysisHasNetworkSignal(result, runtime.GOOS))
 }
 
 // TestSyscallAnalysisHasNetworkSignal_NegativeNumber verifies that a negative syscall
@@ -574,5 +574,5 @@ func TestSyscallAnalysisHasNetworkSignal_NegativeNumber(t *testing.T) {
 			},
 		},
 	}
-	assert.False(t, syscallAnalysisHasNetworkSignal(result))
+	assert.False(t, syscallAnalysisHasNetworkSignal(result, runtime.GOOS))
 }


### PR DESCRIPTION
Cache x86_64, arm64, and macOS syscall tables as package-level variables in both security and elfanalyzer packages instead of allocating new instances on every call. Also add an early return in syscallAnalysisHasNetworkSignal when DetectedSyscalls is empty to skip unnecessary table lookups.