### PR TITLE
docs: add and refine task 0126 shebang script risk analysis design

### DIFF
--- a/docs/tasks/0126_shebang_script_risk_analysis/01_requirements.md
+++ b/docs/tasks/0126_shebang_script_risk_analysis/01_requirements.md
@@ -79,11 +79,16 @@ shebang スクリプトについては、`record` 実行時に `ShebangInterpret
 
 ### 4.2. セキュリティ（フェイルセーフ）
 
-- スクリプトのコンテンツハッシュ不一致: `ErrHashMismatch` として high risk 扱い
-- インタープリタのレコードが存在しない: スキップ（インタープリタのリスク判定をスキップ）
-  - verify 側の `VerifyCommandShebangInterpreter` がインタープリタ未記録を検出する
+- スクリプトのレコードが存在しない（`ErrRecordNotFound`）: **panic（プログラミングエラー）**
+  - `LoadInterpreterAnalysisPath` 到達時点では `LoadNetworkSymbolAnalysis` が成功済みであり、スクリプトレコードは必ず存在するはず。不在は呼び出し側のバグを示す
+  - `checkSyscallCache` が `ErrRecordNotFound` を panic にするのと同一方針
+- スクリプトのコンテンツハッシュ不一致: high risk 扱い（`ErrHashMismatch`）
+- `ShebangInterpreter` フィールドが nil: スキップ（非スクリプト）
+- インタープリタのレコードが存在しない（`ErrRecordNotFound`）: **high risk 扱い**
+  - `record` 実行時に必ずインタープリタレコードが保存されるため、不在は整合性異常を示す
+  - 既存の dynlib 解析（`ErrAnalysisNotFound` → high risk）と同一方針
 - インタープリタのレコードロードエラー: high risk 扱い（fail-closed）
-- インタープリタのコンテンツハッシュが空（未記録）: インタープリタのリスク判定をスキップ
+- インタープリタのコンテンツハッシュが空（整合性異常）: high risk 扱い
 
 ### 4.3. 互換性
 
@@ -106,10 +111,10 @@ shebang スクリプトについては、`record` 実行時に `ShebangInterpret
 | AC-02 | `#!/usr/bin/env python3` スクリプトを runner が処理 | python3 バイナリの解析結果が利用される |
 | AC-03 | インタープリタの共有ライブラリが mprotect(PROT_EXEC) リスクを持つ | `IsNetworkOperation()` の `isHighRisk` が `true` になる |
 | AC-04 | インタープリタの共有ライブラリが dynload シンボルを持つ | `isHighRisk` が `true` になる |
-| AC-05 | インタープリタレコードがストアに存在しない | リスク判定をスキップ（エラーなし） |
-| AC-06 | インタープリタレコードのロードが失敗する | high risk 扱い（fail-closed） |
-| AC-07 | 非スクリプトファイル（ELF バイナリ等）を runner が処理 | 既存の動作が変わらない |
-| AC-08 | インタープリタのコンテンツハッシュが取得できない | インタープリタのリスク判定をスキップ（エラーなし） |
+| AC-05 | スクリプトのレコードがストアに存在しない | panic（プログラミングエラー） |
+| AC-06 | インタープリタレコードがストアに存在しない | high risk 扱い（fail-closed） |
+| AC-07 | インタープリタレコードのロードが失敗する | high risk 扱い（fail-closed） |
+| AC-08 | 非スクリプトファイル（ELF バイナリ等）を runner が処理 | 既存の動作が変わらない |
 
 ---
 

--- a/docs/tasks/0126_shebang_script_risk_analysis/01_requirements.md
+++ b/docs/tasks/0126_shebang_script_risk_analysis/01_requirements.md
@@ -64,7 +64,7 @@ shebang スクリプトについては、`record` 実行時に `ShebangInterpret
 **詳細:**
 - `analyzeBinarySignals(interpPath, interpHash)` を再帰呼び出しし、以下すべてを評価:
   - インタープリタの `SymbolAnalysis`（ネットワークシンボル・dynload シンボル）
-  - インタープリタの `SyscallAnalysis`（mprotect(PROT_EXEC) 等）
+  - インタープリタの `SyscallAnalysis`（svc #0x80・ネットワーク syscall）
   - インタープリタの `DynLibDeps`（推移的ライブラリのリスク）
 - 結果は既存のリスクシグナルと OR 結合する
 
@@ -104,7 +104,7 @@ shebang スクリプトについては、`record` 実行時に `ShebangInterpret
 |----|------|---------|
 | AC-01 | `#!/bin/bash` スクリプトを runner が処理 | bash が network シンボル（`socket` 等）を持つ場合 `IsNetworkOperation()` が `true` を返す |
 | AC-02 | `#!/usr/bin/env python3` スクリプトを runner が処理 | python3 バイナリの解析結果が利用される |
-| AC-03 | インタープリタが mprotect(PROT_EXEC) を持つ | `IsNetworkOperation()` の `isHighRisk` が `true` になる |
+| AC-03 | インタープリタの共有ライブラリが mprotect(PROT_EXEC) リスクを持つ | `IsNetworkOperation()` の `isHighRisk` が `true` になる |
 | AC-04 | インタープリタの共有ライブラリが dynload シンボルを持つ | `isHighRisk` が `true` になる |
 | AC-05 | インタープリタレコードがストアに存在しない | リスク判定をスキップ（エラーなし） |
 | AC-06 | インタープリタレコードのロードが失敗する | high risk 扱い（fail-closed） |

--- a/docs/tasks/0126_shebang_script_risk_analysis/01_requirements.md
+++ b/docs/tasks/0126_shebang_script_risk_analysis/01_requirements.md
@@ -1,0 +1,127 @@
+# 要件定義書：shebang スクリプトのネットワークリスク解析
+
+## 1. 概要
+
+**目的:** `record` コマンドが shebang スクリプト（`#!/bin/bash`, `#!/usr/bin/env python3` 等）を解析する際、インタープリタバイナリの解析結果を用いてネットワーク系 API・動的ロード API・mprotect(PROT_EXEC) のリスク判定を行えるようにする。
+
+**背景:**
+最近の実装（task 0069〜0125）により、`record` はネイティブバイナリ（ELF/Mach-O）に対して以下を検出できるようになった。
+
+- バイナリが直接インポートするネットワーク系シンボル（`socket`, `getaddrinfo` 等）
+- 動的ロード API（`dlopen`, `dlsym`, `dlvsym`）
+- mprotect(PROT_EXEC)（`SyscallAnalysis` 経由）
+- 共有ライブラリ経由の推移的なネットワーク・動的ロード・mprotect リスク
+
+shebang スクリプトについては、`record` 実行時に `ShebangInterpreter` フィールド（インタープリタパス等）を記録しており、インタープリタバイナリ自体の record も自動保存される。しかしながら、runner 側のリスク判定（`NetworkAnalyzer.analyzeBinarySignals`）はスクリプト自身の JSON のみを参照するため、インタープリタの JSON に保存されたリスク情報が利用されていない。
+
+---
+
+## 2. 目的とスコープ
+
+### 2.1. 目的
+
+- runner がスクリプトを処理する際、スクリプト自身の JSON に加えてインタープリタバイナリの JSON も参照してリスク判定を行う
+- インタープリタバイナリの `record` 結果（`SymbolAnalysis`・`SyscallAnalysis`・`DynLibDeps`）を活用し、ネイティブバイナリと同等のリスク検出精度をスクリプトにも提供する
+
+### 2.2. スコープ（In Scope）
+
+- `runner/base/security/NetworkAnalyzer.analyzeBinarySignals()` の拡張
+  - shebang スクリプトのインタープリタパスとハッシュを取得するための新ストアインターフェース追加
+  - インタープリタの既存解析結果（`SymbolAnalysis`・`SyscallAnalysis`・`DynLibDeps`）を用いたリスク判定
+- `fileanalysis` パッケージへの新ストアインターフェース実装追加
+- `internal/runner/base/security` パッケージのテスト追加
+- 本機能に関するドキュメント作成
+
+### 2.3. スコープ外（Out of Scope）
+
+- `record` 側コードの変更（インタープリタバイナリは既に自動記録されている）
+- スクリプトのソースコード静的解析（`import socket` 等の内容解析）
+- Windows PE バイナリの解析
+- schema バージョンの更新（既存フィールドを活用）
+
+---
+
+## 3. 機能要件
+
+### F-001: shebang インタープリタ解析パスの取得
+
+**概要:** スクリプトの JSON レコードから、解析対象となるインタープリタバイナリのパスとコンテンツハッシュを取得する。
+
+**詳細:**
+- 新ストアインターフェース `ShebangInterpreterStore` を `fileanalysis` パッケージに追加
+- メソッド: `LoadInterpreterAnalysisPath(scriptPath, scriptContentHash string) (interpPath, interpContentHash string, err error)`
+- 処理内容:
+  1. スクリプトのレコードをロードし、コンテンツハッシュを検証
+  2. `ShebangInterpreter` フィールドからインタープリタパスを取得
+     - `ResolvedPath` が非空（env 形式）→ `ResolvedPath` を使用
+     - `ResolvedPath` が空（direct 形式）→ `InterpreterPath` を使用
+  3. インタープリタのレコードをロードし、`ContentHash` を返す
+
+### F-002: インタープリタの解析結果を用いたリスク判定
+
+**概要:** `NetworkAnalyzer.analyzeBinarySignals()` がインタープリタのシグナルも評価する。
+
+**詳細:**
+- `analyzeBinarySignals(interpPath, interpHash)` を再帰呼び出しし、以下すべてを評価:
+  - インタープリタの `SymbolAnalysis`（ネットワークシンボル・dynload シンボル）
+  - インタープリタの `SyscallAnalysis`（mprotect(PROT_EXEC) 等）
+  - インタープリタの `DynLibDeps`（推移的ライブラリのリスク）
+- 結果は既存のリスクシグナルと OR 結合する
+
+---
+
+## 4. 非機能要件
+
+### 4.1. 性能
+
+- インタープリタの解析は既存 JSON レコードを読み込むだけであり、再解析は行わない
+- `analyzeBinarySignals` の再帰呼び出しは最大 1 段（インタープリタは常にネイティブバイナリであり再帰は発生しない）
+
+### 4.2. セキュリティ（フェイルセーフ）
+
+- スクリプトのコンテンツハッシュ不一致: `ErrHashMismatch` として high risk 扱い
+- インタープリタのレコードが存在しない: スキップ（インタープリタのリスク判定をスキップ）
+  - verify 側の `VerifyCommandShebangInterpreter` がインタープリタ未記録を検出する
+- インタープリタのレコードロードエラー: high risk 扱い（fail-closed）
+- インタープリタのコンテンツハッシュが空（未記録）: インタープリタのリスク判定をスキップ
+
+### 4.3. 互換性
+
+- 既存スクリプトの JSON レコードは変更なし
+- `record` 側コードは無修正
+- schema バージョンの更新不要
+
+### 4.4. 保守性
+
+- 変更は `runner/base/security/network_analyzer.go` と新規ストア実装に集中
+- 新ストアインターフェースは明確な責務を持つ
+
+---
+
+## 5. 受け入れ基準（Acceptance Criteria）
+
+| ID | 条件 | 期待結果 |
+|----|------|---------|
+| AC-01 | `#!/bin/bash` スクリプトを runner が処理 | bash が network シンボル（`socket` 等）を持つ場合 `IsNetworkOperation()` が `true` を返す |
+| AC-02 | `#!/usr/bin/env python3` スクリプトを runner が処理 | python3 バイナリの解析結果が利用される |
+| AC-03 | インタープリタが mprotect(PROT_EXEC) を持つ | `IsNetworkOperation()` の `isHighRisk` が `true` になる |
+| AC-04 | インタープリタの共有ライブラリが dynload シンボルを持つ | `isHighRisk` が `true` になる |
+| AC-05 | インタープリタレコードがストアに存在しない | リスク判定をスキップ（エラーなし） |
+| AC-06 | インタープリタレコードのロードが失敗する | high risk 扱い（fail-closed） |
+| AC-07 | 非スクリプトファイル（ELF バイナリ等）を runner が処理 | 既存の動作が変わらない |
+| AC-08 | インタープリタのコンテンツハッシュが取得できない | インタープリタのリスク判定をスキップ（エラーなし） |
+
+---
+
+## 6. 用語集
+
+| 用語 | 説明 |
+|------|------|
+| shebang | スクリプトファイルの先頭行 `#!` から始まるインタープリタ指定 |
+| インタープリタバイナリ | shebang で指定されたバイナリ（`/bin/bash`, `/usr/bin/python3` 等）|
+| SymbolAnalysis | バイナリがインポートするネットワーク系・dynload シンボルの解析結果 |
+| SyscallAnalysis | バイナリのシステムコール解析結果（mprotect PROT_EXEC 含む）|
+| DynLibDeps | バイナリが依存する共有ライブラリのリスト |
+| ShebangInterpreterStore | スクリプトのレコードからインタープリタパス・ハッシュを取得するストアインターフェース |
+| env 形式 | `#!/usr/bin/env python3` のように `env` を経由してインタープリタを指定する shebang |
+| direct 形式 | `#!/bin/bash` のようにインタープリタパスを直接指定する shebang |

