### PR TITLE
Update security architecture docs with macOS syscall cache and env validation details

### DIFF
--- a/docs/dev/architecture_design/security-architecture.ja.md
+++ b/docs/dev/architecture_design/security-architecture.ja.md
@@ -84,9 +84,14 @@ fv.SetBinaryAnalyzer(security.NewBinaryAnalyzer(runtime.GOOS))
 syscallAnalyzer := elfanalyzer.NewSyscallAnalyzer()
 fv.SetSyscallAnalyzer(libccache.NewSyscallAdapter(syscallAnalyzer))
 
-// LibcCacheManager: libc syscall ラッパーシンボルキャッシュ
+// LibcCacheManager: libc syscall ラッパーシンボルキャッシュ（Linux）
 cacheMgr, _ := libccache.NewLibcCacheManager(cacheDir, fs, libcAnalyzer)
 fv.SetLibcCache(libccache.NewCacheAdapter(cacheMgr, syscallAnalyzer))
+
+// LibSystemCacheManager: macOS libSystem syscall シンボルキャッシュ（macOS）
+machoCacheMgr, _ := libccache.NewMachoLibSystemCacheManager(machoCacheDir)
+fv.SetLibSystemCache(libccache.NewMachoLibSystemAdapter(machoCacheMgr, fs))
+fv.SetMachoSyscallTable(libccache.MacOSSyscallTable{})
 
 // DynLibAnalyzer: 動的ライブラリ依存関係の再帰解析
 fv.SetELFDynLibAnalyzer(d.elfDynlibAnalyzerFactory())
@@ -94,21 +99,26 @@ fv.SetMachODynLibAnalyzer(d.machoDynlibAnalyzerFactory())
 ```
 
 **解析内容**:
-- **syscall 解析** (`internal/security/elfanalyzer/`): x86_64 と arm64 の両アーキテクチャに対応。SYSCALL 命令 (0F 05) / SVC #0 を列挙し、逆方向スキャンで syscall 番号を特定。mprotect/pkey_mprotect + PROT_EXEC の組み合わせ（JIT コード実行相当）を危険パターンとして検出。Go ラッパー呼び出し（syscall.Syscall 等）も Pass 2 で解析
+- **syscall 解析** (`internal/security/elfanalyzer/`): x86_64 と arm64 の両アーキテクチャに対応。SYSCALL 命令 (0F 05) / SVC #0 を列挙し、逆方向スキャンで syscall 番号を特定。mprotect/pkey_mprotect + PROT_EXEC の組み合わせ（JIT コード実行相当）を危険パターンとして検出。Go ラッパー呼び出し（syscall.Syscall 等）も Pass 2 で解析。分岐先収束（Branch Convergence）解析によりレジスタコピーチェーンを追跡し、条件分岐を跨ぐ syscall 番号の特定も対応
 - **ネットワーク機能検出** (`internal/security/binaryanalyzer/`, `internal/security/elfanalyzer/`): socket, connect, bind 等のシンボルの有無からバイナリのネットワーク利用能力を判定
 - **動的ライブラリ依存解析** (`internal/dynlib/elfdynlib/`, `internal/dynlib/machodylib/`): ELF の DT_NEEDED / Mach-O の LC_LOAD_DYLIB を再帰解析し、すべての依存ライブラリのパスとハッシュを記録
-- **libc syscall キャッシュ** (`internal/libccache/`): libc の syscall ラッパーシンボルをキャッシュし、間接的な syscall 呼び出しを解析
+- **libc syscall キャッシュ** (`internal/libccache/`): Linux では libc の syscall ラッパーシンボルをキャッシュし、macOS では libSystem の syscall シンボルをキャッシュすることで、間接的な syscall 呼び出しを解析
 - **shebang 追跡** (`internal/shebang/`): `#!/bin/sh`（直接形式）/ `#!/usr/bin/env python3`（env 形式）等のインタープリタパスを解析・記録
 
 **解析結果の永続化** (`internal/fileanalysis/`):
 
 ```
 fileanalysis.Record（SchemaVersion = 19）
-  ├── ContentHash         // ファイルの SHA-256 ハッシュ
-  ├── DynLibDeps          // 依存ライブラリのパスとハッシュ一覧（[]LibEntry）
-  ├── SyscallAnalysis     // syscall 解析結果（リスクレベル、検出パターン）
-  ├── SymbolAnalysis      // ネットワークシンボル解析結果
-  └── ShebangInterpreter  // インタープリタ情報（スクリプトの場合）
+  ├── ContentHash           // ファイルの SHA-256 ハッシュ
+  ├── DynLibDeps            // 依存ライブラリのパスとハッシュ一覧（[]LibEntry）
+  ├── SyscallAnalysis       // syscall 解析結果
+  │     ├── DetectedSyscalls   // 検出された syscall 一覧（番号・名称・出現箇所・判定方法）
+  │     ├── AnalysisWarnings   // 解析警告（mprotect+PROT_EXEC 検出など）
+  │     ├── ArgEvalResults     // syscall 引数評価結果（mprotect の PROT_EXEC フラグ判定）
+  │     └── DeterminationStats // syscall 番号判定方法の診断統計
+  ├── SymbolAnalysis        // ネットワークシンボル解析結果
+  ├── ShebangInterpreter    // インタープリタ情報（スクリプトの場合）
+  └── AnalysisWarnings      // dynlib 解析の非致命的警告
 ```
 
 **runner 実行時の検証** (`internal/verification/manager.go`):
