### PR TITLE
 add Mach-O binary analysis technical documents

### DIFF
--- a/docs/dev/macho_binary_analysis.ja.md
+++ b/docs/dev/macho_binary_analysis.ja.md
@@ -1,0 +1,262 @@
+# Mach-O バイナリ解析の技術詳細
+
+本ドキュメントは、macOS 向け Mach-O バイナリ解析の技術的な動作仕様と設計判断を記録する。
+
+ELF バイナリ解析は `internal/security/elfanalyzer/` が担うが、
+Mach-O バイナリ解析は以下の 3 つのパッケージに分散して実装されている。
+
+| パッケージ | 役割 |
+|---|---|
+| `internal/security/machoanalyzer/` | ネットワークシンボル検出 + arm64 限定 2-pass syscall 解析 |
+| `internal/dynlib/machodylib/` | `LC_LOAD_DYLIB` 再帰解析（依存ライブラリのハッシュ記録） |
+| `internal/libccache/` Mach-O 側 | `libsystem_kernel.dylib` の syscall ラッパーシンボルキャッシュ |
+
+## 1. ネットワークシンボル検出
+
+### 1.1 目的と対応アーキテクチャ
+
+`StandardMachOAnalyzer` は `binaryanalyzer.BinaryAnalyzer` インタフェースを実装し、
+Mach-O バイナリが socket / connect / bind 等のネットワーク関連シンボルをインポートしているかを判定する。
+単一アーキテクチャ Mach-O およびFat バイナリの両方に対応し、シンボル検出は全アーキテクチャで機能する。
+
+### 1.2 シンボル検出の仕組み
+
+macOS の Mach-O バイナリは原則として 2 レベル名前空間（two-level namespace）を使用するため、
+各シンボルの `Desc` フィールドにライブラリオーディナル（bits[15:8]）が格納されている。
+
+**通常パス（Symtab あり）**:
+
+1. `Dysymtab` で未定義シンボル（undefined external）の範囲を取得する。
+2. 各シンボルの `Desc` フィールドからライブラリオーディナルを抽出し、
+   `LC_LOAD_DYLIB` 一覧と照合して `libSystem` 由来のシンボルかを判定する。
+3. `libSystem` 由来のシンボルを `binaryanalyzer.GetNetworkSymbols()` と照合してネットワーク分類を付与する。
+
+```
+libSystem 由来の判定条件:
+  1. ordinal が範囲内で、対応ライブラリが libSystem.B.dylib または libsystem_*.dylib
+  2. または フラット名前空間の場合（全シンボルの ordinal が 0）かつ
+     インポートライブラリに libSystem が含まれる
+```
+
+**フォールバックパス（Symtab なし）**:
+
+`Symtab` が存在しない stripped バイナリの場合、`ImportedLibraries()` に `libSystem`
+が含まれれば `ImportedSymbols()` で全インポートシンボルを取得し検出する。
+
+### 1.3 Fat バイナリの扱い
+
+Fat バイナリは全スライス（全アーキテクチャ）を解析し、最も深刻なリスクを報告する。
+これにより、arm64 スライスは安全でも x86_64 スライスにネットワーク機能がある場合の
+迂回攻撃（cross-architecture security bypass）を防止する。
+
+```
+重大度の優先順位: NetworkDetected > AnalysisError > NoNetworkSymbols
+
+いずれかのスライスが NetworkDetected → 全体を NetworkDetected として報告
+```
+
+## 2. syscall 静的解析（arm64 限定）
+
+### 2.1 macOS の syscall 規約
+
+macOS の arm64 バイナリは BSD syscall 規約を使用する。
+ELF arm64 の Linux ABI と以下の点が異なる。
+
+| 項目 | macOS (Mach-O) | Linux (ELF) |
+|---|---|---|
+| syscall 命令 | `SVC #0x80` (0xD4001001) | `SVC #0` (0xD4000001) |
+| syscall 番号レジスタ | **X16** | W8/X8 |
+| Go ラッパー引数渡し | **スタック** (`[SP, #8]`) | レジスタ (X0) |
+
+### 2.2 解析フロー概要
+
+```
+ScanSyscallInfos (svc_scanner.go)
+  ↓
+  Fat binary の場合: 全 arm64 スライスに対して analyzeArm64Slice を実行
+  単一 Mach-O の場合: analyzeArm64Slice を実行
+  ↓
+  analyzeArm64Slice
+    ├── ParseMachoPclntab → Go 関数アドレス範囲を取得
+    ├── buildStubRanges  → 既知ラッパー関数の範囲を構築
+    ├── Pass 1: collectSVCAddresses + scanSVCWithX16
+    └── Pass 2: buildWrapperAddrs + scanGoWrapperCalls
+```
+
+### 2.3 pclntab の解析
+
+`ParseMachoPclntab`（`pclntab_macho.go`）は Mach-O 内の `.gopclntab` に相当するセクションを
+解析し、Go 関数名とエントリ/終了アドレスのマップ（`map[string]MachoPclntabFunc`）を返す。
+
+このマップから `knownMachoSyscallImpls`（`syscall.Syscall`、`syscall.RawSyscall` 等）の
+アドレス範囲を `buildStubRanges` で構築する。ラッパー関数内部の `SVC #0x80` は
+Pass 1 / Pass 2 の両方でスキップされる。
+
+### 2.4 Pass 1: SVC #0x80 スキャンと X16 逆方向スキャン
+
+`collectSVCAddresses` は `__TEXT,__text` セクションを 4 バイト単位で走査し、
+`SVC #0x80`（バイト列 `0x01 0x10 0x00 0xD4`）の仮想アドレスを列挙する。
+
+`scanSVCWithX16` は各アドレスに対して以下の処理を行う。
+
+1. アドレスが既知ラッパー関数内部であればスキップ（Pass 2 が担当する）。
+2. `arm64util.BackwardScanX16` で `SVC #0x80` の直前命令列を後向きスキャンし、
+   X16 への即値ロードを探す。
+3. 即値が見つかれば `DeterminationMethod = "immediate"` で記録する。
+4. 見つからなければ `DeterminationMethod = "direct_svc_0x80"` で記録する
+   （番号不明だが直接 syscall を確認したことを示す High Risk シグナル）。
+
+```asm
+; Pass 1 が検出する典型的なパターン（非 Go バイナリ）
+MOV  X16, #4            ; syscall 番号 4 (write) を X16 にロード
+SVC  #0x80              ; BSD syscall を呼び出す
+```
+
+### 2.5 Pass 2: Go ラッパー呼び出しとスタック ABI
+
+Go の `syscall.Syscall` / `syscall.RawSyscall` 等は NOSPLIT アセンブリスタブであり、
+呼び出し規約として**スタックベース ABI** を使用する。呼び出し元は trap 番号を
+`SP+8`（`trap+0(FP)`）に格納してから BL 命令でラッパーを呼び出す。
+
+`scanGoWrapperCalls` は以下の手順で処理する。
+
+1. `__TEXT,__text` を 4 バイト単位で走査し、BL 命令のターゲットアドレスを計算する。
+2. ターゲットが既知ラッパーアドレスに一致するかを確認する。
+   1 段階のトランポリン（`B <wrapper>`）も解決する。
+3. BL 命令自体がラッパー関数内部であればスキップする（内部呼び出しは対象外）。
+4. `arm64util.BackwardScanStackTrap` で BL 直前の命令列を後向きスキャンし、
+   `[SP, #8]` への書き込み（STR/STP）を探してその値の X レジスタへの
+   即値ロードを解決する。
+
+```go
+// Go 呼び出し側が生成する典型的なパターン
+// trap 番号を SP+8 に格納してから syscall.Syscall を呼び出す
+MOV  X0, #4             // trap 番号（write）
+STR  X0, [SP, #8]       // trap+0(FP) に格納
+...
+BL   _syscall.Syscall   // Go ラッパーを呼び出す
+```
+
+**ELF arm64 との相違**: ELF arm64 の Go ラッパー（`syscall.Syscall` 等）は
+レジスタベース ABI を使用し、第 1 引数 (syscall 番号) は X0 レジスタで渡す。
+Mach-O では NOSPLIT スタブのため `[SP, #8]` を使用する。
+
+## 3. 動的ライブラリ依存解析
+
+### 3.1 BFS による再帰解析
+
+`MachODynLibAnalyzer.Analyze`（`machodylib/analyzer.go`）は
+`LC_LOAD_DYLIB` および `LC_LOAD_WEAK_DYLIB` の依存関係を幅優先探索（BFS）で再帰的に解決する。
+
+```
+Analyze(binaryPath)
+  ↓ キュー初期化: バイナリの直接依存を enqueue
+  ↓ BFS ループ（最大深さ: MaxRecursionDepth = 20）
+    ├── install name → 実パス変換
+    │     @rpath         → LC_RPATH エントリを参照
+    │     @loader_path   → 当該 Mach-O のディレクトリ
+    │     @executable_path → バイナリのディレクトリ
+    ├── IsDyldSharedCacheLib → dyld 共有キャッシュなら除外（後述）
+    ├── SHA256 ハッシュ計算
+    ├── LibEntry（SOName, Path, Hash）を追記
+    └── 解決済みライブラリの依存をさらに enqueue
+```
+
+### 3.2 dyld 共有キャッシュの除外
+
+macOS の多くのシステムライブラリ（`libSystem.B.dylib` など）は
+個別ファイルとしてディスクに存在せず、**dyld 共有キャッシュ**として一体化されている。
+このため、ハッシュ検証の対象から除外する必要がある。
+
+`IsDyldSharedCacheLib`（`dyld_extractor_darwin.go`）は以下のパスパターンで
+キャッシュライブラリを識別する。
+
+- `/usr/lib/` 配下のライブラリ
+- `/System/Library/Frameworks/` 配下のフレームワーク
+- その他 Apple が dyld 共有キャッシュに含めるパス
+
+除外されたライブラリは `LibEntry` に含まれず、runner 実行時のハッシュ検証対象にもならない。
+
+### 3.3 runner 実行時の検証
+
+記録済みの `DynLibDeps` が存在する場合、runner の `VerifyCommandDynLibDeps` は
+各ライブラリのハッシュを実際のファイルと照合する。
+動的リンクバイナリで `DynLibDeps` が未記録の場合は再 record を要求する
+（`ErrDynLibDepsRequired`）。
+
+dyld 共有キャッシュのライブラリは記録されていないため、その変更は検証対象外となる。
+これは macOS のシステムアップデートでキャッシュが入れ替わっても
+runner が起動できるようにするための設計上の意図的な除外である。
+
+## 4. libsystem_kernel.dylib ラッパーキャッシュ
+
+### 4.1 役割
+
+macOS の `syscall.Syscall` 等の Go ラッパーは最終的に `libsystem_kernel.dylib`
+内の `_syscallname` 関数（例: `_write`、`_socket`）を BL で呼び出す。
+これらの関数は `SVC #0x80` を含む syscall ラッパーである。
+
+`MachoLibSystemAnalyzer`（`libccache/macho_analyzer.go`）は
+`libsystem_kernel.dylib` の `__TEXT,__text` セクションをスキャンし、
+`SVC #0x80` を含む関数を `WrapperEntry{Name, Number}` として列挙する。
+
+### 4.2 キャッシュの仕組み
+
+`MachoLibSystemCacheManager`（`libccache/macho_cache.go`）は
+解析結果を record コマンドのハッシュディレクトリ配下にキャッシュする。
+キャッシュのキーはライブラリパスと SHA256 ハッシュであり、
+ライブラリが更新されるとキャッシュミスが発生して再解析を行う。
+
+これにより `libsystem_kernel.dylib` の解析コスト（全関数の SVC スキャン）を
+最初の record 時のみに抑えられる。
+
+### 4.3 libccache との関係
+
+ELF 側の `LibcCacheManager`（Linux glibc 向け）と Mach-O 側の `MachoLibSystemCacheManager` は
+同じキャッシュディレクトリ・同じスキーマ（`LibcCacheFile`）を共有する。
+ただし解析対象ライブラリと arm64 限定という制約の点で、実装は独立している。
+
+## 5. ELF arm64 との主な相違点
+
+| 項目 | Mach-O (machoanalyzer) | ELF (elfanalyzer) |
+|---|---|---|
+| syscall 命令 | `SVC #0x80` (0xD4001001) | `SVC #0` (0xD4000001) |
+| syscall 番号レジスタ | X16 | W8/X8 |
+| Go ラッパー引数 | スタック `[SP, #8]` | レジスタ X0 |
+| pclntab 解析 | `ParseMachoPclntab` (Mach-O 専用) | `parsePclntabFuncs` (.gopclntab ELF セクション) |
+| 動的ライブラリ解析 | `machodylib` (LC_LOAD_DYLIB + dyld キャッシュ除外) | `elfdynlib` (DT_NEEDED + ldconfig キャッシュ) |
+| libc キャッシュ | `MachoLibSystemCacheManager` (libsystem_kernel.dylib) | `LibcCacheManager` (glibc) |
+| Fat binary | 全スライスを解析、最悪ケースを報告 | 非対応（ELF は単一アーキテクチャ） |
+| トランポリン解決 | 1 段階 B スタブを解決 | なし |
+
+## 6. 設計判断の根拠
+
+### 6.1 machoanalyzer を elfanalyzer と独立したパッケージにした理由
+
+ELF と Mach-O はバイナリ形式・syscall 規約・ライブラリシステムが根本的に異なるため、
+共有できるコードが少なく、統合するとかえって複雑になる。
+また、macOS 向け機能は Darwin 固有の API（`debug/macho`、dyld キャッシュ）に依存するため、
+ELF 解析と分離することでビルドタグなしに両プラットフォームをサポートできる。
+
+### 6.2 dyld 共有キャッシュを除外する理由
+
+dyld 共有キャッシュは macOS のシステムアップデートで更新されるが、
+個別ファイルとしては存在しないため SHA256 ハッシュを計算できない。
+また、dyld 共有キャッシュの内容はユーザー空間から変更できないため、
+整合性検証の対象とする実益が薄い。
+一方、非キャッシュライブラリ（`@rpath` 経由のカスタムフレームワーク等）は
+攻撃者が置き換える可能性があるため、ハッシュ検証の対象とする。
+
+### 6.3 Pass 2 がスタック ABI を使用する理由
+
+Go の `syscall.Syscall` 等の NOSPLIT アセンブリスタブは Arm64 の Go レジスタ ABI
+（Go 1.17 以降）ではなく、旧来のスタック ABI を維持している。
+これは NOSPLIT スタブが goroutine スタックをスイッチしないため、
+Go ランタイムのスタック管理との互換性を保つためである。
+したがって Pass 2 の逆方向スキャンは X0 ではなく `[SP, #8]` を追跡する必要がある。
+
+### 6.4 Fat binary の全スライス解析
+
+悪意ある開発者が arm64 スライスを安全に見せかけつつ、x86_64 スライスに
+ネットワーク機能や危険な syscall を仕込む可能性がある（cross-slice attack）。
+全スライスを解析して最悪ケースを報告することでこの迂回を防止する。

