### PR TITLE
refactor: normalize dynlib dynamic-load symbols

### DIFF
--- a/internal/dynamicanalysis/schema.go
+++ b/internal/dynamicanalysis/schema.go
@@ -8,25 +8,24 @@ const (
 	//
 	// Version history:
 	//   1 - initial schema
-	SchemaVersion = 1
+	//   2 - remove top-level dynamic_load_symbols; use symbol_analysis.dynamic_load_symbols only
+	SchemaVersion = 2
 )
 
 // File is the JSON schema for a dynamic library analysis store file.
 // Each file stores analysis results for a single library identified by lib_path and lib_hash.
 type File struct {
-	SchemaVersion      int                               `json:"schema_version"`
-	LibPath            string                            `json:"lib_path"`
-	LibHash            string                            `json:"lib_hash"`
-	SyscallAnalysis    *fileanalysis.SyscallAnalysisData `json:"syscall_analysis,omitempty"`
-	SymbolAnalysis     *fileanalysis.SymbolAnalysisData  `json:"symbol_analysis,omitempty"`
-	DynamicLoadSymbols []string                          `json:"dynamic_load_symbols,omitempty"`
+	SchemaVersion   int                               `json:"schema_version"`
+	LibPath         string                            `json:"lib_path"`
+	LibHash         string                            `json:"lib_hash"`
+	SyscallAnalysis *fileanalysis.SyscallAnalysisData `json:"syscall_analysis,omitempty"`
+	SymbolAnalysis  *fileanalysis.SymbolAnalysisData  `json:"symbol_analysis,omitempty"`
 }
 
 // Result holds the in-memory result of a dynamic library analysis.
 // Warnings contain non-fatal messages generated during analysis and are not persisted to disk.
 type Result struct {
-	SyscallAnalysis    *fileanalysis.SyscallAnalysisData
-	SymbolAnalysis     *fileanalysis.SymbolAnalysisData
-	DynamicLoadSymbols []string
-	Warnings           []string
+	SyscallAnalysis *fileanalysis.SyscallAnalysisData
+	SymbolAnalysis  *fileanalysis.SymbolAnalysisData
+	Warnings        []string
 }

--- a/internal/dynamicanalysis/schema.go
+++ b/internal/dynamicanalysis/schema.go
@@ -29,3 +29,11 @@ type Result struct {
 	SymbolAnalysis  *fileanalysis.SymbolAnalysisData
 	Warnings        []string
 }
+
+// DynamicLoadSymbols returns the list of dynamic load symbols from the symbol analysis.
+func (r *Result) DynamicLoadSymbols() []string {
+	if r == nil || r.SymbolAnalysis == nil {
+		return nil
+	}
+	return r.SymbolAnalysis.DynamicLoadSymbols
+}

--- a/internal/dynamicanalysis/store.go
+++ b/internal/dynamicanalysis/store.go
@@ -93,9 +93,8 @@ func (s *store) load(libPath, libHash string) (*Result, error) {
 	}
 
 	return &Result{
-		SyscallAnalysis:    f.SyscallAnalysis,
-		SymbolAnalysis:     f.SymbolAnalysis,
-		DynamicLoadSymbols: f.DynamicLoadSymbols,
+		SyscallAnalysis: f.SyscallAnalysis,
+		SymbolAnalysis:  f.SymbolAnalysis,
 	}, nil
 }
 
@@ -107,12 +106,11 @@ func (s *store) saveResult(libPath, libHash string, result *Result) error {
 	}
 
 	f := File{
-		SchemaVersion:      SchemaVersion,
-		LibPath:            libPath,
-		LibHash:            libHash,
-		SyscallAnalysis:    result.SyscallAnalysis,
-		SymbolAnalysis:     result.SymbolAnalysis,
-		DynamicLoadSymbols: result.DynamicLoadSymbols,
+		SchemaVersion:   SchemaVersion,
+		LibPath:         libPath,
+		LibHash:         libHash,
+		SyscallAnalysis: result.SyscallAnalysis,
+		SymbolAnalysis:  result.SymbolAnalysis,
 	}
 
 	data, err := json.MarshalIndent(f, "", "  ")

