### PR TITLE
Support resolving syscall numbers loaded from package-level global variables in Go binaries

### DIFF
--- a/internal/runner/security/elfanalyzer/x86_decoder.go
+++ b/internal/runner/security/elfanalyzer/x86_decoder.go
@@ -490,24 +490,44 @@ func (d *X86Decoder) ResolveFirstArgGlobal(recentInstructions []DecodedInstructi
 		return false, 0
 	}
 
-	// RIP at execution time points to the instruction following this one.
-	nextPC := inst.Offset + uint64(inst.Len) //nolint:gosec // G115: Len is decoder-validated positive
-
-	// x86asm stores disp32 as a zero-extended uint32 in int64 (not sign-extended),
-	// so 0xFFFFFFF8 is stored as int64(4294967288), not int64(-8).
-	// Re-interpret through int32 to recover the correct signed value before
-	// computing the effective address (RIP + sign_extend(disp32)).
-	dispSigned := int64(int32(mem.Disp)) //nolint:gosec // G115: intentional int32 reinterpretation for sign extension
-	if dispSigned < 0 {
-		negDisp := uint64(-dispSigned) //nolint:gosec // G115: dispSigned is negative; disp32 range guarantees no overflow on negation
-		if negDisp > nextPC {
-			return false, 0
-		}
+	target, ok := x86RIPRelAddr(inst.Offset, inst.Len, mem.Disp)
+	if !ok {
+		return false, 0
 	}
-	target := uint64(int64(nextPC) + dispSigned) //nolint:gosec // G115: underflow checked above; overflow bounded by binary size
 
 	val, ok := d.readGlobal(target, loadSize)
 	return ok, val
+}
+
+// x86RIPRelAddr computes the effective address for a RIP-relative memory
+// operand, guarding against uint64 wraparound and int64 overflow/underflow.
+//
+// nextPC = instOffset + instLen
+// target = nextPC + sign_extend(disp32)
+func x86RIPRelAddr(instOffset uint64, instLen int, rawDisp int64) (uint64, bool) {
+	// Guard uint64 overflow on nextPC.
+	if instOffset > math.MaxUint64-uint64(instLen) { //nolint:gosec // G115: instLen validated non-negative
+		return 0, false
+	}
+	nextPC := instOffset + uint64(instLen) //nolint:gosec // G115: overflow checked above
+	// nextPC must fit in int64 for signed displacement arithmetic.
+	if nextPC > math.MaxInt64 {
+		return 0, false
+	}
+
+	// x86asm stores disp32 as zero-extended in int64, not sign-extended.
+	// Re-interpret through int32 to recover the correct signed value.
+	dispSigned := int64(int32(rawDisp)) //nolint:gosec // G115: intentional int32 reinterpretation for sign extension
+
+	// In Go, signed int64 arithmetic wraps on overflow. Both positive overflow
+	// (nextPC near MaxInt64, large positive disp) and negative underflow
+	// (disp too negative) produce a negative result, so a single < 0 check
+	// catches both cases.
+	target := int64(nextPC) + dispSigned
+	if target < 0 {
+		return 0, false
+	}
+	return uint64(target), true
 }
 
 // writesRDXImplicitly reports whether the instruction unconditionally writes