--- a/docs/dev/macho_binary_analysis.md
+++ b/docs/dev/macho_binary_analysis.md
@@ -1,0 +1,226 @@
+# Mach-O Binary Analysis: Technical Details
+
+This document records the technical behavior specification and design rationale for Mach-O binary analysis on macOS.
+
+ELF binary analysis is handled by `internal/security/elfanalyzer/`, whereas Mach-O binary analysis is implemented across the following three packages.
+
+| Package | Role |
+|---|---|
+| `internal/security/machoanalyzer/` | Network symbol detection + arm64-only 2-pass syscall analysis |
+| `internal/dynlib/machodylib/` | `LC_LOAD_DYLIB` recursive analysis (hash recording of dependency libraries) |
+| `internal/libccache/` Mach-O side | `libsystem_kernel.dylib` syscall wrapper symbol cache |
+
+## 1. Network Symbol Detection
+
+### 1.1 Purpose and Supported Architectures
+
+`StandardMachOAnalyzer` implements the `binaryanalyzer.BinaryAnalyzer` interface and determines whether a Mach-O binary imports network-related symbols such as socket, connect, and bind.
+It supports both single-architecture Mach-O files and Fat binaries; symbol detection works for all architectures.
+
+### 1.2 How Symbol Detection Works
+
+macOS Mach-O binaries use the two-level namespace by default, so the library ordinal (bits[15:8]) for each symbol is stored in the `Desc` field.
+
+**Normal path (Symtab available)**:
+
+1. Use `Dysymtab` to obtain the range of undefined external symbols.
+2. Extract the library ordinal from each symbol's `Desc` field and compare against the `LC_LOAD_DYLIB` list to determine whether the symbol originates from `libSystem`.
+3. Apply network categorization to `libSystem`-derived symbols by matching against `binaryanalyzer.GetNetworkSymbols()`.
+
+```
+libSystem origin determination:
+  1. ordinal is in range and the corresponding library is libSystem.B.dylib or libsystem_*.dylib
+  2. OR flat namespace (all symbol ordinals are 0) AND
+     libSystem is present in imported libraries
+```
+
+**Fallback path (Symtab unavailable)**:
+
+For stripped binaries without `Symtab`, if `ImportedLibraries()` includes `libSystem`, all imported symbols are obtained via `ImportedSymbols()` and detected.
+
+### 1.3 Handling of Fat Binaries
+
+For Fat binaries, all slices (all architectures) are analyzed and the most severe risk is reported.
+This prevents cross-architecture security bypass attacks where an arm64 slice appears safe while an x86_64 slice has network capabilities.
+
+```
+Severity priority: NetworkDetected > AnalysisError > NoNetworkSymbols
+
+If any slice is NetworkDetected → report the entire binary as NetworkDetected
+```
+
+## 2. syscall Static Analysis (arm64 Only)
+
+### 2.1 macOS syscall Convention
+
+macOS arm64 binaries use the BSD syscall convention.
+The following differences exist compared to the Linux ABI for ELF arm64.
+
+| Item | macOS (Mach-O) | Linux (ELF) |
+|---|---|---|
+| syscall instruction | `SVC #0x80` (0xD4001001) | `SVC #0` (0xD4000001) |
+| syscall number register | **X16** | W8/X8 |
+| Go wrapper argument passing | **stack** (`[SP, #8]`) | register (X0) |
+
+### 2.2 Analysis Flow Overview
+
+```
+ScanSyscallInfos (svc_scanner.go)
+  ↓
+  Fat binary: run analyzeArm64Slice on every arm64 slice
+  Single Mach-O: run analyzeArm64Slice
+  ↓
+  analyzeArm64Slice
+    ├── ParseMachoPclntab → obtain Go function address ranges
+    ├── buildStubRanges  → construct ranges for known wrapper functions
+    ├── Pass 1: collectSVCAddresses + scanSVCWithX16
+    └── Pass 2: buildWrapperAddrs + scanGoWrapperCalls
+```
+
+### 2.3 pclntab Parsing
+
+`ParseMachoPclntab` (`pclntab_macho.go`) parses the section in the Mach-O file that corresponds to `.gopclntab` and returns a map (`map[string]MachoPclntabFunc`) of Go function names to their entry and end addresses.
+
+From this map, `buildStubRanges` constructs the address ranges of `knownMachoSyscallImpls` (`syscall.Syscall`, `syscall.RawSyscall`, etc.).
+`SVC #0x80` instructions inside wrapper functions are skipped in both Pass 1 and Pass 2.
+
+### 2.4 Pass 1: SVC #0x80 Scan and X16 Backward Scan
+
+`collectSVCAddresses` traverses the `__TEXT,__text` section in 4-byte units and enumerates the virtual addresses of `SVC #0x80` (byte sequence `0x01 0x10 0x00 0xD4`).
+
+`scanSVCWithX16` performs the following processing for each address.
+
+1. Skip the address if it falls inside a known wrapper function body (Pass 2 handles those).
+2. Backward-scan the instruction sequence immediately preceding `SVC #0x80` using `arm64util.BackwardScanX16` to search for an immediate load into X16.
+3. If an immediate value is found, record it with `DeterminationMethod = "immediate"`.
+4. If not found, record it with `DeterminationMethod = "direct_svc_0x80"` (a High Risk signal indicating that a direct syscall was observed even though the number could not be resolved).
+
+```asm
+; typical pattern detected by Pass 1 (non-Go binary)
+MOV  X16, #4            ; load syscall number 4 (write) into X16
+SVC  #0x80              ; invoke BSD syscall
+```
+
+### 2.5 Pass 2: Go Wrapper Calls and Stack ABI
+
+Go's NOSPLIT assembly stubs such as `syscall.Syscall` / `syscall.RawSyscall` use the **stack-based ABI** rather than the calling convention.
+The caller stores the trap number at `SP+8` (`trap+0(FP)`) before the BL instruction that calls the wrapper.
+
+`scanGoWrapperCalls` performs the following steps.
+
+1. Traverse `__TEXT,__text` in 4-byte units and compute the target address of each BL instruction.
+2. Check whether the target matches a known wrapper address.
+   One-level trampolines (`B <wrapper>`) are also resolved.
+3. Skip BL instructions that originate from inside a stub body (internal calls are excluded).
+4. Backward-scan the instruction sequence immediately preceding the BL using `arm64util.BackwardScanStackTrap` to search for a write to `[SP, #8]` (STR/STP) and resolve the immediate load into the source register.
+
+```go
+// typical pattern generated by Go caller
+// stores trap number at SP+8 before calling syscall.Syscall
+MOV  X0, #4             // trap number (write)
+STR  X0, [SP, #8]       // store at trap+0(FP)
+...
+BL   _syscall.Syscall   // call Go wrapper
+```
+
+**Difference from ELF arm64**: In ELF arm64, Go wrappers such as `syscall.Syscall` use the register-based ABI and pass the first argument (syscall number) in the X0 register.
+In Mach-O, NOSPLIT stubs use `[SP, #8]`.
+
+## 3. Dynamic Library Dependency Analysis
+
+### 3.1 Recursive Analysis via Breadth-First Search
+
+`MachODynLibAnalyzer.Analyze` (`machodylib/analyzer.go`) recursively resolves `LC_LOAD_DYLIB` and `LC_LOAD_WEAK_DYLIB` dependencies using breadth-first search (BFS).
+
+```
+Analyze(binaryPath)
+  ↓ initialize queue: enqueue direct dependencies of the binary
+  ↓ BFS loop (maximum depth: MaxRecursionDepth = 20)
+    ├── install name → real path conversion
+    │     @rpath         → refer to LC_RPATH entries
+    │     @loader_path   → directory of the Mach-O file
+    │     @executable_path → directory of the binary
+    ├── IsDyldSharedCacheLib → exclude dyld shared cache libraries (see below)
+    ├── SHA256 hash computation
+    ├── append LibEntry (SOName, Path, Hash)
+    └── enqueue dependencies of the resolved library
+```
+
+### 3.2 Exclusion of dyld Shared Cache
+
+Many macOS system libraries (such as `libSystem.B.dylib`) do not exist as individual files on disk; instead they are consolidated into the **dyld shared cache**.
+For this reason, they must be excluded from hash verification.
+
+`IsDyldSharedCacheLib` (`dyld_extractor_darwin.go`) identifies cache libraries by the following path patterns.
+
+- Libraries under `/usr/lib/`
+- Frameworks under `/System/Library/Frameworks/`
+- Other paths that Apple includes in the dyld shared cache
+
+Excluded libraries are not included in `LibEntry` and are not subject to hash verification at runner runtime.
+
+### 3.3 Verification at Runner Runtime
+
+When recorded `DynLibDeps` are present, the runner's `VerifyCommandDynLibDeps` matches the hash of each library against the actual file on disk.
+For dynamically linked binaries whose `DynLibDeps` are not recorded, re-recording is required (`ErrDynLibDepsRequired`).
+
+dyld shared cache libraries are not recorded and therefore their changes are not subject to verification.
+This is an intentional design exclusion to allow the runner to start even when the cache is replaced by a macOS system update.
+
+## 4. libsystem_kernel.dylib Wrapper Cache
+
+### 4.1 Role
+
+Go wrappers such as `syscall.Syscall` ultimately call `_syscallname` functions (e.g., `_write`, `_socket`) inside `libsystem_kernel.dylib` via BL.
+These functions are syscall wrappers that contain `SVC #0x80`.
+
+`MachoLibSystemAnalyzer` (`libccache/macho_analyzer.go`) scans the `__TEXT,__text` section of `libsystem_kernel.dylib` and enumerates functions that contain `SVC #0x80` as `WrapperEntry{Name, Number}`.
+
+### 4.2 Cache Mechanism
+
+`MachoLibSystemCacheManager` (`libccache/macho_cache.go`) caches the analysis results under the hash directory of the record command.
+The cache key is the library path and SHA256 hash; a cache miss occurs when the library is updated, triggering re-analysis.
+
+This limits the analysis cost of `libsystem_kernel.dylib` (full-function SVC scan) to the first record invocation only.
+
+### 4.3 Relationship with libccache
+
+The ELF-side `LibcCacheManager` (for Linux glibc) and the Mach-O-side `MachoLibSystemCacheManager` share the same cache directory and the same schema (`LibcCacheFile`).
+However, their implementations are independent in terms of the target library and the arm64-only constraint.
+
+## 5. Key Differences from ELF arm64
+
+| Item | Mach-O (machoanalyzer) | ELF (elfanalyzer) |
+|---|---|---|
+| syscall instruction | `SVC #0x80` (0xD4001001) | `SVC #0` (0xD4000001) |
+| syscall number register | X16 | W8/X8 |
+| Go wrapper arguments | stack `[SP, #8]` | register X0 |
+| pclntab parsing | `ParseMachoPclntab` (Mach-O specific) | `parsePclntabFuncs` (.gopclntab ELF section) |
+| dynamic library analysis | `machodylib` (LC_LOAD_DYLIB + dyld cache exclusion) | `elfdynlib` (DT_NEEDED + ldconfig cache) |
+| libc cache | `MachoLibSystemCacheManager` (libsystem_kernel.dylib) | `LibcCacheManager` (glibc) |
+| Fat binary | analyzes all slices, reports worst case | not applicable (ELF is single-architecture) |
+| trampoline resolution | resolves one-level B stub | none |
+
+## 6. Design Rationale
+
+### 6.1 Reason for Keeping machoanalyzer as a Separate Package from elfanalyzer
+
+ELF and Mach-O are fundamentally different in binary format, syscall convention, and library system, so there is little code that can be shared and integration would increase complexity.
+In addition, macOS-specific features depend on Darwin-specific APIs (`debug/macho`, dyld cache), so separating them from ELF analysis enables support for both platforms without build tags.
+
+### 6.2 Reason for Excluding dyld Shared Cache
+
+The dyld shared cache is updated by macOS system updates but does not exist as individual files, so SHA256 hashes cannot be computed.
+Furthermore, the contents of the dyld shared cache cannot be modified from user space, so the practical benefit of subjecting it to integrity verification is limited.
+On the other hand, non-cache libraries (such as custom frameworks via `@rpath`) can potentially be replaced by an attacker and are therefore subject to hash verification.
+
+### 6.3 Reason Pass 2 Uses the Stack ABI
+
+Go's NOSPLIT assembly stubs such as `syscall.Syscall` maintain the old stack ABI rather than the arm64 Go register ABI (introduced in Go 1.17).
+This is because NOSPLIT stubs do not switch the goroutine stack, so the old ABI must be maintained for compatibility with the Go runtime's stack management.
+Therefore, the backward scan in Pass 2 must track `[SP, #8]` rather than X0.
+
+### 6.4 Analyzing All Slices of Fat Binaries
+
+A malicious developer could make the arm64 slice appear safe while embedding network capabilities or dangerous syscalls in the x86_64 slice (cross-slice attack).
+Analyzing all slices and reporting the worst case prevents this bypass.

