### PR TITLE
Address PR review comments on x86 decoder renames

### DIFF
--- a/internal/runner/security/elfanalyzer/syscall_decoder.go
+++ b/internal/runner/security/elfanalyzer/syscall_decoder.go
@@ -37,7 +37,7 @@ type MachineCodeDecoder interface {
 
 	// WritesSyscallReg returns true if the instruction writes
 	// to the architecture's syscall number register.
-	// x86_64: eax/rax (any write including al, ax, r/eax)
+	// x86_64: any write to the RAX family (AL/AX/EAX/RAX)
 	// arm64:  w8 or x8
 	WritesSyscallReg(inst DecodedInstruction) bool
 

--- a/internal/runner/security/elfanalyzer/syscall_decoder.go
+++ b/internal/runner/security/elfanalyzer/syscall_decoder.go
@@ -37,7 +37,7 @@ type MachineCodeDecoder interface {
 
 	// WritesSyscallReg returns true if the instruction writes
 	// to the architecture's syscall number register.
-	// x86_64: any write to the RAX family (AL/AX/EAX/RAX)
+	// x86_64: any write to any subregister of RAX (AL/AH/AX/EAX/RAX)
 	// arm64:  w8 or x8
 	WritesSyscallReg(inst DecodedInstruction) bool
 

--- a/internal/runner/security/elfanalyzer/x86_decoder.go
+++ b/internal/runner/security/elfanalyzer/x86_decoder.go
@@ -184,12 +184,13 @@ func sameFamily(a, b x86asm.Reg) bool {
 	return aFamily == regFamily(b)
 }
 
-// WritesSyscallReg checks if the instruction modifies eax or rax.
+// WritesSyscallReg returns true if the instruction writes to the RAX register
+// family (AL/AX/EAX/RAX), which is the syscall number register on x86_64.
 func (d *X86Decoder) WritesSyscallReg(inst DecodedInstruction) bool {
 	return d.WritesRegisterFamily(inst, x86asm.RAX)
 }
 
-// WritesRegisterFamily checks whether the instruction modifies the same
+// WritesRegisterFamily reports whether the instruction writes to the same
 // register family as targetReg (e.g. EAX and RAX are in the same family).
 func (d *X86Decoder) WritesRegisterFamily(inst DecodedInstruction, targetReg x86asm.Reg) bool {
 	x86inst, ok := inst.arch.(x86asm.Inst)
@@ -204,6 +205,14 @@ func (d *X86Decoder) WritesRegisterFamily(inst DecodedInstruction, targetReg x86
 	// Instructions that implicitly write RAX/EAX without it appearing as the
 	// first explicit operand (e.g. MUL, one-operand IMUL, DIV, IDIV, CPUID).
 	if sameFamily(targetReg, x86asm.RAX) && writesRAXImplicitly(x86inst) {
+		return true
+	}
+	// Instructions that implicitly write RDX/EDX (e.g. MUL, DIV, CPUID, CQO/CDQ/CWD).
+	if sameFamily(targetReg, x86asm.RDX) && writesRDXImplicitly(x86inst) {
+		return true
+	}
+	// CPUID also implicitly writes EBX and ECX.
+	if (sameFamily(targetReg, x86asm.RBX) || sameFamily(targetReg, x86asm.RCX)) && x86inst.Op == x86asm.CPUID {
 		return true
 	}
 
@@ -415,12 +424,13 @@ func (d *X86Decoder) ResolveFirstArgGlobal(_ []DecodedInstruction, _ int) (bool,
 //     distinguished from multi-operand IMUL by having exactly one non-nil arg
 //   - DIV r/m  — unsigned divide: remainder → rDX
 //   - IDIV r/m — signed divide: remainder → rDX
+//   - CPUID    — writes EDX (along with EAX/EBX/ECX); no explicit operands
 //   - CQO      — sign-extends RAX into RDX:RAX; writes RDX
 //   - CDQ      — sign-extends EAX into EDX:EAX; writes EDX
 //   - CWD      — sign-extends AX into DX:AX; writes DX
 func writesRDXImplicitly(x86inst x86asm.Inst) bool {
 	switch x86inst.Op {
-	case x86asm.MUL, x86asm.DIV, x86asm.IDIV, x86asm.CQO, x86asm.CDQ, x86asm.CWD:
+	case x86asm.MUL, x86asm.DIV, x86asm.IDIV, x86asm.CPUID, x86asm.CQO, x86asm.CDQ, x86asm.CWD:
 		return true
 	case x86asm.IMUL:
 		// Only the one-operand form writes the high half into rDX.

--- a/internal/runner/security/elfanalyzer/x86_decoder.go
+++ b/internal/runner/security/elfanalyzer/x86_decoder.go
@@ -185,7 +185,7 @@ func sameFamily(a, b x86asm.Reg) bool {
 }
 
 // WritesSyscallReg returns true if the instruction writes to the RAX register
-// family (AL/AX/EAX/RAX), which is the syscall number register on x86_64.
+// family (AL/AH/AX/EAX/RAX), which is the syscall number register on x86_64.
 func (d *X86Decoder) WritesSyscallReg(inst DecodedInstruction) bool {
 	return d.WritesRegisterFamily(inst, x86asm.RAX)
 }

--- a/internal/runner/security/elfanalyzer/x86_decoder_test.go
+++ b/internal/runner/security/elfanalyzer/x86_decoder_test.go
@@ -611,6 +611,39 @@ func TestX86Decoder_ModifiesThirdArg(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, decoder.ModifiesThirdArg(inst))
 	})
+
+	t.Run("cpuid returns true (implicit EDX write)", func(t *testing.T) {
+		// 0f a2 = cpuid — writes EAX/EBX/ECX/EDX implicitly
+		code := []byte{0x0f, 0xa2}
+		inst, err := decoder.Decode(code, 0)
+		require.NoError(t, err)
+		assert.True(t, decoder.ModifiesThirdArg(inst))
+	})
+}
+
+func TestX86Decoder_WritesRegisterFamily_CPUID(t *testing.T) {
+	decoder := NewX86Decoder()
+	// 0f a2 = cpuid — implicitly writes EAX/EBX/ECX/EDX
+	cpuidCode := []byte{0x0f, 0xa2}
+
+	tests := []struct {
+		name      string
+		targetReg x86asm.Reg
+		want      bool
+	}{
+		{"RBX family", x86asm.RBX, true},
+		{"RCX family", x86asm.RCX, true},
+		{"RDX family", x86asm.RDX, true},
+		{"RSI family (unrelated)", x86asm.RSI, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inst, err := decoder.Decode(cpuidCode, 0)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, decoder.WritesRegisterFamily(inst, tt.targetReg))
+		})
+	}
 }
 
 func TestX86Decoder_IsThirdArgImm(t *testing.T) {


### PR DESCRIPTION
- Fix doc comments for WritesSyscallReg and WritesRegisterFamily to use "writes" terminology and describe register family semantics accurately
- Clarify WritesSyscallReg interface comment: AL/AX/EAX/RAX instead of r/eax
- Add CPUID to writesRDXImplicitly (CPUID writes EDX implicitly)
- Expand WritesRegisterFamily to cover implicit writes to RDX (via writesRDXImplicitly) and RBX/RCX (CPUID), so transferX86State correctly invalidates all affected register families