### PR TITLE
refactor: inject GOOLS into security analyers and move NewBinaryAnalyzer to binary_analyzer.go

### DIFF
--- a/cmd/record/main.go
+++ b/cmd/record/main.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"runtime"
 
 	"github.com/isseis/go-safe-cmd-runner/internal/cmdcommon"
 	"github.com/isseis/go-safe-cmd-runner/internal/elfdynlib"
@@ -137,7 +138,7 @@ func run(args []string, d deps, stdout, stderr io.Writer) int {
 		if d.machoDynlibAnalyzerFactory != nil {
 			fv.SetMachODynLibAnalyzer(d.machoDynlibAnalyzerFactory())
 		}
-		fv.SetBinaryAnalyzer(security.NewBinaryAnalyzer())
+		fv.SetBinaryAnalyzer(security.NewBinaryAnalyzer(runtime.GOOS))
 
 		syscallAnalyzer := elfanalyzer.NewSyscallAnalyzer()
 		fv.SetSyscallAnalyzer(libccache.NewSyscallAdapter(syscallAnalyzer))

--- a/internal/runner/risk/evaluator.go
+++ b/internal/runner/risk/evaluator.go
@@ -3,6 +3,8 @@
 package risk
 
 import (
+	"runtime"
+
 	"github.com/isseis/go-safe-cmd-runner/internal/fileanalysis"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/runnertypes"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/security"
@@ -31,7 +33,7 @@ func NewStandardEvaluatorWithStores(
 	symStore fileanalysis.NetworkSymbolStore,
 	syscallStore fileanalysis.SyscallAnalysisStore,
 ) Evaluator {
-	return &StandardEvaluator{networkAnalyzer: security.NewNetworkAnalyzerWithStores(symStore, syscallStore)}
+	return &StandardEvaluator{networkAnalyzer: security.NewNetworkAnalyzerWithStores(runtime.GOOS, symStore, syscallStore)}
 }
 
 // EvaluateRisk analyzes a command and returns its risk level

--- a/internal/runner/security/binary_analyzer.go
+++ b/internal/runner/security/binary_analyzer.go
@@ -1,0 +1,28 @@
+package security
+
+import (
+	"github.com/isseis/go-safe-cmd-runner/internal/runner/security/binaryanalyzer"
+	"github.com/isseis/go-safe-cmd-runner/internal/runner/security/elfanalyzer"
+	"github.com/isseis/go-safe-cmd-runner/internal/runner/security/machoanalyzer"
+)
+
+// gosDarwin is the GOOS value for macOS.
+const gosDarwin = "darwin"
+
+func requireGOOS(goos string) string {
+	if goos == "" {
+		panic("goos must not be empty")
+	}
+	return goos
+}
+
+// NewBinaryAnalyzer creates a BinaryAnalyzer appropriate for the specified OS.
+// On macOS, returns StandardMachOAnalyzer; on Linux and other platforms, returns StandardELFAnalyzer.
+func NewBinaryAnalyzer(goos string) binaryanalyzer.BinaryAnalyzer {
+	switch requireGOOS(goos) {
+	case gosDarwin:
+		return machoanalyzer.NewStandardMachOAnalyzer(nil)
+	default: // "linux", etc.
+		return elfanalyzer.NewStandardELFAnalyzer(nil, nil)
+	}
+}

--- a/internal/runner/security/binary_analyzer_test.go
+++ b/internal/runner/security/binary_analyzer_test.go
@@ -1,0 +1,22 @@
+//go:build test
+
+package security
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewBinaryAnalyzer_PanicOnEmptyGOOS(t *testing.T) {
+	assert.Panics(t, func() {
+		_ = NewBinaryAnalyzer("")
+	})
+}
+
+func TestNewBinaryAnalyzer_AcceptCurrentGOOS(t *testing.T) {
+	assert.NotPanics(t, func() {
+		_ = NewBinaryAnalyzer(runtime.GOOS)
+	})
+}

--- a/internal/runner/security/command_analysis_test.go
+++ b/internal/runner/security/command_analysis_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/isseis/go-safe-cmd-runner/internal/common"
@@ -709,7 +710,7 @@ func TestIsNetworkOperation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			analyzer := NewNetworkAnalyzer()
+			analyzer := NewNetworkAnalyzer(runtime.GOOS)
 			isNet, isRisk := analyzer.IsNetworkOperation(tt.cmdName, tt.args, "")
 			assert.Equal(t, tt.expectedNet, isNet, "IsNetworkOperation(%s, %v) network detection. %s",
 				tt.cmdName, tt.args, tt.description)
@@ -1800,7 +1801,7 @@ func TestIsNetworkOperation_FromEvaluatorTests(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			analyzer := NewNetworkAnalyzer()
+			analyzer := NewNetworkAnalyzer(runtime.GOOS)
 			result, _ := analyzer.IsNetworkOperation(tt.cmd, tt.args, "")
 			assert.Equal(t, tt.expected, result, "IsNetworkOperation(%q, %v)", tt.cmd, tt.args)
 		})
@@ -2415,7 +2416,7 @@ func TestIsNetworkOperation_Analysis(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			analyzer := NewNetworkAnalyzer()
+			analyzer := NewNetworkAnalyzer(runtime.GOOS)
 			isNetwork, _ := analyzer.IsNetworkOperation(tc.cmdName, tc.args, "sha256:dummy")
 			assert.Equal(t, tc.expectNetwork, isNetwork, "isNetwork mismatch")
 		})