--- a/docs/translation_glossary.md
+++ b/docs/translation_glossary.md
@@ -413,7 +413,7 @@
 | 安全 | safe | |
 | 関心の分離 | separation of concerns | 設計パターンの文脈 |
 | 符号拡張 | sign extension | 上位ビットを符号ビットで埋める操作 |
-| スライス（Fatバイナリの） | slice | Fat バイナリの各アーキテクチャ断面 |
+| スライス（Fatバイナリの） | slice (Fat binary) | Fat バイナリの各アーキテクチャ断面 |
 | スタックトレース | stack trace | |
 | シンボル | symbol | ELFシンボルテーブルの文脈 |
 | 後続グラフ | successor graph | CFGにおける後続ノードのグラフ |

--- a/docs/translation_glossary.md
+++ b/docs/translation_glossary.md
@@ -37,6 +37,7 @@
 | 後向きスキャン | backward scan | 命令列を末尾から走査する解析手法 |
 | バックアップ | backup | |
 | 分岐収束 | branch convergence | CFG上で複数の分岐が同一点で合流すること |
+| 幅優先探索 | breadth-first search (BFS) | グラフ探索アルゴリズム |
 | ブートストラップ | bootstrap | システム初期化処理の文脈 |
 | バッチ処理 | batch processing | |
 | ベースライン | baseline | |
