### PR TITLE
doc(task 0127): Add design documents for NetworkAnalyzer dependency simplification

### DIFF
--- a/docs/tasks/0127_network_analyzer_dependency_simplification/01_requirements.md
+++ b/docs/tasks/0127_network_analyzer_dependency_simplification/01_requirements.md
@@ -1,0 +1,159 @@
+# 要件定義: NetworkAnalyzer 周辺の依存配線簡素化
+
+## 背景
+
+`internal/runner/base/security/NetworkAnalyzer` は以下の分析用インターフェースを利用している。
+
+- `fileanalysis.NetworkSymbolStore`
+- `fileanalysis.SyscallAnalysisStore`
+- `fileanalysis.DynLibDepsStore`
+- `dynamicanalysis.Store`
+- `fileanalysis.ShebangInterpreterStore`
+
+これらの実体は `internal/verification/Manager` の生成時に初期化されるが、
+実際の利用地点である `NetworkAnalyzer` までの受け渡し経路が長い。
+現在は以下のような配線になっている。
+
+```text
+verification.Manager
+  -> runner.createNormalResourceManager
+  -> resource.Config
+  -> resource.newNormalManager
+  -> risk.NewStandardEvaluator
+  -> security.NewNetworkAnalyzer
+```
+
+この経路では、同じ依存集合を複数レイヤーで個別フィールドとして再定義し、
+再梱包している。
+その結果、以下の問題が生じている。
+
+- 依存追加・削除のたびに複数シグネチャの変更が必要になる
+- `resource` レイヤーが本来不要な分析ストアの知識を持っている
+- `runner` 側で `PathResolver` への複数の型アサーションが必要になる
+- `NetworkAnalyzer` の構成責務が見えにくく、テスト差し替えポイントも散らばる
+
+## 問題
+
+現在の配線は「分析依存の所有者」と「分析依存を利用するレイヤー」の境界が曖昧である。
+
+- 分析ストアの生成責務は `verification` にある
+- リスク判定責務は `risk` / `security` にある
+- しかし中間の `resource` が分析ストアを直接知っている
+
+この構造は、レイヤー境界を越えて詳細が漏れている状態であり、
+責務分離と変更容易性の両方を悪化させている。
+
+## 目標
+
+分析用ストア群の受け渡しを簡素化し、以下を実現する。
+
+- `NetworkAnalyzer` が必要とする依存群を 1 つの論理単位として扱える
+- `resource` レイヤーから分析ストアの詳細知識を取り除ける
+- `runner` の composition root で依存を一度だけ組み立てれば済む
+- 今後ストアが追加・削除されても変更箇所が局所化される
+- 既存のネットワーク判定挙動、フェイルクローズ挙動、dry-run 挙動を維持する
+
+## スコープ
+
+### 対象
+
+- `NetworkAnalyzer` の依存注入方式
+- `risk.StandardEvaluator` への依存の渡し方
+- `resource.Config` における分析依存の扱い
+- `runner.createNormalResourceManager` における依存組み立て
+- `verification.Manager` から分析依存を取得する API
+
+### 非対象
+
+- `NetworkAnalyzer` のネットワーク検知ロジック自体の変更
+- キャッシュの保存形式、ハッシュ仕様、スキーマ変更
+- `record` 側の分析生成ロジックの機能変更
+- dry-run 以外の実行モード追加
+
+## 機能要件
+
+#### F-127-1: 分析依存の集約
+
+`NetworkAnalyzer` が利用する複数の分析依存は、呼び出し側から 1 つの論理単位として渡せること。
+論理単位は bundle / provider / factory などの形を取り得るが、呼び出しシグネチャ上で個別の 5 引数を並べないこと。
+
+**Acceptance Criteria**:
+1. `security.NewNetworkAnalyzer` の公開シグネチャが分析依存 5 個を個別引数で受け取らない。
+2. `risk.NewStandardEvaluator` の公開シグネチャが分析依存 5 個を個別引数で受け取らない。
+3. 分析依存の欠如を表す `nil` の意味は維持され、個別分析の無効化条件が変わらない。
+4. 既存の `NetworkAnalyzer` の判定ロジックは、依存の受け取り方以外で意味変更しない。
+
+#### F-127-2: resource レイヤーの責務縮小
+
+`resource` レイヤーは分析ストア群の詳細を直接保持せず、リスク評価に必要な上位抽象だけを扱うこと。
+
+**Acceptance Criteria**:
+1. `resource.Config` が `NetworkSymbolStore`、`SyscallAnalysisStore`、`DynLibDepsStore`、`dynamicanalysis.Store`、`ShebangInterpreterStore` を個別フィールドとして保持しない。
+2. `resource.newNormalManager` は分析ストア群を直接 `risk.NewStandardEvaluator` へ渡さない。
+3. `NormalResourceManager` の振る舞いは変更されず、コマンド実行前のリスク評価が引き続き行われる。
+
+#### F-127-3: composition root での組み立て一元化
+
+分析依存の具体生成場所は維持しつつ、`runner` 側での配線は 1 回の組み立てで完結すること。
+
+**Acceptance Criteria**:
+1. `runner.createNormalResourceManager` において、分析依存の個別 getter 呼び出しや個別型アサーションが 5 系統並ばない。
+2. `verification.Manager` 由来の分析依存取得 API は、呼び出し側に個別ストアの列挙を強制しない。
+3. 分析依存の生成責務は引き続き `verification` 側に残り、`security` や `risk` に具体生成処理を移さない。
+
+#### F-127-4: 既存挙動の互換維持
+
+このリファクタリングは配線と依存境界の整理を目的とし、外部仕様を変えないこと。
+
+**Acceptance Criteria**:
+1. 既存のネットワーク判定、high risk 判定、shebang 追跡の振る舞いが変わらない。
+2. 分析ストアが利用不能な場合の fail-open / fail-closed ポリシーは既存通り維持される。
+3. dry-run モードと通常実行モードの初期化フローに後方互換性がある。
+4. 既存テストで検証されているネットワーク判定シナリオが引き続き成立する。
+
+#### F-127-5: テスト容易性の向上
+
+新しい依存注入構造は、`NetworkAnalyzer` と `StandardEvaluator` のテストダブル差し替えを現状より悪化させないこと。
+
+**Acceptance Criteria**:
+1. 単体テストから、集約された依存単位または `risk.Evaluator` を差し替え可能である。
+2. 新構造により、テストのためだけに `resource.Config` へ 5 種類のストアを個別設定する必要がない。
+3. モック化の責務境界が文書上で明示されている。
+
+## 制約条件
+
+- 依存の具体生成は composition root もしくは `verification` に残す
+- `security` パッケージに hash directory や store directory の具体構築責務を持ち込まない
+- 既存の公開 API 変更は、変更理由と移行先が設計書で説明されること
+- 実装は YAGNI と DRY を優先し、余分な汎化を避ける
+
+## 受け入れ基準
+
+| # | 基準 |
+|---|------|
+| AC-1 | `NetworkAnalyzer` と `StandardEvaluator` のコンストラクタが分析依存 5 個を個別引数で受け取らない |
+| AC-2 | `resource.Config` から分析ストア群の個別フィールドが除去される、または同等に非公開な 1 単位へ置き換わる |
+| AC-3 | `runner.createNormalResourceManager` での分析依存配線が単一の組み立て操作に簡約される |
+| AC-4 | 分析依存の具体生成責務は `verification` に残り、`security` は具体ストア構築を行わない |
+| AC-5 | 既存のネットワーク判定系テストと runner 初期化系テストが通過する |
+| AC-6 | `make test`、`make lint`、`make build` が成功する |
+
+## 設計方針
+
+### 基本方針
+
+- **依存を束ねて渡す**: 分析用ストア群を 1 つの依存単位として扱う
+- **上位抽象を渡す**: `resource` は分析ストアではなく `risk.Evaluator` または同等の高位依存を扱う
+- **生成と利用を分離する**: 具体生成は `verification`、利用は `risk` / `security` に留める
+- **境界で完結させる**: 型アサーションや変換は composition root で閉じる
+- **挙動不変のリファクタリング**: ロジック変更ではなく配線変更として実施する
+
+### 推奨アプローチ
+
+段階的には以下を推奨する。
+
+1. 分析依存 bundle を導入し、5 個のストア引数を 1 単位に集約する
+2. `resource.Config` は bundle ではなく `risk.Evaluator` を直接受け取る形へ整理する
+3. `verification.Manager` は個別 getter 群ではなく、集約依存を提供する
+
+この順序により、公開 API の変更範囲を制御しつつ、最終的に `resource` から分析詳細を除去できる。