@@ -2468,7 +2469,7 @@ func TestFormatDetectedSymbols(t *testing.T) {
 // TestNewNetworkAnalyzer tests the creation of NetworkAnalyzer.
 func TestNewNetworkAnalyzer(t *testing.T) {
 	t.Run("creates analyzer with default binaryAnalyzer", func(t *testing.T) {
-		analyzer := NewNetworkAnalyzer()
+		analyzer := NewNetworkAnalyzer(runtime.GOOS)
 		assert.NotNil(t, analyzer)
 	})
 

--- a/internal/runner/security/file_validation.go
+++ b/internal/runner/security/file_validation.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"syscall"
@@ -396,30 +395,6 @@ func (v *Validator) validateAllowedOutputPathSymlinks(path string) error {
 		}
 		currentPath = parentPath
 	}
-}
-
-func isAllowedOSManagedSymlink(path string) bool {
-	if runtime.GOOS != "darwin" {
-		return false
-	}
-
-	allowedTargets := map[string]string{
-		"/tmp": "/private/tmp",
-		"/var": "/private/var",
-	}
-
-	cleanPath := filepath.Clean(path)
-	expectedTarget, ok := allowedTargets[cleanPath]
-	if !ok {
-		return false
-	}
-
-	resolvedPath, err := filepath.EvalSymlinks(cleanPath)
-	if err != nil {
-		return false
-	}
-
-	return filepath.Clean(resolvedPath) == expectedTarget
 }
 
 // validateOutputFileWritePermission checks if the user can write to the existing file

--- a/internal/runner/security/file_validation_symlink_darwin.go
+++ b/internal/runner/security/file_validation_symlink_darwin.go
@@ -4,16 +4,16 @@ package security
 
 import "path/filepath"
 