--- a/docs/tasks/0126_shebang_script_risk_analysis/01_requirements.md
+++ b/docs/tasks/0126_shebang_script_risk_analysis/01_requirements.md
@@ -82,13 +82,13 @@ shebang スクリプトについては、`record` 実行時に `ShebangInterpret
 - スクリプトのレコードが存在しない（`ErrRecordNotFound`）: **panic（プログラミングエラー）**
   - `LoadInterpreterAnalysisPath` 到達時点では `LoadNetworkSymbolAnalysis` が成功済みであり、スクリプトレコードは必ず存在するはず。不在は呼び出し側のバグを示す
   - `checkSyscallCache` が `ErrRecordNotFound` を panic にするのと同一方針
-- スクリプトのコンテンツハッシュ不一致: high risk 扱い（`ErrHashMismatch`）
+- スクリプトのコンテンツハッシュ不一致（`ErrHashMismatch`）: **実行中止 + エラー報告**
 - `ShebangInterpreter` フィールドが nil: スキップ（非スクリプト）
-- インタープリタのレコードが存在しない（`ErrRecordNotFound`）: **high risk 扱い**
-  - `record` 実行時に必ずインタープリタレコードが保存されるため、不在は整合性異常を示す
-  - 既存の dynlib 解析（`ErrAnalysisNotFound` → high risk）と同一方針
-- インタープリタのレコードロードエラー: high risk 扱い（fail-closed）
-- インタープリタのコンテンツハッシュが空（整合性異常）: high risk 扱い
+- インタープリタのレコードが存在しない（`ErrRecordNotFound`）: **実行中止 + エラー報告**
+  - `record` 実行時に必ずインタープリタレコードが保存されるため、不在は整合性異常（改ざんまたは破損）を示す
+  - `runner` は当該グループの実行を継続せず、利用者に明示的なエラーを返す
+- インタープリタのレコードロードエラー: **実行中止 + エラー報告**
+- インタープリタのコンテンツハッシュが空（整合性異常）: 実行中止 + エラー報告
 
 ### 4.3. 互換性
 
@@ -112,8 +112,8 @@ shebang スクリプトについては、`record` 実行時に `ShebangInterpret
 | AC-03 | インタープリタの共有ライブラリが mprotect(PROT_EXEC) リスクを持つ | `IsNetworkOperation()` の `isHighRisk` が `true` になる |
 | AC-04 | インタープリタの共有ライブラリが dynload シンボルを持つ | `isHighRisk` が `true` になる |
 | AC-05 | スクリプトのレコードがストアに存在しない | panic（プログラミングエラー） |
-| AC-06 | インタープリタレコードがストアに存在しない | high risk 扱い（fail-closed） |
-| AC-07 | インタープリタレコードのロードが失敗する | high risk 扱い（fail-closed） |
+| AC-06 | インタープリタレコードがストアに存在しない | 当該グループの実行を中止し、エラーを報告する |
+| AC-07 | スクリプトハッシュ不一致またはインタープリタレコードのロードが失敗する | 当該グループの実行を中止し、エラーを報告する |
 | AC-08 | 非スクリプトファイル（ELF バイナリ等）を runner が処理 | 既存の動作が変わらない |
 
 ---

--- a/docs/tasks/0126_shebang_script_risk_analysis/02_architecture.md
+++ b/docs/tasks/0126_shebang_script_risk_analysis/02_architecture.md
@@ -113,7 +113,7 @@ flowchart TD
 
     START["LoadInterpreterAnalysisPath(<br>  scriptPath, scriptContentHash<br>)"] --> LOAD_S["v.store.Load(scriptPath)"]
     LOAD_S --> NOT_FOUND{"ErrRecordNotFound?"}
-    NOT_FOUND -->|"Yes"| RET_NIL1["return ('', '', nil)"]
+    NOT_FOUND -->|"Yes"| RET_ERR0["ErrRecordNotFound を返す<br>（呼び出し元で panic）"]
     NOT_FOUND -->|"No"| ERR1{"他のエラー?"}
     ERR1 -->|"Yes"| RET_ERR1["error を返す"]
     ERR1 -->|"No"| HASH_CHK{"scriptRecord.ContentHash<br>== scriptContentHash?"}
@@ -123,13 +123,15 @@ flowchart TD
     SI -->|"No"| IPATH["interpPath 決定<br>(ResolvedPath 優先)"]
     IPATH --> LOAD_I["v.store.Load(interpPath)"]
     LOAD_I --> NOT_FOUND2{"ErrRecordNotFound?"}
-    NOT_FOUND2 -->|"Yes"| RET_NIL3["return (interpPath, '', nil)"]
+    NOT_FOUND2 -->|"Yes"| RET_ERR3["error を返す<br>（整合性異常 → high risk）"]
     NOT_FOUND2 -->|"No"| ERR2{"他のエラー?"}
     ERR2 -->|"Yes"| RET_ERR2["error を返す"]
-    ERR2 -->|"No"| RET_OK["return (interpPath,<br>  interpRecord.ContentHash,<br>  nil)"]
+    ERR2 -->|"No"| HASH_EMPTY{"interpRecord.ContentHash<br>空?"}
+    HASH_EMPTY -->|"Yes"| RET_ERR4["error を返す<br>（整合性異常 → high risk）"]
+    HASH_EMPTY -->|"No"| RET_OK["return (interpPath,<br>  interpRecord.ContentHash,<br>  nil)"]
 
-    class START,RET_NIL1,RET_NIL2,RET_NIL3,RET_OK data;
-    class LOAD_S,NOT_FOUND,ERR1,HASH_CHK,SI,IPATH,LOAD_I,NOT_FOUND2,ERR2 process;
+    class START,RET_NIL2,RET_OK data;
+    class LOAD_S,NOT_FOUND,ERR1,HASH_CHK,SI,IPATH,LOAD_I,NOT_FOUND2,ERR2,HASH_EMPTY process;
 ```
 
 ---

--- a/docs/tasks/0126_shebang_script_risk_analysis/02_architecture.md
+++ b/docs/tasks/0126_shebang_script_risk_analysis/02_architecture.md
@@ -98,8 +98,9 @@ type ShebangInterpreterStore interface {
     // LoadInterpreterAnalysisPath returns the effective interpreter binary path
     // and its content hash for the shebang script at scriptPath.
     // scriptContentHash is used to validate freshness of the script's record.
-    // Returns ("", "", nil) if the script has no ShebangInterpreter or the
-    // interpreter's record is not found.
+    // Returns ("", "", nil) only when the script has no ShebangInterpreter.
+    // Returns ErrInterpreterRecordMissing when the interpreter record is not
+    // found or its content hash is empty.
     LoadInterpreterAnalysisPath(scriptPath, scriptContentHash string) (interpPath, interpContentHash string, err error)
 }
 ```

--- a/docs/tasks/0126_shebang_script_risk_analysis/02_architecture.md
+++ b/docs/tasks/0126_shebang_script_risk_analysis/02_architecture.md
@@ -22,9 +22,9 @@ flowchart TD
 
     SCRIPT[("script.sh")] --> SHEBANG["resolveShebangInfo()"]
     SHEBANG --> SAVE_INTERP["saveInterpreterRecord(interpPath)"]
-    SAVE_INTERP --> IREC[("インタープリタ record\nSymbolAnalysis\nSyscallAnalysis\nDynLibDeps")]
+    SAVE_INTERP --> IREC[("インタープリタ record<br>SymbolAnalysis<br>SyscallAnalysis<br>DynLibDeps")]
     SCRIPT --> SAVE_SCRIPT["saveRecordCore(scriptPath)"]
-    SAVE_SCRIPT --> SREC[("script record\nShebangInterpreter\n  .InterpreterPath\n  .ResolvedPath\n  ...\nSymbolAnalysis = nil\nDynLibDeps = nil")]
+    SAVE_SCRIPT --> SREC[("script record<br>ShebangInterpreter<br>  .InterpreterPath<br>  .ResolvedPath<br>  ...<br>SymbolAnalysis = nil<br>DynLibDeps = nil")]
 
     class SCRIPT,IREC,SREC data;
     class SHEBANG,SAVE_INTERP,SAVE_SCRIPT process;
@@ -44,21 +44,21 @@ flowchart TD
     classDef process fill:#fff1e6,stroke:#ff7f0e,stroke-width:1px,color:#8a3e00;
     classDef enhanced fill:#e8f5e8,stroke:#2e8b57,stroke-width:2px,color:#006400;
 
-    CMD["IsNetworkOperation(\n  scriptPath, args, contentHash\n)"] --> PROF{"commandProfiles\n一致?"}
+    CMD["IsNetworkOperation(<br>  scriptPath, args, contentHash<br>)"] --> PROF{"commandProfiles<br>一致?"}
     PROF -->|"Yes"| RET1["結果返却"]
-    PROF -->|"No"| BINS["analyzeBinarySignals(\n  scriptPath, contentHash\n)"]
+    PROF -->|"No"| BINS["analyzeBinarySignals(<br>  scriptPath, contentHash<br>)"]
 
