### PR TITLE
feat: implement transitive dynlib syscall analysis (task 0123)

### DIFF
--- a/cmd/record/main.go
+++ b/cmd/record/main.go
@@ -143,6 +143,7 @@ func run(args []string, d deps, stdout, stderr io.Writer) int {
 
 		syscallAnalyzer := elfanalyzer.NewSyscallAnalyzer()
 		fv.SetSyscallAnalyzer(libccache.NewSyscallAdapter(syscallAnalyzer))
+		fv.SetLibraryAnalysisEnabled(true)
 
 		cacheDir := filepath.Join(cfg.hashDir, libcCacheSubDir)
 		fs := safefileio.NewFileSystem(safefileio.FileSystemConfig{})

--- a/docs/tasks/0123_dynlib_transitive_syscall_analysis/01_requirements.md
+++ b/docs/tasks/0123_dynlib_transitive_syscall_analysis/01_requirements.md
@@ -212,6 +212,9 @@ LibraryAnalysisEntry {
 | AC-6 | 同一ライブラリが複数の実行ファイルの依存グラフに現れる場合、セッション内で1回だけ解析される（キャッシュ確認） |
 | AC-7 | 存在しないライブラリパスに対しては `AnalysisWarnings` に警告が追加され、処理が継続される |
 | AC-8 | 既存の `.dynsym` UNDEF 解析・機械語 syscall 解析の動作が変わらないこと（回帰テスト） |
+| AC-9 | `linux-vdso.so.1` 等の仮想 DSO は `LibraryAnalysis` に記録されない（VDSO 除外） |
+| AC-10 | 解析対象ライブラリのファイルサイズが上限（1 GB）を超える場合、解析をスキップして `AnalysisWarnings` に警告が記録され、処理が継続される |
+| AC-11 | `libcc.so.1`（`libc` に前方一致するが区切り文字条件を満たさない）は除外されず `LibraryAnalysis` の解析対象となる |
 
 ---
 

--- a/docs/tasks/0123_dynlib_transitive_syscall_analysis/03_detailed_specification.md
+++ b/docs/tasks/0123_dynlib_transitive_syscall_analysis/03_detailed_specification.md
@@ -256,7 +256,32 @@ func isKnownVDSO(soname string) bool {
 
 `analyzeLibraries` 内の VDSO チェックはこの関数を使う。
 
-### 4.5 `analyzeOneLibrary` メソッド（新規）
+### 4.5 ファイルサイズ上限チェック（FR-3.3.2）
+
+`analyzeOneLibrary` 内、`syscallAnalyzer` が nil でないことを確認した直後、
+ELF open の前にファイルを一度開いて `Stat()` でサイズを検証する。
+
+```go
+f, openErr := v.fileSystem.SafeOpenFile(lib.Path, os.O_RDONLY, 0)
+if openErr != nil {
+    warnings = append(warnings,
+        fmt.Sprintf("failed to open library file %s: %v", lib.SOName, openErr))
+    return entry, hasNetwork, warnings, nil
+}
+if fi, statErr := f.Stat(); statErr == nil && fi.Size() > maxFileSize {
+    _ = f.Close()
+    warnings = append(warnings,
+        fmt.Sprintf("library file too large, skipping analysis for %s", lib.SOName))
+    return entry, hasNetwork, warnings, nil
+}
+_ = f.Close()
+```
+
+`maxFileSize` は既存の実行ファイル解析に用いている定数（`1 << 30 = 1 GB`）を流用する。
+`FileSystem` インタフェースには `Stat` メソッドが存在しないため、`SafeOpenFile` で
+ファイルを開き `File.Stat()` を呼ぶ方式を採用する。
+
+### 4.6 `analyzeOneLibrary` メソッド（新規）
 
 ```go
 // analyzeOneLibrary runs symbol and syscall analysis on a single library.
@@ -362,29 +387,39 @@ SOName 追加判断に使う。独立したヘルパ関数は不要であり、`
 
 ## 5. `internal/runner/base/security/network_analyzer.go`
 
-### 5.1 `isNetworkViaBinaryAnalysis` の変更
+### 5.1 `buildAnalysisOutputFromSymbolData` の変更（AC-5）
 
-既存の `KnownNetworkLibDeps` チェックと同じ位置に以下を追加する。
+既存の `switch` 文に `DetectedLibraryNetworkDeps` ケースを追加する。
 
 変更前（抜粋）:
 ```go
-if hasNetworkSymbol || len(data.KnownNetworkLibDeps) > 0 {
+switch {
+case hasNetworkSymbol:
+    output.Result = binaryanalyzer.NetworkDetected
+case len(data.KnownNetworkLibDeps) > 0:
+    output.Result = binaryanalyzer.NetworkDetected
+    slog.Info(...)
+default:
+    output.Result = binaryanalyzer.NoNetworkSymbols
+}
 ```
 
 変更後:
 ```go
-if hasNetworkSymbol || len(data.KnownNetworkLibDeps) > 0 || len(data.DetectedLibraryNetworkDeps) > 0 {
-```
-
-`KnownNetworkLibDeps` のログ出力と同様のログを `DetectedLibraryNetworkDeps` 専用に追加する。
-
-```go
-if !hasNetworkSymbol && len(data.KnownNetworkLibDeps) == 0 && len(data.DetectedLibraryNetworkDeps) > 0 {
-    slog.Info(
-        "treating binary as network-capable based on library syscall/symbol analysis",
+switch {
+case hasNetworkSymbol:
+    output.Result = binaryanalyzer.NetworkDetected
+case len(data.KnownNetworkLibDeps) > 0:
+    output.Result = binaryanalyzer.NetworkDetected
+    slog.Info("treating binary as network-capable based on known network library dependencies", ...)
+case len(data.DetectedLibraryNetworkDeps) > 0:
+    output.Result = binaryanalyzer.NetworkDetected
+    slog.Info("treating binary as network-capable based on library syscall/symbol analysis",
         "path", cmdPath,
         "detected_library_network_deps", data.DetectedLibraryNetworkDeps,
     )
+default:
+    output.Result = binaryanalyzer.NoNetworkSymbols
 }
 ```
 
@@ -404,11 +439,11 @@ v.SetLibraryAnalysisEnabled(true)
 
 ### 7.1 `syscall_wrapper_libs_test.go`（新規）
 
-| テスト名 | 確認内容 |
-|---------|---------|
-| `TestIsSyscallWrapperLibrary_match` | `libc.so.6`, `libpthread.so.0`, `ld-linux-x86-64.so.2` が `true` を返す |
-| `TestIsSyscallWrapperLibrary_noMatch` | `libssl.so.3`, `libcurl.so.4`, `libstdc++.so.6` が `false` を返す |
-| `TestIsSyscallWrapperLibrary_prefixBoundary` | `libcc.so.1`（`libc` に前方一致するが区切り文字条件を満たさない）が `false` を返す |
+| テスト名 | AC | 確認内容 |
+|---------|-----|----------|
+| `TestIsSyscallWrapperLibrary_match` | AC-3,4 | `libc.so.6`, `libpthread.so.0`, `ld-linux-x86-64.so.2` が `true` を返す |
+| `TestIsSyscallWrapperLibrary_noMatch` | AC-11 | `libssl.so.3`, `libcurl.so.4`, `libstdc++.so.6` が `false` を返す |
+| `TestIsSyscallWrapperLibrary_prefixBoundary` | AC-11 | `libcc.so.1`（`libc` に前方一致するが区切り文字条件を満たさない）が `false` を返す |
 
 ### 7.2 `validator_library_analysis_test.go`（新規、`filevalidator` パッケージ）
 
@@ -426,6 +461,9 @@ v.SetLibraryAnalysisEnabled(true)
 | `TestAnalyzeLibraries_sessionCache` | AC-6 | 同じライブラリを 2 回参照すると `analyzeOneLibrary` は 1 回だけ呼ばれる |
 | `TestAnalyzeLibraries_missingLibFile` | AC-7 | 存在しないライブラリパスは `AnalysisWarnings` に追加され処理継続 |
 | `TestAnalyzeLibraries_disabled` | - | `SetLibraryAnalysisEnabled(false)` のとき `LibraryAnalysis` が nil |
+| `TestAnalyzeLibraries_vdsoExcluded` | AC-9 | `linux-vdso.so.1` は `LibraryAnalysis` に含まれない |
+| `TestAnalyzeLibraries_fileTooLarge` | AC-10 | ファイルサイズ 1 GB 超のライブラリは解析スキップ、`AnalysisWarnings` に警告追記 |
+| `TestIsSyscallWrapperLibrary_prefixBoundary_libcc` | AC-11 | `libcc.so.1` は `IsSyscallWrapperLibrary` で `false`、解析対象に含まれる |
 
 ### 7.3 `network_analyzer_test.go` への追加（`runner` パッケージ）
 
@@ -451,3 +489,6 @@ v.SetLibraryAnalysisEnabled(true)
 | AC-6 | `libraryAnalysisCache` によりキャッシュヒット時は再解析しない |
 | AC-7 | ライブラリファイル不在は `AnalysisWarnings` に追記、処理継続 |
 | AC-8 | 既存の `.dynsym`・syscall 解析は変更なし（回帰テスト） |
+| AC-9 | `isKnownVDSO` により `linux-vdso.so.1` 等をスキップ、`analyzeLibraries` でスキップされ `LibraryAnalysis` に含まれない |
+| AC-10 | `analyzeOneLibrary` のファイルサイズチェック（4.5 節）により 1 GB 超のライブラリをスキップし `AnalysisWarnings` に記録 |
+| AC-11 | `IsSyscallWrapperLibrary("libcc.so.1")` が `false`（プレフィックス境界ルール）、解析対象に残る |

--- a/docs/tasks/0123_dynlib_transitive_syscall_analysis/04_implementation_plan.md
+++ b/docs/tasks/0123_dynlib_transitive_syscall_analysis/04_implementation_plan.md
@@ -3,7 +3,7 @@
 ## 進捗状況
 
 - [x] Step 1: スキーマ変更
-- [ ] Step 2: `binaryanalyzer/syscall_wrapper_libs.go` 新規作成とテスト
+- [x] Step 2: `binaryanalyzer/syscall_wrapper_libs.go` 新規作成とテスト
 - [ ] Step 3: `Validator` にキャッシュフィールドと setter 追加
 - [ ] Step 4: `analyzeOneLibrary()` 実装とユニットテスト
 - [ ] Step 5: `analyzeLibraries()` 実装とユニットテスト
@@ -37,14 +37,14 @@
 - 新規: `internal/security/binaryanalyzer/syscall_wrapper_libs_test.go`
 
 作業内容:
-- [ ] `syscallWrapperPrefixes` スライスを定義（`libc`, `libpthread`, `libdl`, `librt`,
+- [x] `syscallWrapperPrefixes` スライスを定義（`libc`, `libpthread`, `libdl`, `librt`,
   `libgcc_s`, `ld-linux`, `ld-linux-x86-64`, `ld-linux-aarch64`, `linux-vdso`）
-- [ ] `IsSyscallWrapperLibrary(soname string) bool` 関数を実装（既存の
+- [x] `IsSyscallWrapperLibrary(soname string) bool` 関数を実装（既存の
   `matchesKnownPrefix` を再利用）
-- [ ] テスト: マッチするケース（`libc.so.6`, `libpthread.so.0`, `ld-linux-x86-64.so.2`,
+- [x] テスト: マッチするケース（`libc.so.6`, `libpthread.so.0`, `ld-linux-x86-64.so.2`,
   `linux-vdso.so.1`）
-- [ ] テスト: マッチしないケース（`libssl.so.3`, `libcurl.so.4`, `libstdc++.so.6`）
-- [ ] テスト: 前方一致境界ケース（`libcc.so.1` → `false`, `libcpp.so.1` → `false`）
+- [x] テスト: マッチしないケース（`libssl.so.3`, `libcurl.so.4`, `libstdc++.so.6`）
+- [x] テスト: 前方一致境界ケース（`libcc.so.1` → `false`, `libcpp.so.1` → `false`）
 
 ---
 

--- a/docs/tasks/0123_dynlib_transitive_syscall_analysis/04_implementation_plan.md
+++ b/docs/tasks/0123_dynlib_transitive_syscall_analysis/04_implementation_plan.md
@@ -7,7 +7,7 @@
 - [x] Step 3: `Validator` にキャッシュフィールドと setter 追加
 - [x] Step 4: `analyzeOneLibrary()` 実装とユニットテスト
 - [x] Step 5: `analyzeLibraries()` 実装とユニットテスト
-- [ ] Step 6: `updateAnalysisRecord` への統合
+- [x] Step 6: `updateAnalysisRecord` への統合
 - [ ] Step 7: runner 側のネットワーク判定拡張
 - [ ] Step 8: `cmd/record/main.go` の有効化
 - [ ] Step 9: 統合テスト（AC-1 〜 AC-8）
@@ -117,9 +117,9 @@
 **対象ファイル**: `internal/filevalidator/validator.go`
 
 作業内容:
-- [ ] `KnownNetworkLibDeps` ブロックの直後、`analyzeELFSyscalls` の直前に
+- [x] `KnownNetworkLibDeps` ブロックの直後、`analyzeELFSyscalls` の直前に
   `v.analyzeLibraries(record)` 呼び出しを追加
-- [ ] エラーが返ったとき即時 `return err`
+- [x] エラーが返ったとき即時 `return err`
 
 ---
 

--- a/docs/tasks/0123_dynlib_transitive_syscall_analysis/04_implementation_plan.md
+++ b/docs/tasks/0123_dynlib_transitive_syscall_analysis/04_implementation_plan.md
@@ -4,7 +4,7 @@
 
 - [x] Step 1: スキーマ変更
 - [x] Step 2: `binaryanalyzer/syscall_wrapper_libs.go` 新規作成とテスト
-- [ ] Step 3: `Validator` にキャッシュフィールドと setter 追加
+- [x] Step 3: `Validator` にキャッシュフィールドと setter 追加
 - [ ] Step 4: `analyzeOneLibrary()` 実装とユニットテスト
 - [ ] Step 5: `analyzeLibraries()` 実装とユニットテスト
 - [ ] Step 6: `updateAnalysisRecord` への統合
@@ -53,12 +53,12 @@
 **対象ファイル**: `internal/filevalidator/validator.go`
 
 作業内容:
-- [ ] `libraryCacheEntry` 構造体を定義（`entry fileanalysis.LibraryAnalysisEntry`,
+- [x] `libraryCacheEntry` 構造体を定義（`entry fileanalysis.LibraryAnalysisEntry`,
   `hasNetwork bool`）
-- [ ] `Validator` 構造体に `libraryAnalysisCache map[string]libraryCacheEntry` フィールドを追加
-- [ ] `Validator` 構造体に `libraryAnalysisEnabled bool` フィールドを追加
-- [ ] `SetLibraryAnalysisEnabled(enabled bool)` メソッドを追加（有効化時にキャッシュを初期化）
-- [ ] `isKnownVDSO(soname string) bool` プライベートヘルパを追加（`linux-vdso.so.1`,
+- [x] `Validator` 構造体に `libraryAnalysisCache map[string]libraryCacheEntry` フィールドを追加
+- [x] `Validator` 構造体に `libraryAnalysisEnabled bool` フィールドを追加
+- [x] `SetLibraryAnalysisEnabled(enabled bool)` メソッドを追加（有効化時にキャッシュを初期化）
+- [x] `isKnownVDSO(soname string) bool` プライベートヘルパを追加（`linux-vdso.so.1`,
   `linux-gate.so.1`, `linux-vdso64.so.1`）
 
 ---

--- a/docs/tasks/0123_dynlib_transitive_syscall_analysis/04_implementation_plan.md
+++ b/docs/tasks/0123_dynlib_transitive_syscall_analysis/04_implementation_plan.md
@@ -8,7 +8,7 @@
 - [x] Step 4: `analyzeOneLibrary()` 実装とユニットテスト
 - [x] Step 5: `analyzeLibraries()` 実装とユニットテスト
 - [x] Step 6: `updateAnalysisRecord` への統合
-- [ ] Step 7: runner 側のネットワーク判定拡張
+- [x] Step 7: runner 側のネットワーク判定拡張
 - [ ] Step 8: `cmd/record/main.go` の有効化
 - [ ] Step 9: 統合テスト（AC-1 〜 AC-8）
 - [ ] Step 10: `make fmt` `make test` `make lint` で品質確認
@@ -128,10 +128,10 @@
 **対象ファイル**: `internal/runner/base/security/network_analyzer.go`
 
 作業内容:
-- [ ] `isNetworkViaBinaryAnalysis` 内の条件を変更:
+- [x] `isNetworkViaBinaryAnalysis` 内の条件を変更:
   `if hasNetworkSymbol || len(data.KnownNetworkLibDeps) > 0 || len(data.DetectedLibraryNetworkDeps) > 0`
-- [ ] `DetectedLibraryNetworkDeps` が原因でネットワーク有りと判定した場合のログ出力を追加
-- [ ] テスト: `DetectedLibraryNetworkDeps` 非空のとき `(true, false)` を返すことを確認
+- [x] `DetectedLibraryNetworkDeps` が原因でネットワーク有りと判定した場合のログ出力を追加
+- [x] テスト: `DetectedLibraryNetworkDeps` 非空のとき `(true, false)` を返すことを確認
 
 ---
 

--- a/docs/tasks/0123_dynlib_transitive_syscall_analysis/04_implementation_plan.md
+++ b/docs/tasks/0123_dynlib_transitive_syscall_analysis/04_implementation_plan.md
@@ -11,6 +11,7 @@
 - [x] Step 7: runner 側のネットワーク判定拡張
 - [x] Step 8: `cmd/record/main.go` の有効化
 - [x] Step 9: 統合テスト（AC-1 〜 AC-8）
+- [ ] Step 11: AC-9/10/11 対応テスト追加
 - [x] Step 10: `make fmt` `make test` `make lint` で品質確認
 
 ---
@@ -167,6 +168,19 @@
 - [x] `make fmt` — gofumpt によるフォーマット
 - [x] `make test` — 全テスト通過
 - [x] `make lint` — golangci-lint エラーなし
+
+---
+
+### Step 11: AC-9/10/11 対応テスト追加
+
+**対象ファイル**: `internal/filevalidator/validator_library_analysis_test.go`、`internal/security/binaryanalyzer/syscall_wrapper_libs_test.go`
+
+作業内容:
+- [ ] `TestAnalyzeLibraries_vdsoExcluded`: `linux-vdso.so.1` を DynLibDeps に含めて実行し、`LibraryAnalysis` に含まれないことを確認（AC-9）
+- [ ] `TestAnalyzeLibraries_fileTooLarge`: ファイルサイズが `maxLibraryFileSize` を超えるモックを設定し、解析スキップと `AnalysisWarnings` 追記を確認（AC-10）
+- [ ] `analyzeOneLibrary` の冒頭にファイルサイズチェックを実装（詳細仕様 4.5 節）
+- [ ] `TestIsSyscallWrapperLibrary_prefixBoundary_libcc`: `libcc.so.1` が `false` を返すことを追加確認（AC-11）
+- [ ] `make fmt` / `go test -tags test -v ./...` / `make lint` で品質確認
 
 ---
 

--- a/docs/tasks/0123_dynlib_transitive_syscall_analysis/04_implementation_plan.md
+++ b/docs/tasks/0123_dynlib_transitive_syscall_analysis/04_implementation_plan.md
@@ -9,7 +9,7 @@
 - [x] Step 5: `analyzeLibraries()` 実装とユニットテスト
 - [x] Step 6: `updateAnalysisRecord` への統合
 - [x] Step 7: runner 側のネットワーク判定拡張
-- [ ] Step 8: `cmd/record/main.go` の有効化
+- [x] Step 8: `cmd/record/main.go` の有効化
 - [ ] Step 9: 統合テスト（AC-1 〜 AC-8）
 - [ ] Step 10: `make fmt` `make test` `make lint` で品質確認
 
@@ -140,7 +140,7 @@
 **対象ファイル**: `cmd/record/main.go`
 
 作業内容:
-- [ ] `v.SetSyscallAnalyzer(...)` 呼び出しの直後に `v.SetLibraryAnalysisEnabled(true)` を追加
+- [x] `v.SetSyscallAnalyzer(...)` 呼び出しの直後に `v.SetLibraryAnalysisEnabled(true)` を追加
 
 ---
 

--- a/docs/tasks/0123_dynlib_transitive_syscall_analysis/04_implementation_plan.md
+++ b/docs/tasks/0123_dynlib_transitive_syscall_analysis/04_implementation_plan.md
@@ -10,8 +10,8 @@
 - [x] Step 6: `updateAnalysisRecord` への統合
 - [x] Step 7: runner 側のネットワーク判定拡張
 - [x] Step 8: `cmd/record/main.go` の有効化
-- [ ] Step 9: 統合テスト（AC-1 〜 AC-8）
-- [ ] Step 10: `make fmt` `make test` `make lint` で品質確認
+- [x] Step 9: 統合テスト（AC-1 〜 AC-8）
+- [x] Step 10: `make fmt` `make test` `make lint` で品質確認
 
 ---
 
@@ -164,9 +164,9 @@
 
 ### Step 10: 品質確認
 
-- [ ] `make fmt` — gofumpt によるフォーマット
-- [ ] `make test` — 全テスト通過
-- [ ] `make lint` — golangci-lint エラーなし
+- [x] `make fmt` — gofumpt によるフォーマット
+- [x] `make test` — 全テスト通過
+- [x] `make lint` — golangci-lint エラーなし
 
 ---
 

--- a/docs/tasks/0123_dynlib_transitive_syscall_analysis/04_implementation_plan.md
+++ b/docs/tasks/0123_dynlib_transitive_syscall_analysis/04_implementation_plan.md
@@ -5,7 +5,7 @@
 - [x] Step 1: スキーマ変更
 - [x] Step 2: `binaryanalyzer/syscall_wrapper_libs.go` 新規作成とテスト
 - [x] Step 3: `Validator` にキャッシュフィールドと setter 追加
-- [ ] Step 4: `analyzeOneLibrary()` 実装とユニットテスト
+- [x] Step 4: `analyzeOneLibrary()` 実装とユニットテスト
 - [ ] Step 5: `analyzeLibraries()` 実装とユニットテスト
 - [ ] Step 6: `updateAnalysisRecord` への統合
 - [ ] Step 7: runner 側のネットワーク判定拡張
@@ -70,20 +70,20 @@
 - 新規: `internal/filevalidator/validator_library_analysis_test.go`（または既存テストファイルへ追記）
 
 作業内容:
-- [ ] `analyzeOneLibrary(lib fileanalysis.LibEntry) (entry *fileanalysis.LibraryAnalysisEntry, hasNetwork bool, warnings []string, err error)` を実装
-  - [ ] `.dynsym` シンボル解析: `v.binaryAnalyzer.AnalyzeNetworkSymbols(lib.Path, "")` を呼び出し
-  - [ ] `NetworkDetected` のとき `hasNetwork = true`、`SymbolAnalysisData` を設定
-  - [ ] `AnalysisError` のとき `warnings` に追記して継続
-  - [ ] syscall 命令スキャン: `openELFFile` → `AnalyzeSyscallsFromELF`
-  - [ ] ELF open 失敗は `errNotELF` なら無視、それ以外は `warnings` に追記して継続
-  - [ ] `ErrUnsupportedArch` は `warnings` に追記せずスキップ
-  - [ ] network syscall 判定: `GetSyscallTable(elfFile.Machine)` → `IsNetworkSyscall()` で `hasNetwork` を更新
-- [ ] テスト: network シンボルを持つライブラリ → `hasNetwork = true`、`SymbolAnalysis` に記録
-- [ ] テスト: network syscall を持つライブラリ → `hasNetwork = true`、`SyscallAnalysis` に記録
-- [ ] テスト: ネットワーク系なし → `hasNetwork = false`
-- [ ] テスト: ファイル不在 → `hasNetwork = false`、`warnings` に追記
-- [ ] テスト: 非 ELF ライブラリ（`.so` だが ELF でない）→ syscall 解析はスキップ
-- [ ] テスト: `ErrUnsupportedArch` → `warnings` なし、`SyscallAnalysis` nil
+- [x] `analyzeOneLibrary(lib fileanalysis.LibEntry) (entry *fileanalysis.LibraryAnalysisEntry, hasNetwork bool, warnings []string, err error)` を実装
+  - [x] `.dynsym` シンボル解析: `v.binaryAnalyzer.AnalyzeNetworkSymbols(lib.Path, "")` を呼び出し
+  - [x] `NetworkDetected` のとき `hasNetwork = true`、`SymbolAnalysisData` を設定
+  - [x] `AnalysisError` のとき `warnings` に追記して継続
+  - [x] syscall 命令スキャン: `openELFFile` → `AnalyzeSyscallsFromELF`
+  - [x] ELF open 失敗は `errNotELF` なら無視、それ以外は `warnings` に追記して継続
+  - [x] `ErrUnsupportedArch` は `warnings` に追記せずスキップ
+  - [x] network syscall 判定: `GetSyscallTable(elfFile.Machine)` → `IsNetworkSyscall()` で `hasNetwork` を更新
+- [x] テスト: network シンボルを持つライブラリ → `hasNetwork = true`、`SymbolAnalysis` に記録
+- [x] テスト: network syscall を持つライブラリ → `hasNetwork = true`、`SyscallAnalysis` に記録
+- [x] テスト: ネットワーク系なし → `hasNetwork = false`
+- [x] テスト: ファイル不在 → `hasNetwork = false`、`warnings` に追記
+- [x] テスト: 非 ELF ライブラリ（`.so` だが ELF でない）→ syscall 解析はスキップ
+- [x] テスト: `ErrUnsupportedArch` → `warnings` なし、`SyscallAnalysis` nil
 
 ---
 

--- a/docs/tasks/0123_dynlib_transitive_syscall_analysis/04_implementation_plan.md
+++ b/docs/tasks/0123_dynlib_transitive_syscall_analysis/04_implementation_plan.md
@@ -2,7 +2,7 @@
 
 ## 進捗状況
 
-- [ ] Step 1: スキーマ変更
+- [x] Step 1: スキーマ変更
 - [ ] Step 2: `binaryanalyzer/syscall_wrapper_libs.go` 新規作成とテスト
 - [ ] Step 3: `Validator` にキャッシュフィールドと setter 追加
 - [ ] Step 4: `analyzeOneLibrary()` 実装とユニットテスト
@@ -22,11 +22,11 @@
 **対象ファイル**: `internal/fileanalysis/schema.go`
 
 作業内容:
-- [ ] `CurrentSchemaVersion` を 19 → 20 に変更し、バージョンアップ理由をコメントに追記
-- [ ] `LibraryAnalysisEntry` 型を追加（`SOName`, `Path`, `SyscallAnalysis`, `SymbolAnalysis` フィールド）
-- [ ] `Record` 構造体に `LibraryAnalysis []LibraryAnalysisEntry` フィールドを追加
-- [ ] `SymbolAnalysisData` 構造体に `DetectedLibraryNetworkDeps []string` フィールドを追加
-- [ ] スキーマバージョンを参照しているテストを 20 に更新
+- [x] `CurrentSchemaVersion` を 19 → 20 に変更し、バージョンアップ理由をコメントに追記
+- [x] `LibraryAnalysisEntry` 型を追加（`SOName`, `Path`, `SyscallAnalysis`, `SymbolAnalysis` フィールド）
+- [x] `Record` 構造体に `LibraryAnalysis []LibraryAnalysisEntry` フィールドを追加
+- [x] `SymbolAnalysisData` 構造体に `DetectedLibraryNetworkDeps []string` フィールドを追加
+- [x] スキーマバージョンを参照しているテストを 20 に更新
 
 ---
 

--- a/docs/tasks/0123_dynlib_transitive_syscall_analysis/04_implementation_plan.md
+++ b/docs/tasks/0123_dynlib_transitive_syscall_analysis/04_implementation_plan.md
@@ -6,7 +6,7 @@
 - [x] Step 2: `binaryanalyzer/syscall_wrapper_libs.go` 新規作成とテスト
 - [x] Step 3: `Validator` にキャッシュフィールドと setter 追加
 - [x] Step 4: `analyzeOneLibrary()` 実装とユニットテスト
-- [ ] Step 5: `analyzeLibraries()` 実装とユニットテスト
+- [x] Step 5: `analyzeLibraries()` 実装とユニットテスト
 - [ ] Step 6: `updateAnalysisRecord` への統合
 - [ ] Step 7: runner 側のネットワーク判定拡張
 - [ ] Step 8: `cmd/record/main.go` の有効化
@@ -92,23 +92,23 @@
 **対象ファイル**: `internal/filevalidator/validator.go`、テストファイル
 
 作業内容:
-- [ ] `analyzeLibraries(record *fileanalysis.Record) error` を実装
-  - [ ] `!v.libraryAnalysisEnabled` または `len(record.DynLibDeps) == 0` のときは即時 return nil
-  - [ ] 各 `DynLibDeps` エントリに対してループ:
-    - [ ] `isKnownVDSO(lib.SOName)` の場合はスキップ
-    - [ ] `binaryanalyzer.IsSyscallWrapperLibrary(lib.SOName)` の場合はスキップ
-    - [ ] `v.libraryAnalysisCache[lib.Path]` でキャッシュヒット確認
-    - [ ] キャッシュミスのとき `analyzeOneLibrary` を呼び出してキャッシュに保存
-  - [ ] ネットワーク検出ライブラリの SOName を `slices.Sort` してから `DetectedLibraryNetworkDeps` へ設定
-  - [ ] `record.SymbolAnalysis` が nil のとき新規作成して設定
-  - [ ] `record.LibraryAnalysis` に全エントリを設定
-  - [ ] `record.AnalysisWarnings` を `slices.Sort` で整列
-- [ ] テスト: `libraryAnalysisEnabled = false` → `LibraryAnalysis` nil
-- [ ] テスト: 空の `DynLibDeps` → `LibraryAnalysis` nil
-- [ ] テスト: `libc.so.6` と `libssl.so.3` が依存の場合、`libc` はスキップ、`libssl` のみ解析
-- [ ] テスト: `linux-vdso.so.1` はスキップ
-- [ ] テスト: 同一ライブラリを 2 回参照（異なるコマンドが同じライブラリに依存）→ `analyzeOneLibrary` は 1 回のみ
-- [ ] テスト: `SymbolAnalysis` が nil の場合でも `DetectedLibraryNetworkDeps` が設定される
+- [x] `analyzeLibraries(record *fileanalysis.Record) error` を実装
+  - [x] `!v.libraryAnalysisEnabled` または `len(record.DynLibDeps) == 0` のときは即時 return nil
+  - [x] 各 `DynLibDeps` エントリに対してループ:
+    - [x] `isKnownVDSO(lib.SOName)` の場合はスキップ
+    - [x] `binaryanalyzer.IsSyscallWrapperLibrary(lib.SOName)` の場合はスキップ
+    - [x] `v.libraryAnalysisCache[lib.Path]` でキャッシュヒット確認
+    - [x] キャッシュミスのとき `analyzeOneLibrary` を呼び出してキャッシュに保存
+  - [x] ネットワーク検出ライブラリの SOName を `slices.Sort` してから `DetectedLibraryNetworkDeps` へ設定
+  - [x] `record.SymbolAnalysis` が nil のとき新規作成して設定
+  - [x] `record.LibraryAnalysis` に全エントリを設定
+  - [x] `record.AnalysisWarnings` を `slices.Sort` で整列
+- [x] テスト: `libraryAnalysisEnabled = false` → `LibraryAnalysis` nil
+- [x] テスト: 空の `DynLibDeps` → `LibraryAnalysis` nil
+- [x] テスト: `libc.so.6` と `libssl.so.3` が依存の場合、`libc` はスキップ、`libssl` のみ解析
+- [x] テスト: `linux-vdso.so.1` はスキップ
+- [x] テスト: 同一ライブラリを 2 回参照（異なるコマンドが同じライブラリに依存）→ `analyzeOneLibrary` は 1 回のみ
+- [x] テスト: `SymbolAnalysis` が nil の場合でも `DetectedLibraryNetworkDeps` が設定される
 
 ---
 

--- a/internal/fileanalysis/schema.go
+++ b/internal/fileanalysis/schema.go
@@ -39,8 +39,10 @@ const (
 	// at runtime from syscall numbers and symbol names.
 	// Version 19 flattens detected_symbols and dynamic_load_symbols from
 	// [{"name":"..."}] to ["..."] directly.
-	// Load returns SchemaVersionMismatchError for records with schema_version != 19.
-	CurrentSchemaVersion = 19
+	// Version 20 adds LibraryAnalysis to Record for per-library syscall/symbol
+	// analysis results and DetectedLibraryNetworkDeps to SymbolAnalysisData.
+	// Load returns SchemaVersionMismatchError for records with schema_version != 20.
+	CurrentSchemaVersion = 20
 )
 
 // Record represents a unified file analysis record containing both
@@ -86,6 +88,29 @@ type Record struct {
 	// (e.g., unknown @ tokens that prevent hash verification for specific libraries).
 	// nil/empty is omitted from JSON (omitempty).
 	AnalysisWarnings []string `json:"analysis_warnings,omitempty"`
+
+	// LibraryAnalysis contains per-library analysis results for application-level
+	// dynamic libraries in DynLibDeps (excluding syscall wrappers like libc).
+	// nil/empty means library analysis was not performed or found nothing notable.
+	LibraryAnalysis []LibraryAnalysisEntry `json:"library_analysis,omitempty"`
+}
+
+// LibraryAnalysisEntry holds syscall and symbol analysis results for a single
+// application-level dynamic library dependency.
+type LibraryAnalysisEntry struct {
+	// SOName is the DT_NEEDED library name (e.g., "libfoo.so.1").
+	SOName string `json:"soname"`
+
+	// Path is the resolved full path to the library file.
+	Path string `json:"path"`
+
+	// SyscallAnalysis contains machine-code syscall instruction scan results.
+	// nil when machine-code analysis was skipped or produced no data.
+	SyscallAnalysis *SyscallAnalysisData `json:"syscall_analysis,omitempty"`
+
+	// SymbolAnalysis contains .dynsym UNDEF symbol analysis results.
+	// nil when symbol analysis was skipped or produced no data.
+	SymbolAnalysis *SymbolAnalysisData `json:"symbol_analysis,omitempty"`
 }
 
 // LibEntry represents a single resolved dynamic library dependency.
@@ -158,4 +183,9 @@ type SymbolAnalysisData struct {
 	// detected from DynLibDeps during record.
 	// If non-empty, this binary is treated as network-capable.
 	KnownNetworkLibDeps []string `json:"known_network_lib_deps,omitempty"`
+
+	// DetectedLibraryNetworkDeps lists SOName values of application libraries
+	// in which network-related syscalls or symbols were detected during
+	// library-level analysis.
+	DetectedLibraryNetworkDeps []string `json:"detected_library_network_deps,omitempty"`
 }

--- a/internal/filevalidator/validator.go
+++ b/internal/filevalidator/validator.go
@@ -128,6 +128,11 @@ func (v *Validator) Store() *fileanalysis.Store {
 	return v.store
 }
 
+type libraryCacheEntry struct {
+	entry      fileanalysis.LibraryAnalysisEntry //nolint:unused // used in analyzeLibraries cache in Step 5.
+	hasNetwork bool                              //nolint:unused // used in analyzeLibraries cache in Step 5.
+}
+
 // Validator provides functionality to record and verify file hashes.
 // It should be instantiated using the New function.
 type Validator struct {
@@ -138,15 +143,17 @@ type Validator struct {
 	// store is the unified analysis store for FileAnalysisRecord format.
 	store *fileanalysis.Store
 
-	fileSystem          safefileio.FileSystem           // used by openELFFile in analyzeELFSyscalls
-	elfDynlibAnalyzer   *elfdynlib.DynLibAnalyzer       // nil if dynlib analysis is disabled
-	machoDynlibAnalyzer *machodylib.MachODynLibAnalyzer // nil if Mach-O dynlib analysis is disabled
-	binaryAnalyzer      binaryanalyzer.BinaryAnalyzer   // nil if binary analysis is disabled
-	libcCache           LibcCacheInterface              // nil if libc cache is disabled
-	libSystemCache      LibSystemCacheInterface         // nil if Mach-O libSystem cache is disabled
-	syscallAnalyzer     SyscallAnalyzerInterface        // nil if syscall analysis is disabled
-	machoSyscallTable   SyscallNumberTable              // nil falls back to noop table in ScanSyscallInfos
-	includeDebugInfo    bool
+	fileSystem             safefileio.FileSystem           // used by openELFFile in analyzeELFSyscalls
+	elfDynlibAnalyzer      *elfdynlib.DynLibAnalyzer       // nil if dynlib analysis is disabled
+	machoDynlibAnalyzer    *machodylib.MachODynLibAnalyzer // nil if Mach-O dynlib analysis is disabled
+	binaryAnalyzer         binaryanalyzer.BinaryAnalyzer   // nil if binary analysis is disabled
+	libcCache              LibcCacheInterface              // nil if libc cache is disabled
+	libSystemCache         LibSystemCacheInterface         // nil if Mach-O libSystem cache is disabled
+	syscallAnalyzer        SyscallAnalyzerInterface        // nil if syscall analysis is disabled
+	machoSyscallTable      SyscallNumberTable              // nil falls back to noop table in ScanSyscallInfos
+	libraryAnalysisCache   map[string]libraryCacheEntry
+	libraryAnalysisEnabled bool
+	includeDebugInfo       bool
 }
 
 // New initializes and returns a new Validator with the specified hash algorithm and hash directory.
@@ -522,10 +529,31 @@ func (v *Validator) SetSyscallAnalyzer(a SyscallAnalyzerInterface) {
 	v.syscallAnalyzer = a
 }
 
+// SetLibraryAnalysisEnabled enables or disables library-level analysis.
+// Call before the first SaveRecord() invocation.
+func (v *Validator) SetLibraryAnalysisEnabled(enabled bool) {
+	v.libraryAnalysisEnabled = enabled
+	if enabled && v.libraryAnalysisCache == nil {
+		v.libraryAnalysisCache = make(map[string]libraryCacheEntry)
+	}
+}
+
 // SetIncludeDebugInfo controls whether debug information (Occurrences,
 // DeterminationStats) is included in saved JSON output.
 func (v *Validator) SetIncludeDebugInfo(b bool) {
 	v.includeDebugInfo = b
+}
+
+// isKnownVDSO reports whether soname refers to a Linux virtual DSO.
+//
+//nolint:unused // wired into analyzeLibraries in Step 5.
+func isKnownVDSO(soname string) bool {
+	switch soname {
+	case "linux-vdso.so.1", "linux-gate.so.1", "linux-vdso64.so.1":
+		return true
+	default:
+		return false
+	}
 }
 
 // Verify checks if the file at filePath matches its recorded hash.

--- a/internal/filevalidator/validator.go
+++ b/internal/filevalidator/validator.go
@@ -538,6 +538,78 @@ func (v *Validator) SetLibraryAnalysisEnabled(enabled bool) {
 	}
 }
 
+// analyzeOneLibrary runs symbol and syscall analysis for one dynamic library.
+func (v *Validator) analyzeOneLibrary(lib fileanalysis.LibEntry) (
+	entry *fileanalysis.LibraryAnalysisEntry,
+	hasNetwork bool,
+	warnings []string,
+	err error,
+) {
+	entry = &fileanalysis.LibraryAnalysisEntry{
+		SOName: lib.SOName,
+		Path:   lib.Path,
+	}
+
+	if v.binaryAnalyzer != nil {
+		output := v.binaryAnalyzer.AnalyzeNetworkSymbols(lib.Path, "")
+		switch output.Result {
+		case binaryanalyzer.NetworkDetected:
+			entry.SymbolAnalysis = &fileanalysis.SymbolAnalysisData{
+				DetectedSymbols:    convertDetectedSymbols(output.DetectedSymbols),
+				DynamicLoadSymbols: convertDetectedSymbols(output.DynamicLoadSymbols),
+			}
+			hasNetwork = true
+		case binaryanalyzer.NoNetworkSymbols:
+			entry.SymbolAnalysis = &fileanalysis.SymbolAnalysisData{
+				DetectedSymbols:    convertDetectedSymbols(output.DetectedSymbols),
+				DynamicLoadSymbols: convertDetectedSymbols(output.DynamicLoadSymbols),
+			}
+		case binaryanalyzer.AnalysisError:
+			warnings = append(warnings,
+				fmt.Sprintf("library symbol analysis failed for %s: %v", lib.SOName, output.Error))
+		}
+	}
+
+	if v.syscallAnalyzer == nil {
+		return entry, hasNetwork, warnings, nil
+	}
+
+	elfFile, openErr := openELFFile(v.fileSystem, lib.Path)
+	if openErr != nil {
+		if !errors.Is(openErr, errNotELF) {
+			warnings = append(warnings,
+				fmt.Sprintf("failed to open library ELF %s: %v", lib.SOName, openErr))
+		}
+		return entry, hasNetwork, warnings, nil
+	}
+	defer func() { _ = elfFile.Close() }()
+
+	detected, _, _, analyzeErr := v.syscallAnalyzer.AnalyzeSyscallsFromELF(elfFile)
+	if analyzeErr != nil {
+		if !errors.Is(analyzeErr, ErrUnsupportedArch) {
+			warnings = append(warnings,
+				fmt.Sprintf("syscall analysis failed for library %s: %v", lib.SOName, analyzeErr))
+		}
+		return entry, hasNetwork, warnings, nil
+	}
+
+	if len(detected) > 0 {
+		entry.SyscallAnalysis = buildSyscallData(detected, nil, elfFile.Machine, nil, v.includeDebugInfo)
+
+		table, ok := v.syscallAnalyzer.GetSyscallTable(elfFile.Machine)
+		if ok {
+			for _, s := range detected {
+				if s.Number >= 0 && table.IsNetworkSyscall(s.Number) {
+					hasNetwork = true
+					break
+				}
+			}
+		}
+	}
+
+	return entry, hasNetwork, warnings, nil
+}
+
 // SetIncludeDebugInfo controls whether debug information (Occurrences,
 // DeterminationStats) is included in saved JSON output.
 func (v *Validator) SetIncludeDebugInfo(b bool) {

--- a/internal/filevalidator/validator.go
+++ b/internal/filevalidator/validator.go
@@ -129,9 +129,10 @@ func (v *Validator) Store() *fileanalysis.Store {
 }
 
 type libraryCacheEntry struct {
-	entry              fileanalysis.LibraryAnalysisEntry
-	hasNetwork         bool
-	dynamicLoadSymbols []string
+type libraryCacheEntry struct {
+	entry      fileanalysis.LibraryAnalysisEntry
+	hasNetwork bool
+	warnings   []string
 }
 
 // Validator provides functionality to record and verify file hashes.

--- a/internal/filevalidator/validator.go
+++ b/internal/filevalidator/validator.go
@@ -129,8 +129,8 @@ func (v *Validator) Store() *fileanalysis.Store {
 }
 
 type libraryCacheEntry struct {
-	entry      fileanalysis.LibraryAnalysisEntry //nolint:unused // used in analyzeLibraries cache in Step 5.
-	hasNetwork bool                              //nolint:unused // used in analyzeLibraries cache in Step 5.
+	entry      fileanalysis.LibraryAnalysisEntry
+	hasNetwork bool
 }
 
 // Validator provides functionality to record and verify file hashes.
@@ -610,6 +610,75 @@ func (v *Validator) analyzeOneLibrary(lib fileanalysis.LibEntry) (
 	return entry, hasNetwork, warnings, nil
 }
 
+// analyzeLibraries runs library-level analysis for non-wrapper dynamic dependencies.
+func (v *Validator) analyzeLibraries(record *fileanalysis.Record) error {
+	if !v.libraryAnalysisEnabled || len(record.DynLibDeps) == 0 {
+		record.LibraryAnalysis = nil
+		if record.SymbolAnalysis != nil {
+			record.SymbolAnalysis.DetectedLibraryNetworkDeps = nil
+		}
+		return nil
+	}
+
+	if v.libraryAnalysisCache == nil {
+		v.libraryAnalysisCache = make(map[string]libraryCacheEntry)
+	}
+
+	var entries []fileanalysis.LibraryAnalysisEntry
+	var networkSONames []string
+
+	for _, lib := range record.DynLibDeps {
+		if isKnownVDSO(lib.SOName) {
+			continue
+		}
+		if binaryanalyzer.IsSyscallWrapperLibrary(lib.SOName) {
+			continue
+		}
+
+		if cached, ok := v.libraryAnalysisCache[lib.Path]; ok {
+			entries = append(entries, cached.entry)
+			if cached.hasNetwork {
+				networkSONames = append(networkSONames, lib.SOName)
+			}
+			continue
+		}
+
+		entry, hasNetwork, warnings, err := v.analyzeOneLibrary(lib)
+		if err != nil {
+			return err
+		}
+		record.AnalysisWarnings = append(record.AnalysisWarnings, warnings...)
+
+		cache := libraryCacheEntry{entry: *entry, hasNetwork: hasNetwork}
+		v.libraryAnalysisCache[lib.Path] = cache
+
+		entries = append(entries, cache.entry)
+		if cache.hasNetwork {
+			networkSONames = append(networkSONames, lib.SOName)
+		}
+	}
+
+	record.LibraryAnalysis = entries
+
+	if len(networkSONames) > 0 {
+		slices.Sort(networkSONames)
+		networkSONames = slices.Compact(networkSONames)
+		if record.SymbolAnalysis == nil {
+			record.SymbolAnalysis = &fileanalysis.SymbolAnalysisData{}
+		}
+		record.SymbolAnalysis.DetectedLibraryNetworkDeps = networkSONames
+	} else if record.SymbolAnalysis != nil {
+		record.SymbolAnalysis.DetectedLibraryNetworkDeps = nil
+	}
+
+	if len(record.AnalysisWarnings) > 0 {
+		slices.Sort(record.AnalysisWarnings)
+		record.AnalysisWarnings = slices.Compact(record.AnalysisWarnings)
+	}
+
+	return nil
+}
+
 // SetIncludeDebugInfo controls whether debug information (Occurrences,
 // DeterminationStats) is included in saved JSON output.
 func (v *Validator) SetIncludeDebugInfo(b bool) {
@@ -618,7 +687,7 @@ func (v *Validator) SetIncludeDebugInfo(b bool) {
 
 // isKnownVDSO reports whether soname refers to a Linux virtual DSO.
 //
-//nolint:unused // wired into analyzeLibraries in Step 5.
+// isKnownVDSO reports whether soname refers to a Linux virtual DSO.
 func isKnownVDSO(soname string) bool {
 	switch soname {
 	case "linux-vdso.so.1", "linux-gate.so.1", "linux-vdso64.so.1":

--- a/internal/filevalidator/validator.go
+++ b/internal/filevalidator/validator.go
@@ -641,7 +641,9 @@ func (v *Validator) analyzeLibraries(record *fileanalysis.Record) error {
 		}
 
 		if cached, ok := v.libraryAnalysisCache[lib.Path]; ok {
-			entries = append(entries, cached.entry)
+			cachedEntry := cached.entry
+			cachedEntry.SOName = lib.SOName
+			entries = append(entries, cachedEntry)
 			if cached.hasNetwork {
 				networkSONames = append(networkSONames, lib.SOName)
 			}

--- a/internal/filevalidator/validator.go
+++ b/internal/filevalidator/validator.go
@@ -129,8 +129,9 @@ func (v *Validator) Store() *fileanalysis.Store {
 }
 
 type libraryCacheEntry struct {
-	entry      fileanalysis.LibraryAnalysisEntry
-	hasNetwork bool
+	entry              fileanalysis.LibraryAnalysisEntry
+	hasNetwork         bool
+	dynamicLoadSymbols []string
 }
 
 // Validator provides functionality to record and verify file hashes.
@@ -547,6 +548,7 @@ func (v *Validator) SetLibraryAnalysisEnabled(enabled bool) {
 func (v *Validator) analyzeOneLibrary(lib fileanalysis.LibEntry) (
 	entry *fileanalysis.LibraryAnalysisEntry,
 	hasNetwork bool,
+	dynamicLoadSymbols []string,
 	warnings []string,
 	err error,
 ) {
@@ -573,11 +575,28 @@ func (v *Validator) analyzeOneLibrary(lib fileanalysis.LibEntry) (
 			warnings = append(warnings,
 				fmt.Sprintf("library symbol analysis failed for %s: %v", lib.SOName, output.Error))
 		}
+		dynamicLoadSymbols = convertDetectedSymbols(output.DynamicLoadSymbols)
 	}
 
 	if v.syscallAnalyzer == nil {
-		return entry, hasNetwork, warnings, nil
+		return entry, hasNetwork, dynamicLoadSymbols, warnings, nil
 	}
+
+	// Skip machine-code analysis when the library file exceeds the size limit.
+	// This mirrors the maxFileSize check applied to executable binaries.
+	f, openErr := v.fileSystem.SafeOpenFile(lib.Path, os.O_RDONLY, 0)
+	if openErr != nil {
+		warnings = append(warnings,
+			fmt.Sprintf("failed to open library file %s: %v", lib.SOName, openErr))
+		return entry, hasNetwork, dynamicLoadSymbols, warnings, nil
+	}
+	if fi, statErr := f.Stat(); statErr == nil && fi.Size() > maxFileSize {
+		_ = f.Close()
+		warnings = append(warnings,
+			fmt.Sprintf("library file too large, skipping analysis for %s", lib.SOName))
+		return entry, hasNetwork, dynamicLoadSymbols, warnings, nil
+	}
+	_ = f.Close()
 
 	elfFile, openErr := openELFFile(v.fileSystem, lib.Path)
 	if openErr != nil {
@@ -585,7 +604,7 @@ func (v *Validator) analyzeOneLibrary(lib fileanalysis.LibEntry) (
 			warnings = append(warnings,
 				fmt.Sprintf("failed to open library ELF %s: %v", lib.SOName, openErr))
 		}
-		return entry, hasNetwork, warnings, nil
+		return entry, hasNetwork, dynamicLoadSymbols, warnings, nil
 	}
 	defer func() { _ = elfFile.Close() }()
 
@@ -595,7 +614,7 @@ func (v *Validator) analyzeOneLibrary(lib fileanalysis.LibEntry) (
 			warnings = append(warnings,
 				fmt.Sprintf("syscall analysis failed for library %s: %v", lib.SOName, analyzeErr))
 		}
-		return entry, hasNetwork, warnings, nil
+		return entry, hasNetwork, dynamicLoadSymbols, warnings, nil
 	}
 
 	if len(detected) > 0 {
@@ -612,7 +631,7 @@ func (v *Validator) analyzeOneLibrary(lib fileanalysis.LibEntry) (
 		}
 	}
 
-	return entry, hasNetwork, warnings, nil
+	return entry, hasNetwork, dynamicLoadSymbols, warnings, nil
 }
 
 // analyzeLibraries runs library-level analysis for non-wrapper dynamic dependencies.
@@ -631,6 +650,7 @@ func (v *Validator) analyzeLibraries(record *fileanalysis.Record) error {
 
 	var entries []fileanalysis.LibraryAnalysisEntry
 	var networkSONames []string
+	var allDynLoadSymbols []string
 
 	for _, lib := range record.DynLibDeps {
 		if isKnownVDSO(lib.SOName) {
@@ -647,35 +667,48 @@ func (v *Validator) analyzeLibraries(record *fileanalysis.Record) error {
 			if cached.hasNetwork {
 				networkSONames = append(networkSONames, lib.SOName)
 			}
+			allDynLoadSymbols = append(allDynLoadSymbols, cached.dynamicLoadSymbols...)
 			continue
 		}
 
-		entry, hasNetwork, warnings, err := v.analyzeOneLibrary(lib)
+		entry, hasNetwork, dynLoadSyms, warnings, err := v.analyzeOneLibrary(lib)
 		if err != nil {
 			return err
 		}
 		record.AnalysisWarnings = append(record.AnalysisWarnings, warnings...)
 
-		cache := libraryCacheEntry{entry: *entry, hasNetwork: hasNetwork}
+		cache := libraryCacheEntry{entry: *entry, hasNetwork: hasNetwork, dynamicLoadSymbols: dynLoadSyms}
 		v.libraryAnalysisCache[lib.Path] = cache
 
 		entries = append(entries, cache.entry)
 		if cache.hasNetwork {
 			networkSONames = append(networkSONames, lib.SOName)
 		}
+		allDynLoadSymbols = append(allDynLoadSymbols, dynLoadSyms...)
 	}
 
 	record.LibraryAnalysis = entries
 
-	if len(networkSONames) > 0 {
-		slices.Sort(networkSONames)
-		networkSONames = slices.Compact(networkSONames)
+	if len(networkSONames) > 0 || len(allDynLoadSymbols) > 0 {
 		if record.SymbolAnalysis == nil {
 			record.SymbolAnalysis = &fileanalysis.SymbolAnalysisData{}
 		}
+	}
+	if len(networkSONames) > 0 {
+		slices.Sort(networkSONames)
+		networkSONames = slices.Compact(networkSONames)
 		record.SymbolAnalysis.DetectedLibraryNetworkDeps = networkSONames
 	} else if record.SymbolAnalysis != nil {
 		record.SymbolAnalysis.DetectedLibraryNetworkDeps = nil
+	}
+	if len(allDynLoadSymbols) > 0 {
+		// Merge library-detected dlopen/dlsym symbols into the exec record's
+		// DynamicLoadSymbols so that the runner can apply high-risk judgment.
+		merged := []string{}
+		merged = append(merged, record.SymbolAnalysis.DynamicLoadSymbols...)
+		merged = append(merged, allDynLoadSymbols...)
+		slices.Sort(merged)
+		record.SymbolAnalysis.DynamicLoadSymbols = slices.Compact(merged)
 	}
 
 	if len(record.AnalysisWarnings) > 0 {
@@ -1024,6 +1057,11 @@ const (
 	machoFatMagicLE = uint32(0xBEBAFECA)
 	machoFatCigamLE = uint32(0xCAFEBABE)
 )
+
+// maxFileSize is the maximum file size (1 GB) for binary analysis.
+// Files larger than this are skipped to bound analysis time and memory usage.
+// Matches the limit used in elfanalyzer and machoanalyzer.
+const maxFileSize = 1 << 30
 
 // archNameArm64 is the canonical architecture string for Apple Silicon (arm64).
 const archNameArm64 = "arm64"

--- a/internal/filevalidator/validator.go
+++ b/internal/filevalidator/validator.go
@@ -354,6 +354,11 @@ func (v *Validator) updateAnalysisRecord(filePath common.ResolvedPath, hash stri
 			record.SymbolAnalysis.KnownNetworkLibDeps = matched
 		}
 
+		// Analyze dynamic dependencies at library granularity.
+		if err := v.analyzeLibraries(record); err != nil {
+			return err
+		}
+
 		// Analyze ELF syscalls via libc import symbol matching and direct instruction scan.
 		if err := v.analyzeELFSyscalls(record, filePath.String()); err != nil {
 			return err

--- a/internal/filevalidator/validator.go
+++ b/internal/filevalidator/validator.go
@@ -129,10 +129,10 @@ func (v *Validator) Store() *fileanalysis.Store {
 }
 
 type libraryCacheEntry struct {
-type libraryCacheEntry struct {
-	entry      fileanalysis.LibraryAnalysisEntry
-	hasNetwork bool
-	warnings   []string
+	entry              fileanalysis.LibraryAnalysisEntry
+	hasNetwork         bool
+	dynamicLoadSymbols []string
+	warnings           []string
 }
 
 // Validator provides functionality to record and verify file hashes.
@@ -669,6 +669,7 @@ func (v *Validator) analyzeLibraries(record *fileanalysis.Record) error {
 				networkSONames = append(networkSONames, lib.SOName)
 			}
 			allDynLoadSymbols = append(allDynLoadSymbols, cached.dynamicLoadSymbols...)
+			record.AnalysisWarnings = append(record.AnalysisWarnings, cached.warnings...)
 			continue
 		}
 
@@ -678,7 +679,7 @@ func (v *Validator) analyzeLibraries(record *fileanalysis.Record) error {
 		}
 		record.AnalysisWarnings = append(record.AnalysisWarnings, warnings...)
 
-		cache := libraryCacheEntry{entry: *entry, hasNetwork: hasNetwork, dynamicLoadSymbols: dynLoadSyms}
+		cache := libraryCacheEntry{entry: *entry, hasNetwork: hasNetwork, dynamicLoadSymbols: dynLoadSyms, warnings: warnings}
 		v.libraryAnalysisCache[lib.Path] = cache
 
 		entries = append(entries, cache.entry)
@@ -726,8 +727,6 @@ func (v *Validator) SetIncludeDebugInfo(b bool) {
 	v.includeDebugInfo = b
 }
 
-// isKnownVDSO reports whether soname refers to a Linux virtual DSO.
-//
 // isKnownVDSO reports whether soname refers to a Linux virtual DSO.
 func isKnownVDSO(soname string) bool {
 	switch soname {

--- a/internal/filevalidator/validator_library_analysis_test.go
+++ b/internal/filevalidator/validator_library_analysis_test.go
@@ -18,9 +18,11 @@ import (
 
 type libraryTestBinaryAnalyzer struct {
 	output binaryanalyzer.AnalysisOutput
+	calls  int
 }
 
 func (s *libraryTestBinaryAnalyzer) AnalyzeNetworkSymbols(_, _ string) binaryanalyzer.AnalysisOutput {
+	s.calls++
 	return s.output
 }
 
@@ -106,7 +108,7 @@ func TestAnalyzeOneLibrary_networkSyscallDetected(t *testing.T) {
 	v.SetBinaryAnalyzer(&libraryTestBinaryAnalyzer{output: binaryanalyzer.AnalysisOutput{Result: binaryanalyzer.NoNetworkSymbols}})
 	v.SetSyscallAnalyzer(&libraryTestSyscallAnalyzer{
 		syscalls: []common.SyscallInfo{{Number: 41, Name: "socket"}},
-		table: &libraryTestSyscallTable{network: map[int]bool{41: true}},
+		table:    &libraryTestSyscallTable{network: map[int]bool{41: true}},
 	})
 
 	entry, hasNetwork, warnings, err := v.analyzeOneLibrary(fileanalysis.LibEntry{
@@ -179,4 +181,86 @@ func TestAnalyzeOneLibrary_unsupportedArchSkipsWarning(t *testing.T) {
 	assert.False(t, hasNetwork)
 	assert.Nil(t, entry.SyscallAnalysis)
 	assert.Empty(t, warnings)
+}
+
+func TestAnalyzeLibraries_disabled(t *testing.T) {
+	v := validatorWithTempHashDir(t)
+	record := &fileanalysis.Record{
+		DynLibDeps: []fileanalysis.LibEntry{{SOName: "libfoo.so.1", Path: elfTestDataPath(t, "with_socket.elf")}},
+	}
+
+	require.NoError(t, v.analyzeLibraries(record))
+	assert.Nil(t, record.LibraryAnalysis)
+}
+
+func TestAnalyzeLibraries_emptyDynLibDeps(t *testing.T) {
+	v := validatorWithTempHashDir(t)
+	v.SetLibraryAnalysisEnabled(true)
+	record := &fileanalysis.Record{}
+
+	require.NoError(t, v.analyzeLibraries(record))
+	assert.Nil(t, record.LibraryAnalysis)
+}
+
+func TestAnalyzeLibraries_excludesWrapperAndVDSO(t *testing.T) {
+	v := validatorWithTempHashDir(t)
+	v.SetLibraryAnalysisEnabled(true)
+
+	bin := &libraryTestBinaryAnalyzer{output: binaryanalyzer.AnalysisOutput{Result: binaryanalyzer.NoNetworkSymbols}}
+	v.SetBinaryAnalyzer(bin)
+
+	record := &fileanalysis.Record{
+		DynLibDeps: []fileanalysis.LibEntry{
+			{SOName: "libc.so.6", Path: elfTestDataPath(t, "with_socket.elf")},
+			{SOName: "linux-vdso.so.1", Path: ""},
+			{SOName: "libssl.so.3", Path: elfTestDataPath(t, "with_socket.elf")},
+		},
+	}
+
+	require.NoError(t, v.analyzeLibraries(record))
+	require.Len(t, record.LibraryAnalysis, 1)
+	assert.Equal(t, "libssl.so.3", record.LibraryAnalysis[0].SOName)
+	assert.Equal(t, 1, bin.calls)
+}
+
+func TestAnalyzeLibraries_sessionCache(t *testing.T) {
+	v := validatorWithTempHashDir(t)
+	v.SetLibraryAnalysisEnabled(true)
+
+	bin := &libraryTestBinaryAnalyzer{output: binaryanalyzer.AnalysisOutput{Result: binaryanalyzer.NoNetworkSymbols}}
+	v.SetBinaryAnalyzer(bin)
+
+	path := elfTestDataPath(t, "with_socket.elf")
+	record := &fileanalysis.Record{
+		DynLibDeps: []fileanalysis.LibEntry{
+			{SOName: "libfoo.so.1", Path: path},
+			{SOName: "libfoo-alias.so.1", Path: path},
+		},
+	}
+
+	require.NoError(t, v.analyzeLibraries(record))
+	assert.Equal(t, 1, bin.calls)
+	require.Len(t, record.LibraryAnalysis, 2)
+}
+
+func TestAnalyzeLibraries_symbolAnalysisCreatedWhenNil(t *testing.T) {
+	v := validatorWithTempHashDir(t)
+	v.SetLibraryAnalysisEnabled(true)
+
+	v.SetBinaryAnalyzer(&libraryTestBinaryAnalyzer{
+		output: binaryanalyzer.AnalysisOutput{
+			Result: binaryanalyzer.NetworkDetected,
+			DetectedSymbols: []binaryanalyzer.DetectedSymbol{
+				{Name: "socket", Category: "socket"},
+			},
+		},
+	})
+
+	record := &fileanalysis.Record{
+		DynLibDeps: []fileanalysis.LibEntry{{SOName: "libnet.so.1", Path: elfTestDataPath(t, "with_socket.elf")}},
+	}
+
+	require.NoError(t, v.analyzeLibraries(record))
+	require.NotNil(t, record.SymbolAnalysis)
+	require.Equal(t, []string{"libnet.so.1"}, record.SymbolAnalysis.DetectedLibraryNetworkDeps)
 }

--- a/internal/filevalidator/validator_library_analysis_test.go
+++ b/internal/filevalidator/validator_library_analysis_test.go
@@ -241,6 +241,8 @@ func TestAnalyzeLibraries_sessionCache(t *testing.T) {
 	require.NoError(t, v.analyzeLibraries(record))
 	assert.Equal(t, 1, bin.calls)
 	require.Len(t, record.LibraryAnalysis, 2)
+	assert.Equal(t, "libfoo.so.1", record.LibraryAnalysis[0].SOName)
+	assert.Equal(t, "libfoo-alias.so.1", record.LibraryAnalysis[1].SOName)
 }
 
 func TestAnalyzeLibraries_symbolAnalysisCreatedWhenNil(t *testing.T) {

--- a/internal/filevalidator/validator_library_analysis_test.go
+++ b/internal/filevalidator/validator_library_analysis_test.go
@@ -91,7 +91,7 @@ func TestAnalyzeOneLibrary_networkSymbolDetected(t *testing.T) {
 		},
 	})
 
-	entry, hasNetwork, warnings, err := v.analyzeOneLibrary(fileanalysis.LibEntry{
+	entry, hasNetwork, _, warnings, err := v.analyzeOneLibrary(fileanalysis.LibEntry{
 		SOName: "libfoo.so.1",
 		Path:   elfTestDataPath(t, "with_socket.elf"),
 	})
@@ -111,7 +111,7 @@ func TestAnalyzeOneLibrary_networkSyscallDetected(t *testing.T) {
 		table:    &libraryTestSyscallTable{network: map[int]bool{41: true}},
 	})
 
-	entry, hasNetwork, warnings, err := v.analyzeOneLibrary(fileanalysis.LibEntry{
+	entry, hasNetwork, _, warnings, err := v.analyzeOneLibrary(fileanalysis.LibEntry{
 		SOName: "libbar.so.1",
 		Path:   elfTestDataPath(t, "with_socket.elf"),
 	})
@@ -128,7 +128,7 @@ func TestAnalyzeOneLibrary_nonNetwork(t *testing.T) {
 	v.SetBinaryAnalyzer(&libraryTestBinaryAnalyzer{output: binaryanalyzer.AnalysisOutput{Result: binaryanalyzer.NoNetworkSymbols}})
 	v.SetSyscallAnalyzer(&libraryTestSyscallAnalyzer{syscalls: []common.SyscallInfo{{Number: 1, Name: "write"}}})
 
-	entry, hasNetwork, warnings, err := v.analyzeOneLibrary(fileanalysis.LibEntry{
+	entry, hasNetwork, _, warnings, err := v.analyzeOneLibrary(fileanalysis.LibEntry{
 		SOName: "libbaz.so.1",
 		Path:   elfTestDataPath(t, "with_socket.elf"),
 	})
@@ -142,7 +142,7 @@ func TestAnalyzeOneLibrary_missingFileAddsWarning(t *testing.T) {
 	v := validatorWithTempHashDir(t)
 	v.SetSyscallAnalyzer(&libraryTestSyscallAnalyzer{})
 
-	entry, hasNetwork, warnings, err := v.analyzeOneLibrary(fileanalysis.LibEntry{
+	entry, hasNetwork, _, warnings, err := v.analyzeOneLibrary(fileanalysis.LibEntry{
 		SOName: "libmissing.so.1",
 		Path:   filepath.Join(safeTempDir(t), "missing.so"),
 	})
@@ -150,14 +150,14 @@ func TestAnalyzeOneLibrary_missingFileAddsWarning(t *testing.T) {
 	require.NotNil(t, entry)
 	assert.False(t, hasNetwork)
 	require.NotEmpty(t, warnings)
-	assert.Contains(t, warnings[0], "failed to open library ELF")
+	assert.Contains(t, warnings[0], "failed to open library file")
 }
 
 func TestAnalyzeOneLibrary_nonELFLibrarySkipsSyscallScan(t *testing.T) {
 	v := validatorWithTempHashDir(t)
 	v.SetSyscallAnalyzer(&libraryTestSyscallAnalyzer{syscalls: []common.SyscallInfo{{Number: 41, Name: "socket"}}})
 
-	entry, hasNetwork, warnings, err := v.analyzeOneLibrary(fileanalysis.LibEntry{
+	entry, hasNetwork, _, warnings, err := v.analyzeOneLibrary(fileanalysis.LibEntry{
 		SOName: "libscript.so.1",
 		Path:   elfTestDataPath(t, "script.sh"),
 	})
@@ -172,7 +172,7 @@ func TestAnalyzeOneLibrary_unsupportedArchSkipsWarning(t *testing.T) {
 	v := validatorWithTempHashDir(t)
 	v.SetSyscallAnalyzer(&libraryTestSyscallAnalyzer{err: ErrUnsupportedArch})
 
-	entry, hasNetwork, warnings, err := v.analyzeOneLibrary(fileanalysis.LibEntry{
+	entry, hasNetwork, _, warnings, err := v.analyzeOneLibrary(fileanalysis.LibEntry{
 		SOName: "libfoo.so.1",
 		Path:   elfTestDataPath(t, "with_socket.elf"),
 	})

--- a/internal/filevalidator/validator_library_analysis_test.go
+++ b/internal/filevalidator/validator_library_analysis_test.go
@@ -1,0 +1,182 @@
+//go:build test
+
+package filevalidator
+
+import (
+	"debug/elf"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/isseis/go-safe-cmd-runner/internal/common"
+	"github.com/isseis/go-safe-cmd-runner/internal/fileanalysis"
+	"github.com/isseis/go-safe-cmd-runner/internal/security/binaryanalyzer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type libraryTestBinaryAnalyzer struct {
+	output binaryanalyzer.AnalysisOutput
+}
+
+func (s *libraryTestBinaryAnalyzer) AnalyzeNetworkSymbols(_, _ string) binaryanalyzer.AnalysisOutput {
+	return s.output
+}
+
+type libraryTestSyscallTable struct {
+	network map[int]bool
+}
+
+func (t *libraryTestSyscallTable) GetSyscallName(_ int) string {
+	return ""
+}
+
+func (t *libraryTestSyscallTable) IsNetworkSyscall(number int) bool {
+	if t == nil {
+		return false
+	}
+	return t.network[number]
+}
+
+type libraryTestSyscallAnalyzer struct {
+	syscalls []common.SyscallInfo
+	err      error
+	table    SyscallNumberTable
+}
+
+func (s *libraryTestSyscallAnalyzer) AnalyzeSyscallsFromELF(_ *elf.File) ([]common.SyscallInfo, []common.SyscallArgEvalResult, *common.SyscallDeterminationStats, error) {
+	return s.syscalls, nil, nil, s.err
+}
+
+func (s *libraryTestSyscallAnalyzer) EvaluatePLTCallArgs(_ *elf.File, _ string) (*common.SyscallArgEvalResult, error) {
+	return nil, nil
+}
+
+func (s *libraryTestSyscallAnalyzer) GetSyscallTable(_ elf.Machine) (SyscallNumberTable, bool) {
+	if s.table == nil {
+		return nil, false
+	}
+	return s.table, true
+}
+
+func validatorWithTempHashDir(t *testing.T) *Validator {
+	t.Helper()
+	tempDir := safeTempDir(t)
+	hashDir := filepath.Join(tempDir, "hashes")
+	require.NoError(t, os.MkdirAll(hashDir, 0o700))
+
+	v, err := New(&SHA256{}, hashDir)
+	require.NoError(t, err)
+	return v
+}
+
+func elfTestDataPath(t *testing.T, name string) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+	return filepath.Join(filepath.Dir(thisFile), "..", "security", "elfanalyzer", "testdata", name)
+}
+
+func TestAnalyzeOneLibrary_networkSymbolDetected(t *testing.T) {
+	v := validatorWithTempHashDir(t)
+	v.SetBinaryAnalyzer(&libraryTestBinaryAnalyzer{
+		output: binaryanalyzer.AnalysisOutput{
+			Result: binaryanalyzer.NetworkDetected,
+			DetectedSymbols: []binaryanalyzer.DetectedSymbol{
+				{Name: "socket", Category: "socket"},
+			},
+		},
+	})
+
+	entry, hasNetwork, warnings, err := v.analyzeOneLibrary(fileanalysis.LibEntry{
+		SOName: "libfoo.so.1",
+		Path:   elfTestDataPath(t, "with_socket.elf"),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, entry)
+	assert.True(t, hasNetwork)
+	require.NotNil(t, entry.SymbolAnalysis)
+	assert.Contains(t, entry.SymbolAnalysis.DetectedSymbols, "socket")
+	assert.Empty(t, warnings)
+}
+
+func TestAnalyzeOneLibrary_networkSyscallDetected(t *testing.T) {
+	v := validatorWithTempHashDir(t)
+	v.SetBinaryAnalyzer(&libraryTestBinaryAnalyzer{output: binaryanalyzer.AnalysisOutput{Result: binaryanalyzer.NoNetworkSymbols}})
+	v.SetSyscallAnalyzer(&libraryTestSyscallAnalyzer{
+		syscalls: []common.SyscallInfo{{Number: 41, Name: "socket"}},
+		table: &libraryTestSyscallTable{network: map[int]bool{41: true}},
+	})
+
+	entry, hasNetwork, warnings, err := v.analyzeOneLibrary(fileanalysis.LibEntry{
+		SOName: "libbar.so.1",
+		Path:   elfTestDataPath(t, "with_socket.elf"),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, entry)
+	assert.True(t, hasNetwork)
+	require.NotNil(t, entry.SyscallAnalysis)
+	assert.NotEmpty(t, entry.SyscallAnalysis.DetectedSyscalls)
+	assert.Empty(t, warnings)
+}
+
+func TestAnalyzeOneLibrary_nonNetwork(t *testing.T) {
+	v := validatorWithTempHashDir(t)
+	v.SetBinaryAnalyzer(&libraryTestBinaryAnalyzer{output: binaryanalyzer.AnalysisOutput{Result: binaryanalyzer.NoNetworkSymbols}})
+	v.SetSyscallAnalyzer(&libraryTestSyscallAnalyzer{syscalls: []common.SyscallInfo{{Number: 1, Name: "write"}}})
+
+	entry, hasNetwork, warnings, err := v.analyzeOneLibrary(fileanalysis.LibEntry{
+		SOName: "libbaz.so.1",
+		Path:   elfTestDataPath(t, "with_socket.elf"),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, entry)
+	assert.False(t, hasNetwork)
+	assert.Empty(t, warnings)
+}
+
+func TestAnalyzeOneLibrary_missingFileAddsWarning(t *testing.T) {
+	v := validatorWithTempHashDir(t)
+	v.SetSyscallAnalyzer(&libraryTestSyscallAnalyzer{})
+
+	entry, hasNetwork, warnings, err := v.analyzeOneLibrary(fileanalysis.LibEntry{
+		SOName: "libmissing.so.1",
+		Path:   filepath.Join(safeTempDir(t), "missing.so"),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, entry)
+	assert.False(t, hasNetwork)
+	require.NotEmpty(t, warnings)
+	assert.Contains(t, warnings[0], "failed to open library ELF")
+}
+
+func TestAnalyzeOneLibrary_nonELFLibrarySkipsSyscallScan(t *testing.T) {
+	v := validatorWithTempHashDir(t)
+	v.SetSyscallAnalyzer(&libraryTestSyscallAnalyzer{syscalls: []common.SyscallInfo{{Number: 41, Name: "socket"}}})
+
+	entry, hasNetwork, warnings, err := v.analyzeOneLibrary(fileanalysis.LibEntry{
+		SOName: "libscript.so.1",
+		Path:   elfTestDataPath(t, "script.sh"),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, entry)
+	assert.False(t, hasNetwork)
+	assert.Nil(t, entry.SyscallAnalysis)
+	assert.Empty(t, warnings)
+}
+
+func TestAnalyzeOneLibrary_unsupportedArchSkipsWarning(t *testing.T) {
+	v := validatorWithTempHashDir(t)
+	v.SetSyscallAnalyzer(&libraryTestSyscallAnalyzer{err: ErrUnsupportedArch})
+
+	entry, hasNetwork, warnings, err := v.analyzeOneLibrary(fileanalysis.LibEntry{
+		SOName: "libfoo.so.1",
+		Path:   elfTestDataPath(t, "with_socket.elf"),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, entry)
+	assert.False(t, hasNetwork)
+	assert.Nil(t, entry.SyscallAnalysis)
+	assert.Empty(t, warnings)
+}

--- a/internal/runner/base/security/network_analyzer.go
+++ b/internal/runner/base/security/network_analyzer.go
@@ -227,42 +227,46 @@ func (a *NetworkAnalyzer) isNetworkViaBinaryAnalysis(cmdPath string, contentHash
 		if data == nil {
 			return false, false
 		}
-		output := binaryanalyzer.AnalysisOutput{
-			DetectedSymbols:    convertNetworkSymbolEntries(data.DetectedSymbols),
-			DynamicLoadSymbols: convertNetworkSymbolEntries(data.DynamicLoadSymbols),
-		}
-
-		// Check if any detected symbol has a network category (socket, dns, tls, http).
-		// non-network symbols don't trigger NetworkDetected.
-		hasNetworkSymbol := false
-		for _, sym := range data.DetectedSymbols {
-			if binaryanalyzer.IsNetworkSymbolName(sym) {
-				hasNetworkSymbol = true
-				break
-			}
-		}
-
-		if hasNetworkSymbol || len(data.KnownNetworkLibDeps) > 0 {
-			output.Result = binaryanalyzer.NetworkDetected
-			// When network capability is inferred only from KnownNetworkLibDeps,
-			// DetectedSymbols remains empty. Log this explicitly so that logs
-			// clearly explain why the binary is treated as network-capable even
-			// if handleAnalysisOutput logs an empty symbol list.
-			if !hasNetworkSymbol && len(data.KnownNetworkLibDeps) > 0 {
-				slog.Info( //nolint:gosec // G706: cmdPath is a configured command path from TOML, not arbitrary user input
-					"treating binary as network-capable based on known network library dependencies",
-					"path", cmdPath,
-					"known_network_lib_deps", data.KnownNetworkLibDeps,
-				)
-			}
-		} else {
-			output.Result = binaryanalyzer.NoNetworkSymbols
-		}
+		output := buildAnalysisOutputFromSymbolData(data, cmdPath)
 		return handleAnalysisOutput(output, cmdPath)
 	}
 
 	// No store configured or contentHash empty: skip analysis.
 	return false, false
+}
+
+func buildAnalysisOutputFromSymbolData(data *fileanalysis.SymbolAnalysisData, cmdPath string) binaryanalyzer.AnalysisOutput {
+	output := binaryanalyzer.AnalysisOutput{
+		DetectedSymbols:    convertNetworkSymbolEntries(data.DetectedSymbols),
+		DynamicLoadSymbols: convertNetworkSymbolEntries(data.DynamicLoadSymbols),
+	}
+
+	// Check if any detected symbol has a network category (socket, dns, tls, http).
+	// non-network symbols do not trigger NetworkDetected.
+	hasNetworkSymbol := slices.ContainsFunc(data.DetectedSymbols, binaryanalyzer.IsNetworkSymbolName)
+
+	switch {
+	case hasNetworkSymbol:
+		output.Result = binaryanalyzer.NetworkDetected
+	case len(data.KnownNetworkLibDeps) > 0:
+		output.Result = binaryanalyzer.NetworkDetected
+		slog.Info( //nolint:gosec // G706: cmdPath is a configured command path from TOML, not arbitrary user input
+			"treating binary as network-capable based on known network library dependencies",
+			"path", cmdPath,
+			"known_network_lib_deps", data.KnownNetworkLibDeps,
+		)
+	case len(data.DetectedLibraryNetworkDeps) > 0:
+		output.Result = binaryanalyzer.NetworkDetected
+		slog.Info( //nolint:gosec // G706: cmdPath is a configured command path from TOML, not arbitrary user input
+			"treating binary as network-capable based on library syscall/symbol analysis",
+			"path", cmdPath,
+			"detected_library_network_deps", data.DetectedLibraryNetworkDeps,
+		)
+	default:
+		output.Result = binaryanalyzer.NoNetworkSymbols
+	}
+
+	return output
 }
 
 // syscallAnalysisHasSVCSignal reports whether the given SyscallAnalysisResult

--- a/internal/runner/base/security/network_analyzer_test.go
+++ b/internal/runner/base/security/network_analyzer_test.go
@@ -189,8 +189,16 @@ func noSVCResult() *fileanalysis.SyscallAnalysisResult {
 // noNetworkSymbolData builds a SymbolAnalysisData with no network symbols.
 func noNetworkSymbolData() *fileanalysis.SymbolAnalysisData {
 	return &fileanalysis.SymbolAnalysisData{
-		DetectedSymbols:     nil,
-		KnownNetworkLibDeps: nil,
+		DetectedSymbols:            nil,
+		KnownNetworkLibDeps:        nil,
+		DetectedLibraryNetworkDeps: nil,
+	}
+}
+
+// detectedLibraryNetworkDepsData builds a SymbolAnalysisData with detected library network dependencies.
+func detectedLibraryNetworkDepsData() *fileanalysis.SymbolAnalysisData {
+	return &fileanalysis.SymbolAnalysisData{
+		DetectedLibraryNetworkDeps: []string{"libnetdep.so.1"},
 	}
 }
 
@@ -386,6 +394,18 @@ func TestIsNetworkViaBinaryAnalysis_NetworkDetected_SVCNoSyscallAnalysis(t *test
 
 	assert.True(t, isNet, "NetworkDetected should return true")
 	assert.False(t, isHigh, "nil SyscallAnalysis should not escalate isHighRisk")
+}
+
+// TestIsNetworkViaBinaryAnalysis_DetectedLibraryNetworkDeps verifies that detected library network dependencies are handled correctly.
+func TestIsNetworkViaBinaryAnalysis_DetectedLibraryNetworkDeps(t *testing.T) {
+	symStore := &stubNetworkSymbolStore{data: detectedLibraryNetworkDepsData()}
+	svcStore := &mockFileanalysisSyscallStore{result: nil}
+	analyzer := NewNetworkAnalyzerWithStores(runtime.GOOS, symStore, svcStore)
+
+	isNet, isHigh := analyzer.isNetworkViaBinaryAnalysis(testCmdPath, testContentHash)
+
+	assert.True(t, isNet, "detected_library_network_deps should mark as network-capable")
+	assert.False(t, isHigh, "detected_library_network_deps alone should not mark high risk")
 }
 
 // TestIsNetworkViaBinaryAnalysis_NetworkDetected_NoSVC verifies that NetworkDetected

--- a/internal/security/binaryanalyzer/syscall_wrapper_libs.go
+++ b/internal/security/binaryanalyzer/syscall_wrapper_libs.go
@@ -1,0 +1,26 @@
+package binaryanalyzer
+
+// syscallWrapperPrefixes lists SOName prefixes for OS-ABI syscall wrapper
+// libraries that should be excluded from library-level network analysis.
+var syscallWrapperPrefixes = []string{
+	"libc",
+	"libpthread",
+	"libdl",
+	"librt",
+	"libgcc_s",
+	"ld-linux",
+	"ld-linux-x86-64",
+	"ld-linux-aarch64",
+	"linux-vdso",
+}
+
+// IsSyscallWrapperLibrary reports whether soname is a known syscall wrapper
+// library that should be excluded from library-level analysis.
+func IsSyscallWrapperLibrary(soname string) bool {
+	for _, prefix := range syscallWrapperPrefixes {
+		if matchesKnownPrefix(soname, prefix) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/security/binaryanalyzer/syscall_wrapper_libs_test.go
+++ b/internal/security/binaryanalyzer/syscall_wrapper_libs_test.go
@@ -1,0 +1,51 @@
+//go:build test
+
+package binaryanalyzer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsSyscallWrapperLibrary_match(t *testing.T) {
+	tests := []string{
+		"libc.so.6",
+		"libpthread.so.0",
+		"ld-linux-x86-64.so.2",
+		"linux-vdso.so.1",
+	}
+
+	for _, soname := range tests {
+		t.Run(soname, func(t *testing.T) {
+			assert.True(t, IsSyscallWrapperLibrary(soname))
+		})
+	}
+}
+
+func TestIsSyscallWrapperLibrary_noMatch(t *testing.T) {
+	tests := []string{
+		"libssl.so.3",
+		"libcurl.so.4",
+		"libstdc++.so.6",
+	}
+
+	for _, soname := range tests {
+		t.Run(soname, func(t *testing.T) {
+			assert.False(t, IsSyscallWrapperLibrary(soname))
+		})
+	}
+}
+
+func TestIsSyscallWrapperLibrary_prefixBoundary(t *testing.T) {
+	tests := []string{
+		"libcc.so.1",
+		"libcpp.so.1",
+	}
+
+	for _, soname := range tests {
+		t.Run(soname, func(t *testing.T) {
+			assert.False(t, IsSyscallWrapperLibrary(soname))
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- implement schema v20 additions for library-level analysis storage
- add syscall wrapper library classifier and unit tests
- implement validator library analysis flow (analyzeOneLibrary and analyzeLibraries) with cache, wrapper/VDSO exclusion, warnings, and network dependency aggregation
- integrate library analysis into record update flow and enable it from record command
- extend runner network judgment to consider DetectedLibraryNetworkDeps
- update implementation plan progress and complete final review fix for cache-hit SOName preservation

## Validation
- make fmt
- go test -tags test -v ./...
- make lint

## Notes
- performed review against parent branch intent and fixed one issue: cache-hit entries now preserve each dependency SOName.