@@ -298,6 +299,7 @@
 |--------|---------|------|
 | 名前 | name | |
 | 命名 | naming | |
+| 名前空間 | namespace | 2レベル名前空間/フラット名前空間の文脈 |
 | 通知 | notification | |
 | 通知先 | notification destination | |
 
@@ -411,6 +413,7 @@
 | 安全 | safe | |
 | 関心の分離 | separation of concerns | 設計パターンの文脈 |
 | 符号拡張 | sign extension | 上位ビットを符号ビットで埋める操作 |
+| スライス（Fatバイナリの） | slice | Fat バイナリの各アーキテクチャ断面 |
 | スタックトレース | stack trace | |
 | シンボル | symbol | ELFシンボルテーブルの文脈 |
 | 後続グラフ | successor graph | CFGにおける後続ノードのグラフ |
@@ -465,6 +468,7 @@
 | 日本語 | English | 備考 |
 |--------|---------|------|
 | テンプレート | template | コマンドテンプレート機能の文脈 |
+| トランポリン | trampoline | 1命令で別アドレスに分岐するスタブ |
 | テンプレート展開 | template expansion | コマンド定義への置換処理 |
 | テンプレートパラメータ | template parameter | `${...}` 形式の参照 |
 | タグ | tag | TOMLタグの文脈 |