--- a/internal/filevalidator/validator.go
+++ b/internal/filevalidator/validator.go
@@ -585,12 +585,7 @@ func (v *Validator) analyzeOneLibrary(lib fileanalysis.LibEntry) (*dynamicanalys
 		output := v.binaryAnalyzer.AnalyzeNetworkSymbols(lib.Path, "")
 		dynamicLoadSymbols := convertDetectedSymbols(output.DynamicLoadSymbols)
 		switch output.Result {
-		case binaryanalyzer.NetworkDetected:
-			result.SymbolAnalysis = &fileanalysis.SymbolAnalysisData{
-				DetectedSymbols:    convertDetectedSymbols(output.DetectedSymbols),
-				DynamicLoadSymbols: dynamicLoadSymbols,
-			}
-		case binaryanalyzer.NoNetworkSymbols:
+		case binaryanalyzer.NetworkDetected, binaryanalyzer.NoNetworkSymbols:
 			result.SymbolAnalysis = &fileanalysis.SymbolAnalysisData{
 				DetectedSymbols:    convertDetectedSymbols(output.DetectedSymbols),
 				DynamicLoadSymbols: dynamicLoadSymbols,
@@ -657,7 +652,7 @@ func (v *Validator) analyzeLibraries(record *fileanalysis.Record) error {
 		cacheKey := libCacheKey{Path: lib.Path, Hash: lib.Hash}
 		result, cached := v.processedLibAnalysis[cacheKey]
 		if cached {
-			allDynLoadSymbols = append(allDynLoadSymbols, dynamicLoadSymbolsFromResult(result)...)
+			allDynLoadSymbols = append(allDynLoadSymbols, result.DynamicLoadSymbols()...)
 			record.AnalysisWarnings = append(record.AnalysisWarnings, result.Warnings...)
 			continue
 		}
@@ -669,7 +664,7 @@ func (v *Validator) analyzeLibraries(record *fileanalysis.Record) error {
 		}
 		v.processedLibAnalysis[cacheKey] = result
 		record.AnalysisWarnings = append(record.AnalysisWarnings, result.Warnings...)
-		allDynLoadSymbols = append(allDynLoadSymbols, dynamicLoadSymbolsFromResult(result)...)
+		allDynLoadSymbols = append(allDynLoadSymbols, result.DynamicLoadSymbols()...)
 	}
 
 	if len(allDynLoadSymbols) > 0 {
@@ -691,13 +686,6 @@ func (v *Validator) analyzeLibraries(record *fileanalysis.Record) error {
 	}
 
 	return nil
-}
-
-func dynamicLoadSymbolsFromResult(result *dynamicanalysis.Result) []string {
-	if result == nil || result.SymbolAnalysis == nil {
-		return nil
-	}
-	return result.SymbolAnalysis.DynamicLoadSymbols
 }
 
 // SetIncludeDebugInfo controls whether debug information (Occurrences,

--- a/internal/filevalidator/validator.go
+++ b/internal/filevalidator/validator.go
@@ -583,22 +583,24 @@ func (v *Validator) analyzeOneLibrary(lib fileanalysis.LibEntry) (*dynamicanalys
 
 	if v.binaryAnalyzer != nil {
 		output := v.binaryAnalyzer.AnalyzeNetworkSymbols(lib.Path, "")
+		dynamicLoadSymbols := convertDetectedSymbols(output.DynamicLoadSymbols)
 		switch output.Result {
 		case binaryanalyzer.NetworkDetected:
 			result.SymbolAnalysis = &fileanalysis.SymbolAnalysisData{
 				DetectedSymbols:    convertDetectedSymbols(output.DetectedSymbols),
-				DynamicLoadSymbols: convertDetectedSymbols(output.DynamicLoadSymbols),
+				DynamicLoadSymbols: dynamicLoadSymbols,
 			}
 		case binaryanalyzer.NoNetworkSymbols:
 			result.SymbolAnalysis = &fileanalysis.SymbolAnalysisData{
 				DetectedSymbols:    convertDetectedSymbols(output.DetectedSymbols),
-				DynamicLoadSymbols: convertDetectedSymbols(output.DynamicLoadSymbols),
+				DynamicLoadSymbols: dynamicLoadSymbols,
 			}
+		case binaryanalyzer.StaticBinary, binaryanalyzer.NotSupportedBinary:
+			// Library-level symbol analysis is not applicable.
 		case binaryanalyzer.AnalysisError:
 			result.Warnings = append(result.Warnings,
 				fmt.Sprintf("library symbol analysis failed for %s: %v", lib.SOName, output.Error))
 		}
-		result.DynamicLoadSymbols = convertDetectedSymbols(output.DynamicLoadSymbols)
 	}
 
 	if v.syscallAnalyzer == nil {
@@ -655,7 +657,7 @@ func (v *Validator) analyzeLibraries(record *fileanalysis.Record) error {
 		cacheKey := libCacheKey{Path: lib.Path, Hash: lib.Hash}
 		result, cached := v.processedLibAnalysis[cacheKey]
 		if cached {
-			allDynLoadSymbols = append(allDynLoadSymbols, result.DynamicLoadSymbols...)
+			allDynLoadSymbols = append(allDynLoadSymbols, dynamicLoadSymbolsFromResult(result)...)
 			record.AnalysisWarnings = append(record.AnalysisWarnings, result.Warnings...)
 			continue
 		}
@@ -667,7 +669,7 @@ func (v *Validator) analyzeLibraries(record *fileanalysis.Record) error {
 		}
 		v.processedLibAnalysis[cacheKey] = result
 		record.AnalysisWarnings = append(record.AnalysisWarnings, result.Warnings...)
-		allDynLoadSymbols = append(allDynLoadSymbols, result.DynamicLoadSymbols...)
+		allDynLoadSymbols = append(allDynLoadSymbols, dynamicLoadSymbolsFromResult(result)...)
 	}
 
 	if len(allDynLoadSymbols) > 0 {
@@ -689,6 +691,13 @@ func (v *Validator) analyzeLibraries(record *fileanalysis.Record) error {
 	}
 
 	return nil
+}
+
+func dynamicLoadSymbolsFromResult(result *dynamicanalysis.Result) []string {
+	if result == nil || result.SymbolAnalysis == nil {
+		return nil
+	}
+	return result.SymbolAnalysis.DynamicLoadSymbols
 }
 
 // SetIncludeDebugInfo controls whether debug information (Occurrences,

--- a/internal/runner/base/security/network_analyzer.go
+++ b/internal/runner/base/security/network_analyzer.go
@@ -301,11 +301,13 @@ func (a *NetworkAnalyzer) checkDynLibDepsNetwork(cmdPath, contentHash string) (i
 			continue
 		}
 
+		dynLoadSymbols := dynLoadSymbolsFromResult(result)
+
 		// Check for dynamic load symbols (dlopen/dlsym → high risk).
-		if len(result.DynamicLoadSymbols) > 0 {
+		if len(dynLoadSymbols) > 0 {
 			slog.Info("dynlib analysis detected dynamic load symbols",
 				"cmd_path", cmdPath, "dep_path", dep.Path,
-				"symbols", result.DynamicLoadSymbols)
+				"symbols", dynLoadSymbols)
 			isHighRisk = true
 		}
 
@@ -330,6 +332,13 @@ func (a *NetworkAnalyzer) checkDynLibDepsNetwork(cmdPath, contentHash string) (i
 	}
 
 	return isNetwork, isHighRisk
+}
+
+func dynLoadSymbolsFromResult(result *dynamicanalysis.Result) []string {
+	if result == nil || result.SymbolAnalysis == nil {
+		return nil
+	}
+	return result.SymbolAnalysis.DynamicLoadSymbols
 }
 
 // firstNetworkSyscall returns the name of the first network syscall found in

--- a/internal/runner/base/security/network_analyzer.go
+++ b/internal/runner/base/security/network_analyzer.go
@@ -301,7 +301,7 @@ func (a *NetworkAnalyzer) checkDynLibDepsNetwork(cmdPath, contentHash string) (i
 			continue
 		}
 
-		dynLoadSymbols := dynLoadSymbolsFromResult(result)
+		dynLoadSymbols := result.DynamicLoadSymbols()
 
 		// Check for dynamic load symbols (dlopen/dlsym → high risk).
 		if len(dynLoadSymbols) > 0 {
@@ -332,13 +332,6 @@ func (a *NetworkAnalyzer) checkDynLibDepsNetwork(cmdPath, contentHash string) (i
 	}
 
 	return isNetwork, isHighRisk
-}
-
-func dynLoadSymbolsFromResult(result *dynamicanalysis.Result) []string {
-	if result == nil || result.SymbolAnalysis == nil {
-		return nil
-	}
-	return result.SymbolAnalysis.DynamicLoadSymbols
 }
 
 // firstNetworkSyscall returns the name of the first network syscall found in

--- a/internal/runner/base/security/network_analyzer_test.go
+++ b/internal/runner/base/security/network_analyzer_test.go
@@ -692,7 +692,9 @@ func TestCheckDynLibDepsNetwork_DynamicLoadSymbols(t *testing.T) {
 	libStore := &mockDynLibAnalysisStore{
 		results: map[string]*dynamicanalysis.Result{
 			"/usr/lib/libplugin.so": {
-				DynamicLoadSymbols: []string{"dlopen"},
+				SymbolAnalysis: &fileanalysis.SymbolAnalysisData{
+					DynamicLoadSymbols: []string{"dlopen"},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
## Summary
- remove top-level dynamic_load_symbols from dynlib-analysis store schema
- normalize to symbol_analysis.dynamic_load_symbols as the single source of truth
- bump dynamicanalysis schema version to 2 (backward-incompatible)
- update validator and runner risk checks to read dynamic-load symbols from SymbolAnalysis
- update network analyzer tests to the new structure

## Validation
- make fmt
- make test
- make lint