-    BINS --> SCRIPT_SYM["LoadNetworkSymbolAnalysis(scriptPath)\n→ nil (script 自身はシンボルなし)"]
-    BINS --> SCRIPT_SVC["checkSyscallCache(scriptPath)\n→ nil (script に svc なし)"]
-    BINS --> SCRIPT_DYNLIB["checkDynLibDepsNetwork(scriptPath)\n→ nil (script に DynLibDeps なし)"]
+    BINS --> SCRIPT_SYM["LoadNetworkSymbolAnalysis(scriptPath)<br>→ nil (script 自身はシンボルなし)"]
+    BINS --> SCRIPT_SVC["checkSyscallCache(scriptPath)<br>→ nil (script に svc なし)"]
+    BINS --> SCRIPT_DYNLIB["checkDynLibDepsNetwork(scriptPath)<br>→ nil (script に DynLibDeps なし)"]
 
-    BINS --> SHEBANG["新規: ShebangInterpreterStore\n.LoadInterpreterAnalysisPath(\n  scriptPath, contentHash\n)"]
-    SHEBANG --> IPATH[("interpPath\ninterpContentHash")]
-    IPATH --> RECURSE["analyzeBinarySignals(\n  interpPath, interpContentHash\n)"]
+    BINS --> SHEBANG["新規: ShebangInterpreterStore<br>.LoadInterpreterAnalysisPath(<br>  scriptPath, contentHash<br>)"]
+    SHEBANG --> IPATH[("interpPath<br>interpContentHash")]
+    IPATH --> RECURSE["analyzeBinarySignals(<br>  interpPath, interpContentHash<br>)"]
 
-    RECURSE --> INTERP_SYM["LoadNetworkSymbolAnalysis(interpPath)\n← インタープリタの SymbolAnalysis"]
-    RECURSE --> INTERP_SVC["checkSyscallCache(interpPath)\n← インタープリタの SyscallAnalysis\n（mprotect PROT_EXEC 含む）"]
-    RECURSE --> INTERP_DYNLIB["checkDynLibDepsNetwork(interpPath)\n← インタープリタの DynLibDeps\n（推移的ライブラリ解析）"]
+    RECURSE --> INTERP_SYM["LoadNetworkSymbolAnalysis(interpPath)<br>← インタープリタの SymbolAnalysis"]
+    RECURSE --> INTERP_SVC["checkSyscallCache(interpPath)<br>← インタープリタの SyscallAnalysis<br>（mprotect PROT_EXEC 含む）"]
+    RECURSE --> INTERP_DYNLIB["checkDynLibDepsNetwork(interpPath)<br>← インタープリタの DynLibDeps<br>（推移的ライブラリ解析）"]
 
     RECURSE --> OR["OR 結合"]
     BINS --> OR
@@ -111,22 +111,22 @@ flowchart TD
     classDef data fill:#e6f7ff,stroke:#1f77b4,stroke-width:1px,color:#0b3d91;
     classDef process fill:#fff1e6,stroke:#ff7f0e,stroke-width:1px,color:#8a3e00;
 
-    START["LoadInterpreterAnalysisPath(\n  scriptPath, scriptContentHash\n)"] --> LOAD_S["v.store.Load(scriptPath)"]
+    START["LoadInterpreterAnalysisPath(<br>  scriptPath, scriptContentHash<br>)"] --> LOAD_S["v.store.Load(scriptPath)"]
     LOAD_S --> NOT_FOUND{"ErrRecordNotFound?"}
     NOT_FOUND -->|"Yes"| RET_NIL1["return ('', '', nil)"]
     NOT_FOUND -->|"No"| ERR1{"他のエラー?"}
     ERR1 -->|"Yes"| RET_ERR1["error を返す"]
-    ERR1 -->|"No"| HASH_CHK{"scriptRecord.ContentHash\n== scriptContentHash?"}
+    ERR1 -->|"No"| HASH_CHK{"scriptRecord.ContentHash<br>== scriptContentHash?"}
     HASH_CHK -->|"No"| RET_MISMATCH["ErrHashMismatch を返す"]
-    HASH_CHK -->|"Yes"| SI{"ShebangInterpreter\nnil?"}
+    HASH_CHK -->|"Yes"| SI{"ShebangInterpreter<br>nil?"}
     SI -->|"Yes"| RET_NIL2["return ('', '', nil)"]
-    SI -->|"No"| IPATH["interpPath 決定\n(ResolvedPath 優先)"]
+    SI -->|"No"| IPATH["interpPath 決定<br>(ResolvedPath 優先)"]
     IPATH --> LOAD_I["v.store.Load(interpPath)"]
     LOAD_I --> NOT_FOUND2{"ErrRecordNotFound?"}
     NOT_FOUND2 -->|"Yes"| RET_NIL3["return (interpPath, '', nil)"]
     NOT_FOUND2 -->|"No"| ERR2{"他のエラー?"}
     ERR2 -->|"Yes"| RET_ERR2["error を返す"]
-    ERR2 -->|"No"| RET_OK["return (interpPath,\n  interpRecord.ContentHash,\n  nil)"]
+    ERR2 -->|"No"| RET_OK["return (interpPath,<br>  interpRecord.ContentHash,<br>  nil)"]
 
     class START,RET_NIL1,RET_NIL2,RET_NIL3,RET_OK data;
     class LOAD_S,NOT_FOUND,ERR1,HASH_CHK,SI,IPATH,LOAD_I,NOT_FOUND2,ERR2 process;

--- a/docs/tasks/0126_shebang_script_risk_analysis/02_architecture.md
+++ b/docs/tasks/0126_shebang_script_risk_analysis/02_architecture.md
@@ -4,7 +4,7 @@
 
 - runner がスクリプトを処理する際、インタープリタの JSON レコードも読み込み、そこに記録されたリスクシグナル（`SymbolAnalysis`・`SyscallAnalysis`・`DynLibDeps`）を活用する
 - `record` 側のコードを変更せず、インタープリタバイナリの既存レコードを再利用する
-- インタープリタの `SyscallAnalysis`（mprotect PROT_EXEC 含む）・共有ライブラリの推移的解析を自動的に活用する
+- インタープリタの `SyscallAnalysis`（svc #0x80・ネットワーク syscall）・共有ライブラリの推移的解析を自動的に活用する
 - `analyzeBinarySignals` の再帰呼び出しにより既存の解析ロジックを最大限再利用する
 
 ---
@@ -57,7 +57,7 @@ flowchart TD
     IPATH --> RECURSE["analyzeBinarySignals(<br>  interpPath, interpContentHash<br>)"]
 
     RECURSE --> INTERP_SYM["LoadNetworkSymbolAnalysis(interpPath)<br>← インタープリタの SymbolAnalysis"]
-    RECURSE --> INTERP_SVC["checkSyscallCache(interpPath)<br>← インタープリタの SyscallAnalysis<br>（mprotect PROT_EXEC 含む）"]
+    RECURSE --> INTERP_SVC["checkSyscallCache(interpPath)<br>← インタープリタの SyscallAnalysis<br>（svc #0x80 / network syscall）"]
     RECURSE --> INTERP_DYNLIB["checkDynLibDepsNetwork(interpPath)<br>← インタープリタの DynLibDeps<br>（推移的ライブラリ解析）"]
 
     RECURSE --> OR["OR 結合"]