+var allowedDarwinSymlinkTargets = map[string]string{
+	"/tmp": "/private/tmp",
+	"/var": "/private/var",
+}
+
 // isAllowedOSManagedSymlink allows known macOS root-level aliases only when
 // their resolved target exactly matches the expected destination.
 func isAllowedOSManagedSymlink(path string) bool {
-	allowedTargets := map[string]string{
-		"/tmp": "/private/tmp",
-		"/var": "/private/var",
-	}
-
 	cleanPath := filepath.Clean(path)
-	expectedTarget, ok := allowedTargets[cleanPath]
+	expectedTarget, ok := allowedDarwinSymlinkTargets[cleanPath]
 	if !ok {
 		return false
 	}

--- a/internal/runner/security/file_validation_symlink_darwin.go
+++ b/internal/runner/security/file_validation_symlink_darwin.go
@@ -1,0 +1,27 @@
+//go:build darwin
+
+package security
+
+import "path/filepath"
+
+// isAllowedOSManagedSymlink allows known macOS root-level aliases only when
+// their resolved target exactly matches the expected destination.
+func isAllowedOSManagedSymlink(path string) bool {
+	allowedTargets := map[string]string{
+		"/tmp": "/private/tmp",
+		"/var": "/private/var",
+	}
+
+	cleanPath := filepath.Clean(path)
+	expectedTarget, ok := allowedTargets[cleanPath]
+	if !ok {
+		return false
+	}
+
+	resolvedPath, err := filepath.EvalSymlinks(cleanPath)
+	if err != nil {
+		return false
+	}
+
+	return filepath.Clean(resolvedPath) == expectedTarget
+}

--- a/internal/runner/security/file_validation_symlink_other.go
+++ b/internal/runner/security/file_validation_symlink_other.go
@@ -1,0 +1,9 @@
+//go:build !darwin
+
+package security
+
+// isAllowedOSManagedSymlink is darwin-specific. Non-darwin platforms reject all
+// symlink components in output-path validation.
+func isAllowedOSManagedSymlink(_ string) bool {
+	return false
+}

--- a/internal/runner/security/network_analyzer.go
+++ b/internal/runner/security/network_analyzer.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log/slog"
 	"path/filepath"
-	"runtime"
 	"slices"
 	"strings"
 
@@ -31,16 +30,24 @@ func syscallTableForArch(goos, arch string) syscallTableInterface {
 	return elfanalyzer.SyscallTableForArchitecture(arch)
 }
 
+func requireGOOS(goos string) string {
+	if goos == "" {
+		panic("goos must not be empty")
+	}
+	return goos
+}
+
 // NetworkAnalyzer provides network operation detection for commands.
 type NetworkAnalyzer struct {
+	goos         string
 	store        fileanalysis.NetworkSymbolStore   // nil means cache disabled
 	syscallStore fileanalysis.SyscallAnalysisStore // nil means svc cache disabled
 }
 
-// NewBinaryAnalyzer creates a BinaryAnalyzer appropriate for the current platform.
+// NewBinaryAnalyzer creates a BinaryAnalyzer appropriate for the specified OS.
 // On macOS, returns StandardMachOAnalyzer; on Linux and other platforms, returns StandardELFAnalyzer.
-func NewBinaryAnalyzer() binaryanalyzer.BinaryAnalyzer {
-	switch runtime.GOOS {
+func NewBinaryAnalyzer(goos string) binaryanalyzer.BinaryAnalyzer {
+	switch requireGOOS(goos) {
 	case gosDarwin:
 		return machoanalyzer.NewStandardMachOAnalyzer(nil)
 	default: // "linux", etc.
@@ -49,24 +56,26 @@ func NewBinaryAnalyzer() binaryanalyzer.BinaryAnalyzer {
 }
 
 // NewNetworkAnalyzer creates a new NetworkAnalyzer.
-// On macOS, uses StandardMachOAnalyzer; on Linux and other platforms, uses StandardELFAnalyzer.
-func NewNetworkAnalyzer() *NetworkAnalyzer {
-	return &NetworkAnalyzer{}
+// The caller must inject the target GOOS.
+func NewNetworkAnalyzer(goos string) *NetworkAnalyzer {
+	return &NetworkAnalyzer{goos: requireGOOS(goos)}
 }
 
 // NewNetworkAnalyzerWithStore creates a NetworkAnalyzer with a store for cache-based analysis.
-func NewNetworkAnalyzerWithStore(store fileanalysis.NetworkSymbolStore) *NetworkAnalyzer {
-	return &NetworkAnalyzer{store: store}
+func NewNetworkAnalyzerWithStore(goos string, store fileanalysis.NetworkSymbolStore) *NetworkAnalyzer {
+	return &NetworkAnalyzer{goos: requireGOOS(goos), store: store}
 }
 
 // NewNetworkAnalyzerWithStores creates a NetworkAnalyzer with both
 // symbol and syscall stores for cache-based analysis.
 // If either store is nil, the corresponding cache lookup is disabled.
 func NewNetworkAnalyzerWithStores(
+	goos string,
 	symStore fileanalysis.NetworkSymbolStore,
 	svcStore fileanalysis.SyscallAnalysisStore,
 ) *NetworkAnalyzer {
 	return &NetworkAnalyzer{
+		goos:         requireGOOS(goos),
 		store:        symStore,
 		syscallStore: svcStore,
 	}
@@ -219,7 +228,7 @@ func (a *NetworkAnalyzer) isNetworkViaBinaryAnalysis(cmdPath string, contentHash
 					return true, true
 				}
 				// Check whether any non-svc detected syscall is a network syscall.
-				if syscallAnalysisHasNetworkSignal(svcResult, runtime.GOOS) {
+				if syscallAnalysisHasNetworkSignal(svcResult, a.goos) {
 					slog.Info("SyscallAnalysis cache indicates network syscall",
 						"path", cmdPath)
 					return true, false

--- a/internal/runner/security/network_analyzer.go
+++ b/internal/runner/security/network_analyzer.go
@@ -13,11 +13,7 @@ import (
 	"github.com/isseis/go-safe-cmd-runner/internal/libccache"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/security/binaryanalyzer"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/security/elfanalyzer"
-	"github.com/isseis/go-safe-cmd-runner/internal/runner/security/machoanalyzer"
 )
-
-// gosDarwin is the GOOS value for macOS.
-const gosDarwin = "darwin"
 
 type syscallTableInterface interface {
 	IsNetworkSyscall(number int) bool
@@ -30,29 +26,11 @@ func syscallTableForArch(goos, arch string) syscallTableInterface {
 	return elfanalyzer.SyscallTableForArchitecture(arch)
 }
 
-func requireGOOS(goos string) string {
-	if goos == "" {
-		panic("goos must not be empty")
-	}
-	return goos
-}
-
 // NetworkAnalyzer provides network operation detection for commands.
 type NetworkAnalyzer struct {
 	goos         string
 	store        fileanalysis.NetworkSymbolStore   // nil means cache disabled
 	syscallStore fileanalysis.SyscallAnalysisStore // nil means svc cache disabled
-}
-
-// NewBinaryAnalyzer creates a BinaryAnalyzer appropriate for the specified OS.
-// On macOS, returns StandardMachOAnalyzer; on Linux and other platforms, returns StandardELFAnalyzer.
-func NewBinaryAnalyzer(goos string) binaryanalyzer.BinaryAnalyzer {
-	switch requireGOOS(goos) {
-	case gosDarwin:
-		return machoanalyzer.NewStandardMachOAnalyzer(nil)
-	default: // "linux", etc.
-		return elfanalyzer.NewStandardELFAnalyzer(nil, nil)
-	}
 }
 
 // NewNetworkAnalyzer creates a new NetworkAnalyzer.

--- a/internal/runner/security/network_analyzer_test.go
+++ b/internal/runner/security/network_analyzer_test.go
@@ -17,6 +17,36 @@ func TestSyscallAnalysisHasSVCSignal_Nil(t *testing.T) {
 	assert.False(t, syscallAnalysisHasSVCSignal(nil))
 }
 
+func TestConstructors_PanicOnEmptyGOOS(t *testing.T) {
+	assert.Panics(t, func() {
+		_ = NewBinaryAnalyzer("")
+	})
+	assert.Panics(t, func() {
+		_ = NewNetworkAnalyzer("")
+	})
+	assert.Panics(t, func() {
+		_ = NewNetworkAnalyzerWithStore("", nil)
+	})
+	assert.Panics(t, func() {
+		_ = NewNetworkAnalyzerWithStores("", nil, nil)
+	})
+}
+
+func TestConstructors_AcceptCurrentGOOS(t *testing.T) {
+	assert.NotPanics(t, func() {
+		_ = NewBinaryAnalyzer(runtime.GOOS)
+	})
+	assert.NotPanics(t, func() {
+		_ = NewNetworkAnalyzer(runtime.GOOS)
+	})
+	assert.NotPanics(t, func() {
+		_ = NewNetworkAnalyzerWithStore(runtime.GOOS, nil)
+	})
+	assert.NotPanics(t, func() {
+		_ = NewNetworkAnalyzerWithStores(runtime.GOOS, nil, nil)
+	})
+}
+
 // TestSyscallAnalysisHasSVCSignal_Empty verifies that an empty result returns false.
 func TestSyscallAnalysisHasSVCSignal_Empty(t *testing.T) {
 	assert.False(t, syscallAnalysisHasSVCSignal(&fileanalysis.SyscallAnalysisResult{}))

--- a/internal/runner/security/network_analyzer_test.go
+++ b/internal/runner/security/network_analyzer_test.go
@@ -19,9 +19,6 @@ func TestSyscallAnalysisHasSVCSignal_Nil(t *testing.T) {
 
 func TestConstructors_PanicOnEmptyGOOS(t *testing.T) {
 	assert.Panics(t, func() {
-		_ = NewBinaryAnalyzer("")
-	})
-	assert.Panics(t, func() {
 		_ = NewNetworkAnalyzer("")
 	})
 	assert.Panics(t, func() {
@@ -33,9 +30,6 @@ func TestConstructors_PanicOnEmptyGOOS(t *testing.T) {
 }
 
 func TestConstructors_AcceptCurrentGOOS(t *testing.T) {
-	assert.NotPanics(t, func() {
-		_ = NewBinaryAnalyzer(runtime.GOOS)
-	})
 	assert.NotPanics(t, func() {
 		_ = NewNetworkAnalyzer(runtime.GOOS)
 	})

--- a/internal/runner/security/network_analyzer_test_helpers.go
+++ b/internal/runner/security/network_analyzer_test_helpers.go
@@ -3,6 +3,8 @@
 package security
 
 import (
+	"runtime"
+
 	"github.com/isseis/go-safe-cmd-runner/internal/fileanalysis"
 )
 
@@ -12,7 +14,7 @@ import (
 func newNetworkAnalyzer(
 	store fileanalysis.NetworkSymbolStore,
 ) *NetworkAnalyzer {
-	return &NetworkAnalyzer{store: store}
+	return NewNetworkAnalyzerWithStore(runtime.GOOS, store)
 }
 
 // newNetworkAnalyzerWithStores creates a NetworkAnalyzer with a symbol store and
@@ -22,5 +24,5 @@ func newNetworkAnalyzerWithStores(
 	symStore fileanalysis.NetworkSymbolStore,
 	svcStore fileanalysis.SyscallAnalysisStore,
 ) *NetworkAnalyzer {
-	return &NetworkAnalyzer{store: symStore, syscallStore: svcStore}
+	return NewNetworkAnalyzerWithStores(runtime.GOOS, symStore, svcStore)
 }


### PR DESCRIPTION
This pull request refactors how platform-specific logic is handled in the security analysis components, especially around binary and network analyzers, and improves OS portability and testability. The main changes include requiring explicit OS specification (GOOS) for analyzer constructors, splitting OS-specific symlink logic into separate files, and updating tests and call sites accordingly.

**Platform-awareness and constructor changes:**

* Refactored `NewBinaryAnalyzer` and `NewNetworkAnalyzer` (and related constructors) to require an explicit `goos` argument, instead of relying on `runtime.GOOS` internally. This improves portability and makes testing for different platforms easier. The `requireGOOS` helper panics if the argument is empty. [[1]](diffhunk://#diff-95f290a04bb57d1bf39ffa021d383687ad4f7c76d5f3188e7f4882237ba2a7ceR1-R28) [[2]](diffhunk://#diff-46bd649191db8b6b31b1a82e170757c7e4c7fed756986399ad6a3cb47f88e21aR31-R56)
* Updated all call sites and tests to pass `runtime.GOOS` explicitly, including in `cmd/record/main.go`, `evaluator.go`, and all relevant test files. [[1]](diffhunk://#diff-85e219d12105e5ee9a3c08e4525d61f0a59faea396566760aaac92c75b3f0d4fL140-R141) [[2]](diffhunk://#diff-39d52541e22deea47d45aca249527fdfdca634fba8ba783a0874246c9b5c625dL34-R36) [[3]](diffhunk://#diff-d777335bcb4e2f2eb3f7c5e68e1803501994319090cc64de601e407450ca46f1L712-R713) [[4]](diffhunk://#diff-d777335bcb4e2f2eb3f7c5e68e1803501994319090cc64de601e407450ca46f1L1803-R1804) [[5]](diffhunk://#diff-d777335bcb4e2f2eb3f7c5e68e1803501994319090cc64de601e407450ca46f1L2418-R2419) [[6]](diffhunk://#diff-d777335bcb4e2f2eb3f7c5e68e1803501994319090cc64de601e407450ca46f1L2471-R2472) [[7]](diffhunk://#diff-af39fa272ae47754169c43942450b6a80272367e5ed07947f6b072b3da8a1102L15-R17) [[8]](diffhunk://#diff-af39fa272ae47754169c43942450b6a80272367e5ed07947f6b072b3da8a1102L25-R27)

**OS-specific symlink validation:**

* Moved the implementation of `isAllowedOSManagedSymlink` out of `file_validation.go` and into platform-specific files: `file_validation_symlink_darwin.go` for macOS and `file_validation_symlink_other.go` for other platforms, using Go build tags for conditional compilation. This makes OS-specific logic clearer and easier to maintain. [[1]](diffhunk://#diff-3fbd21f1a95b282209f8649042f3b817c4b84226418387b56245d23ecd78b3b3L401-L424) [[2]](diffhunk://#diff-c5669011f6d891bcb213972721965870dd2f3f56ec2a26c6cc407f97004e54dcR1-R27) [[3]](diffhunk://#diff-2ff99cbb2b6702eef76ed80b2ad13220413002a4a800175b98dcaf1844d694b8R1-R9)

**Testing improvements:**

* Added tests to ensure that constructors panic when given an empty `goos` argument and do not panic when passed the current platform, improving robustness and documentation of expected behavior. [[1]](diffhunk://#diff-71f877d9c1b476d66b8122e861df3a3c1bef756c662a80d81828e9fd215e96c1R1-R22) [[2]](diffhunk://#diff-18c72cca0190f6c2657465d66fd5690613a793a6ac4817da1139756085682113R20-R43)

**Code cleanup:**

* Removed now-unnecessary imports of `runtime` and `machoanalyzer` in several files, and eliminated the `gosDarwin` constant and related logic from `network_analyzer.go`. [[1]](diffhunk://#diff-46bd649191db8b6b31b1a82e170757c7e4c7fed756986399ad6a3cb47f88e21aL8) [[2]](diffhunk://#diff-46bd649191db8b6b31b1a82e170757c7e4c7fed756986399ad6a3cb47f88e21aL17-L22) [[3]](diffhunk://#diff-3fbd21f1a95b282209f8649042f3b817c4b84226418387b56245d23ecd78b3b3L9)

**Summary of most important changes:**

**Platform-awareness and constructor refactoring**
- Analyzer constructors now require explicit `goos` (OS) argument, improving portability and testability; all call sites and tests updated to pass `runtime.GOOS` as needed. [[1]](diffhunk://#diff-95f290a04bb57d1bf39ffa021d383687ad4f7c76d5f3188e7f4882237ba2a7ceR1-R28) [[2]](diffhunk://#diff-46bd649191db8b6b31b1a82e170757c7e4c7fed756986399ad6a3cb47f88e21aR31-R56) [[3]](diffhunk://#diff-85e219d12105e5ee9a3c08e4525d61f0a59faea396566760aaac92c75b3f0d4fL140-R141) [[4]](diffhunk://#diff-39d52541e22deea47d45aca249527fdfdca634fba8ba783a0874246c9b5c625dL34-R36) [[5]](diffhunk://#diff-d777335bcb4e2f2eb3f7c5e68e1803501994319090cc64de601e407450ca46f1L712-R713) [[6]](diffhunk://#diff-d777335bcb4e2f2eb3f7c5e68e1803501994319090cc64de601e407450ca46f1L1803-R1804) [[7]](diffhunk://#diff-d777335bcb4e2f2eb3f7c5e68e1803501994319090cc64de601e407450ca46f1L2418-R2419) [[8]](diffhunk://#diff-d777335bcb4e2f2eb3f7c5e68e1803501994319090cc64de601e407450ca46f1L2471-R2472) [[9]](diffhunk://#diff-af39fa272ae47754169c43942450b6a80272367e5ed07947f6b072b3da8a1102L15-R17) [[10]](diffhunk://#diff-af39fa272ae47754169c43942450b6a80272367e5ed07947f6b072b3da8a1102L25-R27)

**OS-specific symlink validation**
- Moved `isAllowedOSManagedSymlink` to platform-specific files using Go build tags, clarifying and isolating OS-dependent logic. [[1]](diffhunk://#diff-3fbd21f1a95b282209f8649042f3b817c4b84226418387b56245d23ecd78b3b3L401-L424) [[2]](diffhunk://#diff-c5669011f6d891bcb213972721965870dd2f3f56ec2a26c6cc407f97004e54dcR1-R27) [[3]](diffhunk://#diff-2ff99cbb2b6702eef76ed80b2ad13220413002a4a800175b98dcaf1844d694b8R1-R9)

**Testing improvements**
- Added tests to verify analyzer constructors panic on empty `goos` and accept valid OS values, ensuring correct usage. [[1]](diffhunk://#diff-71f877d9c1b476d66b8122e861df3a3c1bef756c662a80d81828e9fd215e96c1R1-R22) [[2]](diffhunk://#diff-18c72cca0190f6c2657465d66fd5690613a793a6ac4817da1139756085682113R20-R43)

**Code cleanup**
- Removed unnecessary imports and constants, simplifying code and reducing platform-specific clutter in shared files. [[1]](diffhunk://#diff-46bd649191db8b6b31b1a82e170757c7e4c7fed756986399ad6a3cb47f88e21aL8) [[2]](diffhunk://#diff-46bd649191db8b6b31b1a82e170757c7e4c7fed756986399ad6a3cb47f88e21aL17-L22) [[3]](diffhunk://#diff-3fbd21f1a95b282209f8649042f3b817c4b84226418387b56245d23ecd78b3b3L9)