@@ -654,6 +658,7 @@
 | 2026-04-30 | x86_64命令デコードドキュメント関連の用語を追加 (backward scan, branch convergence, control flow, copy chain, dataflow analysis, determination method, effective address, false positive, forward scan, immediate value, instruction boundary, misanalysis, predecessor node, register, sign extension, successor graph, variable-length instruction, virtual node, visualization) |
 | 2026-04-30 | パッケージリファレンスドキュメント関連の用語を追加 (audit logging, bootstrap, dependency/dependency analysis, injection, integrity, interface, separation of concerns, symbol) |
 | 2026-04-30 | pclntabメンテナンスガイド関連の用語を追加 (code path, compilation unit, constant, garbage collection, header, linker, magic number, stack trace) |
+| 2026-05-01 | Mach-Oバイナリ解析ドキュメント関連の用語を追加 (breadth-first search, namespace, slice (Fat binary), trampoline) |
 
 ---
 


### PR DESCRIPTION
This pull request adds a comprehensive technical specification document for Mach-O binary analysis on macOS, both in Japanese (`macho_binary_analysis.ja.md`) and English (`macho_binary_analysis.md`). It also updates the translation glossary with new terms relevant to Mach-O analysis. The documents detail the architecture, analysis flow, and design rationale for Mach-O binary analysis, including network symbol detection, syscall static analysis, dynamic library dependency analysis, and cache mechanisms. The glossary is expanded to ensure consistent terminology across documentation.

