### PR TITLE
fix: sort all slice fields in Record before writing to file

### DIFF
--- a/internal/filevalidator/validator.go
+++ b/internal/filevalidator/validator.go
@@ -499,7 +499,13 @@ func (v *Validator) analyzeDynLibDeps(filePath string, record *fileanalysis.Reco
 	}
 
 	slices.SortFunc(record.DynLibDeps, func(a, b fileanalysis.LibEntry) int {
-		return cmp.Compare(a.SOName, b.SOName)
+		if c := cmp.Compare(a.SOName, b.SOName); c != 0 {
+			return c
+		}
+		if c := cmp.Compare(a.Path, b.Path); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.Hash, b.Hash)
 	})
 	slices.Sort(record.AnalysisWarnings)
 

--- a/internal/filevalidator/validator.go
+++ b/internal/filevalidator/validator.go
@@ -1125,7 +1125,10 @@ func (v *Validator) analyzeELFSyscalls(record *fileanalysis.Record, filePath str
 	allSyscalls := mergeSyscallInfos(libcSyscalls, directSyscalls)
 	argEvalResults := buildArgEvalResults(libcSyscalls, directArgEvalResults, elfFile, v.syscallAnalyzer)
 	slices.SortFunc(argEvalResults, func(a, b common.SyscallArgEvalResult) int {
-		return cmp.Compare(a.SyscallName, b.SyscallName)
+		if c := cmp.Compare(a.SyscallName, b.SyscallName); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.Status, b.Status)
 	})
 	if len(allSyscalls) > 0 || len(argEvalResults) > 0 {
 		record.SyscallAnalysis = buildSyscallData(allSyscalls, argEvalResults, elfFile.Machine)

--- a/internal/filevalidator/validator.go
+++ b/internal/filevalidator/validator.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 
 	"github.com/isseis/go-safe-cmd-runner/internal/common"
@@ -347,6 +348,7 @@ func (v *Validator) updateAnalysisRecord(filePath common.ResolvedPath, hash stri
 					matched = append(matched, lib.SOName)
 				}
 			}
+			slices.Sort(matched)
 			record.SymbolAnalysis.KnownNetworkLibDeps = matched
 		}
 
@@ -753,6 +755,7 @@ func convertDetectedSymbols(syms []binaryanalyzer.DetectedSymbol) []string {
 	for i, s := range syms {
 		entries[i] = s.Name
 	}
+	slices.Sort(entries)
 	return entries
 }
 

--- a/internal/filevalidator/validator.go
+++ b/internal/filevalidator/validator.go
@@ -2,6 +2,7 @@ package filevalidator
 
 import (
 	"bytes"
+	"cmp"
 	"debug/elf"
 	"debug/macho"
 	"encoding/binary"
@@ -496,6 +497,11 @@ func (v *Validator) analyzeDynLibDeps(filePath string, record *fileanalysis.Reco
 			record.AnalysisWarnings = append(record.AnalysisWarnings, w.String())
 		}
 	}
+
+	slices.SortFunc(record.DynLibDeps, func(a, b fileanalysis.LibEntry) int {
+		return cmp.Compare(a.SOName, b.SOName)
+	})
+	slices.Sort(record.AnalysisWarnings)
 
 	return nil
 }
