### PR TITLE
ci: run build-security-validation and test-ci in parallel with security-scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
   build-security-validation:
     name: Build & Security Validation
     runs-on: ubuntu-latest
-    needs: [check-changes, security-scan]
+    needs: check-changes
     if: needs.check-changes.outputs.has-code-changes == 'true'
     strategy:
       matrix:
@@ -161,7 +161,7 @@ jobs:
   test-ci:
     name: CI Tests (CGO=${{ matrix.cgo }})
     runs-on: ubuntu-latest
-    needs: [check-changes, security-scan]
+    needs: check-changes
     if: needs.check-changes.outputs.has-code-changes == 'true'
     strategy:
       matrix:


### PR DESCRIPTION
Both jobs had security-scan in their needs list but neither depends on its outputs. Since both scan steps use continue-on-error, security-scan never blocks downstream jobs anyway. Removing the dependency lets the heaviest jobs (CGO=1 unit tests, build) start as soon as check-changes completes.