### PR TITLE
Rename x86 decoder symbols for conciseness

### DIFF
--- a/internal/runner/security/elfanalyzer/arm64_decoder.go
+++ b/internal/runner/security/elfanalyzer/arm64_decoder.go
@@ -139,9 +139,9 @@ func arm64OrrZeroRegImm(a arm64asm.Inst, regs ...arm64asm.Reg) (bool, int64) {
 	return ok, val
 }
 
-// ModifiesSyscallReg returns true if the instruction writes to
+// WritesSyscallReg returns true if the instruction writes to
 // the arm64 syscall number register (W8 or X8).
-func (d *ARM64Decoder) ModifiesSyscallReg(inst DecodedInstruction) bool {
+func (d *ARM64Decoder) WritesSyscallReg(inst DecodedInstruction) bool {
 	a, ok := inst.arch.(arm64asm.Inst)
 	if !ok {
 		return false

--- a/internal/runner/security/elfanalyzer/arm64_decoder_test.go
+++ b/internal/runner/security/elfanalyzer/arm64_decoder_test.go
@@ -92,7 +92,7 @@ func TestARM64Decoder_IsSyscallInstruction(t *testing.T) {
 	}
 }
 
-func TestARM64Decoder_ModifiesSyscallReg(t *testing.T) {
+func TestARM64Decoder_WritesSyscallReg(t *testing.T) {
 	decoder := NewARM64Decoder()
 
 	tests := []struct {
@@ -125,7 +125,7 @@ func TestARM64Decoder_ModifiesSyscallReg(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			inst, err := decoder.Decode(tt.code, 0)
 			require.NoError(t, err)
-			assert.Equal(t, tt.want, decoder.ModifiesSyscallReg(inst))
+			assert.Equal(t, tt.want, decoder.WritesSyscallReg(inst))
 		})
 	}
 }

--- a/internal/runner/security/elfanalyzer/syscall_analyzer.go
+++ b/internal/runner/security/elfanalyzer/syscall_analyzer.go
@@ -774,7 +774,7 @@ func (a *SyscallAnalyzer) backwardScanForSyscallNumber(code []byte, baseAddr uin
 
 	value, method := a.backwardScanForRegister(
 		code, baseAddr, syscallOffset, decoder,
-		decoder.ModifiesSyscallReg,
+		decoder.WritesSyscallReg,
 		decoder.IsSyscallNumImm,
 	)
 
@@ -1020,11 +1020,11 @@ func (a *SyscallAnalyzer) scanX86SyscallRegInBlock(instructions []DecodedInstruc
 			break
 		}
 
-		if !x86Decoder.ModifiesRegisterFamily(inst, result.targetReg) {
+		if !x86Decoder.WritesRegisterFamily(inst, result.targetReg) {
 			continue
 		}
 
-		if isImm, value := x86Decoder.IsImmediateToRegisterFamily(inst, result.targetReg); isImm {
+		if isImm, value := x86Decoder.IsImmToRegisterFamily(inst, result.targetReg); isImm {
 			if result.sawRegCopy {
 				result.foundImmediate = true
 				result.immediateValue = value
@@ -1036,7 +1036,7 @@ func (a *SyscallAnalyzer) scanX86SyscallRegInBlock(instructions []DecodedInstruc
 			return result
 		}
 
-		if srcReg, ok := x86Decoder.GetCopySourceForRegisterFamily(inst, result.targetReg); ok {
+		if srcReg, ok := x86Decoder.CopySourceForRegFamily(inst, result.targetReg); ok {
 			result.targetReg = srcReg
 			result.sawRegCopy = true
 			result.hasCopyInstAddr = true
@@ -1333,14 +1333,14 @@ func transferX86State(in []x86RegValue, inst DecodedInstruction, x86Decoder *X86
 		if family == x86RegFamilyUnknown {
 			continue
 		}
-		if !x86Decoder.ModifiesRegisterFamily(inst, reg) {
+		if !x86Decoder.WritesRegisterFamily(inst, reg) {
 			continue
 		}
-		if isImm, value := x86Decoder.IsImmediateToRegisterFamily(inst, reg); isImm {
+		if isImm, value := x86Decoder.IsImmToRegisterFamily(inst, reg); isImm {
 			out[family] = x86RegValue{known: true, value: value}
 			continue
 		}
-		if srcReg, ok := x86Decoder.GetCopySourceForRegisterFamily(inst, reg); ok {
+		if srcReg, ok := x86Decoder.CopySourceForRegFamily(inst, reg); ok {
 			srcFamily := regFamily(srcReg)
 			if srcFamily == x86RegFamilyUnknown {
 				out[family] = x86RegValue{}

--- a/internal/runner/security/elfanalyzer/syscall_analyzer_test.go
+++ b/internal/runner/security/elfanalyzer/syscall_analyzer_test.go
@@ -22,7 +22,7 @@ func (m *MockMachineCodeDecoder) IsSyscallInstruction(_ DecodedInstruction) bool
 	return false
 }
 
-func (m *MockMachineCodeDecoder) ModifiesSyscallReg(_ DecodedInstruction) bool {
+func (m *MockMachineCodeDecoder) WritesSyscallReg(_ DecodedInstruction) bool {
 	return false
 }
 

--- a/internal/runner/security/elfanalyzer/syscall_decoder.go
+++ b/internal/runner/security/elfanalyzer/syscall_decoder.go
@@ -35,11 +35,11 @@ type MachineCodeDecoder interface {
 	// arm64:  SVC #0 (D4000001)
 	IsSyscallInstruction(inst DecodedInstruction) bool
 
-	// ModifiesSyscallReg returns true if the instruction writes
+	// WritesSyscallReg returns true if the instruction writes
 	// to the architecture's syscall number register.
 	// x86_64: eax/rax (any write including al, ax, r/eax)
 	// arm64:  w8 or x8
-	ModifiesSyscallReg(inst DecodedInstruction) bool
+	WritesSyscallReg(inst DecodedInstruction) bool
 
 	// IsSyscallNumImm returns (true, value) if the
 	// instruction sets the syscall number register to a known immediate.

--- a/internal/runner/security/elfanalyzer/x86_decoder.go
+++ b/internal/runner/security/elfanalyzer/x86_decoder.go
@@ -7,8 +7,8 @@ import (
 )
 
 const (
-	// x86_64BitMode is the bit width for 64-bit mode decoding.
-	x86_64BitMode = 64
+	// decodeMode64 is the bit width for 64-bit mode decoding.
+	decodeMode64 = 64
 
 	// minArgsForImmediateMove is the minimum number of arguments
 	// required to check for an immediate move instruction (destination + source).
@@ -25,7 +25,7 @@ func NewX86Decoder() *X86Decoder {
 
 // Decode decodes a single x86_64 instruction.
 func (d *X86Decoder) Decode(code []byte, offset uint64) (DecodedInstruction, error) {
-	inst, err := x86asm.Decode(code, x86_64BitMode)
+	inst, err := x86asm.Decode(code, decodeMode64)
 	if err != nil {
 		return DecodedInstruction{}, err
 	}
@@ -47,12 +47,12 @@ func (d *X86Decoder) IsSyscallInstruction(inst DecodedInstruction) bool {
 	return x86inst.Op == x86asm.SYSCALL
 }
 
-// isReadOnlyFirstOperandOp reports whether op uses its first operand as a
+// isFirstOperandReadOnly reports whether op uses its first operand as a
 // read-only source and does not write to it. Such instructions must not be
 // treated as register modifications during backward scanning.
 // This covers the most common cases; control-flow ops (CALL, JMP, etc.) are
 // handled separately by IsControlFlowInstruction.
-func isReadOnlyFirstOperandOp(op x86asm.Op) bool {
+func isFirstOperandReadOnly(op x86asm.Op) bool {
 	switch op {
 	case x86asm.PUSH, x86asm.CMP, x86asm.TEST, x86asm.BT:
 		return true
@@ -60,7 +60,7 @@ func isReadOnlyFirstOperandOp(op x86asm.Op) bool {
 	return false
 }
 
-// implicitlyWritesRAXEAX reports whether the instruction unconditionally writes
+// writesRAXImplicitly reports whether the instruction unconditionally writes
 // to RAX/EAX as an implicit (unlisted) destination, i.e. RAX does not appear
 // as the first explicit operand. Callers must handle the two/three-operand
 // IMUL forms separately via the first-operand path.
@@ -74,7 +74,7 @@ func isReadOnlyFirstOperandOp(op x86asm.Op) bool {
 //   - CPUID    — writes EAX (plus EBX/ECX/EDX); no explicit operands
 //
 // Not included: CQO/CDQ/CWD — these read rAX and write rDX only.
-func implicitlyWritesRAXEAX(x86inst x86asm.Inst) bool {
+func writesRAXImplicitly(x86inst x86asm.Inst) bool {
 	switch x86inst.Op {
 	case x86asm.MUL, x86asm.DIV, x86asm.IDIV, x86asm.CPUID:
 		return true
@@ -152,7 +152,7 @@ func regFamily(reg x86asm.Reg) x86RegFamily {
 	}
 }
 
-func isFullWidthFamilyWrite(reg x86asm.Reg) bool {
+func isFullWidthWrite(reg x86asm.Reg) bool {
 	switch reg {
 	case x86asm.EAX, x86asm.RAX,
 		x86asm.ECX, x86asm.RCX,
@@ -176,7 +176,7 @@ func isFullWidthFamilyWrite(reg x86asm.Reg) bool {
 	return false
 }
 
-func sameRegFamily(a, b x86asm.Reg) bool {
+func sameFamily(a, b x86asm.Reg) bool {
 	aFamily := regFamily(a)
 	if aFamily == x86RegFamilyUnknown {
 		return false
@@ -184,26 +184,26 @@ func sameRegFamily(a, b x86asm.Reg) bool {
 	return aFamily == regFamily(b)
 }
 
-// ModifiesSyscallReg checks if the instruction modifies eax or rax.
-func (d *X86Decoder) ModifiesSyscallReg(inst DecodedInstruction) bool {
-	return d.ModifiesRegisterFamily(inst, x86asm.RAX)
+// WritesSyscallReg checks if the instruction modifies eax or rax.
+func (d *X86Decoder) WritesSyscallReg(inst DecodedInstruction) bool {
+	return d.WritesRegisterFamily(inst, x86asm.RAX)
 }
 
-// ModifiesRegisterFamily checks whether the instruction modifies the same
+// WritesRegisterFamily checks whether the instruction modifies the same
 // register family as targetReg (e.g. EAX and RAX are in the same family).
-func (d *X86Decoder) ModifiesRegisterFamily(inst DecodedInstruction, targetReg x86asm.Reg) bool {
+func (d *X86Decoder) WritesRegisterFamily(inst DecodedInstruction, targetReg x86asm.Reg) bool {
 	x86inst, ok := inst.arch.(x86asm.Inst)
 	if !ok {
 		return false
 	}
 
-	if isReadOnlyFirstOperandOp(x86inst.Op) {
+	if isFirstOperandReadOnly(x86inst.Op) {
 		return false
 	}
 
 	// Instructions that implicitly write RAX/EAX without it appearing as the
 	// first explicit operand (e.g. MUL, one-operand IMUL, DIV, IDIV, CPUID).
-	if sameRegFamily(targetReg, x86asm.RAX) && implicitlyWritesRAXEAX(x86inst) {
+	if sameFamily(targetReg, x86asm.RAX) && writesRAXImplicitly(x86inst) {
 		return true
 	}
 
@@ -218,7 +218,7 @@ func (d *X86Decoder) ModifiesRegisterFamily(inst DecodedInstruction, targetReg x
 
 	// Check destination register (first argument for most instructions)
 	if arg, ok := args[0].(x86asm.Reg); ok {
-		return sameRegFamily(arg, targetReg)
+		return sameFamily(arg, targetReg)
 	}
 
 	return false
@@ -229,20 +229,20 @@ func (d *X86Decoder) ModifiesRegisterFamily(inst DecodedInstruction, targetReg x
 //   - MOV EAX/RAX, <imm>  — direct immediate load
 //   - XOR EAX, EAX        — idiom for zeroing EAX (equivalent to MOV EAX, 0)
 func (d *X86Decoder) IsSyscallNumImm(inst DecodedInstruction) (bool, int64) {
-	return d.IsImmediateToRegisterFamily(inst, x86asm.RAX)
+	return d.IsImmToRegisterFamily(inst, x86asm.RAX)
 }
 
-// IsImmediateToRegisterFamily returns (true, value) when the instruction sets
+// IsImmToRegisterFamily returns (true, value) when the instruction sets
 // the target register family from an immediate value or a self-XOR zeroing idiom.
-func (d *X86Decoder) IsImmediateToRegisterFamily(inst DecodedInstruction, targetReg x86asm.Reg) (bool, int64) {
-	return d.isImmediateToReg(inst, func(reg x86asm.Reg) bool {
-		return sameRegFamily(reg, targetReg) && isFullWidthFamilyWrite(reg)
+func (d *X86Decoder) IsImmToRegisterFamily(inst DecodedInstruction, targetReg x86asm.Reg) (bool, int64) {
+	return d.isImmToReg(inst, func(reg x86asm.Reg) bool {
+		return sameFamily(reg, targetReg) && isFullWidthWrite(reg)
 	})
 }
 
-// GetCopySourceForRegisterFamily reports source register when instruction is a
+// CopySourceForRegFamily reports source register when instruction is a
 // simple register copy into targetReg family (e.g. MOV EAX, EDX).
-func (d *X86Decoder) GetCopySourceForRegisterFamily(inst DecodedInstruction, targetReg x86asm.Reg) (x86asm.Reg, bool) {
+func (d *X86Decoder) CopySourceForRegFamily(inst DecodedInstruction, targetReg x86asm.Reg) (x86asm.Reg, bool) {
 	x86inst, ok := inst.arch.(x86asm.Inst)
 	if !ok || x86inst.Op != x86asm.MOV {
 		return 0, false
@@ -257,22 +257,22 @@ func (d *X86Decoder) GetCopySourceForRegisterFamily(inst DecodedInstruction, tar
 	}
 
 	destReg, ok := args[0].(x86asm.Reg)
-	if !ok || !sameRegFamily(destReg, targetReg) || !isFullWidthFamilyWrite(destReg) {
+	if !ok || !sameFamily(destReg, targetReg) || !isFullWidthWrite(destReg) {
 		return 0, false
 	}
 
 	srcReg, ok := args[1].(x86asm.Reg)
-	if !ok || !isFullWidthFamilyWrite(srcReg) {
+	if !ok || !isFullWidthWrite(srcReg) {
 		return 0, false
 	}
 
 	return srcReg, true
 }
 
-// isImmediateToReg is an internal helper that checks if an instruction sets
+// isImmToReg is an internal helper that checks if an instruction sets
 // a register (matched by regMatch) to an immediate value.
 // Covers MOV <reg>, <imm> and XOR <reg>, <reg> (zeroing idiom).
-func (d *X86Decoder) isImmediateToReg(inst DecodedInstruction, regMatch func(x86asm.Reg) bool) (bool, int64) {
+func (d *X86Decoder) isImmToReg(inst DecodedInstruction, regMatch func(x86asm.Reg) bool) (bool, int64) {
 	x86inst, ok := inst.arch.(x86asm.Inst)
 	if !ok {
 		return false, 0
@@ -388,7 +388,7 @@ func (d *X86Decoder) GetCallTarget(inst DecodedInstruction, instAddr uint64) (ui
 // Note: same as IsSyscallNumImm for x86_64 (RAX is both syscall
 // number register and first argument register in Go's register-based ABI).
 func (d *X86Decoder) IsFirstArgImm(inst DecodedInstruction) (bool, int64) {
-	ok, val := d.isImmediateToReg(inst, func(reg x86asm.Reg) bool {
+	ok, val := d.isImmToReg(inst, func(reg x86asm.Reg) bool {
 		return reg == x86asm.RAX || reg == x86asm.EAX
 	})
 	return ok, val
@@ -397,7 +397,7 @@ func (d *X86Decoder) IsFirstArgImm(inst DecodedInstruction) (bool, int64) {
 // ModifiesFirstArg returns true if the instruction writes to the
 // first argument register in x86_64 Go ABI (RAX/EAX).
 func (d *X86Decoder) ModifiesFirstArg(inst DecodedInstruction) bool {
-	return d.ModifiesSyscallReg(inst)
+	return d.WritesSyscallReg(inst)
 }
 
 // ResolveFirstArgGlobal returns unresolved on x86_64.
@@ -406,7 +406,7 @@ func (d *X86Decoder) ResolveFirstArgGlobal(_ []DecodedInstruction, _ int) (bool,
 	return false, 0
 }
 
-// implicitlyWritesRDXEDX reports whether the instruction unconditionally writes
+// writesRDXImplicitly reports whether the instruction unconditionally writes
 // to RDX/EDX as an implicit (unlisted) destination.
 //
 // Covered cases:
@@ -418,7 +418,7 @@ func (d *X86Decoder) ResolveFirstArgGlobal(_ []DecodedInstruction, _ int) (bool,
 //   - CQO      — sign-extends RAX into RDX:RAX; writes RDX
 //   - CDQ      — sign-extends EAX into EDX:EAX; writes EDX
 //   - CWD      — sign-extends AX into DX:AX; writes DX
-func implicitlyWritesRDXEDX(x86inst x86asm.Inst) bool {
+func writesRDXImplicitly(x86inst x86asm.Inst) bool {
 	switch x86inst.Op {
 	case x86asm.MUL, x86asm.DIV, x86asm.IDIV, x86asm.CQO, x86asm.CDQ, x86asm.CWD:
 		return true
@@ -441,13 +441,13 @@ func (d *X86Decoder) ModifiesThirdArg(inst DecodedInstruction) bool {
 		return false
 	}
 
-	if isReadOnlyFirstOperandOp(x86inst.Op) {
+	if isFirstOperandReadOnly(x86inst.Op) {
 		return false
 	}
 
 	// Instructions that implicitly write RDX/EDX without it appearing as the
 	// first explicit operand (e.g. MUL, one-operand IMUL, DIV, IDIV, CQO/CDQ/CWD).
-	if implicitlyWritesRDXEDX(x86inst) {
+	if writesRDXImplicitly(x86inst) {
 		return true
 	}
 
@@ -473,7 +473,7 @@ func (d *X86Decoder) ModifiesThirdArg(inst DecodedInstruction) bool {
 // IsThirdArgImm checks if the instruction sets edx/rdx to a known
 // immediate value. Covers MOV EDX/RDX, imm and XOR EDX, EDX (zeroing idiom).
 func (d *X86Decoder) IsThirdArgImm(inst DecodedInstruction) (bool, int64) {
-	return d.isImmediateToReg(inst, func(reg x86asm.Reg) bool {
+	return d.isImmToReg(inst, func(reg x86asm.Reg) bool {
 		return reg == x86asm.EDX || reg == x86asm.RDX
 	})
 }

--- a/internal/runner/security/elfanalyzer/x86_decoder_test.go
+++ b/internal/runner/security/elfanalyzer/x86_decoder_test.go
@@ -105,7 +105,7 @@ func TestX86Decoder_IsSyscallInstruction(t *testing.T) {
 	}
 }
 
-func TestX86Decoder_ModifiesSyscallReg(t *testing.T) {
+func TestX86Decoder_WritesSyscallReg(t *testing.T) {
 	decoder := NewX86Decoder()
 
 	tests := []struct {
@@ -210,7 +210,7 @@ func TestX86Decoder_ModifiesSyscallReg(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			inst, err := decoder.Decode(tt.code, 0)
 			require.NoError(t, err)
-			assert.Equal(t, tt.want, decoder.ModifiesSyscallReg(inst))
+			assert.Equal(t, tt.want, decoder.WritesSyscallReg(inst))
 		})
 	}
 }
@@ -331,14 +331,14 @@ func TestX86Decoder_IsSyscallNumImm_PartialRegisterWritesIgnored(t *testing.T) {
 	}
 }
 
-func TestX86Decoder_GetCopySourceForRegisterFamily_PartialRegisterWritesIgnored(t *testing.T) {
+func TestX86Decoder_CopySourceForRegFamily_PartialRegisterWritesIgnored(t *testing.T) {
 	decoder := NewX86Decoder()
 
 	t.Run("mov AL DL is ignored for RAX family", func(t *testing.T) {
 		inst, err := decoder.Decode([]byte{0x88, 0xd0}, 0)
 		require.NoError(t, err)
 
-		_, ok := decoder.GetCopySourceForRegisterFamily(inst, x86asm.RAX)
+		_, ok := decoder.CopySourceForRegFamily(inst, x86asm.RAX)
 		assert.False(t, ok)
 	})
 
@@ -346,7 +346,7 @@ func TestX86Decoder_GetCopySourceForRegisterFamily_PartialRegisterWritesIgnored(
 		inst, err := decoder.Decode([]byte{0x89, 0xd0}, 0)
 		require.NoError(t, err)
 
-		src, ok := decoder.GetCopySourceForRegisterFamily(inst, x86asm.RAX)
+		src, ok := decoder.CopySourceForRegFamily(inst, x86asm.RAX)
 		assert.True(t, ok)
 		assert.Equal(t, x86asm.EDX, src)
 	})


### PR DESCRIPTION
This pull request focuses on improving clarity and consistency in the ELF analyzer's decoder logic, particularly for x86 and ARM64 architectures. The changes primarily involve renaming functions and variables to use more precise terminology, consolidating naming conventions, and updating documentation and tests accordingly. These updates make the codebase easier to understand and maintain, especially regarding how register writes and immediate value assignments are detected.

**API and Naming Consistency Improvements:**

* Renamed all instances of `ModifiesSyscallReg` to `WritesSyscallReg` in both the interface (`MachineCodeDecoder`) and its implementations (`ARM64Decoder`, `X86Decoder`), as well as in related tests and mock objects, to better reflect the function's purpose. [[1]](diffhunk://#diff-abff70444d5618dd051dd3547a6d972667685baf496295d641a38884fb40678bL38-R42) [[2]](diffhunk://#diff-4b59113cdddeba290e30e01ae43fbec55be48ead23820f6b9ec4f01319dfa092L142-R144) [[3]](diffhunk://#diff-944f9acb50125540842d5d9ed452418d41e39ce4565b7f3a7495407935255fb4L25-R25) [[4]](diffhunk://#diff-119499ce037e85c926fdc082cf631449b3f3127c84efbf6e39ab38f1df995424L95-R95) [[5]](diffhunk://#diff-119499ce037e85c926fdc082cf631449b3f3127c84efbf6e39ab38f1df995424L128-R128) [[6]](diffhunk://#diff-22fb7c8e1c579d161ec579dae5f8ef12dce56e4c5036eaaa510d3101ec111fc8L777-R777) [[7]](diffhunk://#diff-386f66ea6a4725ee7b926854a08add1b44f56a2c0600233948ab5d30d5309631L108-R108) [[8]](diffhunk://#diff-386f66ea6a4725ee7b926854a08add1b44f56a2c0600233948ab5d30d5309631L213-R213)
* Renamed `ModifiesRegisterFamily` to `WritesRegisterFamily` and `IsImmediateToRegisterFamily` to `IsImmToRegisterFamily` in the x86 decoder, along with their internal helpers, to clarify that these functions detect register writes and immediate assignments, not just any modification. [[1]](diffhunk://#diff-3f1e6ec58c375559ac34bec76b5338291a062eef6a993bdafd1fe51842f99da1L179-R206) [[2]](diffhunk://#diff-3f1e6ec58c375559ac34bec76b5338291a062eef6a993bdafd1fe51842f99da1L232-R245) [[3]](diffhunk://#diff-3f1e6ec58c375559ac34bec76b5338291a062eef6a993bdafd1fe51842f99da1L221-R221) [[4]](diffhunk://#diff-3f1e6ec58c375559ac34bec76b5338291a062eef6a993bdafd1fe51842f99da1L260-R275)
* Updated function and variable names for register family checks (e.g., `sameRegFamily` → `sameFamily`, `isFullWidthFamilyWrite` → `isFullWidthWrite`) and for implicit register writes (e.g., `implicitlyWritesRAXEAX` → `writesRAXImplicitly`, `implicitlyWritesRDXEDX` → `writesRDXImplicitly`) to improve code readability and align with the new naming conventions. [[1]](diffhunk://#diff-3f1e6ec58c375559ac34bec76b5338291a062eef6a993bdafd1fe51842f99da1L155-R155) [[2]](diffhunk://#diff-3f1e6ec58c375559ac34bec76b5338291a062eef6a993bdafd1fe51842f99da1L77-R77) [[3]](diffhunk://#diff-3f1e6ec58c375559ac34bec76b5338291a062eef6a993bdafd1fe51842f99da1L400-R400) [[4]](diffhunk://#diff-3f1e6ec58c375559ac34bec76b5338291a062eef6a993bdafd1fe51842f99da1L409-R409) [[5]](diffhunk://#diff-3f1e6ec58c375559ac34bec76b5338291a062eef6a993bdafd1fe51842f99da1L421-R421) [[6]](diffhunk://#diff-3f1e6ec58c375559ac34bec76b5338291a062eef6a993bdafd1fe51842f99da1L444-R450) [[7]](diffhunk://#diff-3f1e6ec58c375559ac34bec76b5338291a062eef6a993bdafd1fe51842f99da1L476-R476)
* Refactored the helper for register copy detection from `GetCopySourceForRegisterFamily` to `CopySourceForRegFamily` and updated all usages and related tests accordingly. [[1]](diffhunk://#diff-3f1e6ec58c375559ac34bec76b5338291a062eef6a993bdafd1fe51842f99da1L260-R275) [[2]](diffhunk://#diff-22fb7c8e1c579d161ec579dae5f8ef12dce56e4c5036eaaa510d3101ec111fc8L1039-R1039) [[3]](diffhunk://#diff-22fb7c8e1c579d161ec579dae5f8ef12dce56e4c5036eaaa510d3101ec111fc8L1336-R1343) [[4]](diffhunk://#diff-386f66ea6a4725ee7b926854a08add1b44f56a2c0600233948ab5d30d5309631L334-R349)
* Standardized the constant for x86 64-bit decoding from `x86_64BitMode` to `decodeMode64` for clarity. [[1]](diffhunk://#diff-3f1e6ec58c375559ac34bec76b5338291a062eef6a993bdafd1fe51842f99da1L10-R11) [[2]](diffhunk://#diff-3f1e6ec58c375559ac34bec76b5338291a062eef6a993bdafd1fe51842f99da1L28-R28)

These changes collectively enhance the maintainability and clarity of the ELF analyzer's decoder logic, making it easier for future contributors to understand the intent and behavior of the code.