**New documentation:**

* Added `docs/dev/macho_binary_analysis.ja.md`: Japanese technical specification for Mach-O binary analysis, covering architecture, analysis methods, and design decisions.
* Added `docs/dev/macho_binary_analysis.md`: English version of the Mach-O binary analysis technical specification.

**Translation glossary updates:**

_Terms related to Mach-O analysis:_
* Added "breadth-first search (BFS)", "namespace", "slice (Fat binary)", and "trampoline" to the glossary for accurate translation of technical terms. [[1]](diffhunk://#diff-31ae785a26a80e4519b3a2103df474afcdb760243f7452e2b8043a6774ed83a5R40) [[2]](diffhunk://#diff-31ae785a26a80e4519b3a2103df474afcdb760243f7452e2b8043a6774ed83a5R302) [[3]](diffhunk://#diff-31ae785a26a80e4519b3a2103df474afcdb760243f7452e2b8043a6774ed83a5R416) [[4]](diffhunk://#diff-31ae785a26a80e4519b3a2103df474afcdb760243f7452e2b8043a6774ed83a5R471) [[5]](diffhunk://#diff-31ae785a26a80e4519b3a2103df474afcdb760243f7452e2b8043a6774ed83a5R661)

These changes improve the documentation and maintain consistency in technical terminology for Mach-O binary analysis across the codebase.