@@ -1112,6 +1118,9 @@ func (v *Validator) analyzeELFSyscalls(record *fileanalysis.Record, filePath str
 	// Merge results and write SyscallAnalysis; always assign to overwrite any stale value.
 	allSyscalls := mergeSyscallInfos(libcSyscalls, directSyscalls)
 	argEvalResults := buildArgEvalResults(libcSyscalls, directArgEvalResults, elfFile, v.syscallAnalyzer)
+	slices.SortFunc(argEvalResults, func(a, b common.SyscallArgEvalResult) int {
+		return cmp.Compare(a.SyscallName, b.SyscallName)
+	})
 	if len(allSyscalls) > 0 || len(argEvalResults) > 0 {
 		record.SyscallAnalysis = buildSyscallData(allSyscalls, argEvalResults, elfFile.Machine)
 	} else {

--- a/internal/filevalidator/validator_dynlib_sort_linux_test.go
+++ b/internal/filevalidator/validator_dynlib_sort_linux_test.go
@@ -1,0 +1,224 @@
+//go:build test && linux
+
+package filevalidator
+
+import (
+	"bytes"
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/isseis/go-safe-cmd-runner/internal/elfdynlib"
+	"github.com/isseis/go-safe-cmd-runner/internal/safefileio"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// buildMinimalELFWithDeps writes a minimal x86-64 ELF (ET_DYN) to dir/fileName.
+// sonames are recorded as DT_NEEDED entries in the given order.
+// If runpath is non-empty it is set as DT_RUNPATH.
+// Returns the absolute path of the written file.
+//
+// This is a local copy of the elfdynlib test helper — kept here to avoid
+// cross-package test dependencies.
+func buildMinimalELFWithDeps(t *testing.T, dir, fileName string, sonames []string, runpath string) string {
+	t.Helper()
+
+	const (
+		elfHeaderSize = 64
+		phdrSize      = 56
+		shdrSize      = 64
+		dynEntrySize  = 16
+		baseVaddr     = uint64(0x400000)
+
+		elfClass64 = 2
+		elfDataLE  = 1
+		elfVersion = 1
+		etDyn      = 3
+		emX8664    = 62
+		ptLoad     = 1
+		ptDynamic  = 2
+		pfRX       = 5
+		pfRW       = 6
+
+		dtNull    = 0
+		dtNeeded  = 1
+		dtStrtab  = 5
+		dtStrsz   = 10
+		dtRunpath = 29
+
+		shtNull    = 0
+		shtStrtab  = 3
+		shtDynamic = 6
+
+		shfAlloc  = 2
+		shfAllocW = shfAlloc | 1
+	)
+
+	numPhdrs := 2
+
+	var dynstrBuf bytes.Buffer
+	dynstrBuf.WriteByte(0)
+
+	runpathIdx := uint64(0)
+	if runpath != "" {
+		runpathIdx = uint64(dynstrBuf.Len())
+		dynstrBuf.WriteString(runpath)
+		dynstrBuf.WriteByte(0)
+	}
+
+	soIdx := make([]uint64, len(sonames))
+	for i, so := range sonames {
+		soIdx[i] = uint64(dynstrBuf.Len())
+		dynstrBuf.WriteString(so)
+		dynstrBuf.WriteByte(0)
+	}
+	dynstrData := dynstrBuf.Bytes()
+
+	var shstrtabBuf bytes.Buffer
+	shstrtabBuf.WriteByte(0)
+	dynstrNameIdx := uint32(shstrtabBuf.Len())
+	shstrtabBuf.WriteString(".dynstr\x00")
+	dynamicNameIdx := uint32(shstrtabBuf.Len())
+	shstrtabBuf.WriteString(".dynamic\x00")
+	shstrtabNameIdx := uint32(shstrtabBuf.Len())
+	shstrtabBuf.WriteString(".shstrtab\x00")
+	shstrtabData := shstrtabBuf.Bytes()
+
+	numDynEntries := 3
+	if runpath != "" {
+		numDynEntries++
+	}
+	numDynEntries += len(sonames)
+
+	dynSectionOffset := uint64(elfHeaderSize + phdrSize*numPhdrs)
+	dynSectionSize := uint64(numDynEntries * dynEntrySize)
+	dynstrOffset := dynSectionOffset + dynSectionSize
+	shstrtabOffset := dynstrOffset + uint64(len(dynstrData))
+	shOffset := shstrtabOffset + uint64(len(shstrtabData))
+	totalSize := shOffset + uint64(shdrSize)*4
+
+	dynVaddr := baseVaddr + dynSectionOffset
+	dynstrVaddr := baseVaddr + dynstrOffset
+
+	le := binary.LittleEndian
+	var out bytes.Buffer
+
+	out.Write([]byte{
+		0x7f, 'E', 'L', 'F', elfClass64, elfDataLE, elfVersion, 0,
+		0, 0, 0, 0, 0, 0, 0, 0,
+	})
+	_ = binary.Write(&out, le, uint16(etDyn))
+	_ = binary.Write(&out, le, uint16(emX8664))
+	_ = binary.Write(&out, le, uint32(elfVersion))
+	_ = binary.Write(&out, le, uint64(0))
+	_ = binary.Write(&out, le, uint64(elfHeaderSize))
+	_ = binary.Write(&out, le, shOffset)
+	_ = binary.Write(&out, le, uint32(0))
+	_ = binary.Write(&out, le, uint16(elfHeaderSize))
+	_ = binary.Write(&out, le, uint16(phdrSize))
+	_ = binary.Write(&out, le, uint16(numPhdrs))
+	_ = binary.Write(&out, le, uint16(shdrSize))
+	_ = binary.Write(&out, le, uint16(4))
+	_ = binary.Write(&out, le, uint16(3))
+
+	_ = binary.Write(&out, le, uint32(ptLoad))
+	_ = binary.Write(&out, le, uint32(pfRX))
+	_ = binary.Write(&out, le, uint64(0))
+	_ = binary.Write(&out, le, baseVaddr)
+	_ = binary.Write(&out, le, baseVaddr)
+	_ = binary.Write(&out, le, totalSize)
+	_ = binary.Write(&out, le, totalSize)
+	_ = binary.Write(&out, le, uint64(0x1000))
+
+	_ = binary.Write(&out, le, uint32(ptDynamic))
+	_ = binary.Write(&out, le, uint32(pfRW))
+	_ = binary.Write(&out, le, dynSectionOffset)
+	_ = binary.Write(&out, le, dynVaddr)
+	_ = binary.Write(&out, le, dynVaddr)
+	_ = binary.Write(&out, le, dynSectionSize)
+	_ = binary.Write(&out, le, dynSectionSize)
+	_ = binary.Write(&out, le, uint64(8))
+
+	writeDyn := func(tag int64, val uint64) {
+		_ = binary.Write(&out, le, tag)
+		_ = binary.Write(&out, le, val)
+	}
+	writeDyn(dtStrtab, dynstrVaddr)
+	writeDyn(dtStrsz, uint64(len(dynstrData)))
+	if runpath != "" {
+		writeDyn(dtRunpath, runpathIdx)
+	}
+	for _, idx := range soIdx {
+		writeDyn(dtNeeded, idx)
+	}
+	writeDyn(dtNull, 0)
+
+	out.Write(dynstrData)
+	out.Write(shstrtabData)
+
+	writeShdr := func(nameIdx, shType uint32, flags, addr, offset, size uint64,
+		link uint32, addralign, entsize uint64,
+	) {
+		_ = binary.Write(&out, le, nameIdx)
+		_ = binary.Write(&out, le, shType)
+		_ = binary.Write(&out, le, flags)
+		_ = binary.Write(&out, le, addr)
+		_ = binary.Write(&out, le, offset)
+		_ = binary.Write(&out, le, size)
+		_ = binary.Write(&out, le, link)
+		_ = binary.Write(&out, le, uint32(0))
+		_ = binary.Write(&out, le, addralign)
+		_ = binary.Write(&out, le, entsize)
+	}
+
+	writeShdr(0, shtNull, 0, 0, 0, 0, 0, 0, 0)
+	writeShdr(dynstrNameIdx, shtStrtab, uint64(shfAlloc),
+		dynstrVaddr, dynstrOffset, uint64(len(dynstrData)), 0, 1, 0)
+	writeShdr(dynamicNameIdx, shtDynamic, uint64(shfAllocW),
+		dynVaddr, dynSectionOffset, dynSectionSize, 1, 8, uint64(dynEntrySize))
+	writeShdr(shstrtabNameIdx, shtStrtab, 0,
+		0, shstrtabOffset, uint64(len(shstrtabData)), 0, 1, 0)
+
+	path := filepath.Join(dir, fileName)
+	require.NoError(t, os.WriteFile(path, out.Bytes(), 0o644))
+	return path
+}
+
+// TestDynLibDeps_SortedBySOName verifies that DynLibDeps is sorted by SOName
+// (then Path, then Hash) regardless of the order DT_NEEDED entries appear in
+// the binary.
+func TestDynLibDeps_SortedBySOName(t *testing.T) {
+	tmpDir := safeTempDir(t)
+	hashDir := filepath.Join(tmpDir, "hashes")
+	require.NoError(t, os.MkdirAll(hashDir, 0o700))
+
+	// Create leaf libraries (no deps) in the temp dir.
+	buildMinimalELFWithDeps(t, tmpDir, "libz.so.1", nil, "")
+	buildMinimalELFWithDeps(t, tmpDir, "libm.so.6", nil, "")
+	buildMinimalELFWithDeps(t, tmpDir, "liba.so.1", nil, "")
+
+	// Main ELF references the three libraries in reverse-alphabetical order.
+	mainELF := buildMinimalELFWithDeps(t, tmpDir, "main.elf",
+		[]string{"libz.so.1", "libm.so.6", "liba.so.1"}, tmpDir)
+
+	v, err := New(&SHA256{}, hashDir)
+	require.NoError(t, err)
+	v.SetELFDynLibAnalyzer(elfdynlib.NewDynLibAnalyzer(
+		safefileio.NewFileSystem(safefileio.FileSystemConfig{}),
+	))
+
+	_, _, err = v.SaveRecord(mainELF, false)
+	require.NoError(t, err)
+
+	record, err := v.LoadRecord(mainELF)
+	require.NoError(t, err)
+
+	require.Len(t, record.DynLibDeps, 3)
+	sonames := make([]string, len(record.DynLibDeps))
+	for i, e := range record.DynLibDeps {
+		sonames[i] = e.SOName
+	}
+	assert.Equal(t, []string{"liba.so.1", "libm.so.6", "libz.so.1"}, sonames)
+}

--- a/internal/filevalidator/validator_sort_test.go
+++ b/internal/filevalidator/validator_sort_test.go
@@ -1,0 +1,63 @@
+//go:build test
+
+package filevalidator
+
+import (
+	"testing"
+
+	"github.com/isseis/go-safe-cmd-runner/internal/fileanalysis"
+	"github.com/isseis/go-safe-cmd-runner/internal/runner/security/binaryanalyzer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// Sort-stability tests for SymbolAnalysis slice fields
+// ---------------------------------------------------------------------------
+
+func TestRecord_DetectedSymbols_SortedAlphabetically(t *testing.T) {
+	stub := &stubBinaryAnalyzer{
+		result: binaryanalyzer.NetworkDetected,
+		detectedSymbols: []binaryanalyzer.DetectedSymbol{
+			{Name: "socket", Category: "network"},
+			{Name: "connect", Category: "network"},
+			{Name: "bind", Category: "network"},
+		},
+	}
+	record, err := recordWithBinaryAnalyzer(t, stub)
+	require.NoError(t, err)
+	require.NotNil(t, record.SymbolAnalysis)
+	assert.Equal(t, []string{"bind", "connect", "socket"}, record.SymbolAnalysis.DetectedSymbols)
+}
+
+func TestRecord_DynamicLoadSymbols_SortedAlphabetically(t *testing.T) {
+	stub := &stubBinaryAnalyzer{
+		result: binaryanalyzer.NoNetworkSymbols,
+		dynamicLoadSymbols: []binaryanalyzer.DetectedSymbol{
+			{Name: "dlvsym", Category: "dynamic_load"},
+			{Name: "dlopen", Category: "dynamic_load"},
+			{Name: "dlsym", Category: "dynamic_load"},
+		},
+	}
+	record, err := recordWithBinaryAnalyzer(t, stub)
+	require.NoError(t, err)
+	require.NotNil(t, record.SymbolAnalysis)
+	assert.Equal(t, []string{"dlopen", "dlsym", "dlvsym"}, record.SymbolAnalysis.DynamicLoadSymbols)
+}
+
+func TestRecord_KnownNetworkLibDeps_SortedAlphabetically(t *testing.T) {
+	// Feed three known network libs in reverse-alphabetical order to verify sorting.
+	dynLibDeps := []fileanalysis.LibEntry{
+		{SOName: "libssl.so.3", Path: "/usr/lib/libssl.so.3", Hash: "sha256:ccc"},
+		{SOName: "libpython3.11.so.1.0", Path: "/usr/lib/libpython3.11.so.1.0", Hash: "sha256:bbb"},
+		{SOName: "libcurl.so.4", Path: "/usr/lib/libcurl.so.4", Hash: "sha256:aaa"},
+	}
+	stub := &stubBinaryAnalyzer{result: binaryanalyzer.NoNetworkSymbols}
+	record, err := recordWithDynLibDepsAndBinaryAnalyzer(t, dynLibDeps, stub)
+	require.NoError(t, err)
+	require.NotNil(t, record.SymbolAnalysis)
+	assert.Equal(t,
+		[]string{"libcurl.so.4", "libpython3.11.so.1.0", "libssl.so.3"},
+		record.SymbolAnalysis.KnownNetworkLibDeps,
+	)
+}


### PR DESCRIPTION
## Summary

- Sort `DetectedSymbols`, `DynamicLoadSymbols`, and `KnownNetworkLibDeps` (alphabetical) in `convertDetectedSymbols` and at the `KnownNetworkLibDeps` assignment
- Sort `DynLibDeps` by `SOName` and `AnalysisWarnings` (alphabetical) at the end of `analyzeDynLibDeps`
- Sort `ArgEvalResults` by `SyscallName` before passing to `buildSyscallData`

`DetectedSyscalls` and its `Occurrences` were already sorted via `GroupAndSortSyscalls`.
`SyscallAnalysis.AnalysisWarnings` has at most one element and requires no sorting.

These changes make JSON output stable and reproducible regardless of the order in which symbols or libraries appear in the binary.

## Test plan

- [ ] `make test` passes
- [ ] `make lint` reports 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)