--- a/docs/tasks/0126_shebang_script_risk_analysis/02_architecture.md
+++ b/docs/tasks/0126_shebang_script_risk_analysis/02_architecture.md
@@ -1,0 +1,194 @@
+# shebang スクリプトのネットワークリスク解析 アーキテクチャ設計書
+
+## 1. 設計目標
+
+- runner がスクリプトを処理する際、インタープリタの JSON レコードも読み込み、そこに記録されたリスクシグナル（`SymbolAnalysis`・`SyscallAnalysis`・`DynLibDeps`）を活用する
+- `record` 側のコードを変更せず、インタープリタバイナリの既存レコードを再利用する
+- インタープリタの `SyscallAnalysis`（mprotect PROT_EXEC 含む）・共有ライブラリの推移的解析を自動的に活用する
+- `analyzeBinarySignals` の再帰呼び出しにより既存の解析ロジックを最大限再利用する
+
+---
+
+## 2. 現状と課題
+
+### 2.1. record コマンドの動作（変更なし）
+
+`SaveRecord(scriptPath)` は shebang スクリプトを処理するとき、インタープリタバイナリの record も自動保存する。
+
+```mermaid
+flowchart TD
+    classDef data fill:#e6f7ff,stroke:#1f77b4,stroke-width:1px,color:#0b3d91;
+    classDef process fill:#fff1e6,stroke:#ff7f0e,stroke-width:1px,color:#8a3e00;
+
+    SCRIPT[("script.sh")] --> SHEBANG["resolveShebangInfo()"]
+    SHEBANG --> SAVE_INTERP["saveInterpreterRecord(interpPath)"]
+    SAVE_INTERP --> IREC[("インタープリタ record\nSymbolAnalysis\nSyscallAnalysis\nDynLibDeps")]
+    SCRIPT --> SAVE_SCRIPT["saveRecordCore(scriptPath)"]
+    SAVE_SCRIPT --> SREC[("script record\nShebangInterpreter\n  .InterpreterPath\n  .ResolvedPath\n  ...\nSymbolAnalysis = nil\nDynLibDeps = nil")]
+
+    class SCRIPT,IREC,SREC data;
+    class SHEBANG,SAVE_INTERP,SAVE_SCRIPT process;
+```
+
+インタープリタの record には完全な解析結果が保存されているが、script の record の `SymbolAnalysis` と `DynLibDeps` は `nil` のため runner のリスク判定が機能しない（課題）。
+
+---
+
+## 3. 変更後の runner リスク判定フロー
+
+### 3.1. 全体フロー
+
+```mermaid
+flowchart TD
+    classDef data fill:#e6f7ff,stroke:#1f77b4,stroke-width:1px,color:#0b3d91;
+    classDef process fill:#fff1e6,stroke:#ff7f0e,stroke-width:1px,color:#8a3e00;
+    classDef enhanced fill:#e8f5e8,stroke:#2e8b57,stroke-width:2px,color:#006400;
+
+    CMD["IsNetworkOperation(\n  scriptPath, args, contentHash\n)"] --> PROF{"commandProfiles\n一致?"}
+    PROF -->|"Yes"| RET1["結果返却"]
+    PROF -->|"No"| BINS["analyzeBinarySignals(\n  scriptPath, contentHash\n)"]
+
+    BINS --> SCRIPT_SYM["LoadNetworkSymbolAnalysis(scriptPath)\n→ nil (script 自身はシンボルなし)"]
+    BINS --> SCRIPT_SVC["checkSyscallCache(scriptPath)\n→ nil (script に svc なし)"]
+    BINS --> SCRIPT_DYNLIB["checkDynLibDepsNetwork(scriptPath)\n→ nil (script に DynLibDeps なし)"]
+
+    BINS --> SHEBANG["新規: ShebangInterpreterStore\n.LoadInterpreterAnalysisPath(\n  scriptPath, contentHash\n)"]
+    SHEBANG --> IPATH[("interpPath\ninterpContentHash")]
+    IPATH --> RECURSE["analyzeBinarySignals(\n  interpPath, interpContentHash\n)"]
+
+    RECURSE --> INTERP_SYM["LoadNetworkSymbolAnalysis(interpPath)\n← インタープリタの SymbolAnalysis"]
+    RECURSE --> INTERP_SVC["checkSyscallCache(interpPath)\n← インタープリタの SyscallAnalysis\n（mprotect PROT_EXEC 含む）"]
+    RECURSE --> INTERP_DYNLIB["checkDynLibDepsNetwork(interpPath)\n← インタープリタの DynLibDeps\n（推移的ライブラリ解析）"]
+
+    RECURSE --> OR["OR 結合"]
+    BINS --> OR
+    OR --> RET2["(isNetwork, isHighRisk)"]
+
+    class CMD,IPATH data;
+    class PROF,BINS,SCRIPT_SYM,SCRIPT_SVC,SCRIPT_DYNLIB,SHEBANG,INTERP_SYM,INTERP_SVC,INTERP_DYNLIB,OR process;
+    class RECURSE enhanced;
+```
+
+**凡例（Legend）**
+
+```mermaid
+flowchart LR
+    classDef data fill:#e6f7ff,stroke:#1f77b4,stroke-width:1px,color:#0b3d91;
+    classDef process fill:#fff1e6,stroke:#ff7f0e,stroke-width:1px,color:#8a3e00;
+    classDef enhanced fill:#e8f5e8,stroke:#2e8b57,stroke-width:2px,color:#006400;
+
+    D1[("データ")] --> P1["既存コンポーネント"] --> E1["新規 / 拡張コンポーネント"]
+    class D1 data;
+    class P1 process;
+    class E1 enhanced;
+```
+
+---
+
+## 4. `ShebangInterpreterStore` インターフェース
+
+### 4.1. インターフェース定義
+
+`fileanalysis` パッケージに新規追加:
+
+```go
+// ShebangInterpreterStore provides the interpreter binary path and content hash
+// for a shebang script, enabling the runner to follow the shebang chain.
+type ShebangInterpreterStore interface {
+    // LoadInterpreterAnalysisPath returns the effective interpreter binary path
+    // and its content hash for the shebang script at scriptPath.
+    // scriptContentHash is used to validate freshness of the script's record.
+    // Returns ("", "", nil) if the script has no ShebangInterpreter or the
+    // interpreter's record is not found.
+    LoadInterpreterAnalysisPath(scriptPath, scriptContentHash string) (interpPath, interpContentHash string, err error)
+}
+```
+
+### 4.2. 処理フロー
+
+```mermaid
+flowchart TD
+    classDef data fill:#e6f7ff,stroke:#1f77b4,stroke-width:1px,color:#0b3d91;
+    classDef process fill:#fff1e6,stroke:#ff7f0e,stroke-width:1px,color:#8a3e00;
+
+    START["LoadInterpreterAnalysisPath(\n  scriptPath, scriptContentHash\n)"] --> LOAD_S["v.store.Load(scriptPath)"]
+    LOAD_S --> NOT_FOUND{"ErrRecordNotFound?"}
+    NOT_FOUND -->|"Yes"| RET_NIL1["return ('', '', nil)"]
+    NOT_FOUND -->|"No"| ERR1{"他のエラー?"}
+    ERR1 -->|"Yes"| RET_ERR1["error を返す"]
+    ERR1 -->|"No"| HASH_CHK{"scriptRecord.ContentHash\n== scriptContentHash?"}
+    HASH_CHK -->|"No"| RET_MISMATCH["ErrHashMismatch を返す"]
+    HASH_CHK -->|"Yes"| SI{"ShebangInterpreter\nnil?"}
+    SI -->|"Yes"| RET_NIL2["return ('', '', nil)"]
+    SI -->|"No"| IPATH["interpPath 決定\n(ResolvedPath 優先)"]
+    IPATH --> LOAD_I["v.store.Load(interpPath)"]
+    LOAD_I --> NOT_FOUND2{"ErrRecordNotFound?"}
+    NOT_FOUND2 -->|"Yes"| RET_NIL3["return (interpPath, '', nil)"]
+    NOT_FOUND2 -->|"No"| ERR2{"他のエラー?"}
+    ERR2 -->|"Yes"| RET_ERR2["error を返す"]
+    ERR2 -->|"No"| RET_OK["return (interpPath,\n  interpRecord.ContentHash,\n  nil)"]
+
+    class START,RET_NIL1,RET_NIL2,RET_NIL3,RET_OK data;
+    class LOAD_S,NOT_FOUND,ERR1,HASH_CHK,SI,IPATH,LOAD_I,NOT_FOUND2,ERR2 process;
+```
+
+---
+
+## 5. インタープリタパス決定ロジック
+
+| shebang 形式 | 使用するパス | 根拠 |
+|-------------|-------------|------|
+| `#!/bin/bash` (direct 形式) | `ShebangInterpreter.InterpreterPath` | シンボルリンク解決済みのインタープリタバイナリパス |
+| `#!/usr/bin/env python3` (env 形式) | `ShebangInterpreter.ResolvedPath` | `env` ではなく実際に実行される `python3` のパス |
+
+---
+
+## 6. `analyzeBinarySignals` の拡張
+
+### 6.1. 拡張箇所
+
+既存の解析（`SymbolAnalysis`・`SyscallAnalysis`・`DynLibDeps`）の実行後、`shebangStore` が設定されている場合に shebang チェーン追跡を追加する。
+
+```
+analyzeBinarySignals(cmdPath, contentHash):
+  [既存] SymbolAnalysis キャッシュ参照
+  [既存] SyscallAnalysis キャッシュ参照（svc #0x80）
+  [既存] DynLibDeps 推移的解析
+  [新規] if shebangStore != nil && contentHash != "":
+           interpPath, interpHash = shebangStore.LoadInterpreterAnalysisPath(cmdPath, contentHash)
+           if interpPath != "" && interpHash != "":
+               interpNet, interpHigh = analyzeBinarySignals(interpPath, interpHash)
+               isNetwork |= interpNet
+               hasDynLoad |= interpHigh
+```
+
+### 6.2. 再帰呼び出しが安全な理由
+
+- インタープリタは常にネイティブバイナリ（ELF/Mach-O）であり、`record` でのシェバン再帰チェック（`ErrRecursiveShebang`）により保証される
+- インタープリタのレコードには `ShebangInterpreter = nil`（バイナリのため）が格納されるため、再帰呼び出し先では shebang チェーン追跡がスキップされる（最大 1 段の再帰）
+
+---
+
+## 7. `NetworkAnalyzer` への注入
+
+```go
+// NetworkAnalyzer にフィールドを追加
+type NetworkAnalyzer struct {
+    goos             string
+    store            fileanalysis.NetworkSymbolStore
+    syscallStore     fileanalysis.SyscallAnalysisStore
+    depsStore        fileanalysis.DynLibDepsStore
+    libAnalysisStore dynamicanalysis.Store
+    shebangStore     fileanalysis.ShebangInterpreterStore  // 新規（nil で無効化）
+}
+```
+
+`NewNetworkAnalyzer` の引数に `shebangStore fileanalysis.ShebangInterpreterStore` を追加し、DI で注入する。
+
+---
+
+## 8. record 側を変更しない理由
+
+- インタープリタバイナリの `record` 実行時に `SymbolAnalysis`・`SyscallAnalysis`・`DynLibDeps` はすでに保存される
+- runner 側でインタープリタの JSON を読み込むことで、あらゆるリスクシグナルを自動的に取得できる
+- record 側にデータを複製すると整合性の問題（インタープリタが更新された場合のキャッシュ陳腐化）が発生する可能性があるが、本設計では常に最新のインタープリタ記録を参照する

--- a/docs/tasks/0126_shebang_script_risk_analysis/02_architecture.md
+++ b/docs/tasks/0126_shebang_script_risk_analysis/02_architecture.md
@@ -117,17 +117,17 @@ flowchart TD
     NOT_FOUND -->|"No"| ERR1{"他のエラー?"}
     ERR1 -->|"Yes"| RET_ERR1["error を返す"]
     ERR1 -->|"No"| HASH_CHK{"scriptRecord.ContentHash<br>== scriptContentHash?"}
-    HASH_CHK -->|"No"| RET_MISMATCH["ErrHashMismatch を返す"]
+    HASH_CHK -->|"No"| RET_MISMATCH["ErrHashMismatch を返す<br>（整合性異常 → 実行中止）"]
     HASH_CHK -->|"Yes"| SI{"ShebangInterpreter<br>nil?"}
     SI -->|"Yes"| RET_NIL2["return ('', '', nil)"]
     SI -->|"No"| IPATH["interpPath 決定<br>(ResolvedPath 優先)"]
     IPATH --> LOAD_I["v.store.Load(interpPath)"]
     LOAD_I --> NOT_FOUND2{"ErrRecordNotFound?"}
-    NOT_FOUND2 -->|"Yes"| RET_ERR3["error を返す<br>（整合性異常 → high risk）"]
+    NOT_FOUND2 -->|"Yes"| RET_ERR3["error を返す<br>（整合性異常 → 実行中止）"]
     NOT_FOUND2 -->|"No"| ERR2{"他のエラー?"}
     ERR2 -->|"Yes"| RET_ERR2["error を返す"]
     ERR2 -->|"No"| HASH_EMPTY{"interpRecord.ContentHash<br>空?"}
-    HASH_EMPTY -->|"Yes"| RET_ERR4["error を返す<br>（整合性異常 → high risk）"]
+    HASH_EMPTY -->|"Yes"| RET_ERR4["error を返す<br>（整合性異常 → 実行中止）"]
     HASH_EMPTY -->|"No"| RET_OK["return (interpPath,<br>  interpRecord.ContentHash,<br>  nil)"]
 
     class START,RET_NIL2,RET_OK data;

