### PR TITLE
docs: add slack_allowed_host reference to notification settings section

### DIFF
--- a/docs/user/runner_command.ja.md
+++ b/docs/user/runner_command.ja.md
@@ -1297,13 +1297,24 @@ CLICOLOR=1 NO_COLOR=1 runner -config config.toml
 
 ### 4.2 通知設定
 
-Slack通知は環境変数で設定できます。成功通知とエラー通知を別々のWebhookに送信できます。
+Slack通知は環境変数とTOML設定の組み合わせで設定します。Webhook URLはシークレットとして環境変数で管理し、許可するホスト名はTOML設定（ハッシュ検証対象）で管理します。成功通知とエラー通知を別々のWebhookに送信できます。
 
-#### `GSCR_SLACK_WEBHOOK_URL_SUCCESS`
+#### TOML設定: `global.slack_allowed_host`
+
+Webhook URLに許可するホスト名をTOML設定ファイルで指定します。環境変数でWebhook URLを設定する場合は必須です。
+
+```toml
+[global]
+slack_allowed_host = "hooks.slack.com"
+```
+
+詳細は [グローバルレベル設定 - slack_allowed_host](toml_config/04_global_level.ja.md#49-slack_allowed_host---slack-通知ホスト設定) を参照してください。
+
+#### 環境変数: `GSCR_SLACK_WEBHOOK_URL_SUCCESS`
 
 成功通知用のWebhook URLを指定します。設定すると、コマンドグループの正常完了がこのWebhookに通知されます（INFOレベル）。
 
-#### `GSCR_SLACK_WEBHOOK_URL_ERROR`
+#### 環境変数: `GSCR_SLACK_WEBHOOK_URL_ERROR`
 
 エラー通知用のWebhook URLを指定します。設定すると、警告とエラーがこのWebhookに通知されます（WARNおよびERRORレベル）。
 
@@ -1317,6 +1328,12 @@ Slack通知は環境変数で設定できます。成功通知とエラー通知
 | 設定済み | 未設定 | **無効な設定**（エラー） |
 
 **使用例**
+
+```toml
+# config.toml
+[global]
+slack_allowed_host = "hooks.slack.com"
+```
 
 ```bash
 # エラー通知のみ（本番環境推奨）

--- a/docs/user/runner_command.md
+++ b/docs/user/runner_command.md
@@ -1327,13 +1327,24 @@ CLICOLOR=1 NO_COLOR=1 runner -config config.toml
 
 ### 4.2 Notification Configuration
 
-Slack notifications can be configured using environment variables. Success and error notifications can be sent to different webhooks.
+Slack notifications are configured by combining environment variables with a TOML setting. Webhook URLs are managed as secrets via environment variables, while the permitted hostname is declared in the TOML configuration file (which is subject to hash verification). Success and error notifications can be sent to different webhooks.
 
-#### `GSCR_SLACK_WEBHOOK_URL_SUCCESS`
+#### TOML Setting: `global.slack_allowed_host`
+
+Specifies the hostname permitted in Webhook URLs, declared in the TOML configuration file. Required whenever Webhook URL environment variables are set.
+
+```toml
+[global]
+slack_allowed_host = "hooks.slack.com"
+```
+
+For details, see [Global Level Configuration - slack_allowed_host](toml_config/04_global_level.md#49-slack_allowed_host---slack-notification-host-setting).
+
+#### Environment Variable: `GSCR_SLACK_WEBHOOK_URL_SUCCESS`
 
 Specifies the Webhook URL for success notifications. When set, command group completion with success status is notified to this webhook (INFO level).
 
-#### `GSCR_SLACK_WEBHOOK_URL_ERROR`
+#### Environment Variable: `GSCR_SLACK_WEBHOOK_URL_ERROR`
 
 Specifies the Webhook URL for error notifications. When set, warnings and errors are notified to this webhook (WARN and ERROR levels).
 
@@ -1347,6 +1358,12 @@ Specifies the Webhook URL for error notifications. When set, warnings and errors
 | Set | Not set | **Invalid configuration** (error) |
 
 **Usage Examples**
+
+```toml
+# config.toml
+[global]
+slack_allowed_host = "hooks.slack.com"
+```
 
 ```bash
 # Error notifications only (recommended for production)


### PR DESCRIPTION
Explain that Slack notifications require both a TOML slack_allowed_host setting and environment variable Webhook URLs, and link to the detailed description in the global level configuration guide.