### PR TITLE
refactor: change validatorFactory to return *filevalidator.Validator directly

### DIFF
--- a/cmd/record/main.go
+++ b/cmd/record/main.go
@@ -36,7 +36,7 @@ var (
 // deps holds injectable dependencies for the record command.
 // This makes the dependency graph visible at call sites and simplifies testing.
 type deps struct {
-	validatorFactory           func(hashDir string) (hashRecorder, error)
+	validatorFactory           func(hashDir string) (*filevalidator.Validator, error)
 	elfDynlibAnalyzerFactory   func() *elfdynlib.DynLibAnalyzer       // nil means dynlib analysis is disabled
 	machoDynlibAnalyzerFactory func() *machodylib.MachODynLibAnalyzer // nil means Mach-O dynlib analysis is disabled
 	mkdirAll                   func(path string, perm os.FileMode) error
@@ -44,7 +44,7 @@ type deps struct {
 
 func defaultDeps() deps {
 	return deps{
-		validatorFactory: func(hashDir string) (hashRecorder, error) {
+		validatorFactory: func(hashDir string) (*filevalidator.Validator, error) {
 			return filevalidator.New(&filevalidator.SHA256{}, hashDir)
 		},
 		elfDynlibAnalyzerFactory: func() *elfdynlib.DynLibAnalyzer {
@@ -131,49 +131,46 @@ func run(args []string, d deps, stdout, stderr io.Writer) int {
 		return 1
 	}
 
-	// Inject DynLibAnalyzer, BinaryAnalyzer, SyscallAnalyzer, and LibcCache when the validator supports it.
-	// Uses a type assertion so that test fakes implementing only hashRecorder are unaffected.
-	if fv, ok := validator.(*filevalidator.Validator); ok {
-		if d.elfDynlibAnalyzerFactory != nil {
-			fv.SetELFDynLibAnalyzer(d.elfDynlibAnalyzerFactory())
-		}
-		if d.machoDynlibAnalyzerFactory != nil {
-			fv.SetMachODynLibAnalyzer(d.machoDynlibAnalyzerFactory())
-		}
-		fv.SetBinaryAnalyzer(security.NewBinaryAnalyzer(runtime.GOOS))
-
-		syscallAnalyzer := elfanalyzer.NewSyscallAnalyzer()
-		fv.SetSyscallAnalyzer(libccache.NewSyscallAdapter(syscallAnalyzer))
-
-		dynlibStoreDir := filepath.Join(cfg.hashDir, dynamicanalysis.StoreSubDir)
-		dynlibStore, dynlibStoreErr := dynamicanalysis.New(dynlibStoreDir, fv)
-		if dynlibStoreErr != nil {
-			fmt.Fprintf(stderr, "Error: Failed to initialize dynamic library analysis store: %v\n", dynlibStoreErr) //nolint:errcheck
-			return 1
-		}
-		fv.SetDynamicLibAnalysisStore(dynlibStore)
-
-		cacheDir := filepath.Join(cfg.hashDir, libcCacheSubDir)
-		fs := safefileio.NewFileSystem(safefileio.FileSystemConfig{})
-		libcAnalyzer := libccache.NewLibcWrapperAnalyzer(syscallAnalyzer)
-		cacheMgr, cacheErr := libccache.NewLibcCacheManager(cacheDir, fs, libcAnalyzer)
-		if cacheErr != nil {
-			fmt.Fprintf(stderr, "Error: Failed to initialize libc cache: %v\n", cacheErr) //nolint:errcheck
-			return 1
-		}
-		fv.SetLibcCache(libccache.NewCacheAdapter(cacheMgr, syscallAnalyzer))
-		fv.SetIncludeDebugInfo(cfg.debugInfo)
-
-		// Inject MachoLibSystemAdapter for Mach-O libSystem import-symbol matching.
-		machoCacheDir := filepath.Join(cfg.hashDir, libcCacheSubDir)
-		machoCacheMgr, machoCacheErr := libccache.NewMachoLibSystemCacheManager(machoCacheDir)
-		if machoCacheErr != nil {
-			fmt.Fprintf(stderr, "Error: Failed to initialize machoLibSystem cache: %v\n", machoCacheErr) //nolint:errcheck
-			return 1
-		}
-		fv.SetLibSystemCache(libccache.NewMachoLibSystemAdapter(machoCacheMgr, fs))
-		fv.SetMachoSyscallTable(libccache.MacOSSyscallTable{})
+	// Inject DynLibAnalyzer, BinaryAnalyzer, SyscallAnalyzer, and LibcCache.
+	if d.elfDynlibAnalyzerFactory != nil {
+		validator.SetELFDynLibAnalyzer(d.elfDynlibAnalyzerFactory())
 	}
+	if d.machoDynlibAnalyzerFactory != nil {
+		validator.SetMachODynLibAnalyzer(d.machoDynlibAnalyzerFactory())
+	}
+	validator.SetBinaryAnalyzer(security.NewBinaryAnalyzer(runtime.GOOS))
+
+	syscallAnalyzer := elfanalyzer.NewSyscallAnalyzer()
+	validator.SetSyscallAnalyzer(libccache.NewSyscallAdapter(syscallAnalyzer))
+
+	dynlibStoreDir := filepath.Join(cfg.hashDir, dynamicanalysis.StoreSubDir)
+	dynlibStore, dynlibStoreErr := dynamicanalysis.New(dynlibStoreDir, validator)
+	if dynlibStoreErr != nil {
+		fmt.Fprintf(stderr, "Error: Failed to initialize dynamic library analysis store: %v\n", dynlibStoreErr) //nolint:errcheck
+		return 1
+	}
+	validator.SetDynamicLibAnalysisStore(dynlibStore)
+
+	cacheDir := filepath.Join(cfg.hashDir, libcCacheSubDir)
+	safeFS := safefileio.NewFileSystem(safefileio.FileSystemConfig{})
+	libcAnalyzer := libccache.NewLibcWrapperAnalyzer(syscallAnalyzer)
+	cacheMgr, cacheErr := libccache.NewLibcCacheManager(cacheDir, safeFS, libcAnalyzer)
+	if cacheErr != nil {
+		fmt.Fprintf(stderr, "Error: Failed to initialize libc cache: %v\n", cacheErr) //nolint:errcheck
+		return 1
+	}
+	validator.SetLibcCache(libccache.NewCacheAdapter(cacheMgr, syscallAnalyzer))
+	validator.SetIncludeDebugInfo(cfg.debugInfo)
+
+	// Inject MachoLibSystemAdapter for Mach-O libSystem import-symbol matching.
+	machoCacheDir := filepath.Join(cfg.hashDir, libcCacheSubDir)
+	machoCacheMgr, machoCacheErr := libccache.NewMachoLibSystemCacheManager(machoCacheDir)
+	if machoCacheErr != nil {
+		fmt.Fprintf(stderr, "Error: Failed to initialize machoLibSystem cache: %v\n", machoCacheErr) //nolint:errcheck
+		return 1
+	}
+	validator.SetLibSystemCache(libccache.NewMachoLibSystemAdapter(machoCacheMgr, safeFS))
+	validator.SetMachoSyscallTable(libccache.MacOSSyscallTable{})
 
 	return processFiles(validator, cfg, stdout, stderr)
 }

--- a/cmd/record/main_test.go
+++ b/cmd/record/main_test.go
@@ -28,7 +28,6 @@ type recordCall struct {
 type fakeRecorder struct {
 	responses map[string]error
 	calls     []recordCall
-	hashDir   string
 }
 
 func (f *fakeRecorder) SaveRecord(filePath string, force bool) (string, string, error) {
@@ -39,41 +38,45 @@ func (f *fakeRecorder) SaveRecord(filePath string, force bool) (string, string, 
 	return fmt.Sprintf("/hash/%s.json", filepath.Base(filePath)), "sha256:fakehash", nil
 }
 
-// testDeps returns a deps with the given recorder wired as the validatorFactory.
-// Callers can override individual fields afterwards when needed.
-func testDeps(recorder *fakeRecorder) deps {
-	return deps{
-		validatorFactory: func(hashDir string) (hashRecorder, error) {
-			if recorder != nil {
-				recorder.hashDir = hashDir
-			}
-			return recorder, nil
-		},
-		mkdirAll: os.MkdirAll,
+// testDeps returns a deps suitable for tests that need to exercise run() setup
+// (arg parsing, TOCTOU check, deprecated warning). The validatorFactory creates
+// a real Validator rooted at the given hashDir; callers that only need to test
+// processFiles() behavior should call processFiles() directly instead.
+func testRunDeps(hashDir string) deps {
+	d := defaultDeps()
+	d.validatorFactory = func(dir string) (*filevalidator.Validator, error) {
+		return filevalidator.New(&filevalidator.SHA256{}, dir)
 	}
+	d.mkdirAll = func(path string, perm os.FileMode) error {
+		if path == hashDir {
+			return nil // already created by the test
+		}
+		return os.MkdirAll(path, perm)
+	}
+	return d
 }
 
 func TestRunRequiresAtLeastOneFile(t *testing.T) {
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
 
-	exitCode := run([]string{}, testDeps(nil), stdout, stderr)
+	// validatorFactory is never called when arg parsing fails, so it can be nil.
+	exitCode := run([]string{}, deps{mkdirAll: os.MkdirAll}, stdout, stderr)
 
 	require.Equal(t, 1, exitCode)
 	assert.Contains(t, stderr.String(), "at least one file path")
 }
 
-func TestRunProcessesMultipleFiles(t *testing.T) {
-	tempDir := commontesting.SafeTempDir(t)
+func TestProcessFiles_MultipleFiles(t *testing.T) {
 	recorder := &fakeRecorder{responses: map[string]error{}}
 
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
+	cfg := &recordConfig{files: []string{"file1.txt", "file2.txt"}}
 
-	exitCode := run([]string{"-d", tempDir, "file1.txt", "file2.txt"}, testDeps(recorder), stdout, stderr)
+	exitCode := processFiles(recorder, cfg, stdout, stderr)
 
 	require.Equal(t, 0, exitCode)
-	assert.Equal(t, tempDir, recorder.hashDir)
 	require.Len(t, recorder.calls, 2)
 	assert.Equal(t, []recordCall{{"file1.txt", false}, {"file2.txt", false}}, recorder.calls)
 	assert.Contains(t, stdout.String(), "Processing 2 files...")
@@ -81,16 +84,16 @@ func TestRunProcessesMultipleFiles(t *testing.T) {
 	assert.Empty(t, stderr.String())
 }
 
-func TestRunReportsFailuresAndContinues(t *testing.T) {
-	tempDir := commontesting.SafeTempDir(t)
+func TestProcessFiles_ReportsFailuresAndContinues(t *testing.T) {
 	recorder := &fakeRecorder{responses: map[string]error{
 		"bad.dat": errors.New("calculate hash failure"),
 	}}
 
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
+	cfg := &recordConfig{files: []string{"good1", "bad.dat", "good2"}, force: true}
 
-	exitCode := run([]string{"-force", "-hash-dir", tempDir, "good1", "bad.dat", "good2"}, testDeps(recorder), stdout, stderr)
+	exitCode := processFiles(recorder, cfg, stdout, stderr)
 
 	require.Equal(t, 1, exitCode)
 	require.Len(t, recorder.calls, 3)
@@ -103,17 +106,18 @@ func TestRunReportsFailuresAndContinues(t *testing.T) {
 }
 
 func TestRunWarnsWhenDeprecatedFlagUsed(t *testing.T) {
-	tempDir := commontesting.SafeTempDir(t)
-	recorder := &fakeRecorder{responses: map[string]error{}}
+	hashDir := commontesting.SafeTempDir(t)
+	legacyFile := filepath.Join(hashDir, "legacy.txt")
+	newFile := filepath.Join(hashDir, "new.txt")
+	require.NoError(t, os.WriteFile(legacyFile, []byte("legacy content"), 0o644))
+	require.NoError(t, os.WriteFile(newFile, []byte("new content"), 0o644))
 
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
 
-	exitCode := run([]string{"-hash-dir", tempDir, "-file", "legacy.txt", "new.txt"}, testDeps(recorder), stdout, stderr)
+	exitCode := run([]string{"-hash-dir", hashDir, "-file", legacyFile, newFile}, testRunDeps(hashDir), stdout, stderr)
 
 	require.Equal(t, 0, exitCode)
-	require.Len(t, recorder.calls, 2)
-	assert.Equal(t, "legacy.txt", recorder.calls[0].file)
 	assert.Contains(t, stderr.String(), "deprecated")
 }
 
@@ -134,19 +138,18 @@ func TestRunUsesDefaultHashDirectoryWhenNotSpecified(t *testing.T) {
 	assert.False(t, cfg.debugInfo)
 }
 
-func TestRunWithSyscallAnalysis(t *testing.T) {
+func TestProcessFiles_WithELF(t *testing.T) {
 	tempDir := commontesting.SafeTempDir(t)
 	recorder := &fakeRecorder{responses: map[string]error{}}
 
-	// Create a static ELF file for testing
 	staticELF := filepath.Join(tempDir, "static.elf")
 	elfanalyzertesting.CreateStaticELFFile(t, staticELF)
 
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
+	cfg := &recordConfig{files: []string{staticELF}}
 
-	// Syscall analysis is always enabled
-	exitCode := run([]string{"-d", tempDir, staticELF}, testDeps(recorder), stdout, stderr)
+	exitCode := processFiles(recorder, cfg, stdout, stderr)
 
 	require.Equal(t, 0, exitCode)
 	require.Len(t, recorder.calls, 1)
@@ -154,24 +157,22 @@ func TestRunWithSyscallAnalysis(t *testing.T) {
 	assert.Contains(t, stdout.String(), "OK")
 }
 
-func TestRunWithSyscallAnalysisSkipsNonELF(t *testing.T) {
+func TestProcessFiles_SkipsNonELF(t *testing.T) {
 	tempDir := commontesting.SafeTempDir(t)
 	recorder := &fakeRecorder{responses: map[string]error{}}
 
-	// Create a non-ELF file
 	nonELF := filepath.Join(tempDir, "script.sh")
 	err := os.WriteFile(nonELF, []byte("#!/bin/bash\necho hello"), 0o755)
 	require.NoError(t, err)
 
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
+	cfg := &recordConfig{files: []string{nonELF}}
 
-	// Syscall analysis is always enabled but should skip non-ELF files without warning
-	exitCode := run([]string{"-d", tempDir, nonELF}, testDeps(recorder), stdout, stderr)
+	exitCode := processFiles(recorder, cfg, stdout, stderr)
 
 	require.Equal(t, 0, exitCode)
 	require.Len(t, recorder.calls, 1)
-	// No warning should be printed for non-ELF files
 	assert.NotContains(t, stderr.String(), "Syscall analysis failed")
 }
 
@@ -192,17 +193,16 @@ func TestRunTOCTOU_ContinuesOnWorldWritableDir(t *testing.T) {
 	require.NoError(t, err)
 
 	hashDir := commontesting.SafeTempDir(t)
-	recorder := &fakeRecorder{responses: map[string]error{}}
 
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
 
 	// record should continue (exit 0) despite the TOCTOU violation
-	exitCode := run([]string{"-d", hashDir, targetFile}, testDeps(recorder), stdout, stderr)
+	exitCode := run([]string{"-d", hashDir, targetFile}, testRunDeps(hashDir), stdout, stderr)
 
 	// record does NOT abort on TOCTOU violations — it only logs a warning
 	assert.Equal(t, 0, exitCode, "record should continue (exit 0) despite world-writable directory")
-	require.Len(t, recorder.calls, 1, "file should have been processed")
+	assert.Contains(t, stdout.String(), "OK", "file should have been processed")
 }
 
 func extractHashFilePathFromStdout(t *testing.T, output string) string {

--- a/cmd/record/main_test.go
+++ b/cmd/record/main_test.go
@@ -44,9 +44,6 @@ func (f *fakeRecorder) SaveRecord(filePath string, force bool) (string, string, 
 // processFiles() behavior should call processFiles() directly instead.
 func testRunDeps(hashDir string) deps {
 	d := defaultDeps()
-	d.validatorFactory = func(dir string) (*filevalidator.Validator, error) {
-		return filevalidator.New(&filevalidator.SHA256{}, dir)
-	}
 	d.mkdirAll = func(path string, perm os.FileMode) error {
 		if path == hashDir {
 			return nil // already created by the test


### PR DESCRIPTION
This pull request refactors the `cmd/record` command's dependency injection and test setup to simplify the code and make tests more robust and maintainable. The main changes involve updating how the validator is injected and used, modernizing and clarifying test helpers, and improving test coverage by focusing on the `processFiles` logic directly.

Dependency injection and validator usage:

* Changed the `validatorFactory` in the `deps` struct and related code to always return a concrete `*filevalidator.Validator` instead of a generic interface, simplifying downstream code and removing unnecessary type assertions. [[1]](diffhunk://#diff-85e219d12105e5ee9a3c08e4525d61f0a59faea396566760aaac92c75b3f0d4fL39-R47) [[2]](diffhunk://#diff-85e219d12105e5ee9a3c08e4525d61f0a59faea396566760aaac92c75b3f0d4fL134-R163) [[3]](diffhunk://#diff-85e219d12105e5ee9a3c08e4525d61f0a59faea396566760aaac92c75b3f0d4fL174-R173)

Test infrastructure improvements:

* Replaced the old `testDeps` helper with a new `testRunDeps` function that provides a realistic `Validator` for integration-style tests, and updated tests to use this new helper. [[1]](diffhunk://#diff-7fabd5af481ceb7f4c4fd6fca48ba3059242300a5805a2254ab6953c30876efeL42-R96) [[2]](diffhunk://#diff-7fabd5af481ceb7f4c4fd6fca48ba3059242300a5805a2254ab6953c30876efeL106-L116) [[3]](diffhunk://#diff-7fabd5af481ceb7f4c4fd6fca48ba3059242300a5805a2254ab6953c30876efeL195-R205)
* Updated tests that only need to exercise `processFiles` to call it directly with a `fakeRecorder`, making the tests more focused and decoupled from argument parsing and setup logic. [[1]](diffhunk://#diff-7fabd5af481ceb7f4c4fd6fca48ba3059242300a5805a2254ab6953c30876efeL42-R96) [[2]](diffhunk://#diff-7fabd5af481ceb7f4c4fd6fca48ba3059242300a5805a2254ab6953c30876efeL137-L174)
* Improved test clarity by renaming test functions to describe their intent more clearly, e.g., `TestProcessFiles_MultipleFiles`, `TestProcessFiles_ReportsFailuresAndContinues`, etc. [[1]](diffhunk://#diff-7fabd5af481ceb7f4c4fd6fca48ba3059242300a5805a2254ab6953c30876efeL42-R96) [[2]](diffhunk://#diff-7fabd5af481ceb7f4c4fd6fca48ba3059242300a5805a2254ab6953c30876efeL137-L174)

Test code simplification:

* Removed the unnecessary `hashDir` field from `fakeRecorder` and related assertions, as it is no longer required by the new test structure. [[1]](diffhunk://#diff-7fabd5af481ceb7f4c4fd6fca48ba3059242300a5805a2254ab6953c30876efeL31) [[2]](diffhunk://#diff-7fabd5af481ceb7f4c4fd6fca48ba3059242300a5805a2254ab6953c30876efeL42-R96)

These changes collectively make the codebase easier to maintain and extend, and the tests more reliable and easier to understand.