--- a/docs/tasks/0126_shebang_script_risk_analysis/03_detailed_specification.md
+++ b/docs/tasks/0126_shebang_script_risk_analysis/03_detailed_specification.md
@@ -83,11 +83,11 @@ func NewShebangInterpreterStore(store Store) ShebangInterpreterStore {
 | 条件 | 返却値 | 呼び出し側の扱い |
 |------|--------|----------------|
 | スクリプトレコード不在 | `("", "", ErrRecordNotFound)` | panic（`analyzeBinarySignals` で検出）|
-| スクリプト `contentHash` 不一致 | `("", "", ErrHashMismatch)` | high risk |
+| スクリプト `contentHash` 不一致 | `("", "", ErrHashMismatch)` | エラー返却（当該グループ実行中止）|
 | `ShebangInterpreter == nil` | `("", "", nil)` | スキップ（非スクリプト）|
-| インタープリタレコード不在 | `("", "", error)` | high risk（整合性異常）|
-| インタープリタ `ContentHash` 空 | `("", "", error)` | high risk（整合性異常）|
-| その他のエラー | `("", "", err)` | high risk（fail-closed）|
+| インタープリタレコード不在 | `("", "", ErrInterpreterRecordMissing)` | エラー返却（当該グループ実行中止）|
+| インタープリタ `ContentHash` 空 | `("", "", ErrInterpreterRecordMissing)` | エラー返却（当該グループ実行中止）|
+| その他のエラー（インタープリタレコードロード失敗含む） | `("", "", err)` | エラー返却（当該グループ実行中止）|
 
 `ErrInterpreterRecordMissing` は `fileanalysis` パッケージに新規追加する sentinel error。
 
@@ -132,7 +132,10 @@ func NewNetworkAnalyzer(
 
 ### 3.3. `analyzeBinarySignals` の変更
 
-既存の解析（`SymbolAnalysis`・`SyscallAnalysis`・`DynLibDeps`）の実行後に shebang チェーン追跡を追加する。挿入位置は関数末尾の `return isNetwork, hasDynLoad` の直前。
+既存の解析（`SymbolAnalysis`・`SyscallAnalysis`・`DynLibDeps`）の実行後に shebang チェーン追跡を追加する。インタープリタレコード不在は high risk に丸めず、エラーとして呼び出し元へ返却する。
+
+このため、`analyzeBinarySignals` は `error` を返せる形に拡張し、`IsNetworkOperation` → `EvaluateRisk` → グループ実行層へ伝播させる。
+`ErrHashMismatch` とインタープリタレコードロードエラーは high risk へ丸めず、実行中止エラーとして扱う。
 
 ```go
 // Shebang chain: if this is a script, also analyze the interpreter binary.
@@ -152,12 +155,11 @@ if a.shebangStore != nil && contentHash != "" {
         // succeeded). A missing record now indicates a programming error.
         panic(fmt.Sprintf("shebang store: script record disappeared for %q: %v", cmdPath, err))
     case errors.Is(err, fileanalysis.ErrHashMismatch):
-        slog.Warn("shebang script hash mismatch; treating as high risk", "path", cmdPath)
-        return true, true
+        return false, false, fmt.Errorf("shebang script hash mismatch for %q: %w", cmdPath, err)
+    case errors.Is(err, fileanalysis.ErrInterpreterRecordMissing):
+        return false, false, fmt.Errorf("shebang interpreter record missing for %q: %w", cmdPath, err)
     default:
-        slog.Warn("shebang interpreter lookup failed; treating as high risk",
-            "path", cmdPath, "error", err)
-        return true, true
+        return false, false, fmt.Errorf("shebang interpreter lookup failed for %q: %w", cmdPath, err)
     }
 }
 ```
@@ -213,9 +215,9 @@ networkAnalyzer := security.NewNetworkAnalyzer(
 | TC-11 | インタープリタが `socket` シンボルを持つ | `isNetwork = true` |
 | TC-12 | インタープリタの共有ライブラリが mprotect リスクを持つ | `isHighRisk = true` |
 | TC-13 | インタープリタの共有ライブラリが `dlopen` を持つ | `isHighRisk = true` |
-| TC-14 | インタープリタレコード不在（`ErrInterpreterRecordMissing`）| `(true, true)`（high risk）|
-| TC-15 | `ErrHashMismatch` | `(true, true)` |
-| TC-16 | ロードエラー | `(true, true)` |
+| TC-14 | インタープリタレコード不在（`ErrInterpreterRecordMissing`）| エラーを返し、グループ実行を中止 |
+| TC-15 | `ErrHashMismatch` | エラーを返し、グループ実行を中止 |
+| TC-16 | ロードエラー | エラーを返し、グループ実行を中止 |
 | TC-17 | `shebangStore == nil` | 変更なし（既存動作）|
 | TC-18 | 非スクリプト（`ShebangInterpreter == nil`）| 変更なし（AC-07）|
 
@@ -227,9 +229,9 @@ networkAnalyzer := security.NewNetworkAnalyzer(
 | AC-02: env 形式 python3 | TC-02 |
 | AC-03: インタープリタ共有ライブラリの mprotect リスク | TC-12 |
 | AC-04: ライブラリの dynload シンボル | TC-13 |
-| AC-05: スクリプトレコード不在はスキップ | TC-03 |
-| AC-06: インタープリタレコード不在は high risk | TC-06, TC-14 |
-| AC-07: ロードエラーで high risk | TC-15, TC-16 |
+| AC-05: スクリプトレコード不在は panic | TC-03 |
+| AC-06: インタープリタレコード不在は実行中止エラー | TC-06, TC-14 |
+| AC-07: ハッシュ不一致またはロードエラーは実行中止エラー | TC-15, TC-16 |
 | AC-08: ELF バイナリの回帰 | TC-18 |
 
 ---

--- a/docs/tasks/0126_shebang_script_risk_analysis/03_detailed_specification.md
+++ b/docs/tasks/0126_shebang_script_risk_analysis/03_detailed_specification.md
@@ -64,7 +64,7 @@ func NewShebangInterpreterStore(store Store) ShebangInterpreterStore {
 
 1. `validatePath(scriptPath)` → `common.ResolvedPath`
 2. `store.Load(scriptTarget)` でスクリプトのレコードをロード
-   - `ErrRecordNotFound` → `return "", "", nil`
+   - `ErrRecordNotFound` → `return "", "", fileanalysis.ErrRecordNotFound`（呼び出し元で panic）
    - 他のエラー → `return "", "", err`
 3. `scriptRecord.ContentHash != scriptContentHash` → `return "", "", ErrHashMismatch`
 4. `scriptRecord.ShebangInterpreter == nil` → `return "", "", nil`
@@ -73,19 +73,23 @@ func NewShebangInterpreterStore(store Store) ShebangInterpreterStore {
    - それ以外 → `interpPath = si.InterpreterPath`
 6. `validatePath(interpPath)` → `common.ResolvedPath`
 7. `store.Load(interpTarget)` でインタープリタのレコードをロード
-   - `ErrRecordNotFound` → `return interpPath, "", nil`（ハッシュなし=スキップ可能）
+   - `ErrRecordNotFound` → `return "", "", fmt.Errorf("interpreter record not found: %w", ErrInterpreterRecordMissing)`
    - 他のエラー → `return "", "", err`
-8. `return interpPath, interpRecord.ContentHash, nil`
+8. `interpRecord.ContentHash == ""` → `return "", "", fmt.Errorf("interpreter record has empty content hash: %w", ErrInterpreterRecordMissing)`
+9. `return interpPath, interpRecord.ContentHash, nil`
 
 ### 2.3. エラー処理一覧
 
-| 条件 | 返却値 | 意味 |
-|------|--------|------|
-| スクリプトレコード不在 | `("", "", nil)` | 解析スキップ |
-| `contentHash` 不一致 | `("", "", ErrHashMismatch)` | ファイル変更検知 |
-| `ShebangInterpreter == nil` | `("", "", nil)` | 非スクリプト |
-| インタープリタレコード不在 | `(interpPath, "", nil)` | ハッシュ不明（スキップ）|
-| その他のエラー | `("", "", err)` | fail-closed |
+| 条件 | 返却値 | 呼び出し側の扱い |
+|------|--------|----------------|
+| スクリプトレコード不在 | `("", "", ErrRecordNotFound)` | panic（`analyzeBinarySignals` で検出）|
+| スクリプト `contentHash` 不一致 | `("", "", ErrHashMismatch)` | high risk |
+| `ShebangInterpreter == nil` | `("", "", nil)` | スキップ（非スクリプト）|
+| インタープリタレコード不在 | `("", "", error)` | high risk（整合性異常）|
+| インタープリタ `ContentHash` 空 | `("", "", error)` | high risk（整合性異常）|
+| その他のエラー | `("", "", err)` | high risk（fail-closed）|
+
+`ErrInterpreterRecordMissing` は `fileanalysis` パッケージに新規追加する sentinel error。
 
 ---
 
@@ -143,9 +147,12 @@ if a.shebangStore != nil && contentHash != "" {
             isNetwork = isNetwork || interpNet
             hasDynLoad = hasDynLoad || interpHigh
         }
+    case errors.Is(err, fileanalysis.ErrRecordNotFound):
+        // Script record must exist at this point (LoadNetworkSymbolAnalysis already
+        // succeeded). A missing record now indicates a programming error.
+        panic(fmt.Sprintf("shebang store: script record disappeared for %q: %v", cmdPath, err))
     case errors.Is(err, fileanalysis.ErrHashMismatch):
-        slog.Warn("shebang interpreter script hash mismatch; treating as high risk",
-            "path", cmdPath)
+        slog.Warn("shebang script hash mismatch; treating as high risk", "path", cmdPath)
         return true, true
     default:
         slog.Warn("shebang interpreter lookup failed; treating as high risk",
@@ -190,11 +197,12 @@ networkAnalyzer := security.NewNetworkAnalyzer(
 |------------|------|---------|
 | TC-01 | direct 形式、両レコード存在 | `(interpPath, interpHash, nil)` |
 | TC-02 | env 形式、`ResolvedPath` が使用される | `ResolvedPath` のレコードハッシュを返す |
-| TC-03 | スクリプトレコード不在 | `("", "", nil)` |
+| TC-03 | スクリプトレコード不在 | `("", "", ErrRecordNotFound)` |
 | TC-04 | `contentHash` 不一致 | `("", "", ErrHashMismatch)` |
 | TC-05 | `ShebangInterpreter == nil` | `("", "", nil)` |
-| TC-06 | インタープリタレコード不在 | `(interpPath, "", nil)` |
+| TC-06 | インタープリタレコード不在 | `("", "", ErrInterpreterRecordMissing)` |
 | TC-07 | インタープリタロードエラー | `("", "", error)` |
+| TC-08 | インタープリタ `ContentHash` 空 | `("", "", ErrInterpreterRecordMissing)` |
 
 ### 5.2. `analyzeBinarySignals` shebang 拡張テスト
 
@@ -205,7 +213,7 @@ networkAnalyzer := security.NewNetworkAnalyzer(
 | TC-11 | インタープリタが `socket` シンボルを持つ | `isNetwork = true` |
 | TC-12 | インタープリタの共有ライブラリが mprotect リスクを持つ | `isHighRisk = true` |
 | TC-13 | インタープリタの共有ライブラリが `dlopen` を持つ | `isHighRisk = true` |
-| TC-14 | インタープリタレコードのハッシュが不明（`""`）| スキップ、`(false, false)` |
+| TC-14 | インタープリタレコード不在（`ErrInterpreterRecordMissing`）| `(true, true)`（high risk）|
 | TC-15 | `ErrHashMismatch` | `(true, true)` |
 | TC-16 | ロードエラー | `(true, true)` |
 | TC-17 | `shebangStore == nil` | 変更なし（既存動作）|
@@ -219,10 +227,10 @@ networkAnalyzer := security.NewNetworkAnalyzer(
 | AC-02: env 形式 python3 | TC-02 |
 | AC-03: インタープリタ共有ライブラリの mprotect リスク | TC-12 |
 | AC-04: ライブラリの dynload シンボル | TC-13 |
-| AC-05: インタープリタレコード不在はスキップ | TC-14, TC-06 |
-| AC-06: ロードエラーで high risk | TC-15, TC-16 |
-| AC-07: ELF バイナリの回帰 | TC-18 |
-| AC-08: ハッシュ不明はスキップ | TC-14 |
+| AC-05: スクリプトレコード不在はスキップ | TC-03 |
+| AC-06: インタープリタレコード不在は high risk | TC-06, TC-14 |
+| AC-07: ロードエラーで high risk | TC-15, TC-16 |
+| AC-08: ELF バイナリの回帰 | TC-18 |
 
 ---
 

--- a/docs/tasks/0126_shebang_script_risk_analysis/03_detailed_specification.md
+++ b/docs/tasks/0126_shebang_script_risk_analysis/03_detailed_specification.md
@@ -1,0 +1,253 @@
+# shebang スクリプトのネットワークリスク解析 詳細仕様書
+
+## 1. 変更対象ファイル
+
+| ファイル | 変更種別 |
+|--------|---------|
+| `internal/fileanalysis/shebang_store.go` | 新規（`ShebangInterpreterStore` インターフェース・実装）|
+| `internal/runner/base/security/network_analyzer.go` | 変更（`shebangStore` フィールド追加・`analyzeBinarySignals` 拡張）|
+| `internal/runner/base/security/network_analyzer_test.go` | テスト追加 |
+| `cmd/record/main.go` | 変更（`NetworkAnalyzer` 生成時に `shebangStore` を注入）|
+
+---
+
+## 2. `ShebangInterpreterStore` インターフェースと実装
+
+### 2.1. インターフェース定義
+
+**ファイル:** `internal/fileanalysis/shebang_store.go`
+
+```go
+package fileanalysis
+
+// ShebangInterpreterStore provides the interpreter binary path and content hash
+// for a shebang script, enabling the runner to follow the shebang chain for
+// risk assessment without re-analyzing the interpreter binary.
+type ShebangInterpreterStore interface {
+    // LoadInterpreterAnalysisPath returns the effective interpreter binary path
+    // and its content hash for the shebang script at scriptPath.
+    //
+    // scriptContentHash is validated against the stored record to detect
+    // script file changes (ErrHashMismatch).
+    //
+    // Returns ("", "", nil) when:
+    //   - The script has no ShebangInterpreter (not a shebang script)
+    //   - The interpreter's record is not found (ErrRecordNotFound for interpreter)
+    //   - The interpreter's content hash is empty
+    //
+    // Returns error when:
+    //   - The script's record cannot be loaded (non-ErrRecordNotFound errors)
+    //   - scriptContentHash does not match stored hash (ErrHashMismatch)
+    //   - The interpreter's record cannot be loaded (non-ErrRecordNotFound errors)
+    LoadInterpreterAnalysisPath(scriptPath, scriptContentHash string) (interpPath, interpContentHash string, err error)
+}
+```
+
+### 2.2. 実装: `shebangInterpreterStore`
+
+**ファイル:** `internal/fileanalysis/shebang_store.go`
+
+```go
+// shebangInterpreterStore implements ShebangInterpreterStore using the file
+// analysis record store.
+type shebangInterpreterStore struct {
+    store Store  // 既存の Record ストア
+}
+
+// NewShebangInterpreterStore creates a ShebangInterpreterStore backed by store.
+func NewShebangInterpreterStore(store Store) ShebangInterpreterStore {
+    return &shebangInterpreterStore{store: store}
+}
+```
+
+#### 処理手順
+
+1. `validatePath(scriptPath)` → `common.ResolvedPath`
+2. `store.Load(scriptTarget)` でスクリプトのレコードをロード
+   - `ErrRecordNotFound` → `return "", "", nil`
+   - 他のエラー → `return "", "", err`
+3. `scriptRecord.ContentHash != scriptContentHash` → `return "", "", ErrHashMismatch`
+4. `scriptRecord.ShebangInterpreter == nil` → `return "", "", nil`
+5. インタープリタパスの決定:
+   - `si.ResolvedPath != ""` → `interpPath = si.ResolvedPath`
+   - それ以外 → `interpPath = si.InterpreterPath`
+6. `validatePath(interpPath)` → `common.ResolvedPath`
+7. `store.Load(interpTarget)` でインタープリタのレコードをロード
+   - `ErrRecordNotFound` → `return interpPath, "", nil`（ハッシュなし=スキップ可能）
+   - 他のエラー → `return "", "", err`
+8. `return interpPath, interpRecord.ContentHash, nil`
+
+### 2.3. エラー処理一覧
+
+| 条件 | 返却値 | 意味 |
+|------|--------|------|
+| スクリプトレコード不在 | `("", "", nil)` | 解析スキップ |
+| `contentHash` 不一致 | `("", "", ErrHashMismatch)` | ファイル変更検知 |
+| `ShebangInterpreter == nil` | `("", "", nil)` | 非スクリプト |
+| インタープリタレコード不在 | `(interpPath, "", nil)` | ハッシュ不明（スキップ）|
+| その他のエラー | `("", "", err)` | fail-closed |
+
+---
+
+## 3. `NetworkAnalyzer` の変更
+
+### 3.1. フィールド追加
+
+**ファイル:** `internal/runner/base/security/network_analyzer.go`
+
+```go
+type NetworkAnalyzer struct {
+    goos             string
+    store            fileanalysis.NetworkSymbolStore
+    syscallStore     fileanalysis.SyscallAnalysisStore
+    depsStore        fileanalysis.DynLibDepsStore
+    libAnalysisStore dynamicanalysis.Store
+    shebangStore     fileanalysis.ShebangInterpreterStore  // 追加（nil で無効化）
+}
+```
+
+### 3.2. `NewNetworkAnalyzer` の変更
+
+引数に `shebangStore fileanalysis.ShebangInterpreterStore` を追加:
+
+```go
+func NewNetworkAnalyzer(
+    goos string,
+    symStore fileanalysis.NetworkSymbolStore,
+    svcStore fileanalysis.SyscallAnalysisStore,
+    depsStore fileanalysis.DynLibDepsStore,
+    libAnalysisStore dynamicanalysis.Store,
+    shebangStore fileanalysis.ShebangInterpreterStore,  // 追加
+) *NetworkAnalyzer {
+    return &NetworkAnalyzer{
+        // ...
+        shebangStore: shebangStore,
+    }
+}
+```
+
+### 3.3. `analyzeBinarySignals` の変更
+
+既存の解析（`SymbolAnalysis`・`SyscallAnalysis`・`DynLibDeps`）の実行後に shebang チェーン追跡を追加する。挿入位置は関数末尾の `return isNetwork, hasDynLoad` の直前。
+
+```go
+// Shebang chain: if this is a script, also analyze the interpreter binary.
+// The interpreter's record (SymbolAnalysis, SyscallAnalysis, DynLibDeps)
+// was written by `record` when the script was first recorded.
+if a.shebangStore != nil && contentHash != "" {
+    interpPath, interpHash, err := a.shebangStore.LoadInterpreterAnalysisPath(cmdPath, contentHash)
+    switch {
+    case err == nil:
+        if interpPath != "" && interpHash != "" {
+            interpNet, interpHigh := a.analyzeBinarySignals(interpPath, interpHash)
+            isNetwork = isNetwork || interpNet
+            hasDynLoad = hasDynLoad || interpHigh
+        }
+    case errors.Is(err, fileanalysis.ErrHashMismatch):
+        slog.Warn("shebang interpreter script hash mismatch; treating as high risk",
+            "path", cmdPath)
+        return true, true
+    default:
+        slog.Warn("shebang interpreter lookup failed; treating as high risk",
+            "path", cmdPath, "error", err)
+        return true, true
+    }
+}
+```
+
+---
+
+## 4. `NewNetworkAnalyzer` 呼び出し箇所の変更
+
+### 4.1. `cmd/record/main.go`
+
+`NewNetworkAnalyzer` の呼び出しに `shebangStore` を追加する。
+
+```go
+shebangStore := fileanalysis.NewShebangInterpreterStore(analysisStore)
+networkAnalyzer := security.NewNetworkAnalyzer(
+    runtime.GOOS,
+    symStore,
+    svcStore,
+    depsStore,
+    libAnalysisStore,
+    shebangStore,  // 追加
+)
+```
+
+### 4.2. その他の `NewNetworkAnalyzer` 呼び出し箇所
+
+`grep -rn "NewNetworkAnalyzer"` で全呼び出し箇所を確認し、`nil` またはストア実装を適切に渡す。
+
+---
+
+## 5. テスト仕様
+
+### 5.1. `ShebangInterpreterStore` ユニットテスト
+
+**ファイル:** `internal/fileanalysis/shebang_store_test.go`
+
+| テストケース | 条件 | 期待結果 |
+|------------|------|---------|
+| TC-01 | direct 形式、両レコード存在 | `(interpPath, interpHash, nil)` |
+| TC-02 | env 形式、`ResolvedPath` が使用される | `ResolvedPath` のレコードハッシュを返す |
+| TC-03 | スクリプトレコード不在 | `("", "", nil)` |
+| TC-04 | `contentHash` 不一致 | `("", "", ErrHashMismatch)` |
+| TC-05 | `ShebangInterpreter == nil` | `("", "", nil)` |
+| TC-06 | インタープリタレコード不在 | `(interpPath, "", nil)` |
+| TC-07 | インタープリタロードエラー | `("", "", error)` |
+
+### 5.2. `analyzeBinarySignals` shebang 拡張テスト
+
+**ファイル:** `internal/runner/base/security/network_analyzer_test.go`
+
+| テストケース | 条件 | 期待結果 |
+|------------|------|---------|
+| TC-11 | インタープリタが `socket` シンボルを持つ | `isNetwork = true` |
+| TC-12 | インタープリタが mprotect を持つ（`SyscallAnalysis`）| `isHighRisk = true` |
+| TC-13 | インタープリタの共有ライブラリが `dlopen` を持つ | `isHighRisk = true` |
+| TC-14 | インタープリタレコードのハッシュが不明（`""`）| スキップ、`(false, false)` |
+| TC-15 | `ErrHashMismatch` | `(true, true)` |
+| TC-16 | ロードエラー | `(true, true)` |
+| TC-17 | `shebangStore == nil` | 変更なし（既存動作）|
+| TC-18 | 非スクリプト（`ShebangInterpreter == nil`）| 変更なし（AC-07）|
+
+### 5.3. 対応受け入れ基準
+
+| 受け入れ基準 | テスト |
+|------------|-------|
+| AC-01: bash の network シンボル | TC-11 |
+| AC-02: env 形式 python3 | TC-02 |
+| AC-03: インタープリタの mprotect | TC-12 |
+| AC-04: ライブラリの dynload シンボル | TC-13 |
+| AC-05: インタープリタレコード不在はスキップ | TC-14, TC-06 |
+| AC-06: ロードエラーで high risk | TC-15, TC-16 |
+| AC-07: ELF バイナリの回帰 | TC-18 |
+| AC-08: ハッシュ不明はスキップ | TC-14 |
+
+---
+
+## 6. 実装上の注意点
+
+### 6.1. 再帰の安全性
+
+`analyzeBinarySignals(interpPath, interpHash)` の再帰呼び出しにおいて:
+- `interpPath` はネイティブバイナリ（ELF/Mach-O）のパス
+- ネイティブバイナリの record には `ShebangInterpreter = nil` が格納される
+- `LoadInterpreterAnalysisPath` は `ShebangInterpreter == nil` の場合 `("", "", nil)` を返す
+- 再帰の深さは最大 1 段
+
+### 6.2. `shebangStore` の nil 許容
+
+`shebangStore == nil` または `contentHash == ""` の場合、shebang チェーン追跡全体をスキップする。
+これにより、テスト環境やストアが未設定の環境でも既存の動作を維持できる。
+
+### 6.3. `NewNetworkAnalyzer` のシグネチャ変更
+
+`NewNetworkAnalyzer` の引数追加は破壊的変更のため、全呼び出し箇所を更新する必要がある。
+`grep -rn "NewNetworkAnalyzer"` でカバレッジを確認すること。
+
+### 6.4. ログ出力方針
+
+エラーケースは既存の `slog.Warn` パターンに従う（`analyzeBinarySignals` 内の他の警告と統一）。
+正常時の shebang チェーン追跡はログ出力しない（過剰なログを避ける）。

--- a/docs/tasks/0126_shebang_script_risk_analysis/03_detailed_specification.md
+++ b/docs/tasks/0126_shebang_script_risk_analysis/03_detailed_specification.md
@@ -32,12 +32,12 @@ type ShebangInterpreterStore interface {
     //
     // Returns ("", "", nil) when:
     //   - The script has no ShebangInterpreter (not a shebang script)
-    //   - The interpreter's record is not found (ErrRecordNotFound for interpreter)
-    //   - The interpreter's content hash is empty
     //
     // Returns error when:
     //   - The script's record cannot be loaded (non-ErrRecordNotFound errors)
     //   - scriptContentHash does not match stored hash (ErrHashMismatch)
+    //   - The interpreter's record is not found (ErrInterpreterRecordMissing)
+    //   - The interpreter's content hash is empty (ErrInterpreterRecordMissing)
     //   - The interpreter's record cannot be loaded (non-ErrRecordNotFound errors)
     LoadInterpreterAnalysisPath(scriptPath, scriptContentHash string) (interpPath, interpContentHash string, err error)
 }
@@ -145,7 +145,7 @@ if a.shebangStore != nil && contentHash != "" {
     interpPath, interpHash, err := a.shebangStore.LoadInterpreterAnalysisPath(cmdPath, contentHash)
     switch {
     case err == nil:
-        if interpPath != "" && interpHash != "" {
+        if interpPath != "" {
             interpNet, interpHigh := a.analyzeBinarySignals(interpPath, interpHash)
             isNetwork = isNetwork || interpNet
             hasDynLoad = hasDynLoad || interpHigh

--- a/docs/tasks/0126_shebang_script_risk_analysis/03_detailed_specification.md
+++ b/docs/tasks/0126_shebang_script_risk_analysis/03_detailed_specification.md
@@ -51,18 +51,18 @@ type ShebangInterpreterStore interface {
 // shebangInterpreterStore implements ShebangInterpreterStore using the file
 // analysis record store.
 type shebangInterpreterStore struct {
-    store Store  // 既存の Record ストア
+    store *Store  // 既存の Record ストア（他のストア実装と同様にポインタを使用）
 }
 
 // NewShebangInterpreterStore creates a ShebangInterpreterStore backed by store.
-func NewShebangInterpreterStore(store Store) ShebangInterpreterStore {
+func NewShebangInterpreterStore(store *Store) ShebangInterpreterStore {
     return &shebangInterpreterStore{store: store}
 }
 ```
 
 #### 処理手順
 
-1. `validatePath(scriptPath)` → `common.ResolvedPath`
+1. `common.NewResolvedPath(scriptPath)` → `common.ResolvedPath`（`networkSymbolStore` 等の既存実装と同じパターン）
 2. `store.Load(scriptTarget)` でスクリプトのレコードをロード
    - `ErrRecordNotFound` → `return "", "", fileanalysis.ErrRecordNotFound`（呼び出し元で panic）
    - 他のエラー → `return "", "", err`
@@ -71,7 +71,7 @@ func NewShebangInterpreterStore(store Store) ShebangInterpreterStore {
 5. インタープリタパスの決定:
    - `si.ResolvedPath != ""` → `interpPath = si.ResolvedPath`
    - それ以外 → `interpPath = si.InterpreterPath`
-6. `validatePath(interpPath)` → `common.ResolvedPath`
+6. `common.NewResolvedPath(interpPath)` → `common.ResolvedPath`
 7. `store.Load(interpTarget)` でインタープリタのレコードをロード
    - `ErrRecordNotFound` → `return "", "", fmt.Errorf("interpreter record not found: %w", ErrInterpreterRecordMissing)`
    - 他のエラー → `return "", "", err`
@@ -133,6 +133,8 @@ func NewNetworkAnalyzer(
 ### 3.3. `analyzeBinarySignals` の変更
 
 既存の解析（`SymbolAnalysis`・`SyscallAnalysis`・`DynLibDeps`）の実行後に shebang チェーン追跡を追加する。インタープリタレコード不在は high risk に丸めず、エラーとして呼び出し元へ返却する。
+
+> **設計上の意図:** このタスクは意図的に `analyzeBinarySignals` の戻り値に `error` を追加し、ランナーの契約を変更する。既存の `ErrHashMismatch` 等の処理（`return true, true`）とは異なり、shebang インタープリタのレコード不在・ハッシュ不一致はエラーとして伝播させ、グループ実行を中止する。これは AC-06・AC-07 で定義された fail-closed ポリシーに従ったものであり、「解析結果が得られない場合は実行を継続しない」という設計方針の一貫性を確保するためである。
 
 このため、`analyzeBinarySignals` は `error` を返せる形に拡張し、`IsNetworkOperation` → `EvaluateRisk` → グループ実行層へ伝播させる。
 `ErrHashMismatch` とインタープリタレコードロードエラーは high risk へ丸めず、実行中止エラーとして扱う。

--- a/docs/tasks/0126_shebang_script_risk_analysis/03_detailed_specification.md
+++ b/docs/tasks/0126_shebang_script_risk_analysis/03_detailed_specification.md
@@ -7,7 +7,7 @@
 | `internal/fileanalysis/shebang_store.go` | 新規（`ShebangInterpreterStore` インターフェース・実装）|
 | `internal/runner/base/security/network_analyzer.go` | 変更（`shebangStore` フィールド追加・`analyzeBinarySignals` 拡張）|
 | `internal/runner/base/security/network_analyzer_test.go` | テスト追加 |
-| `cmd/record/main.go` | 変更（`NetworkAnalyzer` 生成時に `shebangStore` を注入）|
+| `internal/runner/base/risk/evaluator.go` | 変更（`NewNetworkAnalyzer` 呼び出しに `shebangStore` を追加）|
 
 ---
 
@@ -159,19 +159,18 @@ if a.shebangStore != nil && contentHash != "" {
 
 ## 4. `NewNetworkAnalyzer` 呼び出し箇所の変更
 
-### 4.1. `cmd/record/main.go`
+### 4.1. `internal/runner/base/risk/evaluator.go`
 
 `NewNetworkAnalyzer` の呼び出しに `shebangStore` を追加する。
 
 ```go
-shebangStore := fileanalysis.NewShebangInterpreterStore(analysisStore)
 networkAnalyzer := security.NewNetworkAnalyzer(
     runtime.GOOS,
     symStore,
-    svcStore,
+    syscallStore,
     depsStore,
     libAnalysisStore,
-    shebangStore,  // 追加
+    shebangStore, // 追加
 )
 ```
 
@@ -204,7 +203,7 @@ networkAnalyzer := security.NewNetworkAnalyzer(
 | テストケース | 条件 | 期待結果 |
 |------------|------|---------|
 | TC-11 | インタープリタが `socket` シンボルを持つ | `isNetwork = true` |
-| TC-12 | インタープリタが mprotect を持つ（`SyscallAnalysis`）| `isHighRisk = true` |
+| TC-12 | インタープリタの共有ライブラリが mprotect リスクを持つ | `isHighRisk = true` |
 | TC-13 | インタープリタの共有ライブラリが `dlopen` を持つ | `isHighRisk = true` |
 | TC-14 | インタープリタレコードのハッシュが不明（`""`）| スキップ、`(false, false)` |
 | TC-15 | `ErrHashMismatch` | `(true, true)` |
@@ -218,7 +217,7 @@ networkAnalyzer := security.NewNetworkAnalyzer(
 |------------|-------|
 | AC-01: bash の network シンボル | TC-11 |
 | AC-02: env 形式 python3 | TC-02 |
-| AC-03: インタープリタの mprotect | TC-12 |
+| AC-03: インタープリタ共有ライブラリの mprotect リスク | TC-12 |
 | AC-04: ライブラリの dynload シンボル | TC-13 |
 | AC-05: インタープリタレコード不在はスキップ | TC-14, TC-06 |
 | AC-06: ロードエラーで high risk | TC-15, TC-16 |

--- a/docs/tasks/0126_shebang_script_risk_analysis/04_implementation_plan.md
+++ b/docs/tasks/0126_shebang_script_risk_analysis/04_implementation_plan.md
@@ -68,7 +68,7 @@
 **対象ファイル（新規）:** `internal/fileanalysis/shebang_store_test.go`
 **対象ファイル（追加）:** `internal/runner/base/security/network_analyzer_test.go`
 
-- [ ] 4-1. `ShebangInterpreterStore` テスト（TC-01〜TC-07）
+- [ ] 4-1. `ShebangInterpreterStore` テスト（TC-01〜TC-08）
   - [ ] TC-01: direct 形式、両レコード存在 → `(interpPath, interpHash, nil)`
   - [ ] TC-02: env 形式、`ResolvedPath` が使用される
   - [ ] TC-03: スクリプトレコード不在 → `("", "", ErrRecordNotFound)`

--- a/docs/tasks/0126_shebang_script_risk_analysis/04_implementation_plan.md
+++ b/docs/tasks/0126_shebang_script_risk_analysis/04_implementation_plan.md
@@ -1,0 +1,93 @@
+# shebang スクリプトのネットワークリスク解析 実装計画書
+
+## 進捗状況
+
+- [ ] Phase 1: `ShebangInterpreterStore` の実装
+- [ ] Phase 2: `NetworkAnalyzer` の拡張
+- [ ] Phase 3: `NewNetworkAnalyzer` 呼び出し箇所の更新
+- [ ] Phase 4: テスト実装
+- [ ] Phase 5: 動作確認・品質チェック
+
+---
+
+## Phase 1: `ShebangInterpreterStore` の実装
+
+**対象ファイル:** `internal/fileanalysis/shebang_store.go`（新規）
+
+- [ ] 1-1. `ShebangInterpreterStore` インターフェースを定義
+  - メソッド: `LoadInterpreterAnalysisPath(scriptPath, scriptContentHash string) (interpPath, interpContentHash string, err error)`
+
+- [ ] 1-2. `shebangInterpreterStore` 構造体の実装
+  - `store Store` フィールド
+  - `NewShebangInterpreterStore(store Store) ShebangInterpreterStore` コンストラクタ
+
+- [ ] 1-3. `LoadInterpreterAnalysisPath` の処理実装
+  - [ ] スクリプトレコードのロード（`ErrRecordNotFound` はスキップ）
+  - [ ] `contentHash` の検証（不一致は `ErrHashMismatch`）
+  - [ ] `ShebangInterpreter == nil` チェック（スキップ）
+  - [ ] インタープリタパスの決定（`ResolvedPath` 優先）
+  - [ ] インタープリタレコードのロード（`ErrRecordNotFound` は `(interpPath, "", nil)`）
+  - [ ] `(interpPath, interpRecord.ContentHash, nil)` を返す
+
+---
+
+## Phase 2: `NetworkAnalyzer` の拡張
+
+**対象ファイル:** `internal/runner/base/security/network_analyzer.go`
+
+- [ ] 2-1. `NetworkAnalyzer` 構造体に `shebangStore fileanalysis.ShebangInterpreterStore` フィールドを追加
+
+- [ ] 2-2. `NewNetworkAnalyzer` の引数に `shebangStore fileanalysis.ShebangInterpreterStore` を追加し、フィールドに代入
+
+- [ ] 2-3. `analyzeBinarySignals` に shebang チェーン追跡を追加（`return` 直前）
+  - [ ] `shebangStore != nil && contentHash != ""` のガード
+  - [ ] `LoadInterpreterAnalysisPath` 呼び出し
+  - [ ] `ErrHashMismatch` → `return true, true`
+  - [ ] その他エラー → `slog.Warn` + `return true, true`
+  - [ ] `interpHash != ""` の場合のみ再帰呼び出し
+  - [ ] 再帰結果を OR 結合
+
+---
+
+## Phase 3: `NewNetworkAnalyzer` 呼び出し箇所の更新
+
+- [ ] 3-1. `grep -rn "NewNetworkAnalyzer"` で全呼び出し箇所を特定
+
+- [ ] 3-2. 各呼び出し箇所に `shebangStore` 引数を追加
+  - `cmd/record/main.go`: `fileanalysis.NewShebangInterpreterStore(analysisStore)` を渡す
+  - テストコード等: 適切なモックまたは `nil` を渡す
+
+---
+
+## Phase 4: テスト実装
+
+**対象ファイル（新規）:** `internal/fileanalysis/shebang_store_test.go`
+**対象ファイル（追加）:** `internal/runner/base/security/network_analyzer_test.go`
+
+- [ ] 4-1. `ShebangInterpreterStore` テスト（TC-01〜TC-07）
+  - [ ] TC-01: direct 形式、両レコード存在 → `(interpPath, interpHash, nil)`
+  - [ ] TC-02: env 形式、`ResolvedPath` が使用される
+  - [ ] TC-03: スクリプトレコード不在 → `("", "", nil)`
+  - [ ] TC-04: `contentHash` 不一致 → `ErrHashMismatch`
+  - [ ] TC-05: `ShebangInterpreter == nil` → `("", "", nil)`
+  - [ ] TC-06: インタープリタレコード不在 → `(interpPath, "", nil)`
+  - [ ] TC-07: インタープリタロードエラー → error
+
+- [ ] 4-2. `analyzeBinarySignals` shebang 拡張テスト（TC-11〜TC-18）
+  - [ ] TC-11: インタープリタが `socket` シンボル → `isNetwork = true`
+  - [ ] TC-12: インタープリタが mprotect（`SyscallAnalysis`）→ `isHighRisk = true`
+  - [ ] TC-13: インタープリタのライブラリが `dlopen` → `isHighRisk = true`
+  - [ ] TC-14: インタープリタのハッシュ不明 → スキップ `(false, false)`
+  - [ ] TC-15: `ErrHashMismatch` → `(true, true)`
+  - [ ] TC-16: ロードエラー → `(true, true)`
+  - [ ] TC-17: `shebangStore == nil` → 変更なし
+  - [ ] TC-18: 非スクリプト（`ShebangInterpreter == nil`）→ 変更なし
+
+---
+
+## Phase 5: 動作確認・品質チェック
+
+- [ ] 5-1. `make fmt` でフォーマット確認
+- [ ] 5-2. `make test` で全テストが通ることを確認
+- [ ] 5-3. `make lint` でリンターエラーがないことを確認
+- [ ] 5-4. 既存テストのリグレッションがないことを確認

--- a/docs/tasks/0126_shebang_script_risk_analysis/04_implementation_plan.md
+++ b/docs/tasks/0126_shebang_script_risk_analysis/04_implementation_plan.md
@@ -54,7 +54,7 @@
 - [ ] 3-1. `grep -rn "NewNetworkAnalyzer"` で全呼び出し箇所を特定
 
 - [ ] 3-2. 各呼び出し箇所に `shebangStore` 引数を追加
-  - `cmd/record/main.go`: `fileanalysis.NewShebangInterpreterStore(analysisStore)` を渡す
+  - `internal/runner/base/risk/evaluator.go`: `NewNetworkAnalyzer` 呼び出しに `shebangStore` を渡す
   - テストコード等: 適切なモックまたは `nil` を渡す
 
 ---
@@ -75,7 +75,7 @@
 
 - [ ] 4-2. `analyzeBinarySignals` shebang 拡張テスト（TC-11〜TC-18）
   - [ ] TC-11: インタープリタが `socket` シンボル → `isNetwork = true`
-  - [ ] TC-12: インタープリタが mprotect（`SyscallAnalysis`）→ `isHighRisk = true`
+  - [ ] TC-12: インタープリタの共有ライブラリが mprotect リスクを持つ → `isHighRisk = true`
   - [ ] TC-13: インタープリタのライブラリが `dlopen` → `isHighRisk = true`
   - [ ] TC-14: インタープリタのハッシュ不明 → スキップ `(false, false)`
   - [ ] TC-15: `ErrHashMismatch` → `(true, true)`

--- a/docs/tasks/0126_shebang_script_risk_analysis/04_implementation_plan.md
+++ b/docs/tasks/0126_shebang_script_risk_analysis/04_implementation_plan.md
@@ -21,12 +21,15 @@
   - `store Store` フィールド
   - `NewShebangInterpreterStore(store Store) ShebangInterpreterStore` コンストラクタ
 
-- [ ] 1-3. `LoadInterpreterAnalysisPath` の処理実装
-  - [ ] スクリプトレコードのロード（`ErrRecordNotFound` はスキップ）
+- [ ] 1-3. `ErrInterpreterRecordMissing` sentinel error を定義
+
+- [ ] 1-4. `LoadInterpreterAnalysisPath` の処理実装
+  - [ ] スクリプトレコードのロード（`ErrRecordNotFound` は `ErrRecordNotFound` を返す）
   - [ ] `contentHash` の検証（不一致は `ErrHashMismatch`）
   - [ ] `ShebangInterpreter == nil` チェック（スキップ）
   - [ ] インタープリタパスの決定（`ResolvedPath` 優先）
-  - [ ] インタープリタレコードのロード（`ErrRecordNotFound` は `(interpPath, "", nil)`）
+  - [ ] インタープリタレコードのロード（`ErrRecordNotFound` は `ErrInterpreterRecordMissing` でエラー返却）
+  - [ ] `interpRecord.ContentHash == ""` も `ErrInterpreterRecordMissing` でエラー返却
   - [ ] `(interpPath, interpRecord.ContentHash, nil)` を返す
 
 ---
@@ -67,17 +70,18 @@
 - [ ] 4-1. `ShebangInterpreterStore` テスト（TC-01〜TC-07）
   - [ ] TC-01: direct 形式、両レコード存在 → `(interpPath, interpHash, nil)`
   - [ ] TC-02: env 形式、`ResolvedPath` が使用される
-  - [ ] TC-03: スクリプトレコード不在 → `("", "", nil)`
+  - [ ] TC-03: スクリプトレコード不在 → `("", "", ErrRecordNotFound)`
   - [ ] TC-04: `contentHash` 不一致 → `ErrHashMismatch`
   - [ ] TC-05: `ShebangInterpreter == nil` → `("", "", nil)`
-  - [ ] TC-06: インタープリタレコード不在 → `(interpPath, "", nil)`
+  - [ ] TC-06: インタープリタレコード不在 → `("", "", ErrInterpreterRecordMissing)`
   - [ ] TC-07: インタープリタロードエラー → error
+  - [ ] TC-08: インタープリタ `ContentHash` 空 → `("", "", ErrInterpreterRecordMissing)`
 
 - [ ] 4-2. `analyzeBinarySignals` shebang 拡張テスト（TC-11〜TC-18）
   - [ ] TC-11: インタープリタが `socket` シンボル → `isNetwork = true`
   - [ ] TC-12: インタープリタの共有ライブラリが mprotect リスクを持つ → `isHighRisk = true`
   - [ ] TC-13: インタープリタのライブラリが `dlopen` → `isHighRisk = true`
-  - [ ] TC-14: インタープリタのハッシュ不明 → スキップ `(false, false)`
+  - [ ] TC-14: インタープリタレコード不在（`ErrInterpreterRecordMissing`）→ `(true, true)`
   - [ ] TC-15: `ErrHashMismatch` → `(true, true)`
   - [ ] TC-16: ロードエラー → `(true, true)`
   - [ ] TC-17: `shebangStore == nil` → 変更なし

--- a/docs/tasks/0126_shebang_script_risk_analysis/04_implementation_plan.md
+++ b/docs/tasks/0126_shebang_script_risk_analysis/04_implementation_plan.md
@@ -45,8 +45,9 @@
 - [ ] 2-3. `analyzeBinarySignals` に shebang チェーン追跡を追加（`return` 直前）
   - [ ] `shebangStore != nil && contentHash != ""` のガード
   - [ ] `LoadInterpreterAnalysisPath` 呼び出し
-  - [ ] `ErrHashMismatch` → `return true, true`
-  - [ ] その他エラー → `slog.Warn` + `return true, true`
+  - [ ] `ErrInterpreterRecordMissing` → エラーを呼び出し元へ返却（実行中止）
+  - [ ] `ErrHashMismatch` → エラーを呼び出し元へ返却（実行中止）
+  - [ ] その他エラー（インタープリタレコードロード失敗を含む）→ エラーを呼び出し元へ返却（実行中止）
   - [ ] `interpHash != ""` の場合のみ再帰呼び出し
   - [ ] 再帰結果を OR 結合
 
@@ -81,9 +82,9 @@
   - [ ] TC-11: インタープリタが `socket` シンボル → `isNetwork = true`
   - [ ] TC-12: インタープリタの共有ライブラリが mprotect リスクを持つ → `isHighRisk = true`
   - [ ] TC-13: インタープリタのライブラリが `dlopen` → `isHighRisk = true`
-  - [ ] TC-14: インタープリタレコード不在（`ErrInterpreterRecordMissing`）→ `(true, true)`
-  - [ ] TC-15: `ErrHashMismatch` → `(true, true)`
-  - [ ] TC-16: ロードエラー → `(true, true)`
+  - [ ] TC-14: インタープリタレコード不在（`ErrInterpreterRecordMissing`）→ エラー返却 + グループ実行中止
+  - [ ] TC-15: `ErrHashMismatch` → エラー返却 + グループ実行中止
+  - [ ] TC-16: ロードエラー → エラー返却 + グループ実行中止
   - [ ] TC-17: `shebangStore == nil` → 変更なし
   - [ ] TC-18: 非スクリプト（`ShebangInterpreter == nil`）→ 変更なし
 


### PR DESCRIPTION
## Summary
- add task 0126 design docs for shebang script risk analysis (requirements, architecture, detailed spec, implementation plan)
- improve Mermaid rendering by replacing line breaks with <br>
- align follow-up documentation with current analyzer behavior and call sites

## Details
- clarify NewNetworkAnalyzer call-site references to evaluator
- update syscall-related descriptions to svc/network syscall wording
- align AC/TC wording for mprotect risk path

## Testing
- documentation changes only (no runtime code changes)