--- a/internal/runner/security/elfanalyzer/x86_decoder.go
+++ b/internal/runner/security/elfanalyzer/x86_decoder.go
@@ -1,6 +1,7 @@
 package elfanalyzer
 
 import (
+	"encoding/binary"
 	"math"
 
 	"golang.org/x/arch/x86/x86asm"
@@ -15,8 +16,17 @@ const (
 	minArgsForImmediateMove = 2
 )
 
+// x86DataSection holds the virtual address and raw bytes of an ELF section
+// used by ResolveFirstArgGlobal to read global variable values.
+type x86DataSection struct {
+	Addr uint64
+	Data []byte
+}
+
 // X86Decoder implements MachineCodeDecoder for x86_64.
-type X86Decoder struct{}
+type X86Decoder struct {
+	dataSections []x86DataSection
+}
 
 // NewX86Decoder creates a new X86Decoder.
 func NewX86Decoder() *X86Decoder {
@@ -400,10 +410,84 @@ func (d *X86Decoder) ModifiesFirstArg(inst DecodedInstruction) bool {
 	return d.WritesSyscallReg(inst)
 }
 
-// ResolveFirstArgGlobal returns unresolved on x86_64.
-// The current Go wrapper resolution path only uses immediate assignments.
-func (d *X86Decoder) ResolveFirstArgGlobal(_ []DecodedInstruction, _ int) (bool, int64) {
-	return false, 0
+// SetDataSections supplies read-only and read-write ELF data sections used
+// by ResolveFirstArgGlobal to read global variable values.
+func (d *X86Decoder) SetDataSections(sections []x86DataSection) {
+	d.dataSections = sections
+}
+
+// readGlobal64 reads a little-endian uint64 from the data sections at addr.
+func (d *X86Decoder) readGlobal64(addr uint64) (int64, bool) {
+	const loadSize = uint64(8)
+	for _, sec := range d.dataSections {
+		if addr < sec.Addr {
+			continue
+		}
+		off := addr - sec.Addr
+		if off+loadSize > uint64(len(sec.Data)) { //nolint:gosec // G115: len(sec.Data) fits in uint64; section sizes are bounded by binary size
+			continue
+		}
+		val := binary.LittleEndian.Uint64(sec.Data[off : off+loadSize])
+		return int64(val), true //nolint:gosec // G115: int64/uint64 reinterpretation; caller validates range
+	}
+	return 0, false
+}
+
+// ResolveFirstArgGlobal resolves the syscall number when it is loaded into
+// RAX/EAX via a RIP-relative memory read, i.e. the pattern:
+//
+//	MOV RAX, [RIP + disp32]
+//
+// This occurs in Go's syscall package when the syscall number is stored in a
+// package-level variable (e.g. syscall.fcntl64Syscall in forkAndExecInChild1).
+// SetDataSections must be called before this method returns useful results.
+func (d *X86Decoder) ResolveFirstArgGlobal(recentInstructions []DecodedInstruction, idx int) (bool, int64) {
+	if len(d.dataSections) == 0 || idx < 0 || idx >= len(recentInstructions) {
+		return false, 0
+	}
+
+	inst := recentInstructions[idx]
+	x86inst, ok := inst.arch.(x86asm.Inst)
+	if !ok || x86inst.Op != x86asm.MOV {
+		return false, 0
+	}
+
+	args := x86inst.Args[:]
+	for len(args) > 0 && args[len(args)-1] == nil {
+		args = args[:len(args)-1]
+	}
+	if len(args) < minArgsForImmediateMove {
+		return false, 0
+	}
+
+	destReg, ok := args[0].(x86asm.Reg)
+	if !ok || !sameFamily(destReg, x86asm.RAX) || !isFullWidthWrite(destReg) {
+		return false, 0
+	}
+
+	mem, ok := args[1].(x86asm.Mem)
+	if !ok || mem.Base != x86asm.RIP || mem.Index != 0 || mem.Scale != 0 {
+		return false, 0
+	}
+
+	// RIP at execution time points to the instruction following this one.
+	nextPC := inst.Offset + uint64(inst.Len) //nolint:gosec // G115: Len is decoder-validated positive
+
+	// x86asm stores disp32 as a zero-extended uint32 in int64 (not sign-extended),
+	// so 0xFFFFFFF8 is stored as int64(4294967288), not int64(-8).
+	// Re-interpret through int32 to recover the correct signed value before
+	// computing the effective address (RIP + sign_extend(disp32)).
+	dispSigned := int64(int32(mem.Disp)) //nolint:gosec // G115: intentional int32 reinterpretation for sign extension
+	if dispSigned < 0 {
+		negDisp := uint64(-dispSigned) //nolint:gosec // G115: dispSigned is negative; disp32 range guarantees no overflow on negation
+		if negDisp > nextPC {
+			return false, 0
+		}
+	}
+	target := uint64(int64(nextPC) + dispSigned) //nolint:gosec // G115: underflow checked above; overflow bounded by binary size
+
+	val, ok := d.readGlobal64(target)
+	return ok, val
 }
 
 // writesRDXImplicitly reports whether the instruction unconditionally writes

--- a/internal/runner/security/elfanalyzer/x86_decoder.go
+++ b/internal/runner/security/elfanalyzer/x86_decoder.go
@@ -14,6 +14,12 @@ const (
 	// minArgsForImmediateMove is the minimum number of arguments
 	// required to check for an immediate move instruction (destination + source).
 	minArgsForImmediateMove = 2
+
+	// x86LoadSize32 is the byte count for 32-bit MOV EAX, [RIP+disp32] loads.
+	x86LoadSize32 = 4
+
+	// x86LoadSize64 is the byte count for 64-bit MOV RAX, [RIP+disp32] loads.
+	x86LoadSize64 = 8
 )
 
 // x86DataSection holds the virtual address and raw bytes of an ELF section
@@ -416,9 +422,8 @@ func (d *X86Decoder) SetDataSections(sections []x86DataSection) {
 	d.dataSections = sections
 }
 
-// readGlobal64 reads a little-endian uint64 from the data sections at addr.
-func (d *X86Decoder) readGlobal64(addr uint64) (int64, bool) {
-	const loadSize = uint64(8)
+// readGlobal reads a little-endian uint32/uint64 from the data sections at addr.
+func (d *X86Decoder) readGlobal(addr uint64, loadSize uint64) (int64, bool) {
 	for _, sec := range d.dataSections {
 		if addr < sec.Addr {
 			continue
@@ -427,8 +432,15 @@ func (d *X86Decoder) readGlobal64(addr uint64) (int64, bool) {
 		if off+loadSize > uint64(len(sec.Data)) { //nolint:gosec // G115: len(sec.Data) fits in uint64; section sizes are bounded by binary size
 			continue
 		}
-		val := binary.LittleEndian.Uint64(sec.Data[off : off+loadSize])
-		return int64(val), true //nolint:gosec // G115: int64/uint64 reinterpretation; caller validates range
+		start := int(off) //nolint:gosec // G115: off is bounded by the section length check above
+		if loadSize == x86LoadSize32 {
+			return int64(binary.LittleEndian.Uint32(sec.Data[start : start+x86LoadSize32])), true
+		}
+		if loadSize == x86LoadSize64 {
+			val := binary.LittleEndian.Uint64(sec.Data[start : start+x86LoadSize64])
+			return int64(val), true //nolint:gosec // G115: int64/uint64 reinterpretation; caller validates range
+		}
+		return 0, false
 	}
 	return 0, false
 }
@@ -464,6 +476,10 @@ func (d *X86Decoder) ResolveFirstArgGlobal(recentInstructions []DecodedInstructi
 	if !ok || !sameFamily(destReg, x86asm.RAX) || !isFullWidthWrite(destReg) {
 		return false, 0
 	}
+	loadSize := uint64(x86LoadSize64)
+	if destReg == x86asm.EAX {
+		loadSize = x86LoadSize32
+	}
 
 	mem, ok := args[1].(x86asm.Mem)
 	if !ok || mem.Base != x86asm.RIP || mem.Index != 0 || mem.Scale != 0 {
@@ -486,7 +502,7 @@ func (d *X86Decoder) ResolveFirstArgGlobal(recentInstructions []DecodedInstructi
 	}
 	target := uint64(int64(nextPC) + dispSigned) //nolint:gosec // G115: underflow checked above; overflow bounded by binary size
 
-	val, ok := d.readGlobal64(target)
+	val, ok := d.readGlobal(target, loadSize)
 	return ok, val
 }
 

--- a/internal/runner/security/elfanalyzer/x86_decoder.go
+++ b/internal/runner/security/elfanalyzer/x86_decoder.go
@@ -14,13 +14,49 @@ const (
 	// minArgsForImmediateMove is the minimum number of arguments
 	// required to check for an immediate move instruction (destination + source).
 	minArgsForImmediateMove = 2
-
-	// x86LoadSize32 is the byte count for 32-bit MOV EAX, [RIP+disp32] loads.
-	x86LoadSize32 = 4
-
-	// x86LoadSize64 is the byte count for 64-bit MOV RAX, [RIP+disp32] loads.
-	x86LoadSize64 = 8
 )
+
+const (
+	x86ByteWidth32 = 4 // byte width of a 32-bit (EAX) load
+	x86ByteWidth64 = 8 // byte width of a 64-bit (RAX) load
+)
+
+// x86LoadOp encodes the byte width and little-endian extraction logic for a
+// global memory load. Construct via newX86LoadOp; the zero value is invalid.
+type x86LoadOp struct {
+	byteWidth int
+}
+
+// newX86LoadOp returns the load operation for a MOV EAX/RAX, [mem] instruction.
+// EAX maps to a 32-bit zero-extending load; RAX maps to a 64-bit load.
+// Returns (zero, false) for any other register.
+func newX86LoadOp(reg x86asm.Reg) (x86LoadOp, bool) {
+	switch reg {
+	case x86asm.EAX:
+		return x86LoadOp{byteWidth: x86ByteWidth32}, true
+	case x86asm.RAX:
+		return x86LoadOp{byteWidth: x86ByteWidth64}, true
+	default:
+		return x86LoadOp{}, false
+	}
+}
+
+// readLE reads a little-endian integer of op's width from data[off:] and
+// returns it as a signed int64.
+func (op x86LoadOp) readLE(data []byte, off int) (int64, bool) {
+	switch op.byteWidth {
+	case x86ByteWidth32:
+		return int64(binary.LittleEndian.Uint32(data[off : off+x86ByteWidth32])), true
+	case x86ByteWidth64:
+		val := binary.LittleEndian.Uint64(data[off : off+x86ByteWidth64])
+		if val > math.MaxInt64 {
+			return 0, false
+		}
+		return int64(val), true
+	default:
+		panic("unreachable: invalid x86LoadOp")
+	}
+}
 
 // x86DataSection holds the virtual address and raw bytes of an ELF section
 // used by ResolveFirstArgGlobal to read global variable values.
@@ -422,29 +458,19 @@ func (d *X86Decoder) SetDataSections(sections []x86DataSection) {
 	d.dataSections = sections
 }
 
-// readGlobal reads a little-endian uint32/uint64 from the data sections at addr.
-func (d *X86Decoder) readGlobal(addr uint64, loadSize uint64) (int64, bool) {
+// readGlobal reads a little-endian integer from the data sections at addr
+// using the width and extraction logic encoded in op.
+func (d *X86Decoder) readGlobal(addr uint64, op x86LoadOp) (int64, bool) {
 	for _, sec := range d.dataSections {
 		if addr < sec.Addr {
 			continue
 		}
 		off := addr - sec.Addr
-		secLen := uint64(len(sec.Data)) //nolint:gosec // G115: section sizes are bounded by binary size
-		if off > secLen || loadSize > secLen-off {
+		secLen := uint64(len(sec.Data))                        //nolint:gosec // G115: section sizes are bounded by binary size
+		if off > secLen || uint64(op.byteWidth) > secLen-off { //nolint:gosec // G115: byteWidth is 4 or 8
 			continue
 		}
-		start := int(off) //nolint:gosec // G115: off <= secLen-loadSize, so off fits in int
-		if loadSize == x86LoadSize32 {
-			return int64(binary.LittleEndian.Uint32(sec.Data[start : start+x86LoadSize32])), true
-		}
-		if loadSize == x86LoadSize64 {
-			val := binary.LittleEndian.Uint64(sec.Data[start : start+x86LoadSize64])
-			if val > math.MaxInt64 {
-				return 0, false
-			}
-			return int64(val), true
-		}
-		return 0, false
+		return op.readLE(sec.Data, int(off)) //nolint:gosec // G115: off <= secLen-uint64(op), so off fits in int
 	}
 	return 0, false
 }
@@ -480,9 +506,9 @@ func (d *X86Decoder) ResolveFirstArgGlobal(recentInstructions []DecodedInstructi
 	if !ok || !sameFamily(destReg, x86asm.RAX) || !isFullWidthWrite(destReg) {
 		return false, 0
 	}
-	loadSize := uint64(x86LoadSize64)
-	if destReg == x86asm.EAX {
-		loadSize = x86LoadSize32
+	op, ok := newX86LoadOp(destReg)
+	if !ok {
+		return false, 0
 	}
 
 	mem, ok := args[1].(x86asm.Mem)
@@ -495,7 +521,7 @@ func (d *X86Decoder) ResolveFirstArgGlobal(recentInstructions []DecodedInstructi
 		return false, 0
 	}
 
-	val, ok := d.readGlobal(target, loadSize)
+	val, ok := d.readGlobal(target, op)
 	return ok, val
 }
 

--- a/internal/runner/security/elfanalyzer/x86_decoder.go
+++ b/internal/runner/security/elfanalyzer/x86_decoder.go
@@ -429,16 +429,20 @@ func (d *X86Decoder) readGlobal(addr uint64, loadSize uint64) (int64, bool) {
 			continue
 		}
 		off := addr - sec.Addr
-		if off+loadSize > uint64(len(sec.Data)) { //nolint:gosec // G115: len(sec.Data) fits in uint64; section sizes are bounded by binary size
+		secLen := uint64(len(sec.Data)) //nolint:gosec // G115: section sizes are bounded by binary size
+		if off > secLen || loadSize > secLen-off {
 			continue
 		}
-		start := int(off) //nolint:gosec // G115: off is bounded by the section length check above
+		start := int(off) //nolint:gosec // G115: off <= secLen-loadSize, so off fits in int
 		if loadSize == x86LoadSize32 {
 			return int64(binary.LittleEndian.Uint32(sec.Data[start : start+x86LoadSize32])), true
 		}
 		if loadSize == x86LoadSize64 {
 			val := binary.LittleEndian.Uint64(sec.Data[start : start+x86LoadSize64])
-			return int64(val), true //nolint:gosec // G115: int64/uint64 reinterpretation; caller validates range
+			if val > math.MaxInt64 {
+				return 0, false
+			}
+			return int64(val), true
 		}
 		return 0, false
 	}

--- a/internal/runner/security/elfanalyzer/x86_decoder_test.go
+++ b/internal/runner/security/elfanalyzer/x86_decoder_test.go
@@ -691,9 +691,160 @@ func TestX86Decoder_ModifiesFirstArg(t *testing.T) {
 	})
 }
 
+// decodeOne decodes a single instruction from code at instAddr and returns it.
+func decodeOne(t *testing.T, code []byte, instAddr uint64) DecodedInstruction {
+	t.Helper()
+	d := NewX86Decoder()
+	inst, err := d.Decode(code, instAddr)
+	require.NoError(t, err)
+	return inst
+}
+
 func TestX86Decoder_ResolveFirstArgGlobal(t *testing.T) {
-	decoder := NewX86Decoder()
-	ok, value := decoder.ResolveFirstArgGlobal(nil, 0)
-	assert.False(t, ok)
-	assert.Equal(t, int64(0), value)
+	const instAddr = uint64(0x1000)
+
+	// MOV RAX, [RIP+disp32]: 48 8B 05 <disp32-le>  (7 bytes, REX.W)
+	// MOV EAX, [RIP+disp32]: 8B 05 <disp32-le>     (6 bytes, no REX.W)
+	// MOV RBX, [RIP+disp32]: 48 8B 1D <disp32-le>  (7 bytes, reg=011=RBX)
+	// MOV RAX, [RBX]:        48 8B 03               (3 bytes, register indirect)
+	// MOV RAX, imm64:        48 B8 <imm64-le>       (10 bytes)
+
+	makeRAXRIPLoad := func(disp int32) []byte {
+		b := []byte{0x48, 0x8B, 0x05, 0, 0, 0, 0}
+		b[3] = byte(disp)
+		b[4] = byte(disp >> 8)
+		b[5] = byte(disp >> 16)
+		b[6] = byte(disp >> 24)
+		return b
+	}
+	makeEAXRIPLoad := func(disp int32) []byte {
+		b := []byte{0x8B, 0x05, 0, 0, 0, 0}
+		b[2] = byte(disp)
+		b[3] = byte(disp >> 8)
+		b[4] = byte(disp >> 16)
+		b[5] = byte(disp >> 24)
+		return b
+	}
+
+	// Helper: build a data section holding val64 at addr.
+	makeSec := func(addr uint64, val uint64) x86DataSection {
+		data := make([]byte, 8)
+		data[0] = byte(val)
+		data[1] = byte(val >> 8)
+		data[2] = byte(val >> 16)
+		data[3] = byte(val >> 24)
+		data[4] = byte(val >> 32)
+		data[5] = byte(val >> 40)
+		data[6] = byte(val >> 48)
+		data[7] = byte(val >> 56)
+		return x86DataSection{Addr: addr, Data: data}
+	}
+
+	t.Run("no data sections", func(t *testing.T) {
+		decoder := NewX86Decoder()
+		inst := decodeOne(t, makeRAXRIPLoad(4), instAddr)
+		ok, val := decoder.ResolveFirstArgGlobal([]DecodedInstruction{inst}, 0)
+		assert.False(t, ok)
+		assert.Equal(t, int64(0), val)
+	})
+
+	t.Run("nil instructions", func(t *testing.T) {
+		decoder := NewX86Decoder()
+		decoder.SetDataSections([]x86DataSection{makeSec(0x2000, 72)})
+		ok, val := decoder.ResolveFirstArgGlobal(nil, 0)
+		assert.False(t, ok)
+		assert.Equal(t, int64(0), val)
+	})
+
+	t.Run("out-of-range index", func(t *testing.T) {
+		decoder := NewX86Decoder()
+		decoder.SetDataSections([]x86DataSection{makeSec(0x2000, 72)})
+		inst := decodeOne(t, makeRAXRIPLoad(4), instAddr)
+		ok, val := decoder.ResolveFirstArgGlobal([]DecodedInstruction{inst}, 1)
+		assert.False(t, ok)
+		assert.Equal(t, int64(0), val)
+	})
+
+	t.Run("MOV RAX [RIP+disp] resolved", func(t *testing.T) {
+		// MOV RAX, [RIP+4] at 0x1000 → nextPC=0x1007, target=0x100B
+		code := makeRAXRIPLoad(4)
+		inst := decodeOne(t, code, instAddr)
+		targetAddr := instAddr + uint64(inst.Len) + 4 // 0x100B
+
+		decoder := NewX86Decoder()
+		decoder.SetDataSections([]x86DataSection{makeSec(targetAddr, 72)})
+		ok, val := decoder.ResolveFirstArgGlobal([]DecodedInstruction{inst}, 0)
+		require.True(t, ok)
+		assert.Equal(t, int64(72), val)
+	})
+
+	t.Run("MOV EAX [RIP+disp] resolved", func(t *testing.T) {
+		// MOV EAX, [RIP+8] at 0x1000 → nextPC=0x1006, target=0x100E
+		code := makeEAXRIPLoad(8)
+		inst := decodeOne(t, code, instAddr)
+		targetAddr := instAddr + uint64(inst.Len) + 8 // 0x100E
+
+		decoder := NewX86Decoder()
+		decoder.SetDataSections([]x86DataSection{makeSec(targetAddr, 59)}) // SYS_execve
+		ok, val := decoder.ResolveFirstArgGlobal([]DecodedInstruction{inst}, 0)
+		require.True(t, ok)
+		assert.Equal(t, int64(59), val)
+	})
+
+	t.Run("negative displacement", func(t *testing.T) {
+		// MOV RAX, [RIP-8] at 0x1010 → nextPC=0x1017, target=0x100F
+		const addr = uint64(0x1010)
+		code := makeRAXRIPLoad(-8)
+		inst := decodeOne(t, code, addr)
+		targetAddr := addr + uint64(inst.Len) - 8 // 0x100F
+
+		decoder := NewX86Decoder()
+		decoder.SetDataSections([]x86DataSection{makeSec(targetAddr, 202)}) // SYS_futex
+		ok, val := decoder.ResolveFirstArgGlobal([]DecodedInstruction{inst}, 0)
+		require.True(t, ok)
+		assert.Equal(t, int64(202), val)
+	})
+
+	t.Run("address not in data section", func(t *testing.T) {
+		code := makeRAXRIPLoad(4)
+		inst := decodeOne(t, code, instAddr)
+
+		decoder := NewX86Decoder()
+		decoder.SetDataSections([]x86DataSection{makeSec(0x9000, 72)}) // wrong address
+		ok, val := decoder.ResolveFirstArgGlobal([]DecodedInstruction{inst}, 0)
+		assert.False(t, ok)
+		assert.Equal(t, int64(0), val)
+	})
+
+	t.Run("non-RIP-relative load MOV RAX [RBX]", func(t *testing.T) {
+		// MOV RAX, [RBX]: 48 8B 03
+		inst := decodeOne(t, []byte{0x48, 0x8B, 0x03}, instAddr)
+		decoder := NewX86Decoder()
+		decoder.SetDataSections([]x86DataSection{makeSec(0x1000, 72)})
+		ok, val := decoder.ResolveFirstArgGlobal([]DecodedInstruction{inst}, 0)
+		assert.False(t, ok)
+		assert.Equal(t, int64(0), val)
+	})
+
+	t.Run("wrong destination register MOV RBX [RIP+disp]", func(t *testing.T) {
+		// MOV RBX, [RIP+disp32]: 48 8B 1D <disp32-le>
+		b := []byte{0x48, 0x8B, 0x1D, 0x04, 0x00, 0x00, 0x00}
+		inst := decodeOne(t, b, instAddr)
+		decoder := NewX86Decoder()
+		decoder.SetDataSections([]x86DataSection{makeSec(instAddr+uint64(inst.Len)+4, 72)})
+		ok, val := decoder.ResolveFirstArgGlobal([]DecodedInstruction{inst}, 0)
+		assert.False(t, ok)
+		assert.Equal(t, int64(0), val)
+	})
+
+	t.Run("MOV RAX imm is not a global load", func(t *testing.T) {
+		// MOV RAX, 72: 48 B8 48 00 00 00 00 00 00 00
+		b := []byte{0x48, 0xB8, 72, 0, 0, 0, 0, 0, 0, 0}
+		inst := decodeOne(t, b, instAddr)
+		decoder := NewX86Decoder()
+		decoder.SetDataSections([]x86DataSection{makeSec(0x1000, 72)})
+		ok, val := decoder.ResolveFirstArgGlobal([]DecodedInstruction{inst}, 0)
+		assert.False(t, ok)
+		assert.Equal(t, int64(0), val)
+	})
 }

--- a/internal/runner/security/elfanalyzer/x86_decoder_test.go
+++ b/internal/runner/security/elfanalyzer/x86_decoder_test.go
@@ -791,6 +791,19 @@ func TestX86Decoder_ResolveFirstArgGlobal(t *testing.T) {
 		assert.Equal(t, int64(59), val)
 	})
 
+	t.Run("MOV EAX [RIP+disp] reads 32-bit value only", func(t *testing.T) {
+		code := makeEAXRIPLoad(8)
+		inst := decodeOne(t, code, instAddr)
+		targetAddr := instAddr + uint64(inst.Len) + 8
+
+		data := []byte{59, 0, 0, 0, 0xff, 0xff, 0xff, 0xff}
+		decoder := NewX86Decoder()
+		decoder.SetDataSections([]x86DataSection{{Addr: targetAddr, Data: data}})
+		ok, val := decoder.ResolveFirstArgGlobal([]DecodedInstruction{inst}, 0)
+		require.True(t, ok)
+		assert.Equal(t, int64(59), val)
+	})
+
 	t.Run("negative displacement", func(t *testing.T) {
 		// MOV RAX, [RIP-8] at 0x1010 → nextPC=0x1017, target=0x100F
 		const addr = uint64(0x1010)

--- a/internal/runner/security/elfanalyzer/x86_go_wrapper_resolver.go
+++ b/internal/runner/security/elfanalyzer/x86_go_wrapper_resolver.go
@@ -21,8 +21,28 @@ func NewX86GoWrapperResolver(elfFile *elf.File) (*X86GoWrapperResolver, error) {
 	if err := r.loadFromPclntab(elfFile); err != nil {
 		return r, err
 	}
+	r.decoder.SetDataSections(loadX86DataSections(elfFile))
 	r.hasSymbols = len(r.symbols) > 0
 	return r, nil
+}
+
+// loadX86DataSections reads ELF sections that may contain package-level
+// variables used as syscall numbers (e.g. syscall.fcntl64Syscall).
+func loadX86DataSections(elfFile *elf.File) []x86DataSection {
+	sectionNames := []string{".noptrdata", ".rodata", ".data"}
+	sections := make([]x86DataSection, 0, len(sectionNames))
+	for _, name := range sectionNames {
+		sec := elfFile.Section(name)
+		if sec == nil {
+			continue
+		}
+		data, err := sec.Data()
+		if err != nil || len(data) == 0 {
+			continue
+		}
+		sections = append(sections, x86DataSection{Addr: sec.Addr, Data: data})
+	}
+	return sections
 }
 
 // newX86GoWrapperResolver creates an empty X86GoWrapperResolver without loading symbols.


### PR DESCRIPTION
This pull request enhances the x86 ELF analyzer to support resolving syscall numbers loaded from package-level global variables in Go binaries, specifically when syscalls are loaded via RIP-relative memory reads (e.g., `MOV RAX, [RIP+disp32]`). It introduces logic to read ELF data sections and extract values referenced by such instructions, improving the analyzer’s ability to detect indirect syscall invocations. Comprehensive tests are added to validate this behavior.

**Global variable syscall resolution:**
* Added the `x86DataSection` type and extended `X86Decoder` to hold relevant ELF data sections for global variable resolution.
* Implemented `SetDataSections` and `readGlobal` methods in `X86Decoder` to allow reading values from ELF data sections.
* Replaced the stub implementation of `ResolveFirstArgGlobal` with logic to resolve syscall numbers loaded via RIP-relative memory reads, handling both 32-bit and 64-bit cases.
* Added `loadX86DataSections` to collect `.noptrdata`, `.rodata`, and `.data` sections from the ELF file and supply them to the decoder.

**Testing improvements:**
* Added extensive unit tests for `ResolveFirstArgGlobal`, covering both successful resolutions and various edge cases (e.g., wrong register, missing data, negative displacement).