--- a/docs/tasks/0127_network_analyzer_dependency_simplification/02_architecture.md
+++ b/docs/tasks/0127_network_analyzer_dependency_simplification/02_architecture.md
@@ -236,6 +236,12 @@ type Config struct {
 - `runner` が composition root として evaluator 組み立てを完結できる
 - `verification` が `risk` 実装へ依存せず、層構造を保てる
 
+**import 依存の変化**: `GetAnalysisDeps()` の戻り値型が `security.AnalysisDeps` であるため、
+`verification` → `security` という新たな import 依存が生じる。
+現時点では `security` は `verification` をインポートしていないため循環は生じない。
+これは意図的な設計判断であり、`verification` が `risk` を直接インポートする案より
+依存方向が適切（基盤層が判定ロジック層に依存しない）。
+
 `verification` に `NewRiskEvaluator()` を持たせる案は採用しない。
 その案は配線をさらに短くできるが、`verification` が `risk` の知識を持つため、
 基盤層の責務が広がるためである。
@@ -317,13 +323,13 @@ sequenceDiagram
     participant VM as verification.Manager
     participant Runner as runner.go
     participant Eval as risk.Evaluator
-    participant Res as resource.NormalResourceManager
+    participant Res as resource.NewDefaultResourceManager
 
     VM->>Runner: GetAnalysisDeps()
     Runner->>Runner: NewNetworkAnalyzer(runtime.GOOS, deps)
     Runner->>Runner: NewStandardEvaluator(networkAnalyzer)
-    Runner->>Res: inject evaluator via Config
-    Res-->>Runner: ready
+    Runner->>Res: NewDefaultResourceManager(Config{RiskEvaluator: evaluator, ...})
+    Res-->>Runner: *DefaultResourceManager
 ```
 
 ### 6.2 実行時フロー
@@ -372,13 +378,19 @@ sequenceDiagram
 ### Phase 2: evaluator 構築責務の整理
 
 - `risk.NewStandardEvaluator` が `NetworkAnalyzer` 完成品を受け取る形へ変更する
-- `resource.Config` から分析ストア詳細を削除する
+- `resource.Config` から分析ストア詳細を削除し、`RiskEvaluator risk.Evaluator` を追加する
 - `NormalResourceManager` は evaluator 注入のみに変更する
+
+> **中間状態の注意**: Phase 2 完了時点では、`runner.createNormalResourceManager` は
+> 引き続き 5 系統の個別型アサーションで分析ストアを取得する。
+> ただしそれらは `NetworkAnalyzer` と `risk.Evaluator` の組み立てにのみ使用し、
+> 完成した evaluator を `resource.Config.RiskEvaluator` として渡す。
+> 個別アサーションの除去は Phase 3 で行う。
 
 ### Phase 3: composition root の単純化
 
-- `verification.Manager` から集約依存を取得する API を追加する
-- `runner.createNormalResourceManager` の個別型アサーションと個別 getter 群を除去する
+- `verification.Manager` に `GetAnalysisDeps() security.AnalysisDeps` を追加する
+- `runner.createNormalResourceManager` の 5 系統の個別型アサーションと個別 getter 群を `GetAnalysisDeps()` 呼び出し 1 本に置き換える
 - 既存初期化テストを更新し、挙動互換を確認する
 
 ## 9. 将来の拡張性

--- a/docs/tasks/0127_network_analyzer_dependency_simplification/02_architecture.md
+++ b/docs/tasks/0127_network_analyzer_dependency_simplification/02_architecture.md
@@ -1,0 +1,389 @@
+# アーキテクチャ設計書: NetworkAnalyzer 周辺の依存配線簡素化
+
+## 1. 設計の全体像
+
+### 1.1 設計目標
+
+- `NetworkAnalyzer` 周辺の長い依存受け渡し経路を短縮する
+- `resource` レイヤーから分析ストアの詳細を除去する
+- 分析ストアの生成責務を `verification` に留める
+- 既存のネットワーク判定ロジックとフェイルクローズ挙動を維持する
+- 将来の分析依存追加時の変更範囲を局所化する
+
+### 1.2 設計原則
+
+- **Composition Root 集約**: 依存組み立ては `runner` / `verification` 境界で完結させる
+- **責務分離**: `resource` は実行制御、`risk` は判定、`security` は解析、`verification` は生成を担当する
+- **最小公開面**: 公開コンストラクタは詳細ストア列挙を避け、集約依存または高位抽象のみを受け取る
+- **段階的移行**: まず依存 bundle を導入し、その後 `risk.Evaluator` 注入へ収束させる
+- **挙動不変**: ネットワーク検出アルゴリズムや nil による無効化意味は保持する
+
+### 1.3 コンセプトモデル
+
+```mermaid
+flowchart TD
+    classDef data fill:#e6f7ff,stroke:#1f77b4,stroke-width:1px,color:#0b3d91;
+    classDef process fill:#fff1e6,stroke:#ff7f0e,stroke-width:1px,color:#8a3e00;
+    classDef enhanced fill:#e8f5e8,stroke:#2e8b57,stroke-width:2px,color:#006400;
+
+    A[(Analysis Stores)] --> B["verification.Manager\nowns store instances"]
+    B --> C["AnalysisDeps\naggregates wiring input"]
+    C --> D["risk.Evaluator\nassembled once in runner"]
+    D --> E["resource.NormalResourceManager\nuses high-level dependency only"]
+    D -.-> F["security.NetworkAnalyzer\nconsumes aggregated analysis deps"]
+
+    class A data;
+    class B,D,F process;
+    class C,E enhanced;
+```
+
+**凡例（Legend）**
+
+```mermaid
+flowchart LR
+    classDef data fill:#e6f7ff,stroke:#1f77b4,stroke-width:1px,color:#0b3d91;
+    classDef process fill:#fff1e6,stroke:#ff7f0e,stroke-width:1px,color:#8a3e00;
+    classDef enhanced fill:#e8f5e8,stroke:#2e8b57,stroke-width:2px,color:#006400;
+
+    D1[(Configuration / Store Data)] --> P1[Existing Component] --> E1[Enhanced Component]
+    class D1 data
+    class P1 process
+    class E1 enhanced
+```
+
+## 2. システム構成
+
+### 2.1 現状と目標の比較
+
+```mermaid
+flowchart TB
+    classDef data fill:#e6f7ff,stroke:#1f77b4,stroke-width:1px,color:#0b3d91;
+    classDef process fill:#fff1e6,stroke:#ff7f0e,stroke-width:1px,color:#8a3e00;
+    classDef enhanced fill:#e8f5e8,stroke:#2e8b57,stroke-width:2px,color:#006400;
+    classDef risk fill:#fff5e6,stroke:#cc7a00,stroke-width:2px,color:#7a4900;
+
+    subgraph Current[現状]
+        C1["verification.Manager\nGetXxxStore x5"] --> C2["runner.createNormalResourceManager\ncollect stores individually"]
+        C2 --> C3["resource.Config\n5 store fields"]
+        C3 --> C4["newNormalManager"]
+        C4 --> C5["risk.NewStandardEvaluator\n5 store args"]
+        C5 --> C6["security.NewNetworkAnalyzer\n5 store args"]
+    end
+
+    subgraph Target[目標]
+        T1["verification.Manager\nGetAnalysisDeps"] --> T2["runner composition root\nassemble once"]
+        T2 --> T3["resource.Config\nEvaluator only"]
+        T3 --> T4["newNormalManager"]
+        T4 --> T5["risk.Evaluator"]
+        T5 --> T6["security.NewNetworkAnalyzer\naggregated deps"]
+    end
+
+    class C1,C2,C4,C5,C6,T1,T2,T4,T5,T6 process;
+    class C3,T3 enhanced;
+    class Current,Target risk;
+```
+
+### 2.2 コンポーネント配置
+
+```mermaid
+graph TB
+    classDef data fill:#e6f7ff,stroke:#1f77b4,stroke-width:1px,color:#0b3d91;
+    classDef process fill:#fff1e6,stroke:#ff7f0e,stroke-width:1px,color:#8a3e00;
+    classDef enhanced fill:#e8f5e8,stroke:#2e8b57,stroke-width:2px,color:#006400;
+
+    subgraph verification[internal/verification]
+        V1["manager.go\nstore ownership"]
+        V2["analysis deps provider\nnew"]
+    end
+
+    subgraph runner[internal/runner]
+        R1["runner.go\ncomposition root"]
+        R2["resource/default_manager.go\nConfig simplified"]
+        R3["resource/normal_manager.go\nEvaluator injected"]
+    end
+
+    subgraph risk[internal/runner/base/risk]
+        K1["evaluator.go\nNewStandardEvaluator"]
+    end
+
+    subgraph security[internal/runner/base/security]
+        S1["network_analyzer.go\nAnalysisDeps consumed"]
+    end
+
+    V1 --> V2 --> R1 --> R2 --> R3 --> K1 --> S1
+
+    class V1,R1,R3,K1,S1 process;
+    class V2,R2 enhanced;
+```
+
+### 2.3 データフロー
+
+```mermaid
+sequenceDiagram
+    participant VM as verification.Manager
+    participant RC as runner composition root
+    participant RM as resource.NewDefaultResourceManager
+    participant RE as risk.NewStandardEvaluator
+    participant NA as security.NewNetworkAnalyzer
+
+    VM->>RC: provide AnalysisDeps
+    RC->>NA: pass aggregated analysis deps
+    NA-->>RC: ready analyzer
+    RC->>RE: build evaluator once
+    RE-->>RC: ready risk evaluator
+    RC->>RM: pass Evaluator in resource.Config
+```
+
+## 3. コンポーネント設計
+
+### 3.1 依存集約の基本形
+
+分析用ストア群を 1 つの型に集約する。
+
+```go
+// analysis dependencies for network-oriented risk evaluation
+// nil fields preserve current "feature disabled" behavior.
+type AnalysisDeps struct {
+    NetworkSymbolStore fileanalysis.NetworkSymbolStore
+    SyscallStore       fileanalysis.SyscallAnalysisStore
+    DynLibDepsStore    fileanalysis.DynLibDepsStore
+    LibAnalysisStore   dynamicanalysis.Store
+    ShebangStore       fileanalysis.ShebangInterpreterStore
+}
+```
+
+この型の配置候補は以下の 2 つである。
+
+- `internal/runner/base/security`: `NetworkAnalyzer` に最も近い依存定義として配置する
+- `internal/runner/base/risk`: evaluator 構築専用の束として配置する
+
+推奨は `security` 配置である。理由は、依存の実利用者が `NetworkAnalyzer` であり、
+束の意味を最も自然に説明できるためである。
+
+### 3.2 NetworkAnalyzer のコンストラクタ設計
+
+`NewNetworkAnalyzer` は個別ストア列挙をやめ、集約依存を受け取る。
+
+```go
+func NewNetworkAnalyzer(goos string, deps AnalysisDeps) *NetworkAnalyzer
+```
+
+内部保持も同じ集約単位へ寄せる。
+
+```go
+type NetworkAnalyzer struct {
+    goos string
+    deps AnalysisDeps
+}
+```
+
+この変更により、依存追加時の修正箇所は以下に限定される。
+
+- `AnalysisDeps` 定義
+- 依存を組み立てる composition root
+- `NetworkAnalyzer` 内部の参照箇所
+
+### 3.3 StandardEvaluator のコンストラクタ設計
+
+`StandardEvaluator` は分析ストア群を知らず、`AnalysisDeps` または完成済み `NetworkAnalyzer` を受け取る。
+
+候補は 2 つある。
+
+1. `NewStandardEvaluator(deps security.AnalysisDeps) Evaluator`
+2. `NewStandardEvaluator(networkAnalyzer *security.NetworkAnalyzer) Evaluator`
+
+推奨は 1 ではなく 2 である。
+理由は、`risk` が保持すべきものは判定器であり、分析ストア構成そのものではないためである。
+最終形としては `risk` が `NetworkAnalyzer` の完成品だけを受け取り、
+依存組み立てはその手前で終える。
+
+### 3.4 resource.Config の簡素化
+
+`resource.Config` から分析ストア群の個別フィールドを削除し、
+`risk.Evaluator` を直接保持する。
+
+```go
+type Config struct {
+    Executor         executor.CommandExecutor
+    FileSystem       executor.FileSystem
+    PrivilegeManager runnertypes.PrivilegeManager
+    PathResolver     PathResolver
+    Logger           *slog.Logger
+    Mode             ExecutionMode
+    DryRunOpts       *DryRunOptions
+    OutputManager    output.CaptureManager
+    MaxOutputSize    int64
+    RiskEvaluator    risk.Evaluator
+}
+```
+
+`newNormalManager` は以下のどちらかを行う。
+
+- `cfg.RiskEvaluator` をそのまま使用する
+- 未指定時のみ既定 evaluator を補完する
+
+推奨は前者である。`resource` は evaluator を利用するだけに留め、
+既定 evaluator の生成責務を持たない方が境界が明確になる。
+
+### 3.5 verification.Manager の提供 API
+
+`verification.Manager` は分析ストア群の所有者として、
+`GetAnalysisDeps() security.AnalysisDeps` を提供する。
+
+この API を採用する理由は以下の通り。
+
+- `verification` は分析基盤の生成責務に集中できる
+- `runner` が composition root として evaluator 組み立てを完結できる
+- `verification` が `risk` 実装へ依存せず、層構造を保てる
+
+`verification` に `NewRiskEvaluator()` を持たせる案は採用しない。
+その案は配線をさらに短くできるが、`verification` が `risk` の知識を持つため、
+基盤層の責務が広がるためである。
+
+### 3.6 推奨する最終責務分担
+
+- `verification.Manager`: 分析ストア生成と集約依存の提供
+- `runner.createNormalResourceManager`: 集約依存から `NetworkAnalyzer` / `risk.Evaluator` を 1 回だけ組み立てる
+- `resource.DefaultResourceManager`: evaluator を受け取って保持する
+- `risk.StandardEvaluator`: `NetworkAnalyzer` を使ってコマンドリスクを判定する
+- `security.NetworkAnalyzer`: 分析依存を使ってネットワーク関連シグナルを判定する
+
+## 4. エラーハンドリング設計
+
+### 4.1 基本方針
+
+- 配線変更によって既存のエラー分類を変えない
+- 分析ストアの `nil` は従来通り「該当分析が無効」を意味する
+- `verification` の初期化失敗時ポリシーは既存の fail-open / fail-closed に従う
+- `resource` は evaluator 組み立て済みを受け取るため、依存欠落の解釈を持たない
+
+### 4.2 エラー境界
+
+```mermaid
+flowchart TD
+    classDef data fill:#e6f7ff,stroke:#1f77b4,stroke-width:1px,color:#0b3d91;
+    classDef process fill:#fff1e6,stroke:#ff7f0e,stroke-width:1px,color:#8a3e00;
+    classDef enhanced fill:#e8f5e8,stroke:#2e8b57,stroke-width:2px,color:#006400;
+
+    A[(Store initialization failure)] --> B[verification.Manager]
+    B --> C{"production and required?"}
+    C -->|Yes| D[return initialization error]
+    C -->|No| E[expose nil-backed deps]
+    E --> F[NetworkAnalyzer]
+    F --> G[existing disabled-analysis behavior]
+
+    class A data;
+    class B,D,F,G process;
+    class C,E enhanced;
+```
+
+## 5. セキュリティ考慮事項
+
+### 5.1 セキュリティ設計原則
+
+- 具体ストア生成を `security` に移さない
+- `nil` による分析無効化意味を変更しない
+- フェイルクローズ条件を配線整理で弱めない
+- shebang 追跡や dynlib 解析の高リスク判定を不変とする
+
+### 5.2 脅威モデル
+
+```mermaid
+flowchart LR
+    classDef data fill:#e6f7ff,stroke:#1f77b4,stroke-width:1px,color:#0b3d91;
+    classDef process fill:#fff1e6,stroke:#ff7f0e,stroke-width:1px,color:#8a3e00;
+    classDef enhanced fill:#e8f5e8,stroke:#2e8b57,stroke-width:2px,color:#006400;
+
+    A[(Refactor regression)] --> B["Analysis dependency wiring"]
+    B --> C["Risk evaluation bypass"]
+    B --> D["Unexpected fail-open"]
+    B --> E["Shebang or dynlib analysis skipped"]
+    B --> F["Test setup complexity remains"]
+
+    G["Aggregated deps + evaluator injection"] --> H["Single composition point"]
+    H --> I["behavior-preserving refactor"]
+
+    class A data;
+    class B,C,D,E,F process;
+    class G,H,I enhanced;
+```
+
+## 6. 処理フロー詳細
+
+### 6.1 初期化フロー
+
+```mermaid
+sequenceDiagram
+    participant VM as verification.Manager
+    participant Runner as runner.go
+    participant Eval as risk.Evaluator
+    participant Res as resource.NormalResourceManager
+
+    VM->>Runner: GetAnalysisDeps()
+    Runner->>Runner: NewNetworkAnalyzer(runtime.GOOS, deps)
+    Runner->>Runner: NewStandardEvaluator(networkAnalyzer)
+    Runner->>Res: inject evaluator via Config
+    Res-->>Runner: ready
+```
+
+### 6.2 実行時フロー
+
+```mermaid
+sequenceDiagram
+    participant RM as NormalResourceManager
+    participant RE as StandardEvaluator
+    participant NA as NetworkAnalyzer
+
+    RM->>RE: EvaluateRisk(cmd)
+    RE->>NA: IsNetworkOperation(cmd, args, hash)
+    NA->>NA: analyze via aggregated deps
+    NA-->>RE: isNetwork, isHighRisk
+    RE-->>RM: RiskLevel
+```
+
+## 7. テスト戦略
+
+### 7.1 単体テスト
+
+- `security.NewNetworkAnalyzer` が集約依存を受け取る構造へ変更されても既存判定ロジックが保たれることを確認する
+- `risk.NewStandardEvaluator` が `NetworkAnalyzer` 完成品を受け取ることを確認する
+- `resource.newNormalManager` が evaluator を直接利用し、分析ストア詳細を持たないことを確認する
+
+### 7.2 統合テスト
+
+- runner 初期化時に `verification.Manager` 由来の分析依存から evaluator が正しく構築されることを確認する
+- ネットワーク判定を含む既存 integration test が通ることを確認する
+- dry-run / normal の両モードで初期化が壊れていないことを確認する
+
+### 7.3 セキュリティテスト
+
+- 分析ストア欠落時の fail-open / fail-closed ポリシーが不変であることを確認する
+- shebang 追跡と dynlib 依存分析が従来通り有効化・無効化されることを確認する
+- 分析依存の配線変更によりリスク評価がスキップされないことを確認する
+
+## 8. 実装の優先順位
+
+### Phase 1: 依存集約型の導入
+
+- `AnalysisDeps` を定義する
+- `NewNetworkAnalyzer` を集約依存へ対応させる
+- 既存の個別引数呼び出し箇所を置き換える
+
+### Phase 2: evaluator 構築責務の整理
+
+- `risk.NewStandardEvaluator` が `NetworkAnalyzer` 完成品を受け取る形へ変更する
+- `resource.Config` から分析ストア詳細を削除する
+- `NormalResourceManager` は evaluator 注入のみに変更する
+
+### Phase 3: composition root の単純化
+
+- `verification.Manager` から集約依存を取得する API を追加する
+- `runner.createNormalResourceManager` の個別型アサーションと個別 getter 群を除去する
+- 既存初期化テストを更新し、挙動互換を確認する
+
+## 9. 将来の拡張性
+
+- 分析ストアが 1 つ増えても `AnalysisDeps` と組み立て箇所だけの変更で済む
+- `resource` は evaluator のみを知るため、新しい分析機能追加の影響を受けにくい
+- `verification.Manager` が他の分析セットを提供する場合も、provider 境界を増やすだけで対応できる
+- 将来的に evaluator factory を導入する場合でも、現在の集約依存設計を土台として段階移行できる

--- a/docs/tasks/0127_network_analyzer_dependency_simplification/02_architecture.md
+++ b/docs/tasks/0127_network_analyzer_dependency_simplification/02_architecture.md
@@ -26,11 +26,11 @@ flowchart TD
     classDef process fill:#fff1e6,stroke:#ff7f0e,stroke-width:1px,color:#8a3e00;
     classDef enhanced fill:#e8f5e8,stroke:#2e8b57,stroke-width:2px,color:#006400;
 
-    A[(Analysis Stores)] --> B["verification.Manager\nowns store instances"]
-    B --> C["AnalysisDeps\naggregates wiring input"]
-    C --> D["risk.Evaluator\nassembled once in runner"]
-    D --> E["resource.NormalResourceManager\nuses high-level dependency only"]
-    D -.-> F["security.NetworkAnalyzer\nconsumes aggregated analysis deps"]
+    A[(Analysis Stores)] --> B["verification.Manager<br>owns store instances"]
+    B --> C["AnalysisDeps<br>aggregates wiring input"]
+    C --> D["risk.Evaluator<br>assembled once in runner"]
+    D --> E["resource.NormalResourceManager<br>uses high-level dependency only"]
+    D -.-> F["security.NetworkAnalyzer<br>consumes aggregated analysis deps"]
 
     class A data;
     class B,D,F process;
@@ -63,19 +63,19 @@ flowchart TB
     classDef risk fill:#fff5e6,stroke:#cc7a00,stroke-width:2px,color:#7a4900;
 
     subgraph Current[現状]
-        C1["verification.Manager\nGetXxxStore x5"] --> C2["runner.createNormalResourceManager\ncollect stores individually"]
-        C2 --> C3["resource.Config\n5 store fields"]
+        C1["verification.Manager<br>GetXxxStore x5"] --> C2["runner.createNormalResourceManager<br>collect stores individually"]
+        C2 --> C3["resource.Config<br>5 store fields"]
         C3 --> C4["newNormalManager"]
-        C4 --> C5["risk.NewStandardEvaluator\n5 store args"]
-        C5 --> C6["security.NewNetworkAnalyzer\n5 store args"]
+        C4 --> C5["risk.NewStandardEvaluator<br>5 store args"]
+        C5 --> C6["security.NewNetworkAnalyzer<br>5 store args"]
     end
 
     subgraph Target[目標]
-        T1["verification.Manager\nGetAnalysisDeps"] --> T2["runner composition root\nassemble once"]
-        T2 --> T3["resource.Config\nEvaluator only"]
+        T1["verification.Manager<br>GetAnalysisDeps"] --> T2["runner composition root<br>assemble once"]
+        T2 --> T3["resource.Config<br>Evaluator only"]
         T3 --> T4["newNormalManager"]
         T4 --> T5["risk.Evaluator"]
-        T5 --> T6["security.NewNetworkAnalyzer\naggregated deps"]
+        T5 --> T6["security.NewNetworkAnalyzer<br>aggregated deps"]
     end
 
     class C1,C2,C4,C5,C6,T1,T2,T4,T5,T6 process;
@@ -92,22 +92,22 @@ graph TB
     classDef enhanced fill:#e8f5e8,stroke:#2e8b57,stroke-width:2px,color:#006400;
 
     subgraph verification[internal/verification]
-        V1["manager.go\nstore ownership"]
-        V2["analysis deps provider\nnew"]
+        V1["manager.go<br>store ownership"]
+        V2["analysis deps provider<br>new"]
     end
 
     subgraph runner[internal/runner]
-        R1["runner.go\ncomposition root"]
-        R2["resource/default_manager.go\nConfig simplified"]
-        R3["resource/normal_manager.go\nEvaluator injected"]
+        R1["runner.go<br>composition root"]
+        R2["resource/default_manager.go<br>Config simplified"]
+        R3["resource/normal_manager.go<br>Evaluator injected"]
     end
 
     subgraph risk[internal/runner/base/risk]
-        K1["evaluator.go\nNewStandardEvaluator"]
+        K1["evaluator.go<br>NewStandardEvaluator"]
     end
 
     subgraph security[internal/runner/base/security]
-        S1["network_analyzer.go\nAnalysisDeps consumed"]
+        S1["network_analyzer.go<br>AnalysisDeps consumed"]
     end
 
     V1 --> V2 --> R1 --> R2 --> R3 --> K1 --> S1

--- a/docs/tasks/0127_network_analyzer_dependency_simplification/03_detailed_specification.md
+++ b/docs/tasks/0127_network_analyzer_dependency_simplification/03_detailed_specification.md
@@ -1,0 +1,569 @@
+# 詳細仕様書: NetworkAnalyzer 周辺の依存配線簡素化
+
+## 1. 変更対象ファイル
+
+| ファイル | 変更種別 |
+|---------|---------|
+| `internal/runner/base/security/network_analyzer.go` | 型追加・シグネチャ変更 |
+| `internal/runner/base/security/network_analyzer_test_helpers.go` | テストヘルパー更新 |
+| `internal/runner/base/security/network_analyzer_test.go` | コンストラクタ呼び出し更新 |
+| `internal/runner/base/security/command_analysis_test.go` | コンストラクタ呼び出し更新 |
+| `internal/runner/base/risk/evaluator.go` | シグネチャ変更 |
+| `internal/runner/base/risk/evaluator_test.go` | コンストラクタ呼び出し更新 |
+| `internal/runner/resource/default_manager.go` | Config フィールド変更 |
+| `internal/runner/resource/normal_manager.go` | newNormalManager 変更 |
+| `internal/runner/resource/test_helpers.go` | テストヘルパー更新 |
+| `internal/runner/resource/testutil/helpers.go` | テストヘルパー更新 |
+| `internal/runner/runner.go` | createNormalResourceManager 簡素化 |
+| `internal/runner/runner_test.go` | TestCreateNormalResourceManager_* 更新 |
+| `internal/verification/manager.go` | GetAnalysisDeps 追加・旧 getter 削除 |
+
+---
+
+## 2. Phase 1: security.AnalysisDeps 導入と NetworkAnalyzer 更新
+
+### 2.1 AnalysisDeps 型定義
+
+`internal/runner/base/security/network_analyzer.go` に追加する。
+
+```go
+// AnalysisDeps aggregates the analysis stores consumed by NetworkAnalyzer.
+// A nil field disables the corresponding analysis, preserving the existing
+// "feature disabled" behavior.
+type AnalysisDeps struct {
+    NetworkSymbolStore fileanalysis.NetworkSymbolStore
+    SyscallStore       fileanalysis.SyscallAnalysisStore
+    DynLibDepsStore    fileanalysis.DynLibDepsStore
+    LibAnalysisStore   dynamicanalysis.Store
+    ShebangStore       fileanalysis.ShebangInterpreterStore
+}
+```
+
+### 2.2 NetworkAnalyzer 構造体変更
+
+変更前:
+```go
+type NetworkAnalyzer struct {
+    goos             string
+    store            fileanalysis.NetworkSymbolStore
+    syscallStore     fileanalysis.SyscallAnalysisStore
+    depsStore        fileanalysis.DynLibDepsStore
+    libAnalysisStore dynamicanalysis.Store
+    shebangStore     fileanalysis.ShebangInterpreterStore
+}
+```
+
+変更後:
+```go
+type NetworkAnalyzer struct {
+    goos string
+    deps AnalysisDeps
+}
+```
+
+### 2.3 NewNetworkAnalyzer シグネチャ変更
+
+変更前:
+```go
+func NewNetworkAnalyzer(
+    goos string,
+    symStore fileanalysis.NetworkSymbolStore,
+    svcStore fileanalysis.SyscallAnalysisStore,
+    depsStore fileanalysis.DynLibDepsStore,
+    libAnalysisStore dynamicanalysis.Store,
+    shebangStore fileanalysis.ShebangInterpreterStore,
+) *NetworkAnalyzer
+```
+
+変更後:
+```go
+func NewNetworkAnalyzer(goos string, deps AnalysisDeps) *NetworkAnalyzer
+```
+
+### 2.4 内部フィールド参照の置き換え
+
+`NetworkAnalyzer` のメソッド内での参照を以下の通り一括置換する。
+
+| 変更前 | 変更後 |
+|--------|--------|
+| `a.store` | `a.deps.NetworkSymbolStore` |
+| `a.syscallStore` | `a.deps.SyscallStore` |
+| `a.depsStore` | `a.deps.DynLibDepsStore` |
+| `a.libAnalysisStore` | `a.deps.LibAnalysisStore` |
+| `a.shebangStore` | `a.deps.ShebangStore` |
+
+### 2.5 network_analyzer_test_helpers.go の更新
+
+`newNetworkAnalyzerWithStore` は `AnalysisDeps` を使う形に変更する。
+`newNetworkAnalyzer` は構造体リテラルから `deps` フィールドが消えるのみ（変更不要）。
+
+```go
+func newNetworkAnalyzerWithStore(goos string, store fileanalysis.NetworkSymbolStore) *NetworkAnalyzer {
+    return &NetworkAnalyzer{goos: isec.RequireGOOS(goos), deps: AnalysisDeps{NetworkSymbolStore: store}}
+}
+```
+
+### 2.6 テスト変更: network_analyzer_test.go と command_analysis_test.go
+
+`NewNetworkAnalyzer` を呼び出している箇所をすべて新シグネチャに変換する。
+変換パターンは以下の通り。
+
+| 変換前 | 変換後 |
+|--------|--------|
+| `NewNetworkAnalyzer(runtime.GOOS, nil, nil, nil, nil, nil)` | `NewNetworkAnalyzer(runtime.GOOS, AnalysisDeps{})` |
+| `NewNetworkAnalyzer(runtime.GOOS, symStore, svcStore, nil, nil, nil)` | `NewNetworkAnalyzer(runtime.GOOS, AnalysisDeps{NetworkSymbolStore: symStore, SyscallStore: svcStore})` |
+| `NewNetworkAnalyzer(runtime.GOOS, nil, nil, depsStore, libStore, nil)` | `NewNetworkAnalyzer(runtime.GOOS, AnalysisDeps{DynLibDepsStore: depsStore, LibAnalysisStore: libStore})` |
+| `NewNetworkAnalyzer(runtime.GOOS, symStore, svcStore, depsStore, libStore, shebangStore)` | `NewNetworkAnalyzer(runtime.GOOS, AnalysisDeps{NetworkSymbolStore: symStore, SyscallStore: svcStore, DynLibDepsStore: depsStore, LibAnalysisStore: libStore, ShebangStore: shebangStore})` |
+
+`command_analysis_test.go` は package `security` 内のため、`security.` プレフィックスは不要。
+`network_analyzer_test.go` も同様。
+
+---
+
+## 3. Phase 2: risk.NewStandardEvaluator と resource.Config の変更
+
+### 3.1 risk.NewStandardEvaluator シグネチャ変更
+
+変更前:
+```go
+func NewStandardEvaluator(
+    symStore fileanalysis.NetworkSymbolStore,
+    syscallStore fileanalysis.SyscallAnalysisStore,
+    depsStore fileanalysis.DynLibDepsStore,
+    libAnalysisStore dynamicanalysis.Store,
+    shebangStore fileanalysis.ShebangInterpreterStore,
+) Evaluator
+```
+
+変更後:
+```go
+func NewStandardEvaluator(networkAnalyzer *security.NetworkAnalyzer) Evaluator
+```
+
+`NewStandardEvaluator` の内部実装:
+
+```go
+func NewStandardEvaluator(networkAnalyzer *security.NetworkAnalyzer) Evaluator {
+    return &StandardEvaluator{networkAnalyzer: networkAnalyzer}
+}
+```
+
+`runtime` および分析ストアの import は不要になる。`security` import は既存のまま維持する。
+
+### 3.2 risk/evaluator_test.go の更新
+
+変更前:
+```go
+evaluator := NewStandardEvaluator(nil, nil, nil, nil, nil)
+```
+
+変更後:
+```go
+evaluator := NewStandardEvaluator(security.NewNetworkAnalyzer(runtime.GOOS, security.AnalysisDeps{}))
+```
+
+テストファイルに `"runtime"` と `security` の import を追加する。
+
+### 3.3 resource.Config の変更
+
+変更前（`internal/runner/resource/default_manager.go`）:
+```go
+type Config struct {
+    // ...
+    NetworkSymbolStore fileanalysis.NetworkSymbolStore
+    SyscallStore       fileanalysis.SyscallAnalysisStore
+    DynLibDepsStore    fileanalysis.DynLibDepsStore
+    LibAnalysisStore   dynamicanalysis.Store
+    ShebangStore       fileanalysis.ShebangInterpreterStore
+}
+```
+
+変更後:
+```go
+type Config struct {
+    Executor         executor.CommandExecutor
+    FileSystem       executor.FileSystem
+    PrivilegeManager runnertypes.PrivilegeManager
+    PathResolver     PathResolver
+    Logger           *slog.Logger
+    Mode             ExecutionMode
+    DryRunOpts       *DryRunOptions
+    OutputManager    output.CaptureManager
+    MaxOutputSize    int64
+    RiskEvaluator    risk.Evaluator
+}
+```
+
+`default_manager.go` から不要になる import (`fileanalysis`, `dynamicanalysis`) を削除する。
+
+### 3.4 resource/normal_manager.go の変更
+
+`newNormalManager` の `riskEvaluator` 組み立て行を `cfg.RiskEvaluator` の直接代入に変更する。
+
+変更前:
+```go
+riskEvaluator: risk.NewStandardEvaluator(cfg.NetworkSymbolStore, cfg.SyscallStore, cfg.DynLibDepsStore, cfg.LibAnalysisStore, cfg.ShebangStore),
+```
+
+変更後:
+```go
+riskEvaluator: cfg.RiskEvaluator,
+```
+
+`cfg.RiskEvaluator` が nil の場合、`EvaluateRisk` 呼び出し時に nil ポインタパニックとなる。
+これは呼び出し側（composition root またはテストヘルパー）の責任で非 nil を保証すること。
+
+### 3.5 runner.go の中間状態（Phase 2）
+
+`resource.Config` からストアフィールドが削除されるため、`runner.go` を同時に更新してコンパイルを通す。
+この時点では 5 系統の型アサーションは残るが、取得したストアで `AnalysisDeps` と evaluator を組み立てて
+`resource.Config.RiskEvaluator` に渡す中間形態とする。
+
+```go
+// Intermediate state after Phase 2 (5 type assertions remain, evaluator assembled here)
+deps := security.AnalysisDeps{
+    NetworkSymbolStore: networkStore,
+    SyscallStore:       syscallStore,
+    DynLibDepsStore:    dynLibDepsStore,
+    LibAnalysisStore:   dynlibAnalysisStore,
+    ShebangStore:       shebangStore,
+}
+networkAnalyzer := security.NewNetworkAnalyzer(runtime.GOOS, deps)
+evaluator := risk.NewStandardEvaluator(networkAnalyzer)
+
+resourceManager, err := resource.NewDefaultResourceManager(resource.Config{
+    // ... other fields ...
+    RiskEvaluator: evaluator,
+})
+```
+
+追加 import: `"runtime"`, `risk`。
+`fileanalysis`, `dynamicanalysis` の import は Phase 3 まで残す。
+
+### 3.6 resource/test_helpers.go の変更
+
+`NetworkSymbolStore` 引数を削除し、テスト専用の evaluator を内部で生成する。
+
+変更前:
+```go
+func NewNormalResourceManagerWithOutput(
+    exec executor.CommandExecutor,
+    fs executor.FileSystem,
+    privMgr runnertypes.PrivilegeManager,
+    outputMgr output.CaptureManager,
+    maxOutputSize int64,
+    logger *slog.Logger,
+    store fileanalysis.NetworkSymbolStore,
+) *NormalResourceManager {
+    return newNormalManager(Config{
+        Executor:           exec,
+        FileSystem:         fs,
+        PrivilegeManager:   privMgr,
+        MaxOutputSize:      maxOutputSize,
+        Logger:             logger,
+        NetworkSymbolStore: store,
+    }, outputMgr)
+}
+```
+
+変更後:
+```go
+func NewNormalResourceManagerWithOutput(
+    exec executor.CommandExecutor,
+    fs executor.FileSystem,
+    privMgr runnertypes.PrivilegeManager,
+    outputMgr output.CaptureManager,
+    maxOutputSize int64,
+    logger *slog.Logger,
+) *NormalResourceManager {
+    return newNormalManager(Config{
+        Executor:         exec,
+        FileSystem:       fs,
+        PrivilegeManager: privMgr,
+        MaxOutputSize:    maxOutputSize,
+        Logger:           logger,
+        RiskEvaluator:    defaultTestEvaluator(),
+    }, outputMgr)
+}
+```
+
+`NewNormalResourceManager` も同様に更新する。
+
+`NewDefaultResourceManagerForTest` は `symStore fileanalysis.NetworkSymbolStore` パラメータを削除し、
+`Config.RiskEvaluator` に `defaultTestEvaluator()` を設定する。
+
+`defaultTestEvaluator` はテスト専用のヘルパー関数として同ファイルに定義する:
+
+```go
+func defaultTestEvaluator() risk.Evaluator {
+    return risk.NewStandardEvaluator(security.NewNetworkAnalyzer(runtime.GOOS, security.AnalysisDeps{}))
+}
+```
+
+`test_helpers.go` に `runtime`, `risk`, `security` の import を追加する。
+`fileanalysis` の import は削除する。
+
+### 3.7 resource/testutil/helpers.go の変更
+
+`symStore fileanalysis.NetworkSymbolStore` パラメータを削除し、
+`resource.NewDefaultResourceManager` に渡す `Config.RiskEvaluator` に evaluator を設定する。
+
+`testutil` パッケージは `resource` の公開 API のみ呼べるため、
+`resource/test_helpers.go` の `defaultTestEvaluator()` は参照できない。
+`testutil/helpers.go` 内で直接 evaluator を生成する。
+
+```go
+func NewDefaultResourceManager(
+    exec executor.CommandExecutor,
+    fs executor.FileSystem,
+    privMgr runnertypes.PrivilegeManager,
+    pathResolver resource.PathResolver,
+    logger *slog.Logger,
+    mode resource.ExecutionMode,
+    dryRunOpts *resource.DryRunOptions,
+    outputMgr output.CaptureManager,
+    maxOutputSize int64,
+) (*resource.DefaultResourceManager, error) {
+    return resource.NewDefaultResourceManager(resource.Config{
+        Executor:         exec,
+        FileSystem:       fs,
+        PrivilegeManager: privMgr,
+        PathResolver:     pathResolver,
+        Logger:           logger,
+        Mode:             mode,
+        DryRunOpts:       dryRunOpts,
+        OutputManager:    outputMgr,
+        MaxOutputSize:    maxOutputSize,
+        RiskEvaluator:    risk.NewStandardEvaluator(security.NewNetworkAnalyzer(runtime.GOOS, security.AnalysisDeps{})),
+    })
+}
+```
+
+`testutil/helpers.go` に `"runtime"`、`risk`、`security` の import を追加する。
+不要になる `fileanalysis` の import を削除する。
+
+### 3.8 テスト呼び出しの更新
+
+`NewNormalResourceManagerWithOutput(exec, fs, priv, outputMgr, maxSize, logger, nil)` → 末尾の `nil` 引数を削除。
+`NewDefaultResourceManagerForTest(..., nil, 0, nil)` → 末尾の `nil` (symStore) を削除して `..., nil, 0`。
+
+変更対象ファイル:
+- `internal/runner/resource/normal_manager_test.go`
+- `internal/runner/resource/error_scenarios_test.go`
+- `internal/runner/resource/default_manager_test.go`
+- `internal/runner/resource/performance_test.go`
+- `internal/runner/e2e_slack_redaction_test.go`
+- `internal/runner/integration_dual_defense_test.go`
+- `internal/runner/command_output_capture_test.go`
+
+---
+
+## 4. Phase 3: verification.Manager の API 追加と runner 簡素化
+
+### 4.1 verification.Manager.GetAnalysisDeps() の追加
+
+`internal/verification/manager.go` に追加する。
+
+```go
+// GetAnalysisDeps returns the aggregated analysis dependencies owned by this Manager.
+// Nil fields in the returned AnalysisDeps indicate that the corresponding analysis
+// is unavailable (e.g. hash dir absent or store initialization failed).
+func (m *Manager) GetAnalysisDeps() security.AnalysisDeps {
+    return security.AnalysisDeps{
+        NetworkSymbolStore: m.networkSymbolStore,
+        SyscallStore:       m.syscallAnalysisStore,
+        DynLibDepsStore:    m.dynLibDepsStore,
+        LibAnalysisStore:   m.dynlibAnalysisStore,
+        ShebangStore:       m.shebangStore,
+    }
+}
+```
+
+`verification` パッケージに `security` の import が追加される。
+現時点で `security` → `verification` の依存はないため、循環 import は生じない。
+
+### 4.2 旧 getter の削除
+
+以下のメソッドは `runner.go` からの参照がなくなるため削除する。
+
+- `GetNetworkSymbolStore() fileanalysis.NetworkSymbolStore`
+- `GetSyscallAnalysisStore() fileanalysis.SyscallAnalysisStore`
+- `GetDynLibAnalysisStore() dynamicanalysis.Store`
+- `GetDynLibDepsStore() fileanalysis.DynLibDepsStore`
+- `GetShebangInterpreterStore() fileanalysis.ShebangInterpreterStore`
+
+`fileanalysis` および `dynamicanalysis` の import は `Manager` 構造体フィールドや他のメソッドで
+引き続き使用されるため、旧 getter 削除後も残す。
+
+### 4.3 runner.createNormalResourceManager の簡素化
+
+Phase 3 完了後の `createNormalResourceManager`:
+
+```go
+func createNormalResourceManager(opts *runnerOptions, _ *runnertypes.ConfigSpec, pathResolver resource.PathResolver, validator *security.Validator) error {
+    fs := common.NewDefaultFileSystem()
+    maxOutputSize := int64(0)
+
+    outputMgr := output.NewDefaultOutputCaptureManager(validator)
+
+    var deps security.AnalysisDeps
+    type analysisDepsProvider interface {
+        GetAnalysisDeps() security.AnalysisDeps
+    }
+    if p, ok := pathResolver.(analysisDepsProvider); ok {
+        deps = p.GetAnalysisDeps()
+    }
+
+    networkAnalyzer := security.NewNetworkAnalyzer(runtime.GOOS, deps)
+    evaluator := risk.NewStandardEvaluator(networkAnalyzer)
+
+    resourceManager, err := resource.NewDefaultResourceManager(resource.Config{
+        Executor:         opts.executor,
+        FileSystem:       fs,
+        PrivilegeManager: opts.privilegeManager,
+        PathResolver:     pathResolver,
+        Logger:           slog.Default(),
+        Mode:             resource.ExecutionModeNormal,
+        DryRunOpts:       &resource.DryRunOptions{},
+        OutputManager:    outputMgr,
+        MaxOutputSize:    maxOutputSize,
+        RiskEvaluator:    evaluator,
+    })
+    if err != nil {
+        return fmt.Errorf("failed to create default resource manager: %w", err)
+    }
+    opts.resourceManager = resourceManager
+    return nil
+}
+```
+
+不要になる import: `fileanalysis`, `dynamicanalysis`。
+追加が必要な import: `runtime`, `risk`。
+
+### 4.4 runner_test.go の更新
+
+`TestCreateNormalResourceManager_AnalysisStoresInjected` は `GetAnalysisDeps()` が呼ばれることを検証する形に変更する。
+
+変更前（`pathResolverWithStore`）:
+```go
+type pathResolverWithStore struct {
+    networkStoreCalled *bool
+    syscallStoreCalled *bool
+}
+
+func (p *pathResolverWithStore) GetNetworkSymbolStore() fileanalysis.NetworkSymbolStore { ... }
+func (p *pathResolverWithStore) GetSyscallAnalysisStore() fileanalysis.SyscallAnalysisStore { ... }
+```
+
+変更後（`pathResolverWithDeps`）:
+```go
+type pathResolverWithDeps struct {
+    called *bool
+}
+
+func (p *pathResolverWithDeps) ResolvePath(path string) (string, error) {
+    return path, nil
+}
+
+func (p *pathResolverWithDeps) GetAnalysisDeps() security.AnalysisDeps {
+    *p.called = true
+    return security.AnalysisDeps{}
+}
+```
+
+テスト本体:
+```go
+func TestCreateNormalResourceManager_AnalysisStoresInjected(t *testing.T) {
+    called := false
+    resolver := &pathResolverWithDeps{called: &called}
+
+    opts := &runnerOptions{}
+    err := createNormalResourceManager(opts, &runnertypes.ConfigSpec{}, resolver, nil)
+    require.NoError(t, err)
+
+    assert.True(t, called, "GetAnalysisDeps must be called when pathResolver implements the interface")
+    assert.NotNil(t, opts.resourceManager)
+}
+```
+
+`TestCreateNormalResourceManager_NoStoreWhenResolverLacksInterface` はロジック変更なし（pathResolver が `GetAnalysisDeps` を実装しない場合に空の deps が使われることを確認）。
+
+---
+
+## 5. 受け入れ基準とテストの対応
+
+| AC | 基準 | 検証方法 |
+|----|------|---------|
+| AC-1 | `NetworkAnalyzer` と `StandardEvaluator` のコンストラクタが分析依存 5 個を個別引数で受け取らない | コンパイル確認（シグネチャ変更後は旧シグネチャが使えない） |
+| AC-2 | `resource.Config` から分析ストア群の個別フィールドが除去される | コンパイル確認 |
+| AC-3 | `runner.createNormalResourceManager` での分析依存配線が単一の組み立て操作に簡約される | コードレビュー（型アサーション 1 系統のみ） |
+| AC-4 | 分析依存の具体生成責務は `verification` に残り、`security` は具体ストア構築を行わない | コードレビュー（`security` パッケージに hash/store dir 構築コードがない） |
+| AC-5 | 既存のネットワーク判定系テストと runner 初期化系テストが通過する | `make test` |
+| AC-6 | `make test`、`make lint`、`make build` が成功する | CI |
+
+既存テストの補完として以下を確認する。
+
+- `TestCreateNormalResourceManager_AnalysisStoresInjected`: `GetAnalysisDeps()` が呼ばれる
+- `verification.Manager.GetAnalysisDeps()` が 5 フィールドすべてを返す（新規テスト）
+- 既存の `network_analyzer_test.go` のすべてのシナリオが新シグネチャで通過する
+
+### 新規テスト: TestManager_GetAnalysisDeps
+
+`internal/verification/manager_test.go`（または既存の verification テストファイル）に追加。
+
+```go
+func TestManager_GetAnalysisDeps(t *testing.T) {
+    m := &Manager{}
+    deps := m.GetAnalysisDeps()
+    // All fields nil when manager has no stores initialized
+    assert.Nil(t, deps.NetworkSymbolStore)
+    assert.Nil(t, deps.SyscallStore)
+    assert.Nil(t, deps.DynLibDepsStore)
+    assert.Nil(t, deps.LibAnalysisStore)
+    assert.Nil(t, deps.ShebangStore)
+}
+```
+
+---
+
+## 6. モック境界の定義（F-127-5 AC-3）
+
+本リファクタリング後の推奨モック境界は以下の通り。
+
+### 単体テスト（security パッケージ）
+
+- `NetworkAnalyzer` の単体テストは `AnalysisDeps` のフィールドに stub store を注入する
+- `AnalysisDeps` 全体をゼロ値にすれば、すべての store が無効化された状態を手軽に再現できる
+- `NewNetworkAnalyzer(runtime.GOOS, AnalysisDeps{...})` を直接呼ぶ
+
+### 単体テスト（risk パッケージ）
+
+- `risk.Evaluator` インターフェース全体を mock にして `NormalResourceManager` を差し替えることができる
+- `NewStandardEvaluator` 自体のテストは `*security.NetworkAnalyzer` を注入する
+
+### 統合テスト（runner パッケージ）
+
+- `pathResolverWithDeps` など最小の struct で `GetAnalysisDeps()` を実装すれば十分
+- `WithVerificationManager` Option で本物の `verification.Manager` を差し込む統合シナリオも引き続き利用可能
+
+### テスト用ヘルパーの責任範囲
+
+- `resource/test_helpers.go`: ストア詳細を不要とし、`defaultTestEvaluator()` で標準 evaluator を内包する
+- `resource/testutil/helpers.go`: 公開 API 経由で `Config.RiskEvaluator` にデフォルト evaluator を設定する
+- テストが特定のリスク判定挙動を検証したい場合は、`risk.Evaluator` を実装した mock を `resource.Config.RiskEvaluator` に直接渡す
+
+---
+
+## 7. import 依存の変化
+
+| 変化 | 方向 | 理由 |
+|------|------|------|
+| `verification` → `security` | 追加 | `GetAnalysisDeps()` の戻り値型が `security.AnalysisDeps` |
+| `runner` → `risk` | 追加 | `risk.NewStandardEvaluator` を呼ぶ |
+| `runner` → `fileanalysis`, `dynamicanalysis` | 削除 | 個別型アサーションが不要になる |
+| `resource` → `fileanalysis`, `dynamicanalysis` | 削除 | Config フィールドから削除 |
+| `risk` → `fileanalysis`, `dynamicanalysis` | 削除 | コンストラクタ引数から削除 |
+
+循環 import の懸念:
+- `verification` → `security`: `security` が `verification` を import していないため問題なし
+- `runner` → `risk`, `security`: すでに両方 import 済み

--- a/docs/tasks/0127_network_analyzer_dependency_simplification/04_implementation_plan.md
+++ b/docs/tasks/0127_network_analyzer_dependency_simplification/04_implementation_plan.md
@@ -1,0 +1,186 @@
+# 実装計画書: NetworkAnalyzer 周辺の依存配線簡素化
+
+## 進捗サマリー
+
+- Phase 1: security.AnalysisDeps 導入
+- Phase 2: risk / resource レイヤーの整理
+- Phase 3: composition root の簡素化
+
+---
+
+## Phase 1: security.AnalysisDeps 導入と NetworkAnalyzer 更新
+
+### 1-1. AnalysisDeps 型と NewNetworkAnalyzer の変更
+
+- [ ] `internal/runner/base/security/network_analyzer.go`
+  - [ ] `AnalysisDeps` 構造体を追加する
+  - [ ] `NetworkAnalyzer` 構造体のフィールドを `goos string` + `deps AnalysisDeps` に変更する
+  - [ ] `NewNetworkAnalyzer(goos string, deps AnalysisDeps)` にシグネチャを変更する
+  - [ ] `analyzeBinarySignals` 内の `a.store` → `a.deps.NetworkSymbolStore` に置換する
+  - [ ] `checkAnalysisCache` 内の `a.store` → `a.deps.NetworkSymbolStore` に置換する
+  - [ ] `checkSyscallCache` 内の `a.syscallStore` → `a.deps.SyscallStore` に置換する
+  - [ ] `checkDynLibDepsNetwork` 内の `a.depsStore` → `a.deps.DynLibDepsStore`、`a.libAnalysisStore` → `a.deps.LibAnalysisStore` に置換する
+  - [ ] `followShebangChain` 内の `a.shebangStore` → `a.deps.ShebangStore` に置換する
+  - [ ] 条件式（`a.store != nil` 等）を新フィールド参照に更新する
+
+### 1-2. テストヘルパーの更新
+
+- [ ] `internal/runner/base/security/network_analyzer_test_helpers.go`
+  - [ ] `newNetworkAnalyzerWithStore` を `AnalysisDeps{NetworkSymbolStore: store}` を使う形に変更する
+
+### 1-3. security パッケージのテスト更新
+
+- [ ] `internal/runner/base/security/network_analyzer_test.go`
+  - [ ] `NewNetworkAnalyzer` を呼ぶ 24 箇所を新シグネチャ（`AnalysisDeps{...}`）に変更する
+- [ ] `internal/runner/base/security/command_analysis_test.go`
+  - [ ] `NewNetworkAnalyzer` を呼ぶ 1 箇所（line 2516 付近）を新シグネチャに変更する
+
+### 1-4. ビルド・テスト確認
+
+- [ ] `make build` が成功することを確認する
+- [ ] `make test` が成功することを確認する
+- [ ] `make lint` が成功することを確認する
+
+---
+
+## Phase 2: risk / resource レイヤーの整理
+
+### 2-1. risk.NewStandardEvaluator のシグネチャ変更
+
+- [ ] `internal/runner/base/risk/evaluator.go`
+  - [ ] `NewStandardEvaluator` の引数を `networkAnalyzer *security.NetworkAnalyzer` 1 つに変更する
+  - [ ] コンストラクタ本体で `security.NewNetworkAnalyzer(runtime.GOOS, ...)` の呼び出しを削除する
+  - [ ] 不要になる import（`fileanalysis`、`dynamicanalysis`、`runtime`）を削除する
+
+### 2-2. risk パッケージのテスト更新
+
+- [ ] `internal/runner/base/risk/evaluator_test.go`
+  - [ ] `NewStandardEvaluator(nil, nil, nil, nil, nil)` を `NewStandardEvaluator(security.NewNetworkAnalyzer(runtime.GOOS, security.AnalysisDeps{}))` に変更する（2 箇所）
+  - [ ] `"runtime"` と `security` の import を追加する
+
+### 2-3. resource.Config の変更
+
+- [ ] `internal/runner/resource/default_manager.go`
+  - [ ] `Config` から `NetworkSymbolStore`、`SyscallStore`、`DynLibDepsStore`、`LibAnalysisStore`、`ShebangStore` フィールドを削除する
+  - [ ] `Config` に `RiskEvaluator risk.Evaluator` フィールドを追加する
+  - [ ] 不要になる import（`fileanalysis`、`dynamicanalysis`）を削除する
+
+### 2-4. resource/normal_manager.go の変更
+
+- [ ] `internal/runner/resource/normal_manager.go`
+  - [ ] `newNormalManager` の `riskEvaluator` 設定行を `cfg.RiskEvaluator` の直接代入に変更する
+
+### 2-4b. runner.go の中間状態更新
+
+Phase 2 で `resource.Config` のストアフィールドが削除されるため、
+`runner.go` を同時にコンパイルが通る中間状態に更新する。
+（個別型アサーションはまだ残すが、evaluator を組み立てて Config に渡す形に変更する）
+
+- [ ] `internal/runner/runner.go`
+  - [ ] `createNormalResourceManager` で取得した 5 つのストアから `security.AnalysisDeps{...}` を構築する
+  - [ ] `security.NewNetworkAnalyzer(runtime.GOOS, deps)` を呼ぶ
+  - [ ] `risk.NewStandardEvaluator(networkAnalyzer)` を呼ぶ
+  - [ ] `resource.Config` のストアフィールド 5 個を `RiskEvaluator: evaluator` に置き換える
+  - [ ] `"runtime"` と `risk` の import を追加する
+  - [ ] `fileanalysis` と `dynamicanalysis` の import はまだ残す（型アサーションで使用中）
+
+### 2-5. resource テストヘルパーの変更
+
+- [ ] `internal/runner/resource/test_helpers.go`
+  - [ ] `defaultTestEvaluator()` ヘルパー関数を追加する（`risk.NewStandardEvaluator(security.NewNetworkAnalyzer(runtime.GOOS, security.AnalysisDeps{}))` を返す）
+  - [ ] `NewNormalResourceManagerWithOutput` から `store fileanalysis.NetworkSymbolStore` 引数を削除し、`Config.RiskEvaluator: defaultTestEvaluator()` を設定する
+  - [ ] `NewNormalResourceManager` から `store` 引数を削除する（内部で `NewNormalResourceManagerWithOutput` を呼ぶため連動する）
+  - [ ] `NewDefaultResourceManagerForTest` から `symStore fileanalysis.NetworkSymbolStore` 引数を削除し、`Config.RiskEvaluator: defaultTestEvaluator()` を設定する
+  - [ ] `"runtime"` と `risk`、`security` の import を追加する
+  - [ ] 不要になる `fileanalysis` の import を削除する
+
+- [ ] `internal/runner/resource/testutil/helpers.go`
+  - [ ] `NewNormalResourceManager` の `store` 引数を削除する（`resource.NewNormalResourceManagerWithOutput` の変更に追随する）
+  - [ ] `NewDefaultResourceManager` の `symStore fileanalysis.NetworkSymbolStore` 引数を削除する
+  - [ ] `NewDefaultResourceManager` 内で `Config.RiskEvaluator` に `risk.NewStandardEvaluator(security.NewNetworkAnalyzer(runtime.GOOS, security.AnalysisDeps{}))` を設定する
+  - [ ] `"runtime"`、`risk`、`security` の import を追加する
+  - [ ] 不要になる `fileanalysis` の import を削除する
+
+### 2-6. resource テストヘルパー呼び出し元の更新
+
+- [ ] `internal/runner/resource/normal_manager_test.go`
+  - [ ] `NewNormalResourceManagerWithOutput(..., nil)` の末尾 `nil` 引数を削除する（1 箇所）
+- [ ] `internal/runner/resource/error_scenarios_test.go`
+  - [ ] `NewNormalResourceManager(...)` の呼び出しを更新する（2 箇所）
+  - [ ] `NewDefaultResourceManagerForTest(..., nil, 0, nil)` の末尾 `nil` を削除する（複数箇所）
+- [ ] `internal/runner/resource/default_manager_test.go`
+  - [ ] `NewDefaultResourceManagerForTest(..., nil)` の末尾 `nil` を削除する（約 15 箇所）
+- [ ] `internal/runner/resource/performance_test.go`
+  - [ ] `NewDefaultResourceManagerForTest(..., nil)` の末尾 `nil` を削除する（1 箇所）
+- [ ] `internal/runner/e2e_slack_redaction_test.go`
+  - [ ] `resourcetestutil.NewDefaultResourceManager(..., nil)` の末尾 `nil` を削除する（2 箇所）
+- [ ] `internal/runner/integration_dual_defense_test.go`
+  - [ ] `resourcetestutil.NewDefaultResourceManager(..., nil)` の末尾 `nil` を削除する（4 箇所）
+- [ ] `internal/runner/command_output_capture_test.go`
+  - [ ] `resourcetestutil.NewDefaultResourceManager(..., nil)` の末尾 `nil` を削除する（2 箇所）
+
+### 2-7. ビルド・テスト確認
+
+- [ ] `make build` が成功することを確認する
+- [ ] `make test` が成功することを確認する
+- [ ] `make lint` が成功することを確認する
+
+---
+
+## Phase 3: verification.Manager の API 追加と runner 簡素化
+
+### 3-1. verification.Manager.GetAnalysisDeps() の追加
+
+- [ ] `internal/verification/manager.go`
+  - [ ] `GetAnalysisDeps() security.AnalysisDeps` メソッドを追加する
+  - [ ] `security` の import を追加する
+  - [ ] `GetNetworkSymbolStore()` を削除する
+  - [ ] `GetSyscallAnalysisStore()` を削除する
+  - [ ] `GetDynLibAnalysisStore()` を削除する
+  - [ ] `GetDynLibDepsStore()` を削除する
+  - [ ] `GetShebangInterpreterStore()` を削除する
+  - [ ] `fileanalysis` と `dynamicanalysis` の import は他のメソッドで使用されているため削除しない
+
+### 3-2. verification パッケージのテスト追加
+
+- [ ] `internal/verification/manager_test.go`（または既存の verification テストファイル）
+  - [ ] `TestManager_GetAnalysisDeps` を追加する（`Manager` のゼロ値で `GetAnalysisDeps()` を呼び、全フィールドが nil であることを確認する）
+
+### 3-3. runner.createNormalResourceManager の簡素化
+
+- [ ] `internal/runner/runner.go`
+  - [ ] `createNormalResourceManager` の 5 系統の型アサーション（`networkSymbolStoreProvider` など）を削除する
+  - [ ] `analysisDepsProvider` インターフェースを定義し、`GetAnalysisDeps()` の 1 系統の型アサーションに変更する
+  - [ ] `security.NewNetworkAnalyzer(runtime.GOOS, deps)` と `risk.NewStandardEvaluator(networkAnalyzer)` を呼ぶ
+  - [ ] 組み立てた evaluator を `resource.Config.RiskEvaluator` に設定する
+  - [ ] 不要になる import（`fileanalysis`、`dynamicanalysis`）を削除する
+  - [ ] 不要になる var 宣言（`networkStore`、`syscallStore` 等）を削除する
+  - [ ] `"runtime"` と `risk` の import を追加する（未追加の場合）
+
+### 3-4. runner_test.go の更新
+
+- [ ] `internal/runner/runner_test.go`
+  - [ ] `pathResolverWithStore` 構造体と関連メソッドを削除する
+  - [ ] `pathResolverWithDeps` 構造体（`ResolvePath` + `GetAnalysisDeps`）を追加する
+  - [ ] `TestCreateNormalResourceManager_AnalysisStoresInjected` を `GetAnalysisDeps()` が呼ばれることを確認する形に更新する
+  - [ ] 不要になる import（`fileanalysis`）を削除する
+  - [ ] `security` の import を追加する（`AnalysisDeps` の使用のため）
+
+### 3-5. ビルド・テスト確認
+
+- [ ] `make build` が成功することを確認する
+- [ ] `make test` が成功することを確認する
+- [ ] `make lint` が成功することを確認する
+
+---
+
+## 最終確認
+
+- [ ] `AC-1`: `NewNetworkAnalyzer` と `NewStandardEvaluator` のシグネチャが分析依存 5 個を個別引数で受け取らない
+- [ ] `AC-2`: `resource.Config` に `NetworkSymbolStore`、`SyscallStore`、`DynLibDepsStore`、`LibAnalysisStore`、`ShebangStore` フィールドが存在しない
+- [ ] `AC-3`: `runner.createNormalResourceManager` に型アサーションが 1 系統（`analysisDepsProvider`）のみ残り、5 系統の個別 getter 呼び出しが存在しない
+- [ ] `AC-4`: `security` パッケージに hash dir や store dir の具体構築コードが存在しない
+- [ ] `AC-5`: `make test` で全テストが通過する
+- [ ] `AC-6`: `make test`、`make lint`、`make build` がすべて成功する
+- [ ] コード中に日本語が含まれていない（コメント・文字列ともに）
+- [ ] 不要 import が残っていない（lint 確認）


### PR DESCRIPTION
## Summary

- Add requirements and architecture documents for task 0127 (NetworkAnalyzer dependency simplification)
- Add detailed specification covering all API changes across 3 phases
- Add implementation plan with checkboxes for tracking progress

## Changes

### New documents

- `docs/tasks/0127_network_analyzer_dependency_simplification/01_requirements.md` — requirements and acceptance criteria
- `docs/tasks/0127_network_analyzer_dependency_simplification/02_architecture.md` — high-level architecture with Mermaid diagrams
- `docs/tasks/0127_network_analyzer_dependency_simplification/03_detailed_specification.md` — detailed spec covering type definitions, API signatures, import changes, test strategy, and mock boundaries
- `docs/tasks/0127_network_analyzer_dependency_simplification/04_implementation_plan.md` — phased implementation plan with task-level checkboxes

### Design overview

Refactors the wiring of analysis stores to `NetworkAnalyzer` in 3 phases:

1. **Phase 1**: Introduce `security.AnalysisDeps` struct; change `NewNetworkAnalyzer` from 6 individual args to `(goos, AnalysisDeps)`
2. **Phase 2**: Change `risk.NewStandardEvaluator` to accept `*security.NetworkAnalyzer`; replace 5 store fields in `resource.Config` with `RiskEvaluator risk.Evaluator`
3. **Phase 3**: Add `verification.Manager.GetAnalysisDeps()`; simplify `runner.createNormalResourceManager` from 5 type assertions to 1

## Test plan

- [ ] No code changes in this PR — documentation only
- [ ] All existing tests continue to pass (`make test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)