### PR TITLE
fix: restrict env-form shebang detection to trusted system paths

### DIFF
--- a/internal/shebang/parser.go
+++ b/internal/shebang/parser.go
@@ -131,7 +131,9 @@ func Parse(filePath string, fs safefileio.FileSystem) (*Info, error) {
 	// Detect env-form based on the original shebang token, before symlink
 	// resolution. Checking after EvalSymlinks would misclassify env-form
 	// shebangs when /usr/bin/env is a symlink (e.g., to busybox).
-	isEnvForm := filepath.Base(interpreterPath) == "env"
+	// Only well-known system paths are recognised as env(1); a binary named
+	// "env" at an arbitrary attacker-controlled path must not bypass analysis.
+	isEnvForm := isTrustedEnvBinary(interpreterPath)
 
 	// Resolve symlinks for interpreter path.
 	resolvedInterpreter, err := filepath.EvalSymlinks(interpreterPath)
@@ -150,6 +152,19 @@ func Parse(filePath string, fs safefileio.FileSystem) (*Info, error) {
 		RawInterpreterPath: interpreterPath,
 		InterpreterPath:    resolvedInterpreter,
 	}, nil
+}
+
+// trustedEnvPaths is the set of absolute paths recognised as the system env(1)
+// binary. Keyed on the raw (pre-symlink-resolution) shebang token so that
+// systems where /usr/bin/env is a symlink (e.g., to busybox) work correctly.
+var trustedEnvPaths = map[string]bool{
+	"/usr/bin/env": true,
+	"/bin/env":     true,
+}
+
+// isTrustedEnvBinary reports whether path is a known system env(1) binary.
+func isTrustedEnvBinary(path string) bool {
+	return trustedEnvPaths[path]
 }
 
 // parseEnvForm handles "#!/usr/bin/env <cmd>" shebangs.

--- a/internal/shebang/parser_test.go
+++ b/internal/shebang/parser_test.go
@@ -100,6 +100,28 @@ func TestParse_EnvForm(t *testing.T) {
 	assert.Equal(t, expectedResolvedPath, info.ResolvedPath)
 }
 
+func TestParse_FakeEnvBinaryTreatedAsDirectForm(t *testing.T) {
+	// A binary named "env" at an untrusted path must not trigger env-form
+	// resolution. If it did, the binary itself would be skipped and only
+	// the PATH-resolved command would be analysed, allowing an attacker to
+	// bypass risk assessment by naming their malicious binary "env".
+	binDir := commontesting.SafeTempDir(t)
+	fakeEnv := commontesting.WriteExecutableFile(t, binDir, "env", []byte("#!/bin/sh\necho fake\n"))
+
+	path := writeScript(t, "#!"+fakeEnv+" python3\n")
+	info, err := shebang.Parse(path, realFS())
+	require.NoError(t, err)
+	require.NotNil(t, info)
+
+	// Treated as direct form: interpreter is the fake env binary itself.
+	expectedInterp, err := filepath.EvalSymlinks(fakeEnv)
+	require.NoError(t, err)
+	assert.Equal(t, expectedInterp, info.InterpreterPath)
+	// No env-form fields populated.
+	assert.Empty(t, info.CommandName)
+	assert.Empty(t, info.ResolvedPath)
+}
+
 func TestParse_NotShebang_ELF(t *testing.T) {
 	// ELF magic bytes: \x7fELF
 	elfHeader := []byte{0x7f, 'E', 'L', 'F', 0x02, 0x01, 0x01, 0x00}


### PR DESCRIPTION
## Summary

- `#!/usr/bin/env python3` のような shebang の env-form 判定を、ファイル名が `env` かどうかではなく、`/usr/bin/env` や `/bin/env` といった信頼できるシステムパスかどうかで行うよう修正
- 修正前は `/home/attacker/bin/env python3` のような shebang で攻撃者のバイナリが解析対象から除外され、リスク評価を回避できる脆弱性があった
- `isTrustedEnvBinary` 関数と `trustedEnvPaths` マップを導入し、`TestParse_FakeEnvBinaryTreatedAsDirectForm` でリグレッションを防止

## Test plan

- [ ] `go test -tags test -v ./internal/shebang/...` で全テストパス
- [ ] `make test` で全テストパス
- [ ] `make lint` でエラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)