@@ -167,30 +177,35 @@ type Filter struct {
 - `InheritanceModeExplicit`: グループ固有の許可リストのみを使用
 - `InheritanceModeReject`: 環境変数を許可しない（空の許可リスト）
 
-**変数検証**:
+**変数値の安全性検証**:
 ```go
-// 場所: internal/runner/config/validator.go
-func (v *Validator) validateVariableValue(value string) error {
-    // 一元化されたセキュリティ検証を使用
-    if err := security.IsVariableValueSafe(value); err != nil {
-        // 一貫性のため検証エラー型でセキュリティエラーをラップ
-        return fmt.Errorf("%w: %s", ErrDangerousPattern, err.Error())
+// 場所: internal/runner/base/security/environment_validation.go
+// コマンドはシェルを介さず直接実行されるため、; | $( > < 等のシェルメタ文字は
+// インジェクションリスクがなく、検証対象外とする。
+func (v *Validator) ValidateEnvironmentValue(key, value string) error {
+    if strings.ContainsRune(value, '\x00') {
+        return fmt.Errorf("%w: environment variable %s contains null byte",
+            ErrUnsafeEnvironmentVar, key)
+    }
+    if strings.ContainsAny(value, "\n\r") {
+        return fmt.Errorf("%w: environment variable %s contains newline or carriage return character",
+            ErrUnsafeEnvironmentVar, key)
     }
     return nil
 }
 ```
 
-**危険パターン検出**:
-- コマンド区切り文字: `;`, `|`, `&&`, `||`
-- コマンド置換: `$(...)`, バッククォート
-- ファイル操作: `>`, `<`, `rm `, `dd if=`, `dd of=`
-- コード実行: `exec `, `system `, `eval `
+**変数値の検証対象**:
+コマンドはシェルを介さず直接実行されるため、シェルメタ文字（`;`、`|`、`$(...)`、`>`、`<` 等）はインジェクションリスクを持たず検証対象外とする。以下の文字のみを拒否する：
+- ヌルバイト: `\x00`（ヘッダーインジェクションや構造化出力の破壊に悪用可能）
+- 改行文字: `\n`、`\r`（同上）
 
 #### セキュリティ保証
 - ゼロトラスト環境変数モデル（許可リストのみ）
 - 環境ベースのコマンドインジェクションを防止
 - 機密変数のグループレベル分離
-- 危険なパターンに対する変数名と値の検証
+- 変数名の検証（POSIX 準拠・予約プレフィックスチェック）
+- ヌルバイト・改行文字による変数値の検証（コマンドはシェル経由ではなく直接実行されるため、シェルメタ文字は検証対象外）
 
 ### 4. 安全なファイル操作
 
@@ -1082,9 +1097,9 @@ if !filepath.IsAbs(hashDir) {
 
 **対策**:
 - 厳格な許可リストベースフィルタリング
-- 危険パターン検出
 - グループレベル環境分離
-- 変数名と値の検証
+- 変数名の検証（POSIX 準拠）
+- ヌルバイト・改行文字に対する変数値の検証（コマンドはシェル経由で実行されないため、シェルメタ文字によるインジェクション不成立）
 
 ### コマンドインジェクション
 

--- a/docs/dev/architecture_design/security-architecture.ja.md
+++ b/docs/dev/architecture_design/security-architecture.ja.md
@@ -99,7 +99,7 @@ fv.SetMachODynLibAnalyzer(d.machoDynlibAnalyzerFactory())
 ```
 
 **解析内容**:
-- **syscall 解析** (`internal/security/elfanalyzer/`): x86_64 と arm64 の両アーキテクチャに対応。SYSCALL 命令 (0F 05) / SVC #0 を列挙し、逆方向スキャンで syscall 番号を特定。mprotect/pkey_mprotect + PROT_EXEC の組み合わせ（JIT コード実行相当）を危険パターンとして検出。Go ラッパー呼び出し（syscall.Syscall 等）も Pass 2 で解析。分岐先収束（Branch Convergence）解析によりレジスタコピーチェーンを追跡し、条件分岐を跨ぐ syscall 番号の特定も対応
+- syscall 解析 (internal/security/elfanalyzer/): x86_64 と arm64 の両アーキテクチャに対応。SYSCALL 命令 (0F 05) / SVC #0 を列挙し、逆方向スキャンで syscall 番号を特定。mprotect/pkey_mprotect + PROT_EXEC の組み合わせ（JIT コード実行相当）を危険パターンとして検出。Go ラッパー呼び出し（syscall.Syscall 等）も Pass 2 で解析。分岐先収束（Branch Convergence）解析によりレジスタコピーチェーンを追跡し、条件分岐を跨ぐ syscall 番号の特定にも対応
 - **ネットワーク機能検出** (`internal/security/binaryanalyzer/`, `internal/security/elfanalyzer/`): socket, connect, bind 等のシンボルの有無からバイナリのネットワーク利用能力を判定
 - **動的ライブラリ依存解析** (`internal/dynlib/elfdynlib/`, `internal/dynlib/machodylib/`): ELF の DT_NEEDED / Mach-O の LC_LOAD_DYLIB を再帰解析し、すべての依存ライブラリのパスとハッシュを記録
 - **libc syscall キャッシュ** (`internal/libccache/`): Linux では libc の syscall ラッパーシンボルをキャッシュし、macOS では libSystem の syscall シンボルをキャッシュすることで、間接的な syscall 呼び出しを解析

--- a/docs/dev/architecture_design/security-architecture.md
+++ b/docs/dev/architecture_design/security-architecture.md
@@ -84,9 +84,14 @@ fv.SetBinaryAnalyzer(security.NewBinaryAnalyzer(runtime.GOOS))
 syscallAnalyzer := elfanalyzer.NewSyscallAnalyzer()
 fv.SetSyscallAnalyzer(libccache.NewSyscallAdapter(syscallAnalyzer))
 
-// LibcCacheManager: libc syscall wrapper symbol cache
+// LibcCacheManager: libc syscall wrapper symbol cache (Linux)
 cacheMgr, _ := libccache.NewLibcCacheManager(cacheDir, fs, libcAnalyzer)
 fv.SetLibcCache(libccache.NewCacheAdapter(cacheMgr, syscallAnalyzer))
+
+// LibSystemCacheManager: macOS libSystem syscall symbol cache (macOS)
+machoCacheMgr, _ := libccache.NewMachoLibSystemCacheManager(machoCacheDir)
+fv.SetLibSystemCache(libccache.NewMachoLibSystemAdapter(machoCacheMgr, fs))
+fv.SetMachoSyscallTable(libccache.MacOSSyscallTable{})
 
 // DynLibAnalyzer: recursive analysis of dynamic library dependencies
 fv.SetELFDynLibAnalyzer(d.elfDynlibAnalyzerFactory())
@@ -94,21 +99,26 @@ fv.SetMachODynLibAnalyzer(d.machoDynlibAnalyzerFactory())
 ```
 
 **Analysis content**:
-- **syscall analysis** (`internal/security/elfanalyzer/`): Supports both x86_64 and arm64 architectures. Enumerates SYSCALL instructions (0F 05) / SVC #0 and identifies syscall numbers via backward scanning. Detects mprotect/pkey_mprotect + PROT_EXEC combinations (equivalent to JIT code execution) as dangerous patterns. Also analyzes Go wrapper calls (syscall.Syscall, etc.) in Pass 2.
+- **syscall analysis** (`internal/security/elfanalyzer/`): Supports both x86_64 and arm64 architectures. Enumerates SYSCALL instructions (0F 05) / SVC #0 and identifies syscall numbers via backward scanning. Detects mprotect/pkey_mprotect + PROT_EXEC combinations (equivalent to JIT code execution) as dangerous patterns. Also analyzes Go wrapper calls (syscall.Syscall, etc.) in Pass 2. Branch convergence analysis tracks register copy chains to identify syscall numbers across conditional branches.
 - **Network capability detection** (`internal/security/binaryanalyzer/`, `internal/security/elfanalyzer/`): Determines binary network capability from the presence of socket, connect, bind, etc. symbols.
 - **Dynamic library dependency analysis** (`internal/dynlib/elfdynlib/`, `internal/dynlib/machodylib/`): Recursively analyzes ELF DT_NEEDED / Mach-O LC_LOAD_DYLIB to record the paths and hashes of all dependency libraries.
-- **libc syscall cache** (`internal/libccache/`): Caches libc syscall wrapper symbols to analyze indirect syscall calls.
+- **libc syscall cache** (`internal/libccache/`): On Linux, caches libc syscall wrapper symbols; on macOS, caches libSystem syscall symbols, enabling analysis of indirect syscall calls on both platforms.
 - **shebang tracking** (`internal/shebang/`): Parses and records interpreter paths from `#!/bin/sh` (direct form) / `#!/usr/bin/env python3` (env form), etc.
 
 **Analysis result persistence** (`internal/fileanalysis/`):
 
 ```
 fileanalysis.Record (SchemaVersion = 19)
-  ├── ContentHash         // SHA-256 hash of the file
-  ├── DynLibDeps          // List of dependency library paths and hashes ([]LibEntry)
-  ├── SyscallAnalysis     // syscall analysis result (risk level, detected patterns)
-  ├── SymbolAnalysis      // network symbol analysis result
-  └── ShebangInterpreter  // interpreter information (for scripts)
+  ├── ContentHash           // SHA-256 hash of the file
+  ├── DynLibDeps            // List of dependency library paths and hashes ([]LibEntry)
+  ├── SyscallAnalysis       // syscall analysis result
+  │     ├── DetectedSyscalls   // list of detected syscalls (number, name, occurrences, determination method)
+  │     ├── AnalysisWarnings   // analysis warnings (e.g., mprotect+PROT_EXEC detected)
+  │     ├── ArgEvalResults     // syscall argument evaluation results (PROT_EXEC flag determination for mprotect)
+  │     └── DeterminationStats // diagnostic statistics for syscall number determination methods
+  ├── SymbolAnalysis        // network symbol analysis result
+  ├── ShebangInterpreter    // interpreter information (for scripts)
+  └── AnalysisWarnings      // non-fatal warnings from dynlib analysis
 ```
 
 **Runner-side verification** (`internal/verification/manager.go`):
@@ -167,30 +177,35 @@ type Filter struct {
 - `InheritanceModeExplicit`: Use only group-specific allowlist
 - `InheritanceModeReject`: Allow no environment variables (empty allowlist)
 
-**Variable Validation**:
+**Environment Variable Value Safety Validation**:
 ```go
-// Location: internal/runner/config/validator.go
-func (v *Validator) validateVariableValue(value string) error {
-    // Use centralized security validation
-    if err := security.IsVariableValueSafe(value); err != nil {
-        // Wrap security error with validation error type for consistency
-        return fmt.Errorf("%w: %s", ErrDangerousPattern, err.Error())
+// Location: internal/runner/base/security/environment_validation.go
+// Shell metacharacters such as ; | $( > < are intentionally allowed because
+// commands are executed directly (not via a shell), so these characters carry no injection risk.
+func (v *Validator) ValidateEnvironmentValue(key, value string) error {
+    if strings.ContainsRune(value, '\x00') {
+        return fmt.Errorf("%w: environment variable %s contains null byte",
+            ErrUnsafeEnvironmentVar, key)
+    }
+    if strings.ContainsAny(value, "\n\r") {
+        return fmt.Errorf("%w: environment variable %s contains newline or carriage return character",
+            ErrUnsafeEnvironmentVar, key)
     }
     return nil
 }
 ```
 
-**Dangerous Pattern Detection**:
-- Command separators: `;`, `|`, `&&`, `||`
-- Command substitution: `$(...)`, backticks
-- File operations: `>`, `<`, `rm `, `dd if=`, `dd of=`
-- Code execution: `exec `, `system `, `eval `
+**Validated Variable Value Constraints**:
+Because commands are executed directly without a shell, shell metacharacters (`;`, `|`, `$(...)`, `>`, `<`, etc.) carry no injection risk and are not validated. Only the following characters are rejected:
+- Null byte: `\x00` (can be used to inject headers or corrupt structured output)
+- Newline characters: `\n`, `\r` (same)
 
 #### Security Guarantees
 - Zero-trust environment variable model (allowlist only)
 - Prevents environment-based command injection
 - Group-level isolation of sensitive variables
-- Validation of variable names and values against dangerous patterns
+- Validation of variable names (POSIX compliance and reserved prefix check)
+- Validation of variable values for null bytes and newline characters (shell metacharacters are not validated because commands are executed directly, not via a shell)
 
 ### 4. Secure File Operations
 
@@ -1082,9 +1097,9 @@ The system implements multiple security layers:
 
 **Countermeasures**:
 - Strict allowlist-based filtering
-- Dangerous pattern detection
 - Group-level environment isolation
-- Variable name and value validation
+- Variable name validation (POSIX compliance)
+- Variable value validation for null bytes and newline characters (shell metacharacter injection does not apply because commands are not executed via a shell)
 
 ### Command Injection
 


### PR DESCRIPTION
- Add macOS libSystem syscall cache description in security architecture docs
- Expand syscall analysis section with branch convergence tracking
- Enhance fileanalysis.Record schema documentation with detailed SyscallAnalysis fields
- Clarify environment variable validation rules and safe shell metacharacter handling in docs