### PR TITLE
Refactor validator setup to constructor-based config

### DIFF
--- a/cmd/record/main.go
+++ b/cmd/record/main.go
@@ -36,7 +36,7 @@ var (
 // deps holds injectable dependencies for the record command.
 // This makes the dependency graph visible at call sites and simplifies testing.
 type deps struct {
-	validatorFactory           func(hashDir string) (*filevalidator.Validator, error)
+	validatorFactory           func(hashDir string, cfg filevalidator.ValidatorConfig) (*filevalidator.Validator, error)
 	elfDynlibAnalyzerFactory   func() *elfdynlib.DynLibAnalyzer       // nil means dynlib analysis is disabled
 	machoDynlibAnalyzerFactory func() *machodylib.MachODynLibAnalyzer // nil means Mach-O dynlib analysis is disabled
 	mkdirAll                   func(path string, perm os.FileMode) error
@@ -44,8 +44,8 @@ type deps struct {
 
 func defaultDeps() deps {
 	return deps{
-		validatorFactory: func(hashDir string) (*filevalidator.Validator, error) {
-			return filevalidator.New(&filevalidator.SHA256{}, hashDir)
+		validatorFactory: func(hashDir string, cfg filevalidator.ValidatorConfig) (*filevalidator.Validator, error) {
+			return filevalidator.New(&filevalidator.SHA256{}, hashDir, cfg)
 		},
 		elfDynlibAnalyzerFactory: func() *elfdynlib.DynLibAnalyzer {
 			return elfdynlib.NewDynLibAnalyzer(safefileio.NewFileSystem(safefileio.FileSystemConfig{}))
@@ -125,42 +125,15 @@ func run(args []string, d deps, stdout, stderr io.Writer) int {
 	toctouDirs := security.CollectTOCTOUCheckDirs(absFiles, nil, absHashDir)
 	security.RunTOCTOUPermissionCheck(secValidator, toctouDirs, slog.Default())
 
-	validator, err := d.validatorFactory(cfg.hashDir)
-	if err != nil {
-		fmt.Fprintf(stderr, "Error creating validator: %v\n", err) //nolint:errcheck
-		return 1
-	}
-
-	// Inject DynLibAnalyzer, BinaryAnalyzer, SyscallAnalyzer, and LibcCache.
-	if d.elfDynlibAnalyzerFactory != nil {
-		validator.SetELFDynLibAnalyzer(d.elfDynlibAnalyzerFactory())
-	}
-	if d.machoDynlibAnalyzerFactory != nil {
-		validator.SetMachODynLibAnalyzer(d.machoDynlibAnalyzerFactory())
-	}
-	validator.SetBinaryAnalyzer(security.NewBinaryAnalyzer(runtime.GOOS))
-
-	syscallAnalyzer := elfanalyzer.NewSyscallAnalyzer()
-	validator.SetSyscallAnalyzer(libccache.NewSyscallAdapter(syscallAnalyzer))
-
-	dynlibStoreDir := filepath.Join(cfg.hashDir, dynamicanalysis.StoreSubDir)
-	dynlibStore, dynlibStoreErr := dynamicanalysis.New(dynlibStoreDir, validator)
-	if dynlibStoreErr != nil {
-		fmt.Fprintf(stderr, "Error: Failed to initialize dynamic library analysis store: %v\n", dynlibStoreErr) //nolint:errcheck
-		return 1
-	}
-	validator.SetDynamicLibAnalysisStore(dynlibStore)
-
-	cacheDir := filepath.Join(cfg.hashDir, libcCacheSubDir)
 	safeFS := safefileio.NewFileSystem(safefileio.FileSystemConfig{})
+	syscallAnalyzer := elfanalyzer.NewSyscallAnalyzer()
+	cacheDir := filepath.Join(cfg.hashDir, libcCacheSubDir)
 	libcAnalyzer := libccache.NewLibcWrapperAnalyzer(syscallAnalyzer)
 	cacheMgr, cacheErr := libccache.NewLibcCacheManager(cacheDir, safeFS, libcAnalyzer)
 	if cacheErr != nil {
 		fmt.Fprintf(stderr, "Error: Failed to initialize libc cache: %v\n", cacheErr) //nolint:errcheck
 		return 1
 	}
-	validator.SetLibcCache(libccache.NewCacheAdapter(cacheMgr, syscallAnalyzer))
-	validator.SetIncludeDebugInfo(cfg.debugInfo)
 
 	// Inject MachoLibSystemAdapter for Mach-O libSystem import-symbol matching.
 	machoCacheDir := filepath.Join(cfg.hashDir, libcCacheSubDir)
@@ -169,8 +142,35 @@ func run(args []string, d deps, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "Error: Failed to initialize machoLibSystem cache: %v\n", machoCacheErr) //nolint:errcheck
 		return 1
 	}
-	validator.SetLibSystemCache(libccache.NewMachoLibSystemAdapter(machoCacheMgr, safeFS))
-	validator.SetMachoSyscallTable(libccache.MacOSSyscallTable{})
+
+	vCfg := filevalidator.ValidatorConfig{
+		BinaryAnalyzer:    security.NewBinaryAnalyzer(runtime.GOOS),
+		SyscallAnalyzer:   libccache.NewSyscallAdapter(syscallAnalyzer),
+		LibcCache:         libccache.NewCacheAdapter(cacheMgr, syscallAnalyzer),
+		LibSystemCache:    libccache.NewMachoLibSystemAdapter(machoCacheMgr, safeFS),
+		MachoSyscallTable: libccache.MacOSSyscallTable{},
+		DebugInfo:         cfg.debugInfo,
+	}
+	if d.elfDynlibAnalyzerFactory != nil {
+		vCfg.ELFDynLibAnalyzer = d.elfDynlibAnalyzerFactory()
+	}
+	if d.machoDynlibAnalyzerFactory != nil {
+		vCfg.MachODynLibAnalyzer = d.machoDynlibAnalyzerFactory()
+	}
+
+	validator, err := d.validatorFactory(cfg.hashDir, vCfg)
+	if err != nil {
+		fmt.Fprintf(stderr, "Error creating validator: %v\n", err) //nolint:errcheck
+		return 1
+	}
+
+	dynlibStoreDir := filepath.Join(cfg.hashDir, dynamicanalysis.StoreSubDir)
+	dynlibStore, dynlibStoreErr := dynamicanalysis.New(dynlibStoreDir, validator)
+	if dynlibStoreErr != nil {
+		fmt.Fprintf(stderr, "Error: Failed to initialize dynamic library analysis store: %v\n", dynlibStoreErr) //nolint:errcheck
+		return 1
+	}
+	validator.SetDynamicLibAnalysisStore(dynlibStore)
 
 	return processFiles(validator, cfg, stdout, stderr)
 }

--- a/cmd/record/main_test.go
+++ b/cmd/record/main_test.go
@@ -175,7 +175,7 @@ func TestProcessFiles_SkipsNonELF(t *testing.T) {
 
 // TestRunTOCTOU_ContinuesOnWorldWritableDir verifies that the record command
 // continues processing even when the file's parent directory is world-writable.
-// This validates AC-M2S-7: record warns but does not abort on TOCTOU violations.
+// Ensures record warns but does not abort on TOCTOU violations.
 func TestRunTOCTOU_ContinuesOnWorldWritableDir(t *testing.T) {
 	// Create a world-writable directory with a target file
 	worldWritableDir := commontesting.SafeTempDir(t)
@@ -254,7 +254,7 @@ func TestRun_ReRecordOldSchemaWithoutForce(t *testing.T) {
 	targetFile := filepath.Join(hashDir, "target.txt")
 	require.NoError(t, os.WriteFile(targetFile, []byte("hello"), 0o644))
 
-	seedValidator, err := filevalidator.New(&filevalidator.SHA256{}, hashDir)
+	seedValidator, err := filevalidator.New(&filevalidator.SHA256{}, hashDir, filevalidator.ValidatorConfig{})
 	require.NoError(t, err)
 	recordPath, _, err := seedValidator.SaveRecord(targetFile, false)
 	require.NoError(t, err)
@@ -275,7 +275,7 @@ func TestRun_ReRecordOldSchemaWithoutForce(t *testing.T) {
 	exitCode := run([]string{"-d", hashDir, targetFile}, defaultDeps(), stdout, stderr)
 	require.Equal(t, 0, exitCode, "stderr: %s", stderr.String())
 
-	validator, err := filevalidator.New(&filevalidator.SHA256{}, hashDir)
+	validator, err := filevalidator.New(&filevalidator.SHA256{}, hashDir, filevalidator.ValidatorConfig{})
 	require.NoError(t, err)
 	recorded, err := validator.LoadRecord(targetFile)
 	require.NoError(t, err)

--- a/cmd/runner/integration_security_test.go
+++ b/cmd/runner/integration_security_test.go
@@ -428,7 +428,7 @@ func TestUnverifiedDataAccessPrevention(t *testing.T) {
 	require.NoError(t, os.WriteFile(unverifiedFile, []byte("sensitive unverified data"), 0o644), "Failed to create unverified data file")
 
 	// Attempt to verify the unverified file - this should fail
-	validator, err := filevalidator.New(&filevalidator.SHA256{}, hashDir)
+	validator, err := filevalidator.New(&filevalidator.SHA256{}, hashDir, filevalidator.ValidatorConfig{})
 	require.NoError(t, err, "Failed to create validator")
 
 	// Test that verification of unverified data fails appropriately

--- a/docs/tasks/0132_validator_config_struct/01_requirements.md
+++ b/docs/tasks/0132_validator_config_struct/01_requirements.md
@@ -106,11 +106,15 @@ func New(algorithm HashAlgorithm, hashDir string, cfg ValidatorConfig) (*Validat
 
 #### FR-3.3.1: `cmd/record/main.go` の `validatorFactory` 型変更
 
-現在の factory は `func(hashDir string) (hashRecorder, error)` だが、
+現在の factory は `func(hashDir string) (*filevalidator.Validator, error)` だが、
 `ValidatorConfig` を渡せるよう変更が必要。
 
-方針: factory の型を `func(hashDir string, cfg ValidatorConfig) (hashRecorder, error)` に変更し、
-`run()` 内で `cfg` を組み立てて factory に渡す。
+方針: factory の型を
+`func(hashDir string, cfg filevalidator.ValidatorConfig) (*filevalidator.Validator, error)`
+に変更し、`run()` 内で `cfg` を組み立てて factory に渡す。
+返り値の具象型 (`*filevalidator.Validator`) は維持する。残存する
+`SetDynamicLibAnalysisStore` を `run()` から呼び出すため、`hashRecorder`
+インタフェースに丸める必要はない。
 
 #### FR-3.3.2: テスト側の更新
 

--- a/docs/tasks/0132_validator_config_struct/01_requirements.md
+++ b/docs/tasks/0132_validator_config_struct/01_requirements.md
@@ -1,0 +1,161 @@
+# Validator 設定構造体への移行 要件定義書
+
+## 1. 概要
+
+### 1.1 背景
+
+現在 `filevalidator.Validator` は、`New(algorithm, hashDir)` で基本部分のみを構成し、
+動的解析に必要な依存（`BinaryAnalyzer`, `SyscallAnalyzer`, `LibcCache` 等）を
+個別のセッターメソッドで後から注入する設計になっている。
+
+各セッターのドキュメントには「`Call before the first SaveRecord() invocation`」という
+契約コメントを付与している（タスク 0130 で実施）が、この制約はコンパイラによって強制されない。
+
+セッターによる設定変更には以下のリスクがある。
+
+- `includeDebugInfo` を `SaveRecord` 後に変更すると、セッション内の
+  `processedInterpreterAnalysis` / `processedLibAnalysis` キャッシュが
+  debug 出力の有無について一貫性を欠く（タスク 0130 で文書化）
+- `binaryAnalyzer` / `syscallAnalyzer` 等を変更すると、キャッシュ済みの
+  解析結果（`SymbolAnalysis` / `SyscallAnalysis`）と後続の解析結果が
+  異なるアナライザで生成される
+
+### 1.2 目的
+
+セッターで注入していた「`SaveRecord` 前に 1 度だけ設定する」フィールドを
+`ValidatorConfig` 構造体に集約し、`New` のコンストラクタ引数として受け取ることで、
+Validator の設定フェーズと実行フェーズをコンパイル時に分離する。
+
+ただし、`dynamicLibAnalysisStore` だけは `Validator` 自身を `dynamicanalysis.Analyzer`
+として渡す必要があり（`dynamicanalysis.New(storeDir, fv)` の形）、完全なコンストラクタ
+一括初期化が構造上困難なため、引き続きセッターで注入する（後述 1.3）。
+
+### 1.3 スコープ
+
+**対象（`ValidatorConfig` に移す）**:
+- `binaryAnalyzer`（`SetBinaryAnalyzer` を削除）
+- `syscallAnalyzer`（`SetSyscallAnalyzer` を削除）
+- `libcCache`（`SetLibcCache` を削除）
+- `libSystemCache`（`SetLibSystemCache` を削除）
+- `machoSyscallTable`（`SetMachoSyscallTable` を削除）
+- `elfDynlibAnalyzer`（`SetELFDynLibAnalyzer` を削除）
+- `machoDynlibAnalyzer`（`SetMachODynLibAnalyzer` を削除）
+- `includeDebugInfo`（`SetIncludeDebugInfo` を削除）
+
+**対象外（引き続きセッターで注入）**:
+- `dynamicLibAnalysisStore`（`SetDynamicLibAnalysisStore` は存続）
+  理由: `Validator` 自身を `dynamicanalysis.Analyzer` として `dynamicanalysis.New` に
+  渡す必要があり、`ValidatorConfig` の段階では `*Validator` がまだ存在しないため
+
+---
+
+## 2. 用語定義
+
+| 用語 | 定義 |
+|------|------|
+| 設定フェーズ | `New` 呼び出しから最初の `SaveRecord` 呼び出しまでの期間 |
+| 実行フェーズ | `SaveRecord` / `VerifyRecord` 等を呼び出す期間 |
+| `ValidatorConfig` | 設定フェーズでのみ使用するフィールドをまとめたオプション構造体 |
+| セッター | `Set*` メソッド群。本タスク後は `SetDynamicLibAnalysisStore` のみ残存 |
+
+---
+
+## 3. 機能要件
+
+### 3.1 `ValidatorConfig` 構造体
+
+#### FR-3.1.1: フィールド定義
+
+`ValidatorConfig` を `internal/filevalidator` パッケージに定義する。
+
+必須フィールド（ゼロ値 = 無効化）:
+
+| フィールド名 | 型 | 意味 |
+|---|---|---|
+| `ELFDynLibAnalyzer` | `*elfdynlib.DynLibAnalyzer` | nil で ELF dynlib 解析無効 |
+| `MachODynLibAnalyzer` | `*machodylib.MachODynLibAnalyzer` | nil で Mach-O dynlib 解析無効 |
+| `BinaryAnalyzer` | `binaryanalyzer.BinaryAnalyzer` | nil でシンボル解析無効 |
+| `SyscallAnalyzer` | `SyscallAnalyzerInterface` | nil で syscall 解析無効 |
+| `LibcCache` | `LibcCacheInterface` | nil で libc ラッパ解析無効 |
+| `LibSystemCache` | `LibSystemCacheInterface` | nil で Mach-O libSystem 解析無効 |
+| `MachoSyscallTable` | `SyscallNumberTable` | nil で番号解決なし |
+| `DebugInfo` | `bool` | false でデバッグ出力なし |
+
+`ValidatorConfig{}` のゼロ値は「すべての解析を無効にした最小構成」として機能する。
+これにより既存の `New(&SHA256{}, hashDir)` 相当の呼び出しは
+`New(&SHA256{}, hashDir, ValidatorConfig{})` に自然に移行できる。
+
+#### FR-3.1.2: `New` のシグネチャ変更
+
+```go
+func New(algorithm HashAlgorithm, hashDir string, cfg ValidatorConfig) (*Validator, error)
+```
+
+- `ValidatorConfig` のゼロ値（`ValidatorConfig{}`）は既存の「アナライザなし」構成に相当し、
+  既存テストのほとんどはゼロ値を渡せばよい
+- `dynamicLibAnalysisStore` は `ValidatorConfig` に含まない（1.3 参照）
+
+### 3.2 セッター削除
+
+対象セッター（FR-3.1.1 に対応するもの）を削除し、既存呼び出し箇所を
+`ValidatorConfig` フィールドへの代入に変更する。
+
+`SetDynamicLibAnalysisStore` は残存させる。
+
+### 3.3 既存 API との互換
+
+#### FR-3.3.1: `cmd/record/main.go` の `validatorFactory` 型変更
+
+現在の factory は `func(hashDir string) (hashRecorder, error)` だが、
+`ValidatorConfig` を渡せるよう変更が必要。
+
+方針: factory の型を `func(hashDir string, cfg ValidatorConfig) (hashRecorder, error)` に変更し、
+`run()` 内で `cfg` を組み立てて factory に渡す。
+
+#### FR-3.3.2: テスト側の更新
+
+テストが `Set*` メソッドを呼んでいた箇所は `ValidatorConfig` フィールド指定に置き換える。
+`New(&SHA256{}, hashDir)` は `New(&SHA256{}, hashDir, ValidatorConfig{})` に変更する。
+
+---
+
+## 4. 非機能要件
+
+### 4.1 互換性
+
+- `fileanalysis.Record` のスキーマ変更なし
+- `dynamicanalysis.Store` のスキーマ変更なし
+- `Validator` の実行時挙動（解析結果の内容）は変更なし
+
+### 4.2 テスタビリティ
+
+- テストでは `ValidatorConfig` の該当フィールドだけを設定し、残りはゼロ値のまま使えることを確認する
+- `SetDynamicLibAnalysisStore` は残存するため、テストでの遅延注入パターンは維持される
+
+---
+
+## 5. 受け入れ基準
+
+| ID | 基準 |
+|----|------|
+| AC-1 | `ValidatorConfig{}` を渡した `New` 呼び出しが、旧来の「セッターなし」構成と同一の挙動をする |
+| AC-2 | 削除対象のセッター（`SetBinaryAnalyzer` 等）を呼び出すコードがコンパイルエラーになる |
+| AC-3 | `SetDynamicLibAnalysisStore` は引き続き利用可能であり、`dynamicanalysis.New(dir, fv)` 後に呼び出せる |
+| AC-4 | `cmd/record/main.go` がすべての設定フィールドを `ValidatorConfig` 経由で渡し、旧セッター呼び出しが残っていない |
+| AC-5 | `make fmt` / `go test -tags test -v ./...` / `make lint` がすべて成功する |
+
+---
+
+## 6. 制約事項
+
+1. `dynamicLibAnalysisStore` の注入は `ValidatorConfig` 経由にしない（1.3 の理由による）
+2. `validatorFactory` の型変更は `cmd/record` パッケージ内にとどめる
+3. `Validator` のエクスポートされていないフィールド名は変更しない
+
+---
+
+## 7. 想定外（Non-Goals）
+
+- `dynamicLibAnalysisStore` の循環依存問題の解消（別タスク）
+- `Validator` のセッターを完全にゼロにすること
+- `validatorFactory` を `Validator` 以外の型で使えるようにすること

--- a/docs/tasks/0132_validator_config_struct/02_architecture.md
+++ b/docs/tasks/0132_validator_config_struct/02_architecture.md
@@ -143,8 +143,8 @@ graph LR
     classDef process fill:#fff1e6,stroke:#ff7f0e,stroke-width:1px,color:#8a3e00;
 
     subgraph deps構造体
-        FAC_OLD["validatorFactory<br/>func(hashDir string) (hashRecorder, error)<br/>現状"]
-        FAC_NEW["validatorFactory<br/>func(hashDir string, cfg filevalidator.ValidatorConfig) (hashRecorder, error)<br/>変更後"]
+        FAC_OLD["validatorFactory<br/>func(hashDir string) (*filevalidator.Validator, error)<br/>現状"]
+        FAC_NEW["validatorFactory<br/>func(hashDir string, cfg filevalidator.ValidatorConfig) (*filevalidator.Validator, error)<br/>変更後"]
     end
 
     subgraph run関数
@@ -160,8 +160,12 @@ graph LR
 ```
 
 `deps.elfDynlibAnalyzerFactory` / `deps.machoDynlibAnalyzerFactory` は
-そのまま残し、`run()` 内で `ValidatorConfig.ELFDynLibAnalyzer` に代入してから
-factory に渡す。
+そのまま残し、`run()` 内で `ValidatorConfig.ELFDynLibAnalyzer` /
+`ValidatorConfig.MachODynLibAnalyzer` に代入してから factory に渡す。
+
+factory の返り値は具象型 `*filevalidator.Validator` のまま維持する。
+`SetDynamicLibAnalysisStore` は引き続きセッターで注入する必要があり、
+呼び出し側 (`run()`) は `*Validator` を直接保持するのが自然なため。
 
 ---
 
@@ -184,13 +188,16 @@ factory に渡す。
 | 追加 | `ValidatorConfig` を組み立てるコード |
 | 削除 | `Set*` 呼び出し（`SetDynamicLibAnalysisStore` を除く） |
 
-### 5.3 テスト（71 箇所以上）
+### 5.3 テスト・呼び出し箇所の見込み
 
 | 変更パターン | 件数の見込み |
 |---|---|
-| `New(&SHA256{}, hashDir)` → `New(&SHA256{}, hashDir, ValidatorConfig{})` | 約 71 箇所（テスト 67 + production 4）の大半が `, ValidatorConfig{}` 追加のみ |
-| `v.SetBinaryAnalyzer(spy)` 等を `ValidatorConfig{BinaryAnalyzer: spy}` に変更 | 約 75 箇所（production 16 + テスト 59） |
-| `testDeps()` の factory 型更新 | `cmd/record/main_test.go` 等 数箇所 |
+| `New(&SHA256{}, hashDir)` → `New(&SHA256{}, hashDir, ValidatorConfig{})` | 約 75 箇所（production 4 + テスト 71）の大半が `, ValidatorConfig{}` 追加のみ |
+| `v.SetBinaryAnalyzer(spy)` 等を `ValidatorConfig{BinaryAnalyzer: spy}` に変更 | 約 73 箇所（production 8（`cmd/record/main.go`） + テスト 65）に加え、`internal/filevalidator/validator.go` のセッター宣言 8 個を削除 |
+| `testRunDeps()` の factory 型更新 | `cmd/record/main_test.go` 等 数箇所 |
+
+> **補足**: 件数は本タスク開始時点でのコードベース調査によるおおよその見積もり。
+> 実装時に新規テストが追加・削除されても誤差の範囲。
 
 ---
 

--- a/docs/tasks/0132_validator_config_struct/02_architecture.md
+++ b/docs/tasks/0132_validator_config_struct/02_architecture.md
@@ -1,0 +1,292 @@
+# Validator 設定構造体への移行 アーキテクチャ設計書
+
+## 1. 設計目標
+
+- `Validator` の設定フェーズ（`New` 呼び出し）と実行フェーズ（`SaveRecord` 等）を
+  型レベルで分離し、セッターによる設定変更をコンパイル時に防ぐ
+- `dynamicLibAnalysisStore` については循環依存の都合で例外とし、引き続きセッターを維持する
+- `ValidatorConfig{}` ゼロ値 = 「すべての解析を無効」として既存テストの移行コストを最小化する
+- `cmd/record/main.go` の factory 型を更新して `ValidatorConfig` を受け渡しできる形にする
+
+---
+
+## 2. 設計原則
+
+- **YAGNI**: `ValidatorConfig` には今タスクで削除するセッターのフィールドのみを追加する
+- **DRY**: `elfDynlibAnalyzerFactory` / `machoDynlibAnalyzerFactory` は
+  `deps` に残り、factory 呼び出し後に `ValidatorConfig` フィールドへ組み込む
+- **ゼロ値有効**: `ValidatorConfig{}` が有効な「最小構成」として機能すること
+
+---
+
+## 3. 全体フロー
+
+### 3.1 現状フロー
+
+```mermaid
+flowchart TD
+    classDef data fill:#e6f7ff,stroke:#1f77b4,stroke-width:1px,color:#0b3d91;
+    classDef process fill:#fff1e6,stroke:#ff7f0e,stroke-width:1px,color:#8a3e00;
+    classDef enhanced fill:#e8f5e8,stroke:#2e8b57,stroke-width:2px,color:#006400;
+
+    MAIN[cmd/record run] --> FAC[validatorFactory hashDir]
+    FAC --> NEW[filevalidator.New algorithm hashDir]
+    NEW --> V[(Validator)]
+    MAIN --> SET1[SetBinaryAnalyzer]
+    MAIN --> SET2[SetSyscallAnalyzer]
+    MAIN --> SET3[SetLibcCache]
+    MAIN --> SET4[SetIncludeDebugInfo]
+    MAIN --> SETN[... 他 4 setter]
+    SET1 --> V
+    SET2 --> V
+    SET3 --> V
+    SET4 --> V
+    SETN --> V
+    MAIN --> STORE[dynamicanalysis.New storeDir fv]
+    STORE --> SETDS[SetDynamicLibAnalysisStore]
+    SETDS --> V
+    V --> SR[SaveRecord]
+
+    class V,SR data;
+    class MAIN,FAC,NEW,SET1,SET2,SET3,SET4,SETN,STORE,SETDS process;
+```
+
+### 3.2 変更後フロー
+
+```mermaid
+flowchart TD
+    classDef data fill:#e6f7ff,stroke:#1f77b4,stroke-width:1px,color:#0b3d91;
+    classDef process fill:#fff1e6,stroke:#ff7f0e,stroke-width:1px,color:#8a3e00;
+    classDef enhanced fill:#e8f5e8,stroke:#2e8b57,stroke-width:2px,color:#006400;
+
+    MAIN[cmd/record run] --> BUILD[ValidatorConfig を組み立て]
+    BUILD --> CFG[(ValidatorConfig)]
+    MAIN --> FAC[validatorFactory hashDir cfg]
+    CFG --> FAC
+    FAC --> NEW[filevalidator.New algorithm hashDir cfg]
+    NEW --> V[(Validator 設定済み)]
+    MAIN --> STORE[dynamicanalysis.New storeDir fv]
+    STORE --> SETDS[SetDynamicLibAnalysisStore 唯一残るセッター]
+    SETDS --> V
+    V --> SR[SaveRecord]
+
+    class V,CFG,SR data;
+    class MAIN,BUILD,FAC,NEW,STORE,SETDS process;
+    class V enhanced;
+```
+
+`Set*` の呼び出しが `SetDynamicLibAnalysisStore` のみになり、
+設定フェーズが `ValidatorConfig` の組み立てに集約される。
+
+---
+
+## 4. コンポーネント設計
+
+### 4.1 `ValidatorConfig` 型
+
+```mermaid
+graph TB
+    classDef data fill:#e6f7ff,stroke:#1f77b4,stroke-width:1px,color:#0b3d91;
+    classDef process fill:#fff1e6,stroke:#ff7f0e,stroke-width:1px,color:#8a3e00;
+
+    subgraph filevalidator[internal/filevalidator]
+        CFG[ValidatorConfig]
+        V[Validator struct]
+        NEW_FN[New algorithm hashDir cfg]
+
+        CFG -.フィールドをコピー.-> V
+        NEW_FN --> V
+    end
+
+    CFG --> |ELFDynLibAnalyzer| V
+    CFG --> |MachODynLibAnalyzer| V
+    CFG --> |BinaryAnalyzer| V
+    CFG --> |SyscallAnalyzer| V
+    CFG --> |LibcCache| V
+    CFG --> |LibSystemCache| V
+    CFG --> |MachoSyscallTable| V
+    CFG --> |DebugInfo| V
+
+    class CFG data;
+    class V,NEW_FN process;
+```
+
+**`ValidatorConfig` の定義骨格**（型名・フィールド名のみ; 実装詳細は実装時に確定）:
+
+```go
+type ValidatorConfig struct {
+    ELFDynLibAnalyzer   *elfdynlib.DynLibAnalyzer
+    MachODynLibAnalyzer *machodylib.MachODynLibAnalyzer
+    BinaryAnalyzer      binaryanalyzer.BinaryAnalyzer
+    SyscallAnalyzer     SyscallAnalyzerInterface
+    LibcCache           LibcCacheInterface
+    LibSystemCache      LibSystemCacheInterface
+    MachoSyscallTable   SyscallNumberTable
+    DebugInfo           bool
+}
+```
+
+### 4.2 `New` シグネチャ
+
+```go
+func New(algorithm HashAlgorithm, hashDir string, cfg ValidatorConfig) (*Validator, error)
+```
+
+`newValidator`（内部関数）も同様に `cfg ValidatorConfig` を受け取り、
+各フィールドを `Validator` 構造体に展開する。
+
+### 4.3 `cmd/record/main.go` の factory 型変更
+
+```mermaid
+graph LR
+    classDef data fill:#e6f7ff,stroke:#1f77b4,stroke-width:1px,color:#0b3d91;
+    classDef process fill:#fff1e6,stroke:#ff7f0e,stroke-width:1px,color:#8a3e00;
+
+    subgraph deps構造体
+        FAC_OLD["validatorFactory<br/>func(hashDir string) (hashRecorder, error)<br/>現状"]
+        FAC_NEW["validatorFactory<br/>func(hashDir string, cfg filevalidator.ValidatorConfig) (hashRecorder, error)<br/>変更後"]
+    end
+
+    subgraph run関数
+        BUILD["ValidatorConfig を組み立てる<br/>cfg := filevalidator.ValidatorConfig{<br/>    BinaryAnalyzer: ...<br/>    SyscallAnalyzer: ...<br/>    ...<br/>}"]
+        CALL["d.validatorFactory(cfg.hashDir, vCfg)"]
+    end
+
+    FAC_OLD -.-> FAC_NEW
+    BUILD --> CALL
+
+    class FAC_OLD,FAC_NEW data;
+    class BUILD,CALL process;
+```
+
+`deps.elfDynlibAnalyzerFactory` / `deps.machoDynlibAnalyzerFactory` は
+そのまま残し、`run()` 内で `ValidatorConfig.ELFDynLibAnalyzer` に代入してから
+factory に渡す。
+
+---
+
+## 5. 影響範囲
+
+### 5.1 `internal/filevalidator/`
+
+| 変更種別 | 対象 |
+|---|---|
+| 新規定義 | `ValidatorConfig` 型 |
+| シグネチャ変更 | `New`, `newValidator` |
+| 削除 | `SetBinaryAnalyzer`, `SetSyscallAnalyzer`, `SetLibcCache`, `SetLibSystemCache`, `SetMachoSyscallTable`, `SetELFDynLibAnalyzer`, `SetMachODynLibAnalyzer`, `SetIncludeDebugInfo` |
+| 変更なし | `SetDynamicLibAnalysisStore`, `Validator` フィールド名 |
+
+### 5.2 `cmd/record/main.go`
+
+| 変更種別 | 対象 |
+|---|---|
+| 型変更 | `validatorFactory` の関数型 |
+| 追加 | `ValidatorConfig` を組み立てるコード |
+| 削除 | `Set*` 呼び出し（`SetDynamicLibAnalysisStore` を除く） |
+
+### 5.3 テスト（71 箇所以上）
+
+| 変更パターン | 件数の見込み |
+|---|---|
+| `New(&SHA256{}, hashDir)` → `New(&SHA256{}, hashDir, ValidatorConfig{})` | 約 71 箇所（テスト 67 + production 4）の大半が `, ValidatorConfig{}` 追加のみ |
+| `v.SetBinaryAnalyzer(spy)` 等を `ValidatorConfig{BinaryAnalyzer: spy}` に変更 | 約 75 箇所（production 16 + テスト 59） |
+| `testDeps()` の factory 型更新 | `cmd/record/main_test.go` 等 数箇所 |
+
+---
+
+## 6. エラー処理設計
+
+`ValidatorConfig` 自体のバリデーションは行わない。
+
+- ゼロ値フィールド = 該当解析が無効（現状のセッターを nil で呼ぶことと等価）
+- 将来的に「アナライザの組み合わせが不正」な場合を検出したければ
+  `New` 内でチェック関数を追加できるが、本タスクでは行わない
+
+---
+
+## 7. セキュリティ考慮事項
+
+`ValidatorConfig` の各フィールドはすべてインタフェース/ポインタであり、
+セッター廃止後は `New` 呼び出し以降に外部から書き換えられない。
+
+`processedInterpreterAnalysis` / `processedLibAnalysis` の一貫性問題（タスク 0130 で文書化）は、
+`includeDebugInfo` / `binaryAnalyzer` / `syscallAnalyzer` の全フィールドが
+構成時に固定されることで解消される。
+
+`dynamicLibAnalysisStore` は例外だが、セッターの契約コメント（タスク 0130 で追記）で
+「`SaveRecord` 前に呼ぶこと」が文書化されており、実運用上の呼び出し順は保証されている。
+
+---
+
+## 8. 処理フロー詳細
+
+### 8.1 `cmd/record/run()` での `ValidatorConfig` 組み立て順
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant run as cmd/record run()
+    participant deps as deps
+    participant fv as filevalidator
+
+    run->>run: ValidatorConfig を組み立て<br/>(BinaryAnalyzer, SyscallAnalyzer, ...)<br/>elfDynlibAnalyzerFactory も呼び出して代入
+    run->>deps: validatorFactory(hashDir, vCfg)
+    deps->>fv: New(SHA256, hashDir, vCfg)
+    fv-->>deps: *Validator
+    deps-->>run: hashRecorder
+    run->>run: dynamicanalysis.New(storeDir, fv)
+    run->>fv: SetDynamicLibAnalysisStore(store)
+    run->>run: processFiles(...)
+```
+
+`elfDynlibAnalyzerFactory` の呼び出しが `run()` 内に移動する。
+現在は `run()` が type assertion で `*Validator` を取り出してセッターを呼んでいるが、
+変更後は factory に `ValidatorConfig` を渡す形になる。
+
+---
+
+## 9. テスト戦略
+
+### 9.1 既存テストの移行方針
+
+移行は機械的なため、新規テストは追加しない。AC-1（ゼロ値等価性）だけは、
+`ValidatorConfig{}` を渡した場合に既存テストが同じ結果を返すことで自動的に保証される。
+
+### 9.2 削除された setter に対する回帰テスト
+
+削除されたセッターはコンパイルエラーを引き起こすため、AC-2 はビルド成功により担保される。
+
+### 9.3 重点確認
+
+- `cmd/record/main.go` の統合テスト（`TestRunWithSyscallAnalysis` 等）が
+  `ValidatorConfig` 経由でも同じ解析結果を返すことを確認
+- `internal/libccache/integration_test.go` など、外部テストがセッターを呼んでいた箇所を
+  `ValidatorConfig` フィールドに置き換えた後も pass することを確認
+
+---
+
+## 10. 実装の優先順位
+
+| フェーズ | 内容 |
+|---|---|
+| Phase 1 | `ValidatorConfig` 型定義、`New` / `newValidator` シグネチャ変更 |
+| Phase 2 | `internal/filevalidator` パッケージ内テストの移行 |
+| Phase 3 | `cmd/record/main.go` の factory 型変更・`ValidatorConfig` 組み立て |
+| Phase 4 | 外部テスト（`libccache`, `runner`, `verification` 等）の移行 |
+| Phase 5 | `make fmt` / `make test` / `make lint` |
+
+---
+
+## 11. 将来の拡張性
+
+### 11.1 `dynamicLibAnalysisStore` の循環依存解消
+
+将来的に `Validator` が `dynamicanalysis.Analyzer` インタフェースを実装するのではなく、
+外部から別の `Analyzer` を渡せる設計に変えることができれば、
+`dynamicLibAnalysisStore` も `ValidatorConfig` に含められる。
+ただし、それには `Validator.AnalyzeLibrary` の呼び出し設計変更を伴うため別タスクとする。
+
+### 11.2 `newValidator` の非公開維持
+
+`newValidator` は引き続き非公開とし、テスト用の迂回路は作らない。
+テストは `New(&SHA256{}, hashDir, cfg)` のみを経由する。

--- a/docs/tasks/0132_validator_config_struct/04_implementation_plan.md
+++ b/docs/tasks/0132_validator_config_struct/04_implementation_plan.md
@@ -1,0 +1,331 @@
+# 実装計画書: Validator 設定構造体への移行
+
+## 受け入れ条件とタスクの対応表
+
+| AC | 内容 | 対応タスク |
+|---|---|---|
+| AC-1 | `ValidatorConfig{}` を渡した `New` が「セッターなし」構成と同一の挙動をする | 1.1, 1.2 — 移行後の既存テスト全通過で自動確認 |
+| AC-2 | 削除セッター（`SetBinaryAnalyzer` 等）の呼び出しがコンパイルエラーになる | 1.3 — ビルド成功 ＝ 残存呼び出しが 0 を意味する |
+| AC-3 | `SetDynamicLibAnalysisStore` が `dynamicanalysis.New(dir, fv)` 後に呼び出せる | 1.3 — validator_library_analysis_test.go の `validatorWithStore` が残存テスト |
+| AC-4 | `cmd/record/main.go` が全設定を `ValidatorConfig` 経由で渡し旧セッター呼び出しが残っていない | 3.1, 3.2 — ビルド成功 ＋ Phase 3 完了で確認 |
+| AC-5 | `make fmt` / `make test` / `make lint` が全成功する | 5.1 |
+
+---
+
+## フェーズ 1: `ValidatorConfig` 定義とコア変更
+
+### タスク 1.1: `ValidatorConfig` 型の定義
+
+対象: `internal/filevalidator/validator.go`
+
+- [ ] `ValidatorConfig` 構造体をファイル先頭付近（`Validator` 構造体定義より前）に追加する
+  ```go
+  type ValidatorConfig struct {
+      ELFDynLibAnalyzer   *elfdynlib.DynLibAnalyzer
+      MachODynLibAnalyzer *machodylib.MachODynLibAnalyzer
+      BinaryAnalyzer      binaryanalyzer.BinaryAnalyzer
+      SyscallAnalyzer     SyscallAnalyzerInterface
+      LibcCache           LibcCacheInterface
+      LibSystemCache      LibSystemCacheInterface
+      MachoSyscallTable   SyscallNumberTable
+      DebugInfo           bool
+  }
+  ```
+- [ ] コメントは英語で記載し日本語を含まないことを確認する
+
+AC カバレッジ: AC-1 (ゼロ値 = 全解析無効)
+
+### タスク 1.2: `New` / `newValidator` シグネチャ変更と設定フィールド反映
+
+対象: `internal/filevalidator/validator.go`
+
+- [ ] `New` の第 3 引数に `cfg ValidatorConfig` を追加する
+  ```go
+  func New(algorithm HashAlgorithm, hashDir string, cfg ValidatorConfig) (*Validator, error)
+  ```
+- [ ] `newValidator` の第 4 引数に `cfg ValidatorConfig` を追加し、返却する `&Validator{}` リテラルで各フィールドを設定する
+  ```go
+  func newValidator(algorithm HashAlgorithm, hashDir common.ResolvedPath, hashFilePathGetter common.HashFilePathGetter, cfg ValidatorConfig) (*Validator, error)
+  ```
+  設定対象フィールド: `elfDynlibAnalyzer`, `machoDynlibAnalyzer`, `binaryAnalyzer`,
+  `syscallAnalyzer`, `libcCache`, `libSystemCache`, `machoSyscallTable`, `includeDebugInfo`
+- [ ] `New` から `newValidator` へ `cfg` を転送する
+
+AC カバレッジ: AC-1
+
+### タスク 1.3: セッター削除
+
+対象: `internal/filevalidator/validator.go`
+
+削除対象メソッド（8 個）:
+- [ ] `SetELFDynLibAnalyzer`
+- [ ] `SetMachODynLibAnalyzer`
+- [ ] `SetBinaryAnalyzer`
+- [ ] `SetSyscallAnalyzer`
+- [ ] `SetLibcCache`
+- [ ] `SetLibSystemCache`
+- [ ] `SetMachoSyscallTable`
+- [ ] `SetIncludeDebugInfo`
+
+存続させるメソッド（変更なし）:
+- `SetDynamicLibAnalysisStore` — 循環依存のため除外（02_architecture.md 1.3 参照）
+
+AC カバレッジ: AC-2, AC-3
+
+---
+
+## フェーズ 2: `internal/filevalidator` パッケージ内テスト移行
+
+> フェーズ 1 完了後、パッケージ内テストがコンパイルエラーになるため優先して修正する。
+
+### タスク 2.1: `validatorWithTempHashDir` ヘルパー拡張
+
+対象: `internal/filevalidator/validator_library_analysis_test.go`
+
+- [ ] `validatorWithTempHashDir(t *testing.T)` を
+  `validatorWithTempHashDir(t *testing.T, cfg ValidatorConfig)` に変更する
+- [ ] 内部の `New(&SHA256{}, hashDir)` を `New(&SHA256{}, hashDir, cfg)` に変更する
+- [ ] このヘルパーを呼ぶすべての箇所（同ファイル内）に `ValidatorConfig{}` または必要な設定を渡すよう更新する（下記 2.2 で詳細化）
+
+AC カバレッジ: AC-1 (ゼロ値等価)
+
+### タスク 2.2: `validator_library_analysis_test.go` 内セッター呼び出し移行（19 箇所）
+
+対象: `internal/filevalidator/validator_library_analysis_test.go`
+
+- [ ] `validatorWithTempHashDir(t)` 呼び出し後にセッターを呼ぶ各テストを、
+  `validatorWithTempHashDir(t, ValidatorConfig{BinaryAnalyzer: ..., SyscallAnalyzer: ...})` 形式に変更する
+- [ ] `validatorWithStore` は `validatorWithTempHashDir(t, ValidatorConfig{})` を呼ぶよう更新する
+  （`SetDynamicLibAnalysisStore` の呼び出しはそのまま残す — AC-3 テスト）
+- [ ] セッター呼び出し行を削除し、コンパイルエラーがなくなることを確認する
+
+AC カバレッジ: AC-1, AC-2, AC-3
+
+### タスク 2.3: `validator_test.go` 移行（27 `New` 呼び出し + 23 セッター呼び出し）
+
+対象: `internal/filevalidator/validator_test.go`
+
+- [ ] `New(&SHA256{}, hashDir)` を全 27 箇所で `New(&SHA256{}, hashDir, ValidatorConfig{})` に変更する
+- [ ] `newValidatorWithStubs(t, libcCache)` ヘルパーを修正する
+  - `v.SetLibcCache(libcCache)` を削除し、`New(&SHA256{}, hashDir, ValidatorConfig{LibcCache: libcCache})` に変更する
+  - nil ガード（`if libcCache != nil`）は不要になるため削除する
+- [ ] 各テスト内で `v.SetXxx(...)` を呼んでいる箇所は、直前の `New` 呼び出しの `ValidatorConfig` に移動する（23 箇所）
+- [ ] `newCollisionValidator` ヘルパー内の `newValidator(&SHA256{}, resolvedHashDir, getter)` を
+  `newValidator(&SHA256{}, resolvedHashDir, getter, ValidatorConfig{})` に変更する
+
+AC カバレッジ: AC-1, AC-2
+
+### タスク 2.4: `validator_shebang_cache_test.go` 移行（4 `New` + 4 セッター）
+
+対象: `internal/filevalidator/validator_shebang_cache_test.go`
+
+- [ ] `New(&SHA256{}, hashDir)` を 4 箇所で `ValidatorConfig{BinaryAnalyzer: spy}` 付きに変更する
+- [ ] `v.SetBinaryAnalyzer(spy)` 呼び出し 4 箇所を削除する
+
+AC カバレッジ: AC-1, AC-2
+
+### タスク 2.5: `validator_macho_test.go` 移行（6 `New` + 9 セッター）
+
+対象: `internal/filevalidator/validator_macho_test.go`
+
+- [ ] `New(&SHA256{}, hashDir)` 6 箇所に対応する `ValidatorConfig` を設定する
+- [ ] セッター呼び出し 9 箇所（`SetBinaryAnalyzer`, `SetIncludeDebugInfo`, `SetLibSystemCache`）を削除し、`ValidatorConfig` に移動する
+
+AC カバレッジ: AC-1, AC-2
+
+### タスク 2.6: `validator_macho_darwin_test.go` 移行（1 `New` + 1 セッター）
+
+対象: `internal/filevalidator/validator_macho_darwin_test.go`
+
+- [ ] `New(&SHA256{}, hashDir)` に `ValidatorConfig{MachODynLibAnalyzer: ...}` を追加する
+- [ ] `v.SetMachODynLibAnalyzer(...)` を削除する
+
+AC カバレッジ: AC-1, AC-2
+
+### タスク 2.7: `validator_dynlib_sort_linux_test.go` 移行（1 `New` + 1 セッター）
+
+対象: `internal/filevalidator/validator_dynlib_sort_linux_test.go`
+
+- [ ] `New(&SHA256{}, hashDir)` に `ValidatorConfig{ELFDynLibAnalyzer: ...}` を追加する
+- [ ] `v.SetELFDynLibAnalyzer(...)` を削除する
+
+AC カバレッジ: AC-1, AC-2
+
+### タスク 2.8: その他パッケージ内テストファイルの `New` 呼び出し更新
+
+- [ ] `validator_error_test.go` — 3 箇所に `ValidatorConfig{}` を追加する
+- [ ] `validator_shebang_test.go` — 7 箇所に `ValidatorConfig{}` を追加する
+- [ ] `benchmark_test.go` — 1 箇所に `ValidatorConfig{}` を追加する
+
+AC カバレッジ: AC-1
+
+---
+
+## フェーズ 3: `cmd/record/main.go` 更新
+
+### タスク 3.1: `validatorFactory` 型変更
+
+対象: `cmd/record/main.go`
+
+- [ ] `deps.validatorFactory` フィールドの型を変更する
+  ```go
+  validatorFactory func(hashDir string, cfg filevalidator.ValidatorConfig) (*filevalidator.Validator, error)
+  ```
+- [ ] `defaultDeps()` 内の factory ラムダを更新する
+  ```go
+  validatorFactory: func(hashDir string, cfg filevalidator.ValidatorConfig) (*filevalidator.Validator, error) {
+      return filevalidator.New(&filevalidator.SHA256{}, hashDir, cfg)
+  },
+  ```
+
+AC カバレッジ: AC-4
+
+### タスク 3.2: `run()` 内での `ValidatorConfig` 組み立てとセッター呼び出し削除
+
+対象: `cmd/record/main.go`
+
+- [ ] `elfDynlibAnalyzerFactory` / `machoDynlibAnalyzerFactory` を呼び出す前に
+  `ValidatorConfig` を組み立てるコードブロックを追加する
+  ```go
+  vCfg := filevalidator.ValidatorConfig{
+      BinaryAnalyzer:      security.NewBinaryAnalyzer(runtime.GOOS),
+      SyscallAnalyzer:     libccache.NewSyscallAdapter(syscallAnalyzer),
+      LibcCache:           libccache.NewCacheAdapter(cacheMgr, syscallAnalyzer),
+      LibSystemCache:      libccache.NewMachoLibSystemAdapter(machoCacheMgr, safeFS),
+      MachoSyscallTable:   libccache.MacOSSyscallTable{},
+      DebugInfo:           cfg.debugInfo,
+  }
+  if d.elfDynlibAnalyzerFactory != nil {
+      vCfg.ELFDynLibAnalyzer = d.elfDynlibAnalyzerFactory()
+  }
+  if d.machoDynlibAnalyzerFactory != nil {
+      vCfg.MachODynLibAnalyzer = d.machoDynlibAnalyzerFactory()
+  }
+  ```
+- [ ] `d.validatorFactory(cfg.hashDir)` を `d.validatorFactory(cfg.hashDir, vCfg)` に変更する
+- [ ] 旧セッター呼び出し 8 行（`SetELFDynLibAnalyzer`, `SetMachODynLibAnalyzer`, `SetBinaryAnalyzer`,
+  `SetSyscallAnalyzer`, `SetLibcCache`, `SetIncludeDebugInfo`, `SetLibSystemCache`,
+  `SetMachoSyscallTable`）を削除する
+- [ ] `SetDynamicLibAnalysisStore` の呼び出しはそのまま残す
+
+> **実行順序の変更について**: 現状のコードでは `syscallAnalyzer`（line 143）・`cacheMgr`（line 157）・
+> `machoCacheMgr`（line 167）の生成が `validatorFactory` 呼び出し（line 128）の**後**にある。
+> `ValidatorConfig` にこれらを渡すには生成順序を以下に変更する必要がある。
+>
+> 1. `safeFS` を生成する（現 line 155 → 先頭へ移動）
+> 2. `syscallAnalyzer` を生成する
+> 3. `cacheMgr` を生成する（失敗時に早期 return — エラーハンドリングは維持する）
+> 4. `machoCacheMgr` を生成する（同上）
+> 5. `ValidatorConfig` を組み立て、`validatorFactory` を呼ぶ
+> 6. `dynamicanalysis.New(dynlibStoreDir, validator)` を呼ぶ（`validator` が必要なため変更不可）
+> 7. `SetDynamicLibAnalysisStore` を呼ぶ（変更なし）
+
+AC カバレッジ: AC-4
+
+### タスク 3.3: `cmd/record/main_test.go` factory 型更新
+
+対象: `cmd/record/main_test.go`
+
+- [ ] `testRunDeps` は `defaultDeps()` を呼ぶだけなので、factory 型変更は自動的に反映される
+  — コンパイルが通ることで確認する
+- [ ] `filevalidator.New` を直接呼ぶ 2 箇所（line 257, 278）に `filevalidator.ValidatorConfig{}` を追加する
+
+AC カバレッジ: AC-4, AC-5
+
+---
+
+## フェーズ 4: 外部プロダクションコードの更新
+
+### タスク 4.1: `internal/cmdcommon/common.go`
+
+- [ ] `filevalidator.New(&filevalidator.SHA256{}, hashDir)` を
+  `filevalidator.New(&filevalidator.SHA256{}, hashDir, filevalidator.ValidatorConfig{})` に変更する
+
+### タスク 4.2: `internal/runner/base/security/hash_validation.go`
+
+- [ ] `filevalidator.New(&filevalidator.SHA256{}, hashDir)` に `filevalidator.ValidatorConfig{}` を追加する
+
+### タスク 4.3: `internal/verification/manager.go`
+
+- [ ] `filevalidator.New(&filevalidator.SHA256{}, hashDir)` に `filevalidator.ValidatorConfig{}` を追加する
+
+AC カバレッジ: AC-5 (コンパイル成功)
+
+---
+
+## フェーズ 5: 外部テストの更新
+
+### タスク 5.1: `internal/libccache/integration_test.go`（1 `New` + 4 セッター）
+
+- [ ] `filevalidator.New(&filevalidator.SHA256{}, hashDir)` に対応する `ValidatorConfig`
+  （`ELFDynLibAnalyzer`, `SyscallAnalyzer`, `LibcCache`, `DebugInfo: true`）を渡すよう変更する
+- [ ] セッター呼び出し 4 行を削除する
+
+### タスク 5.2: `internal/libccache/integration_darwin_test.go`（2 `New` + 2 セッター）
+
+- [ ] `filevalidator.New` の 2 箇所のうちセッターを呼ぶ箇所（line 42 付近）に
+  `ValidatorConfig{MachODynLibAnalyzer: ..., LibSystemCache: ...}` を渡すよう変更する
+- [ ] もう 1 箇所（line 240 付近）は `ValidatorConfig{}` のみ追加する
+- [ ] セッター呼び出し 2 行を削除する
+
+### タスク 5.3: `internal/verification/manager_macho_test.go`（2 `New` + 2 セッター）
+
+- [ ] 各 `filevalidator.New` 呼び出し後の `SetMachODynLibAnalyzer` を
+  `ValidatorConfig{MachODynLibAnalyzer: ...}` に移動する
+
+### タスク 5.4: その他外部テストの `New` 呼び出し更新（`ValidatorConfig{}` 追加のみ）
+
+- [ ] `internal/runner/e2e_shebang_test.go` — 4 箇所
+- [ ] `internal/runner/bootstrap/config_test.go` — 1 箇所
+- [ ] `internal/runner/config/loader_verification_test.go` — 1 箇所
+- [ ] `cmd/runner/integration_security_test.go` — 1 箇所
+- [ ] `test/security/hash_bypass_test.go` — 4 箇所
+
+AC カバレッジ: AC-5 (コンパイル成功)
+
+---
+
+## フェーズ 6: 品質確認
+
+### タスク 6.1: フォーマット・テスト・リント
+
+- [ ] `make fmt` を実行してフォーマットエラーがないことを確認する
+- [ ] `go test -tags test -v ./...` を実行して全テストが通ることを確認する
+- [ ] `make lint` を実行して linter エラーがないことを確認する
+
+AC カバレッジ: AC-5
+
+---
+
+## 実施上の注意事項
+
+1. フェーズ 1 完了後、コンパイルエラーが多数発生する。フェーズ 2→5 を順に修正する。
+2. `ValidatorConfig` のフィールド名は Go の公開命名規則（`DebugInfo` 等）を使用し、
+   既存の private フィールド名（`includeDebugInfo`）とは意図的に異なる。
+3. コード（コメント含む）に日本語を使用しない。
+4. `newValidator` の `cfg ValidatorConfig` 引数は、`hashFilePathGetter` の後に追加する
+   （既存の引数順を乱さないため）。
+
+---
+
+## 受け入れ条件の検証方法
+
+**AC-1**: `ValidatorConfig{}` ゼロ値等価性
+- 検証: フェーズ 2 完了後に既存テスト（旧来は「セッターなし」で動作していたもの）が
+  `ValidatorConfig{}` を渡すだけで全通過することで自動確認される。
+- テスト: `validator_test.go` の `TestRecord_*` 等（既存テスト群を移行したもの）
+
+**AC-2**: 削除セッターがコンパイルエラーを引き起こす
+- 検証: ビルド成功 ＝ 全呼び出し箇所が除去済みであることの証明。
+  `go build ./...` が通れば旧セッター呼び出しは存在しない。
+
+**AC-3**: `SetDynamicLibAnalysisStore` の継続利用
+- テスト: `internal/filevalidator/validator_library_analysis_test.go` — `validatorWithStore`
+  が `New(cfg) → dynamicanalysis.New(dir, v) → SetDynamicLibAnalysisStore(store)` の順で呼び、
+  `TestAnalyzeLibraries_*` が動作することで確認。
+
+**AC-4**: `cmd/record` での旧セッター完全排除
+- 検証: タスク 3.2 でセッター行 8 本を削除 ＋ ビルド成功で確認。
+
+**AC-5**: `make fmt` / `make test` / `make lint` 全成功
+- 検証: タスク 6.1 の実行結果で確認。

--- a/docs/tasks/0132_validator_config_struct/04_implementation_plan.md
+++ b/docs/tasks/0132_validator_config_struct/04_implementation_plan.md
@@ -18,7 +18,7 @@
 
 対象: `internal/filevalidator/validator.go`
 
-- [ ] `ValidatorConfig` 構造体をファイル先頭付近（`Validator` 構造体定義より前）に追加する
+- [x] `ValidatorConfig` 構造体をファイル先頭付近（`Validator` 構造体定義より前）に追加する
   ```go
   type ValidatorConfig struct {
       ELFDynLibAnalyzer   *elfdynlib.DynLibAnalyzer
@@ -31,7 +31,7 @@
       DebugInfo           bool
   }
   ```
-- [ ] コメントは英語で記載し日本語を含まないことを確認する
+- [x] コメントは英語で記載し日本語を含まないことを確認する
 
 AC カバレッジ: AC-1 (ゼロ値 = 全解析無効)
 
@@ -39,17 +39,17 @@ AC カバレッジ: AC-1 (ゼロ値 = 全解析無効)
 
 対象: `internal/filevalidator/validator.go`
 
-- [ ] `New` の第 3 引数に `cfg ValidatorConfig` を追加する
+- [x] `New` の第 3 引数に `cfg ValidatorConfig` を追加する
   ```go
   func New(algorithm HashAlgorithm, hashDir string, cfg ValidatorConfig) (*Validator, error)
   ```
-- [ ] `newValidator` の第 4 引数に `cfg ValidatorConfig` を追加し、返却する `&Validator{}` リテラルで各フィールドを設定する
+- [x] `newValidator` の第 4 引数に `cfg ValidatorConfig` を追加し、返却する `&Validator{}` リテラルで各フィールドを設定する
   ```go
   func newValidator(algorithm HashAlgorithm, hashDir common.ResolvedPath, hashFilePathGetter common.HashFilePathGetter, cfg ValidatorConfig) (*Validator, error)
   ```
   設定対象フィールド: `elfDynlibAnalyzer`, `machoDynlibAnalyzer`, `binaryAnalyzer`,
   `syscallAnalyzer`, `libcCache`, `libSystemCache`, `machoSyscallTable`, `includeDebugInfo`
-- [ ] `New` から `newValidator` へ `cfg` を転送する
+- [x] `New` から `newValidator` へ `cfg` を転送する
 
 AC カバレッジ: AC-1
 
@@ -58,14 +58,14 @@ AC カバレッジ: AC-1
 対象: `internal/filevalidator/validator.go`
 
 削除対象メソッド（8 個）:
-- [ ] `SetELFDynLibAnalyzer`
-- [ ] `SetMachODynLibAnalyzer`
-- [ ] `SetBinaryAnalyzer`
-- [ ] `SetSyscallAnalyzer`
-- [ ] `SetLibcCache`
-- [ ] `SetLibSystemCache`
-- [ ] `SetMachoSyscallTable`
-- [ ] `SetIncludeDebugInfo`
+- [x] `SetELFDynLibAnalyzer`
+- [x] `SetMachODynLibAnalyzer`
+- [x] `SetBinaryAnalyzer`
+- [x] `SetSyscallAnalyzer`
+- [x] `SetLibcCache`
+- [x] `SetLibSystemCache`
+- [x] `SetMachoSyscallTable`
+- [x] `SetIncludeDebugInfo`
 
 存続させるメソッド（変更なし）:
 - `SetDynamicLibAnalysisStore` — 循環依存のため除外（02_architecture.md 1.3 参照）
@@ -82,10 +82,10 @@ AC カバレッジ: AC-2, AC-3
 
 対象: `internal/filevalidator/validator_library_analysis_test.go`
 
-- [ ] `validatorWithTempHashDir(t *testing.T)` を
+- [x] `validatorWithTempHashDir(t *testing.T)` を
   `validatorWithTempHashDir(t *testing.T, cfg ValidatorConfig)` に変更する
-- [ ] 内部の `New(&SHA256{}, hashDir)` を `New(&SHA256{}, hashDir, cfg)` に変更する
-- [ ] このヘルパーを呼ぶすべての箇所（同ファイル内）に `ValidatorConfig{}` または必要な設定を渡すよう更新する（下記 2.2 で詳細化）
+- [x] 内部の `New(&SHA256{}, hashDir)` を `New(&SHA256{}, hashDir, cfg)` に変更する
+- [x] このヘルパーを呼ぶすべての箇所（同ファイル内）に `ValidatorConfig{}` または必要な設定を渡すよう更新する（下記 2.2 で詳細化）
 
 AC カバレッジ: AC-1 (ゼロ値等価)
 
@@ -93,11 +93,11 @@ AC カバレッジ: AC-1 (ゼロ値等価)
 
 対象: `internal/filevalidator/validator_library_analysis_test.go`
 
-- [ ] `validatorWithTempHashDir(t)` 呼び出し後にセッターを呼ぶ各テストを、
+- [x] `validatorWithTempHashDir(t)` 呼び出し後にセッターを呼ぶ各テストを、
   `validatorWithTempHashDir(t, ValidatorConfig{BinaryAnalyzer: ..., SyscallAnalyzer: ...})` 形式に変更する
-- [ ] `validatorWithStore` は `validatorWithTempHashDir(t, ValidatorConfig{})` を呼ぶよう更新する
+- [x] `validatorWithStore` は `validatorWithTempHashDir(t, ValidatorConfig{})` を呼ぶよう更新する
   （`SetDynamicLibAnalysisStore` の呼び出しはそのまま残す — AC-3 テスト）
-- [ ] セッター呼び出し行を削除し、コンパイルエラーがなくなることを確認する
+- [x] セッター呼び出し行を削除し、コンパイルエラーがなくなることを確認する
 
 AC カバレッジ: AC-1, AC-2, AC-3
 
@@ -105,12 +105,12 @@ AC カバレッジ: AC-1, AC-2, AC-3
 
 対象: `internal/filevalidator/validator_test.go`
 
-- [ ] `New(&SHA256{}, hashDir)` を全 27 箇所で `New(&SHA256{}, hashDir, ValidatorConfig{})` に変更する
-- [ ] `newValidatorWithStubs(t, libcCache)` ヘルパーを修正する
+- [x] `New(&SHA256{}, hashDir)` を全 27 箇所で `New(&SHA256{}, hashDir, ValidatorConfig{})` に変更する
+- [x] `newValidatorWithStubs(t, libcCache)` ヘルパーを修正する
   - `v.SetLibcCache(libcCache)` を削除し、`New(&SHA256{}, hashDir, ValidatorConfig{LibcCache: libcCache})` に変更する
   - nil ガード（`if libcCache != nil`）は不要になるため削除する
-- [ ] 各テスト内で `v.SetXxx(...)` を呼んでいる箇所は、直前の `New` 呼び出しの `ValidatorConfig` に移動する（23 箇所）
-- [ ] `newCollisionValidator` ヘルパー内の `newValidator(&SHA256{}, resolvedHashDir, getter)` を
+- [x] 各テスト内で `v.SetXxx(...)` を呼んでいる箇所は、直前の `New` 呼び出しの `ValidatorConfig` に移動する（23 箇所）
+- [x] `newCollisionValidator` ヘルパー内の `newValidator(&SHA256{}, resolvedHashDir, getter)` を
   `newValidator(&SHA256{}, resolvedHashDir, getter, ValidatorConfig{})` に変更する
 
 AC カバレッジ: AC-1, AC-2
@@ -119,8 +119,8 @@ AC カバレッジ: AC-1, AC-2
 
 対象: `internal/filevalidator/validator_shebang_cache_test.go`
 
-- [ ] `New(&SHA256{}, hashDir)` を 4 箇所で `ValidatorConfig{BinaryAnalyzer: spy}` 付きに変更する
-- [ ] `v.SetBinaryAnalyzer(spy)` 呼び出し 4 箇所を削除する
+- [x] `New(&SHA256{}, hashDir)` を 4 箇所で `ValidatorConfig{BinaryAnalyzer: spy}` 付きに変更する
+- [x] `v.SetBinaryAnalyzer(spy)` 呼び出し 4 箇所を削除する
 
 AC カバレッジ: AC-1, AC-2
 
@@ -128,8 +128,8 @@ AC カバレッジ: AC-1, AC-2
 
 対象: `internal/filevalidator/validator_macho_test.go`
 
-- [ ] `New(&SHA256{}, hashDir)` 6 箇所に対応する `ValidatorConfig` を設定する
-- [ ] セッター呼び出し 9 箇所（`SetBinaryAnalyzer`, `SetIncludeDebugInfo`, `SetLibSystemCache`）を削除し、`ValidatorConfig` に移動する
+- [x] `New(&SHA256{}, hashDir)` 6 箇所に対応する `ValidatorConfig` を設定する
+- [x] セッター呼び出し 9 箇所（`SetBinaryAnalyzer`, `SetIncludeDebugInfo`, `SetLibSystemCache`）を削除し、`ValidatorConfig` に移動する
 
 AC カバレッジ: AC-1, AC-2
 
@@ -137,8 +137,8 @@ AC カバレッジ: AC-1, AC-2
 
 対象: `internal/filevalidator/validator_macho_darwin_test.go`
 
-- [ ] `New(&SHA256{}, hashDir)` に `ValidatorConfig{MachODynLibAnalyzer: ...}` を追加する
-- [ ] `v.SetMachODynLibAnalyzer(...)` を削除する
+- [x] `New(&SHA256{}, hashDir)` に `ValidatorConfig{MachODynLibAnalyzer: ...}` を追加する
+- [x] `v.SetMachODynLibAnalyzer(...)` を削除する
 
 AC カバレッジ: AC-1, AC-2
 
@@ -146,16 +146,16 @@ AC カバレッジ: AC-1, AC-2
 
 対象: `internal/filevalidator/validator_dynlib_sort_linux_test.go`
 
-- [ ] `New(&SHA256{}, hashDir)` に `ValidatorConfig{ELFDynLibAnalyzer: ...}` を追加する
-- [ ] `v.SetELFDynLibAnalyzer(...)` を削除する
+- [x] `New(&SHA256{}, hashDir)` に `ValidatorConfig{ELFDynLibAnalyzer: ...}` を追加する
+- [x] `v.SetELFDynLibAnalyzer(...)` を削除する
 
 AC カバレッジ: AC-1, AC-2
 
 ### タスク 2.8: その他パッケージ内テストファイルの `New` 呼び出し更新
 
-- [ ] `validator_error_test.go` — 3 箇所に `ValidatorConfig{}` を追加する
-- [ ] `validator_shebang_test.go` — 7 箇所に `ValidatorConfig{}` を追加する
-- [ ] `benchmark_test.go` — 1 箇所に `ValidatorConfig{}` を追加する
+- [x] `validator_error_test.go` — 3 箇所に `ValidatorConfig{}` を追加する
+- [x] `validator_shebang_test.go` — 7 箇所に `ValidatorConfig{}` を追加する
+- [x] `benchmark_test.go` — 1 箇所に `ValidatorConfig{}` を追加する
 
 AC カバレッジ: AC-1
 
@@ -167,11 +167,11 @@ AC カバレッジ: AC-1
 
 対象: `cmd/record/main.go`
 
-- [ ] `deps.validatorFactory` フィールドの型を変更する
+- [x] `deps.validatorFactory` フィールドの型を変更する
   ```go
   validatorFactory func(hashDir string, cfg filevalidator.ValidatorConfig) (*filevalidator.Validator, error)
   ```
-- [ ] `defaultDeps()` 内の factory ラムダを更新する
+- [x] `defaultDeps()` 内の factory ラムダを更新する
   ```go
   validatorFactory: func(hashDir string, cfg filevalidator.ValidatorConfig) (*filevalidator.Validator, error) {
       return filevalidator.New(&filevalidator.SHA256{}, hashDir, cfg)
@@ -184,7 +184,7 @@ AC カバレッジ: AC-4
 
 対象: `cmd/record/main.go`
 
-- [ ] `elfDynlibAnalyzerFactory` / `machoDynlibAnalyzerFactory` を呼び出す前に
+- [x] `elfDynlibAnalyzerFactory` / `machoDynlibAnalyzerFactory` を呼び出す前に
   `ValidatorConfig` を組み立てるコードブロックを追加する
   ```go
   vCfg := filevalidator.ValidatorConfig{
@@ -202,11 +202,11 @@ AC カバレッジ: AC-4
       vCfg.MachODynLibAnalyzer = d.machoDynlibAnalyzerFactory()
   }
   ```
-- [ ] `d.validatorFactory(cfg.hashDir)` を `d.validatorFactory(cfg.hashDir, vCfg)` に変更する
-- [ ] 旧セッター呼び出し 8 行（`SetELFDynLibAnalyzer`, `SetMachODynLibAnalyzer`, `SetBinaryAnalyzer`,
+- [x] `d.validatorFactory(cfg.hashDir)` を `d.validatorFactory(cfg.hashDir, vCfg)` に変更する
+- [x] 旧セッター呼び出し 8 行（`SetELFDynLibAnalyzer`, `SetMachODynLibAnalyzer`, `SetBinaryAnalyzer`,
   `SetSyscallAnalyzer`, `SetLibcCache`, `SetIncludeDebugInfo`, `SetLibSystemCache`,
   `SetMachoSyscallTable`）を削除する
-- [ ] `SetDynamicLibAnalysisStore` の呼び出しはそのまま残す
+- [x] `SetDynamicLibAnalysisStore` の呼び出しはそのまま残す
 
 > **実行順序の変更について**: 現状のコードでは `syscallAnalyzer`（line 143）・`cacheMgr`（line 157）・
 > `machoCacheMgr`（line 167）の生成が `validatorFactory` 呼び出し（line 128）の**後**にある。
@@ -226,9 +226,9 @@ AC カバレッジ: AC-4
 
 対象: `cmd/record/main_test.go`
 
-- [ ] `testRunDeps` は `defaultDeps()` を呼ぶだけなので、factory 型変更は自動的に反映される
+- [x] `testRunDeps` は `defaultDeps()` を呼ぶだけなので、factory 型変更は自動的に反映される
   — コンパイルが通ることで確認する
-- [ ] `filevalidator.New` を直接呼ぶ 2 箇所（line 257, 278）に `filevalidator.ValidatorConfig{}` を追加する
+- [x] `filevalidator.New` を直接呼ぶ 2 箇所（line 257, 278）に `filevalidator.ValidatorConfig{}` を追加する
 
 AC カバレッジ: AC-4, AC-5
 
@@ -238,16 +238,16 @@ AC カバレッジ: AC-4, AC-5
 
 ### タスク 4.1: `internal/cmdcommon/common.go`
 
-- [ ] `filevalidator.New(&filevalidator.SHA256{}, hashDir)` を
+- [x] `filevalidator.New(&filevalidator.SHA256{}, hashDir)` を
   `filevalidator.New(&filevalidator.SHA256{}, hashDir, filevalidator.ValidatorConfig{})` に変更する
 
 ### タスク 4.2: `internal/runner/base/security/hash_validation.go`
 
-- [ ] `filevalidator.New(&filevalidator.SHA256{}, hashDir)` に `filevalidator.ValidatorConfig{}` を追加する
+- [x] `filevalidator.New(&filevalidator.SHA256{}, hashDir)` に `filevalidator.ValidatorConfig{}` を追加する
 
 ### タスク 4.3: `internal/verification/manager.go`
 
-- [ ] `filevalidator.New(&filevalidator.SHA256{}, hashDir)` に `filevalidator.ValidatorConfig{}` を追加する
+- [x] `filevalidator.New(&filevalidator.SHA256{}, hashDir)` に `filevalidator.ValidatorConfig{}` を追加する
 
 AC カバレッジ: AC-5 (コンパイル成功)
 
@@ -257,29 +257,29 @@ AC カバレッジ: AC-5 (コンパイル成功)
 
 ### タスク 5.1: `internal/libccache/integration_test.go`（1 `New` + 4 セッター）
 
-- [ ] `filevalidator.New(&filevalidator.SHA256{}, hashDir)` に対応する `ValidatorConfig`
+- [x] `filevalidator.New(&filevalidator.SHA256{}, hashDir)` に対応する `ValidatorConfig`
   （`ELFDynLibAnalyzer`, `SyscallAnalyzer`, `LibcCache`, `DebugInfo: true`）を渡すよう変更する
-- [ ] セッター呼び出し 4 行を削除する
+- [x] セッター呼び出し 4 行を削除する
 
 ### タスク 5.2: `internal/libccache/integration_darwin_test.go`（2 `New` + 2 セッター）
 
-- [ ] `filevalidator.New` の 2 箇所のうちセッターを呼ぶ箇所（line 42 付近）に
+- [x] `filevalidator.New` の 2 箇所のうちセッターを呼ぶ箇所（line 42 付近）に
   `ValidatorConfig{MachODynLibAnalyzer: ..., LibSystemCache: ...}` を渡すよう変更する
-- [ ] もう 1 箇所（line 240 付近）は `ValidatorConfig{}` のみ追加する
-- [ ] セッター呼び出し 2 行を削除する
+- [x] もう 1 箇所（line 240 付近）は `ValidatorConfig{}` のみ追加する
+- [x] セッター呼び出し 2 行を削除する
 
 ### タスク 5.3: `internal/verification/manager_macho_test.go`（2 `New` + 2 セッター）
 
-- [ ] 各 `filevalidator.New` 呼び出し後の `SetMachODynLibAnalyzer` を
+- [x] 各 `filevalidator.New` 呼び出し後の `SetMachODynLibAnalyzer` を
   `ValidatorConfig{MachODynLibAnalyzer: ...}` に移動する
 
 ### タスク 5.4: その他外部テストの `New` 呼び出し更新（`ValidatorConfig{}` 追加のみ）
 
-- [ ] `internal/runner/e2e_shebang_test.go` — 4 箇所
-- [ ] `internal/runner/bootstrap/config_test.go` — 1 箇所
-- [ ] `internal/runner/config/loader_verification_test.go` — 1 箇所
-- [ ] `cmd/runner/integration_security_test.go` — 1 箇所
-- [ ] `test/security/hash_bypass_test.go` — 4 箇所
+- [x] `internal/runner/e2e_shebang_test.go` — 4 箇所
+- [x] `internal/runner/bootstrap/config_test.go` — 1 箇所
+- [x] `internal/runner/config/loader_verification_test.go` — 1 箇所
+- [x] `cmd/runner/integration_security_test.go` — 1 箇所
+- [x] `test/security/hash_bypass_test.go` — 4 箇所
 
 AC カバレッジ: AC-5 (コンパイル成功)
 
@@ -289,9 +289,9 @@ AC カバレッジ: AC-5 (コンパイル成功)
 
 ### タスク 6.1: フォーマット・テスト・リント
 
-- [ ] `make fmt` を実行してフォーマットエラーがないことを確認する
-- [ ] `go test -tags test -v ./...` を実行して全テストが通ることを確認する
-- [ ] `make lint` を実行して linter エラーがないことを確認する
+- [x] `make fmt` を実行してフォーマットエラーがないことを確認する
+- [x] `go test -tags test -v ./...` を実行して全テストが通ることを確認する
+- [x] `make lint` を実行して linter エラーがないことを確認する
 
 AC カバレッジ: AC-5
 

--- a/internal/cmdcommon/common.go
+++ b/internal/cmdcommon/common.go
@@ -12,5 +12,5 @@ var (
 
 // CreateValidator creates a new file validator with the hybrid hash path getter.
 func CreateValidator(hashDir string) (filevalidator.FileValidator, error) {
-	return filevalidator.New(&filevalidator.SHA256{}, hashDir)
+	return filevalidator.New(&filevalidator.SHA256{}, hashDir, filevalidator.ValidatorConfig{})
 }

--- a/internal/filevalidator/benchmark_test.go
+++ b/internal/filevalidator/benchmark_test.go
@@ -8,7 +8,7 @@ import (
 // BenchmarkValidator_Verify benchmarks the standard Verify method
 func BenchmarkValidator_Verify(b *testing.B) {
 	tempDir := b.TempDir()
-	validator, err := New(&SHA256{}, tempDir)
+	validator, err := New(&SHA256{}, tempDir, ValidatorConfig{})
 	if err != nil {
 		b.Fatalf("Failed to create validator: %v", err)
 	}

--- a/internal/filevalidator/validator.go
+++ b/internal/filevalidator/validator.go
@@ -133,6 +133,19 @@ func (v *Validator) Store() *fileanalysis.Store {
 	return v.store
 }
 
+// ValidatorConfig configures optional analyzers and caches for Validator.
+// Zero values disable the corresponding analysis features.
+type ValidatorConfig struct {
+	ELFDynLibAnalyzer   *elfdynlib.DynLibAnalyzer
+	MachODynLibAnalyzer *machodylib.MachODynLibAnalyzer
+	BinaryAnalyzer      binaryanalyzer.BinaryAnalyzer
+	SyscallAnalyzer     SyscallAnalyzerInterface
+	LibcCache           LibcCacheInterface
+	LibSystemCache      LibSystemCacheInterface
+	MachoSyscallTable   SyscallNumberTable
+	DebugInfo           bool
+}
+
 // Validator provides functionality to record and verify file hashes.
 // It should be instantiated using the New function.
 type Validator struct {
@@ -163,7 +176,7 @@ type Validator struct {
 // The hash directory is created automatically if it does not exist.
 // This constructor uses the FileAnalysisRecord format for storing hash and analysis results.
 // The analysis store preserves existing fields (e.g., SyscallAnalysis) when updating hashes.
-func New(algorithm HashAlgorithm, hashDir string) (*Validator, error) {
+func New(algorithm HashAlgorithm, hashDir string, cfg ValidatorConfig) (*Validator, error) {
 	hashFilePathGetter := NewHybridHashFilePathGetter()
 
 	// Create analysis store first — this creates the directory if it doesn't exist.
@@ -179,7 +192,7 @@ func New(algorithm HashAlgorithm, hashDir string) (*Validator, error) {
 	}
 
 	// Now create the validator — the directory is guaranteed to exist.
-	v, err := newValidator(algorithm, resolvedHashDir, hashFilePathGetter)
+	v, err := newValidator(algorithm, resolvedHashDir, hashFilePathGetter, cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -190,7 +203,7 @@ func New(algorithm HashAlgorithm, hashDir string) (*Validator, error) {
 
 // newValidator initializes and returns a new Validator with the specified hash algorithm and hash directory.
 // Returns an error if the algorithm is nil or if the hash directory cannot be accessed.
-func newValidator(algorithm HashAlgorithm, hashDir common.ResolvedPath, hashFilePathGetter common.HashFilePathGetter) (*Validator, error) {
+func newValidator(algorithm HashAlgorithm, hashDir common.ResolvedPath, hashFilePathGetter common.HashFilePathGetter, cfg ValidatorConfig) (*Validator, error) {
 	if algorithm == nil {
 		return nil, ErrNilAlgorithm
 	}
@@ -208,10 +221,18 @@ func newValidator(algorithm HashAlgorithm, hashDir common.ResolvedPath, hashFile
 	}
 
 	return &Validator{
-		algorithm:          algorithm,
-		hashDir:            hashDir,
-		hashFilePathGetter: hashFilePathGetter,
-		fileSystem:         safefileio.NewFileSystem(safefileio.FileSystemConfig{}),
+		algorithm:           algorithm,
+		hashDir:             hashDir,
+		hashFilePathGetter:  hashFilePathGetter,
+		fileSystem:          safefileio.NewFileSystem(safefileio.FileSystemConfig{}),
+		elfDynlibAnalyzer:   cfg.ELFDynLibAnalyzer,
+		machoDynlibAnalyzer: cfg.MachODynLibAnalyzer,
+		binaryAnalyzer:      cfg.BinaryAnalyzer,
+		syscallAnalyzer:     cfg.SyscallAnalyzer,
+		libcCache:           cfg.LibcCache,
+		libSystemCache:      cfg.LibSystemCache,
+		machoSyscallTable:   cfg.MachoSyscallTable,
+		includeDebugInfo:    cfg.DebugInfo,
 	}, nil
 }
 
@@ -480,32 +501,6 @@ func (v *Validator) checkNotShebang(path, role string) error {
 	return nil
 }
 
-// SetLibSystemCache injects the LibSystemCacheInterface used during record operations.
-// Call before the first SaveRecord() invocation.
-func (v *Validator) SetLibSystemCache(m LibSystemCacheInterface) {
-	v.libSystemCache = m
-}
-
-// SetMachoSyscallTable injects the SyscallNumberTable used for macOS BSD syscall
-// number resolution during Pass 1 and Pass 2 analysis. When nil, syscall names
-// and network flags are left empty but numbers are still resolved where possible.
-// Call before the first SaveRecord() invocation.
-func (v *Validator) SetMachoSyscallTable(t SyscallNumberTable) {
-	v.machoSyscallTable = t
-}
-
-// SetELFDynLibAnalyzer injects the DynLibAnalyzer used during record operations.
-// Call before the first SaveRecord() invocation. Safe to call with nil (disables dynlib analysis).
-func (v *Validator) SetELFDynLibAnalyzer(a *elfdynlib.DynLibAnalyzer) {
-	v.elfDynlibAnalyzer = a
-}
-
-// SetMachODynLibAnalyzer injects the MachODynLibAnalyzer used during record operations.
-// Call before the first SaveRecord() invocation. Safe to call with nil (disables Mach-O dynlib analysis).
-func (v *Validator) SetMachODynLibAnalyzer(a *machodylib.MachODynLibAnalyzer) {
-	v.machoDynlibAnalyzer = a
-}
-
 // analyzeDynLibDeps analyzes dynamic library dependencies for the given file and
 // updates the record. ELF analysis runs first; Mach-O analysis runs only when ELF
 // returns no results. Both fields are cleared before analysis when at least one
@@ -553,24 +548,6 @@ func (v *Validator) analyzeDynLibDeps(filePath string, record *fileanalysis.Reco
 	slices.Sort(record.AnalysisWarnings)
 
 	return nil
-}
-
-// SetBinaryAnalyzer injects the BinaryAnalyzer used during record operations.
-// Call before the first SaveRecord() invocation. Safe to call with nil (disables binary analysis).
-func (v *Validator) SetBinaryAnalyzer(a binaryanalyzer.BinaryAnalyzer) {
-	v.binaryAnalyzer = a
-}
-
-// SetLibcCache injects the LibcCacheInterface used during record operations.
-// Call before the first SaveRecord() invocation.
-func (v *Validator) SetLibcCache(m LibcCacheInterface) {
-	v.libcCache = m
-}
-
-// SetSyscallAnalyzer injects the SyscallAnalyzer used during record operations.
-// Call before the first SaveRecord() invocation.
-func (v *Validator) SetSyscallAnalyzer(a SyscallAnalyzerInterface) {
-	v.syscallAnalyzer = a
 }
 
 // libCacheKey is the key type for the in-session library analysis cache.
@@ -1072,15 +1049,6 @@ func (a *analysisAggregate) warnings() []string {
 	}
 	slices.Sort(warnings)
 	return warnings
-}
-
-// SetIncludeDebugInfo controls whether debug information (Occurrences,
-// DeterminationStats) is included in saved JSON output.
-// Call before the first SaveRecord() invocation. Changing this after records
-// have been processed causes the in-session interpreter and library analysis
-// caches to return results with inconsistent debug data.
-func (v *Validator) SetIncludeDebugInfo(b bool) {
-	v.includeDebugInfo = b
 }
 
 // elfMachineForArchName converts an architecture name string (as stored in

--- a/internal/filevalidator/validator_dynlib_sort_linux_test.go
+++ b/internal/filevalidator/validator_dynlib_sort_linux_test.go
@@ -203,11 +203,12 @@ func TestDynLibDeps_SortedByPath(t *testing.T) {
 	mainELF := buildMinimalELFWithDeps(t, tmpDir, "main.elf",
 		[]string{"libz.so.1", "libm.so.6", "liba.so.1"}, tmpDir)
 
-	v, err := New(&SHA256{}, hashDir)
+	v, err := New(&SHA256{}, hashDir, ValidatorConfig{
+		ELFDynLibAnalyzer: elfdynlib.NewDynLibAnalyzer(
+			safefileio.NewFileSystem(safefileio.FileSystemConfig{}),
+		),
+	})
 	require.NoError(t, err)
-	v.SetELFDynLibAnalyzer(elfdynlib.NewDynLibAnalyzer(
-		safefileio.NewFileSystem(safefileio.FileSystemConfig{}),
-	))
 
 	_, _, err = v.SaveRecord(mainELF, false)
 	require.NoError(t, err)

--- a/internal/filevalidator/validator_error_test.go
+++ b/internal/filevalidator/validator_error_test.go
@@ -17,7 +17,7 @@ import (
 // TestErrorCases tests various error conditions and their messages
 func TestErrorCases(t *testing.T) {
 	tempDir := safeTempDir(t)
-	validator, err := New(&SHA256{}, tempDir)
+	validator, err := New(&SHA256{}, tempDir, ValidatorConfig{})
 	assert.NoError(t, err, "Failed to create validator")
 
 	tests := []struct {
@@ -94,7 +94,7 @@ func TestErrorCases(t *testing.T) {
 // TestFilesystemEdgeCases tests various edge cases related to filesystem operations
 func TestFilesystemEdgeCases(t *testing.T) {
 	tempDir := safeTempDir(t)
-	validator, err := New(&SHA256{}, tempDir)
+	validator, err := New(&SHA256{}, tempDir, ValidatorConfig{})
 	assert.NoError(t, err, "Failed to create validator")
 
 	t.Run("deleted file", func(t *testing.T) {
@@ -171,7 +171,7 @@ func TestFilesystemEdgeCases(t *testing.T) {
 // TestErrorMessages verifies that error messages are clear and helpful
 func TestErrorMessages(t *testing.T) {
 	tempDir := safeTempDir(t)
-	validator, err := New(&SHA256{}, tempDir)
+	validator, err := New(&SHA256{}, tempDir, ValidatorConfig{})
 	assert.NoError(t, err, "Failed to create validator")
 
 	tests := []struct {

--- a/internal/filevalidator/validator_library_analysis_test.go
+++ b/internal/filevalidator/validator_library_analysis_test.go
@@ -66,13 +66,13 @@ func (s *libraryTestSyscallAnalyzer) GetSyscallTable(_ elf.Machine) (SyscallNumb
 	return s.table, true
 }
 
-func validatorWithTempHashDir(t *testing.T) *Validator {
+func validatorWithTempHashDir(t *testing.T, cfg ValidatorConfig) *Validator {
 	t.Helper()
 	tempDir := safeTempDir(t)
 	hashDir := filepath.Join(tempDir, "hashes")
 	require.NoError(t, os.MkdirAll(hashDir, 0o700))
 
-	v, err := New(&SHA256{}, hashDir)
+	v, err := New(&SHA256{}, hashDir, cfg)
 	require.NoError(t, err)
 	return v
 }
@@ -100,7 +100,7 @@ func requireWithSocketELF(t *testing.T) string {
 // validator itself. Used for tests that exercise the full analyzeLibraries flow.
 func validatorWithStore(t *testing.T) *Validator {
 	t.Helper()
-	v := validatorWithTempHashDir(t)
+	v := validatorWithTempHashDir(t, ValidatorConfig{})
 	storeDir := filepath.Join(t.TempDir(), "dynlibstore")
 	store, err := dynamicanalysis.New(storeDir, v)
 	require.NoError(t, err)
@@ -109,15 +109,14 @@ func validatorWithStore(t *testing.T) *Validator {
 }
 
 func TestAnalyzeOneLibrary_networkSymbolDetected(t *testing.T) {
-	v := validatorWithTempHashDir(t)
-	v.SetBinaryAnalyzer(&libraryTestBinaryAnalyzer{
+	v := validatorWithTempHashDir(t, ValidatorConfig{BinaryAnalyzer: &libraryTestBinaryAnalyzer{
 		output: binaryanalyzer.AnalysisOutput{
 			Result: binaryanalyzer.NetworkDetected,
 			DetectedSymbols: []binaryanalyzer.DetectedSymbol{
 				{Name: "socket", Category: "socket"},
 			},
 		},
-	})
+	}})
 
 	result, err := v.analyzeOneLibrary(fileanalysis.LibEntry{
 		SOName: "libfoo.so.1",
@@ -131,11 +130,12 @@ func TestAnalyzeOneLibrary_networkSymbolDetected(t *testing.T) {
 }
 
 func TestAnalyzeOneLibrary_networkSyscallDetected(t *testing.T) {
-	v := validatorWithTempHashDir(t)
-	v.SetBinaryAnalyzer(&libraryTestBinaryAnalyzer{output: binaryanalyzer.AnalysisOutput{Result: binaryanalyzer.NoNetworkSymbols}})
-	v.SetSyscallAnalyzer(&libraryTestSyscallAnalyzer{
-		syscalls: []common.SyscallInfo{{Number: 41, Name: "socket"}},
-		table:    &libraryTestSyscallTable{network: map[int]bool{41: true}},
+	v := validatorWithTempHashDir(t, ValidatorConfig{
+		BinaryAnalyzer: &libraryTestBinaryAnalyzer{output: binaryanalyzer.AnalysisOutput{Result: binaryanalyzer.NoNetworkSymbols}},
+		SyscallAnalyzer: &libraryTestSyscallAnalyzer{
+			syscalls: []common.SyscallInfo{{Number: 41, Name: "socket"}},
+			table:    &libraryTestSyscallTable{network: map[int]bool{41: true}},
+		},
 	})
 
 	result, err := v.analyzeOneLibrary(fileanalysis.LibEntry{
@@ -150,15 +150,16 @@ func TestAnalyzeOneLibrary_networkSyscallDetected(t *testing.T) {
 }
 
 func TestAnalyzeOneLibrary_preservesArgEvalResults(t *testing.T) {
-	v := validatorWithTempHashDir(t)
-	v.SetBinaryAnalyzer(&libraryTestBinaryAnalyzer{output: binaryanalyzer.AnalysisOutput{Result: binaryanalyzer.NoNetworkSymbols}})
-	v.SetSyscallAnalyzer(&libraryTestSyscallAnalyzer{
-		syscalls: []common.SyscallInfo{{Number: 10, Name: "mprotect"}},
-		argResults: []common.SyscallArgEvalResult{{
-			SyscallName: "mprotect",
-			Status:      common.SyscallArgEvalExecConfirmed,
-			Details:     "prot=0x5",
-		}},
+	v := validatorWithTempHashDir(t, ValidatorConfig{
+		BinaryAnalyzer: &libraryTestBinaryAnalyzer{output: binaryanalyzer.AnalysisOutput{Result: binaryanalyzer.NoNetworkSymbols}},
+		SyscallAnalyzer: &libraryTestSyscallAnalyzer{
+			syscalls: []common.SyscallInfo{{Number: 10, Name: "mprotect"}},
+			argResults: []common.SyscallArgEvalResult{{
+				SyscallName: "mprotect",
+				Status:      common.SyscallArgEvalExecConfirmed,
+				Details:     "prot=0x5",
+			}},
+		},
 	})
 
 	result, err := v.analyzeOneLibrary(fileanalysis.LibEntry{
@@ -175,9 +176,10 @@ func TestAnalyzeOneLibrary_preservesArgEvalResults(t *testing.T) {
 }
 
 func TestAnalyzeOneLibrary_nonNetwork(t *testing.T) {
-	v := validatorWithTempHashDir(t)
-	v.SetBinaryAnalyzer(&libraryTestBinaryAnalyzer{output: binaryanalyzer.AnalysisOutput{Result: binaryanalyzer.NoNetworkSymbols}})
-	v.SetSyscallAnalyzer(&libraryTestSyscallAnalyzer{syscalls: []common.SyscallInfo{{Number: 1, Name: "write"}}})
+	v := validatorWithTempHashDir(t, ValidatorConfig{
+		BinaryAnalyzer:  &libraryTestBinaryAnalyzer{output: binaryanalyzer.AnalysisOutput{Result: binaryanalyzer.NoNetworkSymbols}},
+		SyscallAnalyzer: &libraryTestSyscallAnalyzer{syscalls: []common.SyscallInfo{{Number: 1, Name: "write"}}},
+	})
 
 	result, err := v.analyzeOneLibrary(fileanalysis.LibEntry{
 		SOName: "libbaz.so.1",
@@ -196,8 +198,7 @@ func TestAnalyzeOneLibrary_nonNetwork(t *testing.T) {
 // TestAnalyzeOneLibrary_missingFileReturnsError verifies that a missing library file
 // returns an error rather than a non-fatal warning.
 func TestAnalyzeOneLibrary_missingFileReturnsError(t *testing.T) {
-	v := validatorWithTempHashDir(t)
-	v.SetSyscallAnalyzer(&libraryTestSyscallAnalyzer{})
+	v := validatorWithTempHashDir(t, ValidatorConfig{SyscallAnalyzer: &libraryTestSyscallAnalyzer{}})
 
 	_, err := v.analyzeOneLibrary(fileanalysis.LibEntry{
 		SOName: "libmissing.so.1",
@@ -208,8 +209,7 @@ func TestAnalyzeOneLibrary_missingFileReturnsError(t *testing.T) {
 }
 
 func TestAnalyzeOneLibrary_nonELFLibrarySkipsSyscallScan(t *testing.T) {
-	v := validatorWithTempHashDir(t)
-	v.SetSyscallAnalyzer(&libraryTestSyscallAnalyzer{syscalls: []common.SyscallInfo{{Number: 41, Name: "socket"}}})
+	v := validatorWithTempHashDir(t, ValidatorConfig{SyscallAnalyzer: &libraryTestSyscallAnalyzer{syscalls: []common.SyscallInfo{{Number: 41, Name: "socket"}}}})
 
 	result, err := v.analyzeOneLibrary(fileanalysis.LibEntry{
 		SOName: "libscript.so.1",
@@ -223,8 +223,7 @@ func TestAnalyzeOneLibrary_nonELFLibrarySkipsSyscallScan(t *testing.T) {
 }
 
 func TestAnalyzeOneLibrary_unsupportedArchSkipsWarning(t *testing.T) {
-	v := validatorWithTempHashDir(t)
-	v.SetSyscallAnalyzer(&libraryTestSyscallAnalyzer{err: ErrUnsupportedArch})
+	v := validatorWithTempHashDir(t, ValidatorConfig{SyscallAnalyzer: &libraryTestSyscallAnalyzer{err: ErrUnsupportedArch}})
 
 	result, err := v.analyzeOneLibrary(fileanalysis.LibEntry{
 		SOName: "libfoo.so.1",
@@ -240,8 +239,7 @@ func TestAnalyzeOneLibrary_unsupportedArchSkipsWarning(t *testing.T) {
 // TestAnalyzeLibraries_withoutStore verifies that library analysis still runs
 // without an external dynamic library analysis store.
 func TestAnalyzeLibraries_withoutStore(t *testing.T) {
-	v := validatorWithTempHashDir(t)
-	v.SetBinaryAnalyzer(&libraryTestBinaryAnalyzer{output: binaryanalyzer.AnalysisOutput{Result: binaryanalyzer.NoNetworkSymbols}})
+	v := validatorWithTempHashDir(t, ValidatorConfig{BinaryAnalyzer: &libraryTestBinaryAnalyzer{output: binaryanalyzer.AnalysisOutput{Result: binaryanalyzer.NoNetworkSymbols}}})
 	record := &fileanalysis.Record{
 		DynLibDeps: []fileanalysis.LibEntry{{SOName: "libfoo.so.1", Path: requireWithSocketELF(t), Hash: "sha256:foo"}},
 	}
@@ -263,10 +261,12 @@ func TestAnalyzeLibraries_emptyDynLibDeps(t *testing.T) {
 // TestAnalyzeLibraries_ExcludesWrapperAndVDSO verifies that syscall wrapper libraries
 // (e.g., libc) and VDSO entries are excluded from library analysis.
 func TestAnalyzeLibraries_excludesWrapperAndVDSO(t *testing.T) {
-	v := validatorWithStore(t)
-
 	bin := &libraryTestBinaryAnalyzer{output: binaryanalyzer.AnalysisOutput{Result: binaryanalyzer.NoNetworkSymbols}}
-	v.SetBinaryAnalyzer(bin)
+	v := validatorWithTempHashDir(t, ValidatorConfig{BinaryAnalyzer: bin})
+	storeDir := filepath.Join(t.TempDir(), "dynlibstore")
+	store, err := dynamicanalysis.New(storeDir, v)
+	require.NoError(t, err)
+	v.SetDynamicLibAnalysisStore(store)
 
 	elfPath := requireWithSocketELF(t)
 	record := &fileanalysis.Record{
@@ -284,10 +284,12 @@ func TestAnalyzeLibraries_excludesWrapperAndVDSO(t *testing.T) {
 // TestAnalyzeLibraries_sessionCache verifies that repeated analysis of the same
 // library path and hash within a single session uses the in-session cache.
 func TestAnalyzeLibraries_sessionCache(t *testing.T) {
-	v := validatorWithStore(t)
-
 	bin := &libraryTestBinaryAnalyzer{output: binaryanalyzer.AnalysisOutput{Result: binaryanalyzer.NoNetworkSymbols}}
-	v.SetBinaryAnalyzer(bin)
+	v := validatorWithTempHashDir(t, ValidatorConfig{BinaryAnalyzer: bin})
+	storeDir := filepath.Join(t.TempDir(), "dynlibstore")
+	store, err := dynamicanalysis.New(storeDir, v)
+	require.NoError(t, err)
+	v.SetDynamicLibAnalysisStore(store)
 
 	path := requireWithSocketELF(t)
 	record := &fileanalysis.Record{
@@ -304,16 +306,18 @@ func TestAnalyzeLibraries_sessionCache(t *testing.T) {
 // TestAnalyzeLibraries_symbolAnalysisCreatedWhenNil verifies that DynamicLoadSymbols
 // are merged and SymbolAnalysis is created when a library has dlopen/dlsym symbols.
 func TestAnalyzeLibraries_symbolAnalysisCreatedWhenNil(t *testing.T) {
-	v := validatorWithStore(t)
-
-	v.SetBinaryAnalyzer(&libraryTestBinaryAnalyzer{
+	v := validatorWithTempHashDir(t, ValidatorConfig{BinaryAnalyzer: &libraryTestBinaryAnalyzer{
 		output: binaryanalyzer.AnalysisOutput{
 			Result: binaryanalyzer.NetworkDetected,
 			DynamicLoadSymbols: []binaryanalyzer.DetectedSymbol{
 				{Name: "dlopen", Category: "dynamic_load"},
 			},
 		},
-	})
+	}})
+	storeDir := filepath.Join(t.TempDir(), "dynlibstore")
+	store, err := dynamicanalysis.New(storeDir, v)
+	require.NoError(t, err)
+	v.SetDynamicLibAnalysisStore(store)
 
 	record := &fileanalysis.Record{
 		DynLibDeps: []fileanalysis.LibEntry{
@@ -329,8 +333,11 @@ func TestAnalyzeLibraries_symbolAnalysisCreatedWhenNil(t *testing.T) {
 // TestAnalyzeLibraries_RecordHasNoLibraryAnalysisField verifies that the record does not
 // contain a library_analysis field after analysis (results are stored externally).
 func TestAnalyzeLibraries_RecordHasNoLibraryAnalysisField(t *testing.T) {
-	v := validatorWithStore(t)
-	v.SetBinaryAnalyzer(&libraryTestBinaryAnalyzer{output: binaryanalyzer.AnalysisOutput{Result: binaryanalyzer.NoNetworkSymbols}})
+	v := validatorWithTempHashDir(t, ValidatorConfig{BinaryAnalyzer: &libraryTestBinaryAnalyzer{output: binaryanalyzer.AnalysisOutput{Result: binaryanalyzer.NoNetworkSymbols}}})
+	storeDir := filepath.Join(t.TempDir(), "dynlibstore")
+	store, err := dynamicanalysis.New(storeDir, v)
+	require.NoError(t, err)
+	v.SetDynamicLibAnalysisStore(store)
 
 	record := &fileanalysis.Record{
 		DynLibDeps: []fileanalysis.LibEntry{
@@ -347,9 +354,12 @@ func TestAnalyzeLibraries_RecordHasNoLibraryAnalysisField(t *testing.T) {
 // are correctly recorded in the executable record even when the store reuses
 // an existing analysis result.
 func TestAnalyzeLibraries_DynLibDepsPreservedOnReuse(t *testing.T) {
-	v := validatorWithStore(t)
 	bin := &libraryTestBinaryAnalyzer{output: binaryanalyzer.AnalysisOutput{Result: binaryanalyzer.NoNetworkSymbols}}
-	v.SetBinaryAnalyzer(bin)
+	v := validatorWithTempHashDir(t, ValidatorConfig{BinaryAnalyzer: bin})
+	storeDir := filepath.Join(t.TempDir(), "dynlibstore")
+	store, err := dynamicanalysis.New(storeDir, v)
+	require.NoError(t, err)
+	v.SetDynamicLibAnalysisStore(store)
 
 	path := requireWithSocketELF(t)
 	record := &fileanalysis.Record{
@@ -377,8 +387,11 @@ func TestAnalyzeLibraries_DynLibDepsPreservedOnReuse(t *testing.T) {
 // TestAnalyzeLibraries_MissingLibFileReturnsError verifies that a missing library file
 // causes analyzeLibraries to return an error, and the record is not written.
 func TestAnalyzeLibraries_MissingLibFileReturnsError(t *testing.T) {
-	v := validatorWithStore(t)
-	v.SetSyscallAnalyzer(&libraryTestSyscallAnalyzer{})
+	v := validatorWithTempHashDir(t, ValidatorConfig{SyscallAnalyzer: &libraryTestSyscallAnalyzer{}})
+	storeDir := filepath.Join(t.TempDir(), "dynlibstore")
+	store, err := dynamicanalysis.New(storeDir, v)
+	require.NoError(t, err)
+	v.SetDynamicLibAnalysisStore(store)
 
 	record := &fileanalysis.Record{
 		DynLibDeps: []fileanalysis.LibEntry{
@@ -386,17 +399,20 @@ func TestAnalyzeLibraries_MissingLibFileReturnsError(t *testing.T) {
 		},
 	}
 
-	err := v.analyzeLibraries(record)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to open library file")
+	analyzeErr := v.analyzeLibraries(record)
+	require.Error(t, analyzeErr)
+	assert.Contains(t, analyzeErr.Error(), "failed to open library file")
 }
 
 // TestAnalyzeLibraries_VDSOExcluded verifies that VDSO entries are excluded from
 // library analysis even when they are the only entry in DynLibDeps.
 func TestAnalyzeLibraries_VDSOExcluded(t *testing.T) {
-	v := validatorWithStore(t)
 	bin := &libraryTestBinaryAnalyzer{output: binaryanalyzer.AnalysisOutput{Result: binaryanalyzer.NoNetworkSymbols}}
-	v.SetBinaryAnalyzer(bin)
+	v := validatorWithTempHashDir(t, ValidatorConfig{BinaryAnalyzer: bin})
+	storeDir := filepath.Join(t.TempDir(), "dynlibstore")
+	store, err := dynamicanalysis.New(storeDir, v)
+	require.NoError(t, err)
+	v.SetDynamicLibAnalysisStore(store)
 
 	record := &fileanalysis.Record{
 		DynLibDeps: []fileanalysis.LibEntry{
@@ -411,8 +427,7 @@ func TestAnalyzeLibraries_VDSOExcluded(t *testing.T) {
 // TestValidatorLibraryAnalyzer_Analyze_FileTooLargeReturnsError verifies that a library
 // file exceeding the size limit causes analyzeLibraries to return an error.
 func TestValidatorLibraryAnalyzer_Analyze_FileTooLargeReturnsError(t *testing.T) {
-	v := validatorWithTempHashDir(t)
-	v.SetSyscallAnalyzer(&libraryTestSyscallAnalyzer{})
+	v := validatorWithTempHashDir(t, ValidatorConfig{SyscallAnalyzer: &libraryTestSyscallAnalyzer{}})
 
 	// Use a mock FileSystem that reports maxFileSize+1 for Stat().
 	v.fileSystem = &oversizeFileSystem{FileSystem: v.fileSystem}

--- a/internal/filevalidator/validator_macho_darwin_test.go
+++ b/internal/filevalidator/validator_macho_darwin_test.go
@@ -16,7 +16,7 @@ import (
 
 // TestRecord_Force_MachO_UpdatesDynLibDeps verifies that SaveRecord with force=true
 // re-runs Mach-O dynlib analysis and updates DynLibDeps with the new hash.
-// This covers Phase 3 completion criterion: Mach-O DynLibDeps is updated by record --force.
+// Verifies force re-record updates Mach-O DynLibDeps.
 func TestRecord_Force_MachO_UpdatesDynLibDeps(t *testing.T) {
 	tempDir := safeTempDir(t)
 	hashDir := filepath.Join(tempDir, "hashes")
@@ -31,11 +31,12 @@ func TestRecord_Force_MachO_UpdatesDynLibDeps(t *testing.T) {
 	require.NoError(t, os.WriteFile(binPath,
 		machodylibtesting.BuildMachOWithDeps(machodylibtesting.NativeCPU(), []string{libPath}, nil, nil), 0o700))
 
-	v, err := New(&SHA256{}, hashDir)
+	v, err := New(&SHA256{}, hashDir, ValidatorConfig{
+		MachODynLibAnalyzer: machodylib.NewMachODynLibAnalyzer(
+			safefileio.NewFileSystem(safefileio.FileSystemConfig{}),
+		),
+	})
 	require.NoError(t, err)
-	v.SetMachODynLibAnalyzer(machodylib.NewMachODynLibAnalyzer(
-		safefileio.NewFileSystem(safefileio.FileSystemConfig{}),
-	))
 
 	// First record: DynLibDeps should capture libfoo.dylib with its initial hash.
 	_, _, err = v.SaveRecord(binPath, false)

--- a/internal/filevalidator/validator_macho_test.go
+++ b/internal/filevalidator/validator_macho_test.go
@@ -250,10 +250,11 @@ func recordMachO(t *testing.T, binData []byte, stub *stubBinaryAnalyzer) *filean
 
 	binPath := writeTempBinary(t, tempDir, "target.bin", binData)
 
-	v, err := New(&SHA256{}, hashDir)
+	v, err := New(&SHA256{}, hashDir, ValidatorConfig{
+		BinaryAnalyzer: stub,
+		DebugInfo:      true,
+	})
 	require.NoError(t, err)
-	v.SetBinaryAnalyzer(stub)
-	v.SetIncludeDebugInfo(true)
 
 	_, _, recErr := v.SaveRecord(binPath, false)
 	require.NoError(t, recErr)
@@ -391,9 +392,8 @@ func TestUpdateAnalysisRecord_MachoSVCDetected_BinaryAnalyzerNil(t *testing.T) {
 
 	binPath := writeTempBinary(t, tempDir, "target.bin", buildArm64MachOBinary(t, []uint32{svcEncodingU32}))
 
-	v, err := New(&SHA256{}, hashDir)
+	v, err := New(&SHA256{}, hashDir, ValidatorConfig{DebugInfo: true})
 	require.NoError(t, err)
-	v.SetIncludeDebugInfo(true)
 
 	_, _, recErr := v.SaveRecord(binPath, false)
 	require.NoError(t, recErr)
@@ -457,10 +457,9 @@ func TestUpdateAnalysisRecord_ELFNotAffected(t *testing.T) {
 	// The Mach-O svc scan must also return nil (magic mismatch).
 	textPath := writeTempBinary(t, tempDir, "not_binary.txt", []byte("hello world"))
 
-	v, err := New(&SHA256{}, hashDir)
+	v, err := New(&SHA256{}, hashDir, ValidatorConfig{BinaryAnalyzer: &stubBinaryAnalyzer{result: binaryanalyzer.NotSupportedBinary}})
 	require.NoError(t, err)
 	// Set a non-nil BinaryAnalyzer so the svc scan path is exercised.
-	v.SetBinaryAnalyzer(&stubBinaryAnalyzer{result: binaryanalyzer.NotSupportedBinary})
 
 	_, _, recErr := v.SaveRecord(textPath, false)
 	require.NoError(t, recErr)
@@ -540,15 +539,15 @@ func recordMachOWithLibSystem(
 
 	binPath := writeTempBinary(t, tempDir, "target.bin", binData)
 
-	v, err := New(&SHA256{}, hashDir)
-	require.NoError(t, err)
+	vCfg := ValidatorConfig{DebugInfo: true}
 	if stub != nil {
-		v.SetBinaryAnalyzer(stub)
+		vCfg.BinaryAnalyzer = stub
 	}
-	v.SetIncludeDebugInfo(true)
 	if libsys != nil {
-		v.SetLibSystemCache(libsys)
+		vCfg.LibSystemCache = libsys
 	}
+	v, err := New(&SHA256{}, hashDir, vCfg)
+	require.NoError(t, err)
 
 	_, _, recErr := v.SaveRecord(binPath, false)
 	if recErr != nil {
@@ -577,9 +576,8 @@ func TestUpdateAnalysisRecord_LibSystemImportOnly(t *testing.T) {
 	}
 	stub := &stubLibSystemCache{infos: libsysEntries}
 
-	v, err := New(&SHA256{}, safeTempDir(t))
+	v, err := New(&SHA256{}, safeTempDir(t), ValidatorConfig{LibSystemCache: stub})
 	require.NoError(t, err)
-	v.SetLibSystemCache(stub)
 
 	// Build a record with DynLibDeps so analyzeLibSystem is not skipped.
 	record := &fileanalysis.Record{
@@ -673,9 +671,8 @@ func TestUpdateAnalysisRecord_LibSystemError(t *testing.T) {
 
 	// Build a minimal arm64 Mach-O so machoImportSymbols succeeds (returns empty list).
 	// analyzeLibSystem skips when DynLibDeps is empty, so inject a mock record directly.
-	v, err := New(&SHA256{}, safeTempDir(t))
+	v, err := New(&SHA256{}, safeTempDir(t), ValidatorConfig{LibSystemCache: stub})
 	require.NoError(t, err)
-	v.SetLibSystemCache(stub)
 
 	record := &fileanalysis.Record{
 		DynLibDeps: []fileanalysis.LibEntry{

--- a/internal/filevalidator/validator_shebang_cache_test.go
+++ b/internal/filevalidator/validator_shebang_cache_test.go
@@ -39,9 +39,8 @@ func TestSaveRecord_ShebangInterpreterCacheReuse(t *testing.T) {
 	spy := &shebangCacheSpyBinaryAnalyzer{
 		output: binaryanalyzer.AnalysisOutput{Result: binaryanalyzer.NoNetworkSymbols},
 	}
-	validator, err := New(&SHA256{}, hashDir)
+	validator, err := New(&SHA256{}, hashDir, ValidatorConfig{BinaryAnalyzer: spy})
 	require.NoError(t, err)
-	validator.SetBinaryAnalyzer(spy)
 
 	scriptA := commontesting.WriteExecutableFile(t, scriptDir, "a.sh", []byte("#!/bin/sh\necho A\n"))
 	scriptB := commontesting.WriteExecutableFile(t, scriptDir, "b.sh", []byte("#!/bin/sh\necho B\n"))
@@ -64,9 +63,8 @@ func TestSaveRecord_ShebangInterpreterCacheOutputEquivalence(t *testing.T) {
 	spy := &shebangCacheSpyBinaryAnalyzer{
 		output: binaryanalyzer.AnalysisOutput{Result: binaryanalyzer.NoNetworkSymbols},
 	}
-	validator, err := New(&SHA256{}, hashDir)
+	validator, err := New(&SHA256{}, hashDir, ValidatorConfig{BinaryAnalyzer: spy})
 	require.NoError(t, err)
-	validator.SetBinaryAnalyzer(spy)
 
 	scriptA := commontesting.WriteExecutableFile(t, scriptDir, "a.sh", []byte("#!/bin/sh\necho A\n"))
 	scriptB := commontesting.WriteExecutableFile(t, scriptDir, "b.sh", []byte("#!/bin/sh\necho B\n"))
@@ -99,10 +97,9 @@ func TestSaveRecord_ShebangInterpreterCacheHashChangeReanalyzes(t *testing.T) {
 	interpreterPath := filepath.Join(dir, "test-interpreter")
 	writeTestInterpreterFile(t, interpreterPath, "variant-1")
 
-	validator, err := New(&SHA256{}, hashDir)
-	require.NoError(t, err)
 	spy := &shebangCacheSpyBinaryAnalyzer{output: binaryanalyzer.AnalysisOutput{Result: binaryanalyzer.NoNetworkSymbols}}
-	validator.SetBinaryAnalyzer(spy)
+	validator, err := New(&SHA256{}, hashDir, ValidatorConfig{BinaryAnalyzer: spy})
+	require.NoError(t, err)
 
 	scriptA := commontesting.WriteExecutableFile(t, dir, "a.sh", []byte(fmt.Sprintf("#!%s\necho A\n", interpreterPath)))
 	_, _, err = validator.SaveRecord(scriptA, false)
@@ -151,9 +148,8 @@ func TestSaveRecord_ShebangInterpreterCacheEnvForm(t *testing.T) {
 	spy := &shebangCacheSpyBinaryAnalyzer{
 		output: binaryanalyzer.AnalysisOutput{Result: binaryanalyzer.NoNetworkSymbols},
 	}
-	validator, err := New(&SHA256{}, hashDir)
+	validator, err := New(&SHA256{}, hashDir, ValidatorConfig{BinaryAnalyzer: spy})
 	require.NoError(t, err)
-	validator.SetBinaryAnalyzer(spy)
 
 	scriptA := commontesting.WriteExecutableFile(t, scriptDir, "a.sh", []byte("#!/usr/bin/env sh\necho A\n"))
 	scriptB := commontesting.WriteExecutableFile(t, scriptDir, "b.sh", []byte("#!/usr/bin/env sh\necho B\n"))

--- a/internal/filevalidator/validator_shebang_test.go
+++ b/internal/filevalidator/validator_shebang_test.go
@@ -25,7 +25,7 @@ func TestSaveRecord_ShebangDirect(t *testing.T) {
 	scriptDir := safeTempDir(t)
 
 	script := commontesting.WriteExecutableFile(t, scriptDir, "script.sh", []byte("#!/bin/sh\necho hello\n"))
-	validator, err := New(&SHA256{}, hashDir)
+	validator, err := New(&SHA256{}, hashDir, ValidatorConfig{})
 	require.NoError(t, err)
 
 	_, _, err = validator.SaveRecord(script, false)
@@ -66,7 +66,7 @@ func TestSaveRecord_ShebangEnv(t *testing.T) {
 	scriptDir := safeTempDir(t)
 
 	script := commontesting.WriteExecutableFile(t, scriptDir, "script.py", []byte("#!/usr/bin/env sh\necho hello\n"))
-	validator, err := New(&SHA256{}, hashDir)
+	validator, err := New(&SHA256{}, hashDir, ValidatorConfig{})
 	require.NoError(t, err)
 
 	_, _, err = validator.SaveRecord(script, false)
@@ -108,7 +108,7 @@ func TestSaveRecord_ShebangELF(t *testing.T) {
 	path := filepath.Join(dir, "fake_elf")
 	require.NoError(t, os.WriteFile(path, elfHeader, 0o755))
 
-	validator, err := New(&SHA256{}, hashDir)
+	validator, err := New(&SHA256{}, hashDir, ValidatorConfig{})
 	require.NoError(t, err)
 
 	_, _, err = validator.SaveRecord(path, false)
@@ -128,7 +128,7 @@ func TestSaveRecord_ShebangText(t *testing.T) {
 	path := filepath.Join(dir, "script.sh")
 	require.NoError(t, os.WriteFile(path, []byte("echo hello\n"), 0o755))
 
-	validator, err := New(&SHA256{}, hashDir)
+	validator, err := New(&SHA256{}, hashDir, ValidatorConfig{})
 	require.NoError(t, err)
 
 	_, _, err = validator.SaveRecord(path, false)
@@ -152,7 +152,7 @@ func TestSaveRecord_ShebangRecursive(t *testing.T) {
 	script := commontesting.WriteExecutableFile(t, dir, "script.sh",
 		[]byte(fmt.Sprintf("#!%s\necho hello\n", fakeInterp)))
 
-	validator, err := New(&SHA256{}, hashDir)
+	validator, err := New(&SHA256{}, hashDir, ValidatorConfig{})
 	require.NoError(t, err)
 
 	_, _, err = validator.SaveRecord(script, false)
@@ -169,7 +169,7 @@ func TestSaveRecord_InterpreterForce(t *testing.T) {
 	interpPath, err := filepath.EvalSymlinks("/bin/sh")
 	require.NoError(t, err)
 
-	validator, err := New(&SHA256{}, hashDir)
+	validator, err := New(&SHA256{}, hashDir, ValidatorConfig{})
 	require.NoError(t, err)
 
 	// Record script A.
@@ -207,7 +207,7 @@ func TestSaveRecord_ShebangSymlink(t *testing.T) {
 	symlinkPath := filepath.Join(dir, "link_to_script.sh")
 	require.NoError(t, os.Symlink(script, symlinkPath))
 
-	validator, err := New(&SHA256{}, hashDir)
+	validator, err := New(&SHA256{}, hashDir, ValidatorConfig{})
 	require.NoError(t, err)
 
 	// SaveRecord on the symlink — validatePath resolves it to the real path.

--- a/internal/filevalidator/validator_test.go
+++ b/internal/filevalidator/validator_test.go
@@ -57,7 +57,7 @@ func TestValidator_RecordAndVerify(t *testing.T) {
 	require.NoErrorf(t, err, "Failed to resolve symlinks in test file path: %v", err)
 
 	// Create a validator
-	validator, err := New(&SHA256{}, tempDir)
+	validator, err := New(&SHA256{}, tempDir, ValidatorConfig{})
 	require.NoError(t, err, "Failed to create validator")
 
 	// Test SaveRecord
@@ -128,7 +128,7 @@ func TestNew(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := New(tt.algo, tt.hashDir)
+			_, err := New(tt.algo, tt.hashDir, ValidatorConfig{})
 			if tt.wantErr {
 				assert.Error(t, err, "New() should return an error")
 			} else {
@@ -159,7 +159,7 @@ func TestValidator_Record_Symlink(t *testing.T) {
 	expectedPath := resolvedSymlinkPath
 
 	// Create a validator
-	validator, err := New(&SHA256{}, tempDir)
+	validator, err := New(&SHA256{}, tempDir, ValidatorConfig{})
 	require.NoError(t, err, "Failed to create validator")
 
 	// Test SaveRecord with symlink
@@ -191,7 +191,7 @@ func TestValidator_Verify_Symlink(t *testing.T) {
 	require.NoError(t, err, "Failed to resolve symlinks in test file path")
 
 	// Create a validator and record the original file
-	validator, err := New(&SHA256{}, tempDir)
+	validator, err := New(&SHA256{}, tempDir, ValidatorConfig{})
 	require.NoError(t, err, "Failed to create validator")
 
 	_, _, err = validator.SaveRecord(testFilePath, false)
@@ -214,7 +214,7 @@ func TestValidator_Record_EmptyHashFile(t *testing.T) {
 	require.NoError(t, os.WriteFile(testFilePath, []byte("test content"), 0o644), "Failed to create test file")
 
 	// Create a validator
-	validator, err := New(&SHA256{}, tempDir)
+	validator, err := New(&SHA256{}, tempDir, ValidatorConfig{})
 	require.NoError(t, err, "Failed to create validator")
 
 	// Get the hash file path
@@ -249,7 +249,7 @@ func TestValidator_FileAnalysisRecordFormat(t *testing.T) {
 	require.NoError(t, os.WriteFile(testFilePath, []byte("test content"), 0o644), "Failed to create test file")
 
 	// Create a validator
-	validator, err := New(&SHA256{}, tempDir)
+	validator, err := New(&SHA256{}, tempDir, ValidatorConfig{})
 	require.NoError(t, err, "Failed to create validator")
 
 	// Save the file record
@@ -286,7 +286,7 @@ func TestValidator_HashAlgorithmConsistency(t *testing.T) {
 
 	// Create validator with MockHashAlgorithm (not SHA-256)
 	mockAlgo := &MockHashAlgorithm{}
-	validator, err := New(mockAlgo, tempDir)
+	validator, err := New(mockAlgo, tempDir, ValidatorConfig{})
 	require.NoError(t, err, "Failed to create validator")
 
 	// Save the file record - this should use mockAlgo.Sum()
@@ -337,13 +337,13 @@ func TestValidator_CrossAlgorithmVerificationFails(t *testing.T) {
 	require.NoError(t, err, "Failed to create test file")
 
 	// SaveRecord with MockHashAlgorithm
-	mockValidator, err := New(&MockHashAlgorithm{}, tempDir)
+	mockValidator, err := New(&MockHashAlgorithm{}, tempDir, ValidatorConfig{})
 	require.NoError(t, err, "Failed to create mock validator")
 	_, _, err = mockValidator.SaveRecord(testFilePath, false)
 	require.NoError(t, err, "Failed to record file with MockHashAlgorithm")
 
 	// Attempt verification with SHA-256 validator (different algorithm)
-	sha256Validator, err := New(&SHA256{}, tempDir)
+	sha256Validator, err := New(&SHA256{}, tempDir, ValidatorConfig{})
 	require.NoError(t, err, "Failed to create SHA-256 validator")
 
 	// This should fail because the stored hash uses mock: prefix but sha256 validator
@@ -359,7 +359,7 @@ func TestValidator_VerifyAndRead(t *testing.T) {
 	tempDir := safeTempDir(t)
 
 	// Create a validator
-	validator, err := New(&SHA256{}, tempDir)
+	validator, err := New(&SHA256{}, tempDir, ValidatorConfig{})
 	require.NoError(t, err, "Failed to create validator")
 
 	testContent := "test content for VerifyAndRead"
@@ -443,7 +443,7 @@ func TestValidator_VerifyAndRead_TOCTOUPrevention(t *testing.T) {
 	tempDir := safeTempDir(t)
 
 	// Create a validator
-	validator, err := New(&SHA256{}, tempDir)
+	validator, err := New(&SHA256{}, tempDir, ValidatorConfig{})
 	require.NoError(t, err, "Failed to create validator")
 
 	testContent := "original content for TOCTOU test"
@@ -490,7 +490,7 @@ func TestNew_RecordAndVerify(t *testing.T) {
 	tempDir := safeTempDir(t)
 
 	// Create a validator with analysis store support
-	validator, err := New(&SHA256{}, tempDir)
+	validator, err := New(&SHA256{}, tempDir, ValidatorConfig{})
 	require.NoError(t, err, "Failed to create validator with analysis store")
 
 	// Verify that Store returns a non-nil store
@@ -542,7 +542,7 @@ func TestNew_PreservesExistingFields(t *testing.T) {
 	tempDir := safeTempDir(t)
 
 	// Create a validator with analysis store support
-	validator, err := New(&SHA256{}, tempDir)
+	validator, err := New(&SHA256{}, tempDir, ValidatorConfig{})
 	require.NoError(t, err, "Failed to create validator with analysis store")
 
 	store := validator.Store()
@@ -602,7 +602,7 @@ func TestNew_CreatesDirectory(t *testing.T) {
 	require.True(t, os.IsNotExist(err), "hashDir should not exist before calling New")
 
 	// New should succeed even though hashDir doesn't exist
-	validator, err := New(&SHA256{}, hashDir)
+	validator, err := New(&SHA256{}, hashDir, ValidatorConfig{})
 	require.NoError(t, err, "New should create the directory automatically")
 	require.NotNil(t, validator)
 
@@ -643,7 +643,7 @@ func newCollisionValidator(t *testing.T) (*Validator, string) {
 	resolvedHashDir, err := common.NewResolvedPath(hashDir)
 	require.NoError(t, err)
 
-	v, err := newValidator(&SHA256{}, resolvedHashDir, getter)
+	v, err := newValidator(&SHA256{}, resolvedHashDir, getter, ValidatorConfig{})
 	require.NoError(t, err)
 	v.store = store
 
@@ -697,7 +697,7 @@ func TestValidator_Verify_HashFilePathCollision(t *testing.T) {
 }
 
 // TestAnalyze_Force verifies that record --force updates DynLibDeps.
-// This covers Phase 3 completion criterion: DynLibDeps is updated by `record --force`.
+// Ensures DynLibDeps is updated by `record --force`.
 func TestAnalyze_Force(t *testing.T) {
 	tempDir := safeTempDir(t)
 	hashDir := filepath.Join(tempDir, "hashes")
@@ -706,7 +706,7 @@ func TestAnalyze_Force(t *testing.T) {
 	targetFile := filepath.Join(tempDir, "target.txt")
 	require.NoError(t, os.WriteFile(targetFile, []byte("content"), 0o644))
 
-	v, err := New(&SHA256{}, hashDir)
+	v, err := New(&SHA256{}, hashDir, ValidatorConfig{})
 	require.NoError(t, err)
 
 	// First record without force — succeeds.
@@ -733,7 +733,7 @@ func TestRecord_BinaryAnalyzerNil_NoError(t *testing.T) {
 	targetFile := filepath.Join(tempDir, "target.txt")
 	require.NoError(t, os.WriteFile(targetFile, []byte("content"), 0o644))
 
-	v, err := New(&SHA256{}, hashDir)
+	v, err := New(&SHA256{}, hashDir, ValidatorConfig{})
 	require.NoError(t, err)
 	// binaryAnalyzer is nil by default — do not call SetBinaryAnalyzer.
 
@@ -774,10 +774,11 @@ func recordWithBinaryAnalyzerOptions(t *testing.T, stub *stubBinaryAnalyzer, inc
 	targetFile := filepath.Join(tempDir, "target.bin")
 	require.NoError(t, os.WriteFile(targetFile, []byte("binary content"), 0o644))
 
-	v, err := New(&SHA256{}, hashDir)
+	v, err := New(&SHA256{}, hashDir, ValidatorConfig{
+		BinaryAnalyzer: stub,
+		DebugInfo:      includeDebugInfo,
+	})
 	require.NoError(t, err)
-	v.SetBinaryAnalyzer(stub)
-	v.SetIncludeDebugInfo(includeDebugInfo)
 
 	_, _, recErr := v.SaveRecord(targetFile, false)
 	if recErr != nil {
@@ -797,10 +798,11 @@ func TestRecord_SyscallOccurrence_SourcePathSetWhenDebugInfo(t *testing.T) {
 		targetFile := filepath.Join(tempDir, "target.bin")
 		elfanalyzertesting.CreateDynamicELFFile(t, targetFile)
 
-		v, err := New(&SHA256{}, hashDir)
+		v, err := New(&SHA256{}, hashDir, ValidatorConfig{
+			DebugInfo:       true,
+			SyscallAnalyzer: &stubSyscallAnalyzerWithDebugInfo{},
+		})
 		require.NoError(t, err)
-		v.SetIncludeDebugInfo(true)
-		v.SetSyscallAnalyzer(&stubSyscallAnalyzerWithDebugInfo{})
 
 		_, _, err = v.SaveRecord(targetFile, false)
 		require.NoError(t, err)
@@ -821,20 +823,21 @@ func TestRecord_SyscallOccurrence_SourcePathSetWhenDebugInfo(t *testing.T) {
 		targetFile := filepath.Join(tempDir, "target-libc.bin")
 		elfanalyzertesting.CreateELFWithSymbols(t, targetFile, []elfanalyzertesting.SymbolSpec{{Name: "socket"}})
 
-		v, err := New(&SHA256{}, hashDir)
-		require.NoError(t, err)
-		v.SetIncludeDebugInfo(true)
-		v.SetLibcCache(&stubLibcCache{
-			syscalls: []common.SyscallInfo{{
-				Number: 41,
-				Name:   "socket",
-				Occurrences: []common.SyscallOccurrence{{
-					Location:            0,
-					DeterminationMethod: "lib_cache_match",
-					Source:              "libc_symbol_import",
+		v, err := New(&SHA256{}, hashDir, ValidatorConfig{
+			DebugInfo: true,
+			LibcCache: &stubLibcCache{
+				syscalls: []common.SyscallInfo{{
+					Number: 41,
+					Name:   "socket",
+					Occurrences: []common.SyscallOccurrence{{
+						Location:            0,
+						DeterminationMethod: "lib_cache_match",
+						Source:              "libc_symbol_import",
+					}},
 				}},
-			}},
+			},
 		})
+		require.NoError(t, err)
 
 		record := &fileanalysis.Record{
 			DynLibDeps: []fileanalysis.LibEntry{{
@@ -865,9 +868,8 @@ func TestRecord_SyscallOccurrence_SourcePathOmittedWithoutDebugInfo(t *testing.T
 	targetFile := filepath.Join(tempDir, "target.bin")
 	elfanalyzertesting.CreateDynamicELFFile(t, targetFile)
 
-	v, err := New(&SHA256{}, hashDir)
+	v, err := New(&SHA256{}, hashDir, ValidatorConfig{SyscallAnalyzer: &stubSyscallAnalyzerWithDebugInfo{}})
 	require.NoError(t, err)
-	v.SetSyscallAnalyzer(&stubSyscallAnalyzerWithDebugInfo{})
 
 	_, _, err = v.SaveRecord(targetFile, false)
 	require.NoError(t, err)
@@ -955,15 +957,16 @@ func TestRecord_ShebangChainAggregatesDepsAndTopLevelAnalysis(t *testing.T) {
 		t.Skip("skipping: /bin/sh not available in this environment")
 	}
 
-	v, err := New(&SHA256{}, hashDir)
-	require.NoError(t, err)
-	v.SetBinaryAnalyzer(&stubBinaryAnalyzer{
-		result: binaryanalyzer.NetworkDetected,
-		detectedSymbols: []binaryanalyzer.DetectedSymbol{
-			{Name: "socket", Category: "network"},
+	v, err := New(&SHA256{}, hashDir, ValidatorConfig{
+		BinaryAnalyzer: &stubBinaryAnalyzer{
+			result: binaryanalyzer.NetworkDetected,
+			detectedSymbols: []binaryanalyzer.DetectedSymbol{
+				{Name: "socket", Category: "network"},
+			},
 		},
+		SyscallAnalyzer: &stubSyscallAnalyzerReturnsOne{},
 	})
-	v.SetSyscallAnalyzer(&stubSyscallAnalyzerReturnsOne{})
+	require.NoError(t, err)
 
 	_, _, err = v.SaveRecord(script, false)
 	require.NoError(t, err)
@@ -1025,24 +1028,22 @@ func TestRecord_Force_OverwritesSymbolAnalysis(t *testing.T) {
 	targetFile := filepath.Join(tempDir, "target.bin")
 	require.NoError(t, os.WriteFile(targetFile, []byte("binary content"), 0o644))
 
-	v, err := New(&SHA256{}, hashDir)
-	require.NoError(t, err)
-
-	// First record with network symbols detected.
-	v.SetBinaryAnalyzer(&stubBinaryAnalyzer{
+	v, err := New(&SHA256{}, hashDir, ValidatorConfig{BinaryAnalyzer: &stubBinaryAnalyzer{
 		result: binaryanalyzer.NetworkDetected,
 		detectedSymbols: []binaryanalyzer.DetectedSymbol{
 			{Name: "socket", Category: "network"},
 		},
-	})
+	}})
+	require.NoError(t, err)
+
+	// First record with network symbols detected.
 	_, _, err = v.SaveRecord(targetFile, false)
 	require.NoError(t, err)
 
 	// Second record (force=true) with no network symbols: should overwrite.
-	v.SetBinaryAnalyzer(&stubBinaryAnalyzer{
-		result: binaryanalyzer.NoNetworkSymbols,
-	})
-	_, _, err = v.SaveRecord(targetFile, true)
+	v2, err := New(&SHA256{}, hashDir, ValidatorConfig{BinaryAnalyzer: &stubBinaryAnalyzer{result: binaryanalyzer.NoNetworkSymbols}})
+	require.NoError(t, err)
+	_, _, err = v2.SaveRecord(targetFile, true)
 	require.NoError(t, err)
 
 	record, loadErr := v.LoadRecord(targetFile)
@@ -1064,16 +1065,15 @@ func TestRecord_Force_NetworkToStaticBinary_ClearsSymbolAnalysis(t *testing.T) {
 	targetFile := filepath.Join(tempDir, "target.bin")
 	require.NoError(t, os.WriteFile(targetFile, []byte("binary content"), 0o644))
 
-	v, err := New(&SHA256{}, hashDir)
-	require.NoError(t, err)
-
-	// First record: dynamic ELF with network symbols.
-	v.SetBinaryAnalyzer(&stubBinaryAnalyzer{
+	v, err := New(&SHA256{}, hashDir, ValidatorConfig{BinaryAnalyzer: &stubBinaryAnalyzer{
 		result: binaryanalyzer.NetworkDetected,
 		detectedSymbols: []binaryanalyzer.DetectedSymbol{
 			{Name: "socket", Category: "network"},
 		},
-	})
+	}})
+	require.NoError(t, err)
+
+	// First record: dynamic ELF with network symbols.
 	_, _, err = v.SaveRecord(targetFile, false)
 	require.NoError(t, err)
 
@@ -1082,10 +1082,9 @@ func TestRecord_Force_NetworkToStaticBinary_ClearsSymbolAnalysis(t *testing.T) {
 	require.NotNil(t, record.SymbolAnalysis, "first record should have SymbolAnalysis")
 
 	// Second record (force=true): same binary now analysed as static — SymbolAnalysis must be nil.
-	v.SetBinaryAnalyzer(&stubBinaryAnalyzer{
-		result: binaryanalyzer.StaticBinary,
-	})
-	_, _, err = v.SaveRecord(targetFile, true)
+	v2, err := New(&SHA256{}, hashDir, ValidatorConfig{BinaryAnalyzer: &stubBinaryAnalyzer{result: binaryanalyzer.StaticBinary}})
+	require.NoError(t, err)
+	_, _, err = v2.SaveRecord(targetFile, true)
 	require.NoError(t, err)
 
 	record, loadErr = v.LoadRecord(targetFile)
@@ -1248,9 +1247,8 @@ func TestRecord_DebugInfo_ELF(t *testing.T) {
 	targetFile := filepath.Join(tempDir, "target.bin")
 	elfanalyzertesting.CreateDynamicELFFile(t, targetFile)
 
-	v, err := New(&SHA256{}, hashDir)
+	v, err := New(&SHA256{}, hashDir, ValidatorConfig{SyscallAnalyzer: &stubSyscallAnalyzerWithDebugInfo{}})
 	require.NoError(t, err)
-	v.SetSyscallAnalyzer(&stubSyscallAnalyzerWithDebugInfo{})
 
 	_, _, err = v.SaveRecord(targetFile, false)
 	require.NoError(t, err)
@@ -1262,8 +1260,12 @@ func TestRecord_DebugInfo_ELF(t *testing.T) {
 	assert.Nil(t, withoutDebug.SyscallAnalysis.DetectedSyscalls[0].Occurrences)
 	assert.Nil(t, withoutDebug.SyscallAnalysis.DeterminationStats)
 
-	v.SetIncludeDebugInfo(true)
-	_, _, err = v.SaveRecord(targetFile, true)
+	vWithDebug, err := New(&SHA256{}, hashDir, ValidatorConfig{
+		SyscallAnalyzer: &stubSyscallAnalyzerWithDebugInfo{},
+		DebugInfo:       true,
+	})
+	require.NoError(t, err)
+	_, _, err = vWithDebug.SaveRecord(targetFile, true)
 	require.NoError(t, err)
 
 	withDebug, loadErr := v.LoadRecord(targetFile)
@@ -1291,11 +1293,8 @@ func newValidatorWithStubs(t *testing.T, libcCache LibcCacheInterface) (*Validat
 	targetFile := filepath.Join(tempDir, "target.bin")
 	require.NoError(t, os.WriteFile(targetFile, []byte("not an ELF"), 0o644))
 
-	v, err := New(&SHA256{}, hashDir)
+	v, err := New(&SHA256{}, hashDir, ValidatorConfig{LibcCache: libcCache})
 	require.NoError(t, err)
-	if libcCache != nil {
-		v.SetLibcCache(libcCache)
-	}
 	return v, targetFile
 }
 
@@ -1326,9 +1325,8 @@ func TestRecord_LibcCache_Error_CausesRecordFailure(t *testing.T) {
 	elfanalyzertesting.CreateDynamicELFFile(t, elfPath)
 
 	stub := &stubLibcCache{err: errors.New("libc file not accessible")}
-	v, err := New(&SHA256{}, tempDir)
+	v, err := New(&SHA256{}, tempDir, ValidatorConfig{LibcCache: stub})
 	require.NoError(t, err)
-	v.SetLibcCache(stub)
 
 	// Inject a DynLibDeps record with a libc entry so the libc cache is called.
 	record := &fileanalysis.Record{
@@ -1368,11 +1366,8 @@ func TestRecord_Force_ELFToNonELF_ClearsSyscallAnalysis(t *testing.T) {
 	targetFile := filepath.Join(tempDir, "target.bin")
 	elfanalyzertesting.CreateDynamicELFFile(t, targetFile)
 
-	v, err := New(&SHA256{}, hashDir)
+	v, err := New(&SHA256{}, hashDir, ValidatorConfig{SyscallAnalyzer: &stubSyscallAnalyzerReturnsOne{}})
 	require.NoError(t, err)
-
-	// Inject a stub syscall analyzer that returns one syscall for any ELF.
-	v.SetSyscallAnalyzer(&stubSyscallAnalyzerReturnsOne{})
 
 	_, _, err = v.SaveRecord(targetFile, false)
 	require.NoError(t, err)
@@ -1421,11 +1416,10 @@ func TestRecord_Force_SyscallsToNone_ClearsSyscallAnalysis(t *testing.T) {
 	targetFile := filepath.Join(tempDir, "target.bin")
 	elfanalyzertesting.CreateDynamicELFFile(t, targetFile)
 
-	v, err := New(&SHA256{}, hashDir)
+	v, err := New(&SHA256{}, hashDir, ValidatorConfig{SyscallAnalyzer: &stubSyscallAnalyzerReturnsOne{}})
 	require.NoError(t, err)
 
 	// First record: analyzer returns one syscall.
-	v.SetSyscallAnalyzer(&stubSyscallAnalyzerReturnsOne{})
 	_, _, err = v.SaveRecord(targetFile, false)
 	require.NoError(t, err)
 
@@ -1434,8 +1428,9 @@ func TestRecord_Force_SyscallsToNone_ClearsSyscallAnalysis(t *testing.T) {
 	require.NotNil(t, record.SyscallAnalysis, "precondition: SyscallAnalysis must be set")
 
 	// Second record (force=true): analyzer returns no syscalls.
-	v.SetSyscallAnalyzer(&stubSyscallAnalyzerReturnsNone{})
-	_, _, err = v.SaveRecord(targetFile, true)
+	v2, err := New(&SHA256{}, hashDir, ValidatorConfig{SyscallAnalyzer: &stubSyscallAnalyzerReturnsNone{}})
+	require.NoError(t, err)
+	_, _, err = v2.SaveRecord(targetFile, true)
 	require.NoError(t, err)
 
 	record, loadErr = v.LoadRecord(targetFile)
@@ -1491,24 +1486,22 @@ func TestRecord_Force_NetworkToNotSupportedBinary_ClearsSymbolAnalysis(t *testin
 	targetFile := filepath.Join(tempDir, "target.bin")
 	require.NoError(t, os.WriteFile(targetFile, []byte("binary content"), 0o644))
 
-	v, err := New(&SHA256{}, hashDir)
-	require.NoError(t, err)
-
-	// First record: dynamic ELF with network symbols.
-	v.SetBinaryAnalyzer(&stubBinaryAnalyzer{
+	v, err := New(&SHA256{}, hashDir, ValidatorConfig{BinaryAnalyzer: &stubBinaryAnalyzer{
 		result: binaryanalyzer.NetworkDetected,
 		detectedSymbols: []binaryanalyzer.DetectedSymbol{
 			{Name: "socket", Category: "network"},
 		},
-	})
+	}})
+	require.NoError(t, err)
+
+	// First record: dynamic ELF with network symbols.
 	_, _, err = v.SaveRecord(targetFile, false)
 	require.NoError(t, err)
 
 	// Second record (force=true): now treated as unsupported format.
-	v.SetBinaryAnalyzer(&stubBinaryAnalyzer{
-		result: binaryanalyzer.NotSupportedBinary,
-	})
-	_, _, err = v.SaveRecord(targetFile, true)
+	v2, err := New(&SHA256{}, hashDir, ValidatorConfig{BinaryAnalyzer: &stubBinaryAnalyzer{result: binaryanalyzer.NotSupportedBinary}})
+	require.NoError(t, err)
+	_, _, err = v2.SaveRecord(targetFile, true)
 	require.NoError(t, err)
 
 	record, loadErr := v.LoadRecord(targetFile)

--- a/internal/libccache/integration_darwin_test.go
+++ b/internal/libccache/integration_darwin_test.go
@@ -39,13 +39,7 @@ func skipIfUnsupportedMacOS(t *testing.T) {
 func newTestValidatorMacOS(t *testing.T, hashDir string) *filevalidator.Validator {
 	t.Helper()
 
-	v, err := filevalidator.New(&filevalidator.SHA256{}, hashDir)
-	require.NoError(t, err)
-
 	fs := safefileio.NewFileSystem(safefileio.FileSystemConfig{})
-
-	// Wire Mach-O dynamic library dependency analyzer so DynLibDeps is populated.
-	v.SetMachODynLibAnalyzer(machodylib.NewMachODynLibAnalyzer(fs))
 
 	cacheDir := filepath.Join(hashDir, "lib-cache")
 
@@ -53,7 +47,11 @@ func newTestValidatorMacOS(t *testing.T, hashDir string) *filevalidator.Validato
 	require.NoError(t, err)
 
 	machoAdapter := libccache.NewMachoLibSystemAdapter(machoLibSysMgr, fs)
-	v.SetLibSystemCache(machoAdapter)
+	v, err := filevalidator.New(&filevalidator.SHA256{}, hashDir, filevalidator.ValidatorConfig{
+		MachODynLibAnalyzer: machodylib.NewMachODynLibAnalyzer(fs),
+		LibSystemCache:      machoAdapter,
+	})
+	require.NoError(t, err)
 
 	return v
 }
@@ -237,7 +235,7 @@ func TestLibSystemCache_Integration_ELFFlowNonRegression(t *testing.T) {
 	require.NoError(t, os.MkdirAll(hashDir, 0o700))
 
 	// Use a validator WITHOUT libSystem cache to verify the base pipeline is unaffected.
-	v, err := filevalidator.New(&filevalidator.SHA256{}, hashDir)
+	v, err := filevalidator.New(&filevalidator.SHA256{}, hashDir, filevalidator.ValidatorConfig{})
 	require.NoError(t, err)
 
 	_, _, err = v.SaveRecord(binFile, false)

--- a/internal/libccache/integration_test.go
+++ b/internal/libccache/integration_test.go
@@ -52,23 +52,21 @@ func socketSyscallNumber() int {
 func newTestValidator(t *testing.T, hashDir string) *filevalidator.Validator {
 	t.Helper()
 
-	v, err := filevalidator.New(&filevalidator.SHA256{}, hashDir)
-	require.NoError(t, err)
-
 	fs := safefileio.NewFileSystem(safefileio.FileSystemConfig{})
-	v.SetELFDynLibAnalyzer(elfdynlib.NewDynLibAnalyzer(fs))
-
 	syscallAn := elfanalyzer.NewSyscallAnalyzer()
-	v.SetSyscallAnalyzer(libccache.NewSyscallAdapter(syscallAn))
 
 	cacheDir := filepath.Join(hashDir, "lib-cache")
 	libcAnalyzer := libccache.NewLibcWrapperAnalyzer(syscallAn)
 	cacheMgr, err := libccache.NewLibcCacheManager(cacheDir, fs, libcAnalyzer)
 	require.NoError(t, err)
 
-	v.SetLibcCache(libccache.NewCacheAdapter(cacheMgr, syscallAn))
-	// Keep syscall occurrences in the saved record for integration assertions.
-	v.SetIncludeDebugInfo(true)
+	v, err := filevalidator.New(&filevalidator.SHA256{}, hashDir, filevalidator.ValidatorConfig{
+		ELFDynLibAnalyzer: elfdynlib.NewDynLibAnalyzer(fs),
+		SyscallAnalyzer:   libccache.NewSyscallAdapter(syscallAn),
+		LibcCache:         libccache.NewCacheAdapter(cacheMgr, syscallAn),
+		DebugInfo:         true,
+	})
+	require.NoError(t, err)
 
 	return v
 }
@@ -79,8 +77,6 @@ func newTestValidator(t *testing.T, hashDir string) *filevalidator.Validator {
 // socket is a network syscall (IsNetwork=true) and is reliably detectable across architectures.
 //
 // Syscall numbers: x86_64=41, arm64=198.
-//
-// This covers AC-4.
 func TestLibcCache_Integration_SocketSyscallDetected(t *testing.T) {
 	skipIfUnsupported(t)
 
@@ -138,8 +134,6 @@ int main() {
 
 // TestLibcCache_Integration_CacheReuse verifies that a second SaveRecord call
 // does not overwrite the libc cache file (mtime must not change).
-//
-// This covers AC-3 (cache HIT).
 func TestLibcCache_Integration_CacheReuse(t *testing.T) {
 	skipIfUnsupported(t)
 

--- a/internal/runner/base/security/hash_validation.go
+++ b/internal/runner/base/security/hash_validation.go
@@ -10,7 +10,7 @@ import (
 // validateFileHash verifies cmdPath against a SHA256 hash stored under hashDir.
 // The caller is responsible for ensuring hashDir is non-empty before calling.
 func validateFileHash(cmdPath string, hashDir string) error {
-	validator, err := filevalidator.New(&filevalidator.SHA256{}, hashDir)
+	validator, err := filevalidator.New(&filevalidator.SHA256{}, hashDir, filevalidator.ValidatorConfig{})
 	if err != nil {
 		return fmt.Errorf("hash validation failed to initialize validator: %w", err)
 	}

--- a/internal/runner/bootstrap/config_test.go
+++ b/internal/runner/bootstrap/config_test.go
@@ -149,7 +149,7 @@ func TestBootstrapCommandEnvExpansionIntegration(t *testing.T) {
 	require.NoError(t, err)
 
 	// Record hash for the config file using filevalidator
-	validator, err := filevalidator.New(&filevalidator.SHA256{}, hashDir)
+	validator, err := filevalidator.New(&filevalidator.SHA256{}, hashDir, filevalidator.ValidatorConfig{})
 	require.NoError(t, err)
 	_, _, err = validator.SaveRecord(configPath, false)
 	require.NoError(t, err)

--- a/internal/runner/config/loader_verification_test.go
+++ b/internal/runner/config/loader_verification_test.go
@@ -21,7 +21,7 @@ import (
 func createHashRecord(t *testing.T, hashDir, filePath string) {
 	t.Helper()
 
-	validator, err := filevalidator.New(&filevalidator.SHA256{}, hashDir)
+	validator, err := filevalidator.New(&filevalidator.SHA256{}, hashDir, filevalidator.ValidatorConfig{})
 	require.NoError(t, err, "Failed to create validator for createHashRecord")
 
 	_, _, err = validator.SaveRecord(filePath, false)

--- a/internal/runner/e2e_shebang_test.go
+++ b/internal/runner/e2e_shebang_test.go
@@ -81,7 +81,7 @@ func TestIntegration_ShebangVerification_DirectForm(t *testing.T) {
 
 	// Step 1 (record phase): create a shebang script and save its hash record.
 	scriptPath := commontesting.WriteExecutableFile(t, scriptDir, "deploy.sh", []byte("#!/bin/sh\necho hello\n"))
-	validator, err := filevalidator.New(&filevalidator.SHA256{}, hashDir)
+	validator, err := filevalidator.New(&filevalidator.SHA256{}, hashDir, filevalidator.ValidatorConfig{})
 	require.NoError(t, err)
 	_, _, err = validator.SaveRecord(scriptPath, false)
 	require.NoError(t, err)
@@ -110,7 +110,7 @@ func TestIntegration_ShebangVerification_EnvForm(t *testing.T) {
 	// Step 1 (record phase): create a shebang script and save its hash record.
 	// SaveRecord also records /usr/bin/env and the resolved sh binary automatically.
 	scriptPath := commontesting.WriteExecutableFile(t, scriptDir, "process.sh", []byte("#!/usr/bin/env sh\necho hello\n"))
-	validator, err := filevalidator.New(&filevalidator.SHA256{}, hashDir)
+	validator, err := filevalidator.New(&filevalidator.SHA256{}, hashDir, filevalidator.ValidatorConfig{})
 	require.NoError(t, err)
 	_, _, err = validator.SaveRecord(scriptPath, false)
 	require.NoError(t, err)
@@ -134,7 +134,7 @@ func TestIntegration_ShebangVerification_InterpreterRecordMissing(t *testing.T) 
 
 	// Step 1 (record phase): record the script (which also records the interpreter).
 	scriptPath := commontesting.WriteExecutableFile(t, scriptDir, "deploy.sh", []byte("#!/bin/sh\necho hello\n"))
-	validator, err := filevalidator.New(&filevalidator.SHA256{}, hashDir)
+	validator, err := filevalidator.New(&filevalidator.SHA256{}, hashDir, filevalidator.ValidatorConfig{})
 	require.NoError(t, err)
 	_, _, err = validator.SaveRecord(scriptPath, false)
 	require.NoError(t, err)
@@ -185,7 +185,7 @@ func TestIntegration_ShebangChainRunnerExecution(t *testing.T) {
 	// SaveRecord stores both the script record and shebang interpreter records.
 	scriptContent := "#!" + interpPath + "\n--version\n"
 	scriptPath := commontesting.WriteExecutableFile(t, scriptDir, "network-tool.sh", []byte(scriptContent))
-	validator, err := filevalidator.New(&filevalidator.SHA256{}, hashDir)
+	validator, err := filevalidator.New(&filevalidator.SHA256{}, hashDir, filevalidator.ValidatorConfig{})
 	require.NoError(t, err)
 	_, _, err = validator.SaveRecord(scriptPath, false)
 	require.NoError(t, err)

--- a/internal/verification/manager.go
+++ b/internal/verification/manager.go
@@ -486,7 +486,7 @@ func newManagerInternal(hashDir string, options ...InternalOption) (*Manager, er
 
 	// Initialize file validator with hybrid hash path getter
 	if opts.fileValidatorEnabled {
-		validator, err := filevalidator.New(&filevalidator.SHA256{}, hashDir)
+		validator, err := filevalidator.New(&filevalidator.SHA256{}, hashDir, filevalidator.ValidatorConfig{})
 		if err != nil {
 			// In dry-run mode, a permission error creating the hash directory is
 			// recoverable: the operator may be checking configuration on a machine

--- a/internal/verification/manager_macho_test.go
+++ b/internal/verification/manager_macho_test.go
@@ -184,11 +184,12 @@ func TestVerify_MachOWithDynLibDeps(t *testing.T) {
 
 	// Build a validator with Mach-O dynlib analysis enabled and record the
 	// binary in-process, replicating what the `record` binary would do.
-	v, err := filevalidator.New(&filevalidator.SHA256{}, hashDir)
+	v, err := filevalidator.New(&filevalidator.SHA256{}, hashDir, filevalidator.ValidatorConfig{
+		MachODynLibAnalyzer: machodylib.NewMachODynLibAnalyzer(
+			safefileio.NewFileSystem(safefileio.FileSystemConfig{}),
+		),
+	})
 	require.NoError(t, err)
-	v.SetMachODynLibAnalyzer(machodylib.NewMachODynLibAnalyzer(
-		safefileio.NewFileSystem(safefileio.FileSystemConfig{}),
-	))
 	_, _, err = v.SaveRecord(cmdPath, false)
 	require.NoError(t, err, "SaveRecord should succeed for the test binary")
 
@@ -260,11 +261,12 @@ func TestVerify_MachOLibraryTampered(t *testing.T) {
 	libPath := filepath.Join(filepath.Dir(cmdPath), "libfoo.dylib")
 
 	// Record the binary in-process with Mach-O dynlib analysis enabled.
-	v, err := filevalidator.New(&filevalidator.SHA256{}, hashDir)
+	v, err := filevalidator.New(&filevalidator.SHA256{}, hashDir, filevalidator.ValidatorConfig{
+		MachODynLibAnalyzer: machodylib.NewMachODynLibAnalyzer(
+			safefileio.NewFileSystem(safefileio.FileSystemConfig{}),
+		),
+	})
 	require.NoError(t, err)
-	v.SetMachODynLibAnalyzer(machodylib.NewMachODynLibAnalyzer(
-		safefileio.NewFileSystem(safefileio.FileSystemConfig{}),
-	))
 	_, _, err = v.SaveRecord(cmdPath, false)
 	require.NoError(t, err, "initial record should succeed")
 

--- a/test/security/hash_bypass_test.go
+++ b/test/security/hash_bypass_test.go
@@ -20,7 +20,7 @@ func TestHashValidation_BasicBypassAttempts(t *testing.T) {
 	require.NoError(t, os.MkdirAll(hashDir, 0o755))
 
 	algo := &filevalidator.SHA256{}
-	validator, err := filevalidator.New(algo, hashDir)
+	validator, err := filevalidator.New(algo, hashDir, filevalidator.ValidatorConfig{})
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -118,7 +118,7 @@ func TestHashValidation_ManifestTampering(t *testing.T) {
 	require.NoError(t, os.MkdirAll(hashDir, 0o755))
 
 	algo := &filevalidator.SHA256{}
-	validator, err := filevalidator.New(algo, hashDir)
+	validator, err := filevalidator.New(algo, hashDir, filevalidator.ValidatorConfig{})
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -229,7 +229,7 @@ func TestHashValidation_SymbolicLinkAttack(t *testing.T) {
 	require.NoError(t, os.MkdirAll(hashDir, 0o755))
 
 	algo := &filevalidator.SHA256{}
-	validator, err := filevalidator.New(algo, hashDir)
+	validator, err := filevalidator.New(algo, hashDir, filevalidator.ValidatorConfig{})
 	require.NoError(t, err)
 
 	// Create a legitimate file
@@ -277,7 +277,7 @@ func TestHashValidation_RaceConditionProtection(t *testing.T) {
 	require.NoError(t, os.MkdirAll(hashDir, 0o755))
 
 	algo := &filevalidator.SHA256{}
-	validator, err := filevalidator.New(algo, hashDir)
+	validator, err := filevalidator.New(algo, hashDir, filevalidator.ValidatorConfig{})
 	require.NoError(t, err)
 
 	testFile := filepath.Join(tempDir, "toctou_test.txt")


### PR DESCRIPTION
## Summary
- add ValidatorConfig and wire it through New and newValidator
- remove deprecated validator setters except SetDynamicLibAnalysisStore
- migrate validator call sites and tests to constructor-based config
- update cmd/record to build and pass ValidatorConfig
- update implementation plan checklist and validate with fmt/test/lint

## Validation
- make fmt
- go test -tags test -v ./...
- make lint