### PR TITLE
refactor: apply modern Go idioms (Go 1.21+) across codebase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,7 +145,15 @@ When writing or modifying Go code in this repository, prefer the following moder
 
 ### Other Patterns
 - Use `map[T]struct{}` instead of `map[T]bool` for set semantics (saves memory).
-- Use `errors.Is` / `errors.As` instead of string matching on error messages.
+- Use `errors.Is` / `errors.AsType[T]` instead of string matching on error messages. Prefer `errors.AsType[T]` over `errors.As` — it eliminates the `var target T` declaration:
+  ```go
+  // Before
+  var pathErr *fs.PathError
+  if errors.As(err, &pathErr) { ... }
+
+  // After
+  if pathErr, ok := errors.AsType[*fs.PathError](err); ok { ... }
+  ```
 - In tests, use `t.Cleanup` instead of manual `defer` chains, and `t.TempDir` instead of `os.MkdirTemp` + `defer os.RemoveAll`.
 
 ## Requirements and Acceptance Criteria

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,43 @@ See [Test Organization Guide](docs/dev/developer_guide/test_organization.md) for
 - After editing go files, make sure to run `make fmt` to format the files.
 - After editing files, make sure to run `make test` and `make lint` and fix errors.
 
+## Modern Go Idioms (Go 1.21+)
+
+When writing or modifying Go code in this repository, prefer the following modern idioms over older equivalents. These improve readability, reduce boilerplate, and leverage standard library improvements.
+
+### Language Features
+- Use `any` instead of `interface{}`.
+- Use `for range n` (Go 1.22+) instead of `for i := 0; i < n; i++` when the index is unused or only counts iterations.
+- Rely on per-iteration loop variable scope (Go 1.22+); do not write `i := i` shadowing inside loop bodies.
+- Use range-over-function iterators (Go 1.23+) for custom traversal where appropriate.
+
+### Built-in Functions
+- Use `min(a, b)` / `max(a, b)` instead of hand-written comparisons or `math.Max`/`math.Min`.
+- Use `clear(m)` to clear maps and slices instead of manual `for k := range m { delete(m, k) }`.
+
+### Standard Library
+- Use the `slices` package: `slices.Contains`, `slices.Index`, `slices.Sort`, `slices.SortFunc`, `slices.Equal`, `slices.Clone`, `slices.Concat`, `slices.Delete`, `slices.Insert`, etc., instead of explicit loops.
+- Use the `maps` package: `maps.Keys`, `maps.Values`, `maps.Clone`, `maps.Equal`, `maps.Copy`.
+- Use `cmp.Or(a, b, c)` to return the first non-zero value instead of chained `if x == zero { x = y }`.
+- Use `cmp.Compare` for three-way comparisons, especially in `slices.SortFunc`.
+- Use `errors.Join(err1, err2)` for combining multiple errors.
+- Use `fmt.Errorf("...: %w", err)` for error wrapping.
+- Use `strings.Cut` / `bytes.Cut` instead of `SplitN(s, sep, 2)`.
+- Use `strings.CutPrefix` / `strings.CutSuffix` instead of `HasPrefix` + `TrimPrefix` combinations.
+- Use `sync.OnceFunc` / `sync.OnceValue` / `sync.OnceValues` instead of `sync.Once` + closure boilerplate.
+- Use `log/slog` for structured logging.
+- Use `context.WithoutCancel` to detach cancellation propagation.
+- Use `reflect.TypeFor[T]()` instead of `reflect.TypeOf((*T)(nil)).Elem()`.
+
+### Generics
+- Use type parameters (Go 1.18+) to consolidate duplicated `int`/`int64`/`float64` helpers.
+- Prefer `slices.SortFunc` over `sort.Slice` for type-safe, faster sorting without reflection.
+
+### Other Patterns
+- Use `map[T]struct{}` instead of `map[T]bool` for set semantics (saves memory).
+- Use `errors.Is` / `errors.As` instead of string matching on error messages.
+- In tests, use `t.Cleanup` instead of manual `defer` chains, and `t.TempDir` instead of `os.MkdirTemp` + `defer os.RemoveAll`.
+
 ## Requirements and Acceptance Criteria
 
 When implementing new features or security-critical functionality, follow the process documented in [Requirements Process Guide](docs/dev/developer_guide/requirements_process.md).

--- a/cmd/runner/integration_workdir_test.go
+++ b/cmd/runner/integration_workdir_test.go
@@ -121,11 +121,7 @@ func createRunnerWithOutputCapture(
 	t.Helper()
 
 	// 1. Create temporary hash directory for test
-	tempHashDir, err := os.MkdirTemp("", "test-hash-*")
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		os.RemoveAll(tempHashDir)
-	})
+	tempHashDir := commontesting.SafeTempDir(t)
 
 	// 2. Create temporary config file using helper
 	configPath := setupTestConfig(t, configContent)
@@ -448,10 +444,7 @@ risk_level = "medium"
 			var fixedWorkdir string
 			configContent := tt.configContent
 			if tt.usesFixedWorkdir {
-				var err error
-				fixedWorkdir, err = os.MkdirTemp("", "test-fixed-workdir-*")
-				require.NoError(t, err)
-				defer os.RemoveAll(fixedWorkdir)
+				fixedWorkdir = commontesting.SafeTempDir(t)
 
 				// Escape path for TOML string (Windows compatibility: backslashes must be escaped)
 				escapedPath := strings.ReplaceAll(fixedWorkdir, `\`, `\\`)

--- a/cmd/runner/integration_workdir_unix_test.go
+++ b/cmd/runner/integration_workdir_unix_test.go
@@ -17,17 +17,11 @@ import (
 // This test uses 'pwd' command which is Unix-specific
 func TestIntegration_CommandLevelWorkdir(t *testing.T) {
 	// Create separate fixed workdirs for different commands
-	fixedWorkdir1, err := os.MkdirTemp("", "test-cmd-workdir1-*")
-	require.NoError(t, err)
-	defer os.RemoveAll(fixedWorkdir1)
 	// Resolve symlinks for macOS where /var -> /private/var
-	fixedWorkdir1, err = filepath.EvalSymlinks(fixedWorkdir1)
+	fixedWorkdir1, err := filepath.EvalSymlinks(t.TempDir())
 	require.NoError(t, err)
 
-	fixedWorkdir2, err := os.MkdirTemp("", "test-cmd-workdir2-*")
-	require.NoError(t, err)
-	defer os.RemoveAll(fixedWorkdir2)
-	fixedWorkdir2, err = filepath.EvalSymlinks(fixedWorkdir2)
+	fixedWorkdir2, err := filepath.EvalSymlinks(t.TempDir())
 	require.NoError(t, err)
 
 	configContent := `

--- a/internal/common/testutil/mocks.go
+++ b/internal/common/testutil/mocks.go
@@ -36,7 +36,7 @@ const (
 // MockFileSystem implements FileSystem for testing
 type MockFileSystem struct {
 	files map[string]*MockFileInfo
-	dirs  map[string]bool
+	dirs  map[string]struct{}
 	// Counter for creating unique temp directories
 	tempDirCounter int
 	// Symlinks maps symlink path to target path
@@ -92,7 +92,7 @@ func (m *MockFileInfo) Sys() any {
 func NewMockFileSystem() *MockFileSystem {
 	fs := &MockFileSystem{
 		files:    make(map[string]*MockFileInfo),
-		dirs:     make(map[string]bool),
+		dirs:     make(map[string]struct{}),
 		symlinks: make(map[string]string),
 	}
 
@@ -110,7 +110,7 @@ func (m *MockFileSystem) CreateTempDir(dir string, prefix string) (string, error
 	}
 	m.tempDirCounter++
 	tempDir := filepath.Join(dir, fmt.Sprintf("%s%d", prefix, m.tempDirCounter))
-	m.dirs[tempDir] = true
+	m.dirs[tempDir] = struct{}{}
 	m.files[tempDir] = &MockFileInfo{
 		name:      filepath.Base(tempDir),
 		mode:      DefaultDirPerm,
@@ -340,7 +340,7 @@ func (m *MockFileSystem) AddDirWithOwner(path string, mode os.FileMode, uid, gid
 		return os.ErrExist
 	}
 
-	m.dirs[path] = true
+	m.dirs[path] = struct{}{}
 	m.files[path] = &MockFileInfo{
 		name:      filepath.Base(path),
 		mode:      mode | os.ModeDir, // Add directory flag to mode
@@ -435,7 +435,7 @@ func (m *MockFileSystem) MkdirAll(path string, perm os.FileMode) error {
 				uid:   DefaultUID,
 				gid:   DefaultGID,
 			}
-			m.dirs[currentPath] = true
+			m.dirs[currentPath] = struct{}{}
 		}
 	}
 

--- a/internal/dynlib/elfdynlib/analyzer.go
+++ b/internal/dynlib/elfdynlib/analyzer.go
@@ -1,6 +1,7 @@
 package elfdynlib
 
 import (
+	"cmp"
 	"crypto/sha256"
 	"debug/elf"
 	"encoding/hex"
@@ -10,7 +11,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/isseis/go-safe-cmd-runner/internal/dynlib"
@@ -235,11 +236,11 @@ func (a *DynLibAnalyzer) Analyze(binaryPath string) ([]fileanalysis.LibEntry, er
 	// stable for a given binary but not guaranteed across re-links or tool
 	// changes. Sorting ensures git diff noise is minimised and the JSON output
 	// is reproducible.
-	sort.Slice(libs, func(i, j int) bool {
-		if libs[i].SOName != libs[j].SOName {
-			return libs[i].SOName < libs[j].SOName
+	slices.SortFunc(libs, func(a, b fileanalysis.LibEntry) int {
+		if a.SOName != b.SOName {
+			return cmp.Compare(a.SOName, b.SOName)
 		}
-		return libs[i].Path < libs[j].Path
+		return cmp.Compare(a.Path, b.Path)
 	})
 
 	return libs, nil

--- a/internal/dynlib/machodylib/analyzer.go
+++ b/internal/dynlib/machodylib/analyzer.go
@@ -2,6 +2,7 @@ package machodylib
 
 import (
 	"bytes"
+	"cmp"
 	"crypto/sha256"
 	"debug/macho"
 	"encoding/binary"
@@ -13,7 +14,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"sort"
+	"slices"
 
 	"github.com/isseis/go-safe-cmd-runner/internal/dynlib"
 	"github.com/isseis/go-safe-cmd-runner/internal/fileanalysis"
@@ -240,11 +241,11 @@ func (a *MachODynLibAnalyzer) Analyze(binaryPath string) ([]fileanalysis.LibEntr
 		return nil, warnings, nil
 	}
 
-	sort.Slice(libs, func(i, j int) bool {
-		if libs[i].SOName != libs[j].SOName {
-			return libs[i].SOName < libs[j].SOName
+	slices.SortFunc(libs, func(a, b fileanalysis.LibEntry) int {
+		if a.SOName != b.SOName {
+			return cmp.Compare(a.SOName, b.SOName)
 		}
-		return libs[i].Path < libs[j].Path
+		return cmp.Compare(a.Path, b.Path)
 	})
 
 	return libs, warnings, nil

--- a/internal/dynlib/machodylib/dyld_extractor_darwin.go
+++ b/internal/dynlib/machodylib/dyld_extractor_darwin.go
@@ -4,6 +4,7 @@ package machodylib
 
 import (
 	"bytes"
+	"cmp"
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
@@ -11,7 +12,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"sort"
+	"slices"
 	"strings"
 )
 
@@ -333,8 +334,8 @@ func buildSubCacheList(f *os.File, mainPath string, cacheBase uint64) ([]subCach
 
 	// dyld_subcache_entry order is not guaranteed to be VM-address order.
 	// Sort here because downstream range selection assumes monotonic vmBase.
-	sort.Slice(result, func(i, j int) bool {
-		return result[i].vmBase < result[j].vmBase
+	slices.SortFunc(result, func(a, b subCacheFile) int {
+		return cmp.Compare(a.vmBase, b.vmBase)
 	})
 
 	return result, nil

--- a/internal/dynlib/machodylib/resolver.go
+++ b/internal/dynlib/machodylib/resolver.go
@@ -145,15 +145,13 @@ func (r *LibraryResolver) Resolve(installName, loaderPath string, rpaths []strin
 // expandRpathEntry expands @executable_path and @loader_path tokens
 // within an LC_RPATH entry.
 func (r *LibraryResolver) expandRpathEntry(rpathEntry, loaderPath string) string {
-	if strings.HasPrefix(rpathEntry, "@executable_path") {
-		suffix := strings.TrimPrefix(rpathEntry, "@executable_path")
+	if suffix, ok := strings.CutPrefix(rpathEntry, "@executable_path"); ok {
 		suffix = strings.TrimPrefix(suffix, "/")
 
 		return filepath.Clean(filepath.Join(r.executableDir, suffix))
 	}
 
-	if strings.HasPrefix(rpathEntry, "@loader_path") {
-		suffix := strings.TrimPrefix(rpathEntry, "@loader_path")
+	if suffix, ok := strings.CutPrefix(rpathEntry, "@loader_path"); ok {
 		suffix = strings.TrimPrefix(suffix, "/")
 		loaderDir := filepath.Dir(loaderPath)
 

--- a/internal/fileanalysis/file_analysis_store.go
+++ b/internal/fileanalysis/file_analysis_store.go
@@ -160,9 +160,7 @@ func (s *Store) Update(filePath common.ResolvedPath, updateFn func(*Record) erro
 	// Try to load existing record
 	record, err := s.Load(filePath)
 	if err != nil {
-		var schemaErr *SchemaVersionMismatchError
-		switch {
-		case errors.As(err, &schemaErr):
+		if schemaErr, ok := errors.AsType[*SchemaVersionMismatchError](err); ok {
 			if schemaErr.Actual > schemaErr.Expected {
 				// Future schema: do NOT overwrite (forward compatibility protection)
 				return fmt.Errorf("cannot update record: %w", err)
@@ -170,10 +168,10 @@ func (s *Store) Update(filePath common.ResolvedPath, updateFn func(*Record) erro
 			// Older schema (e.g. v1 record, current binary expects v2):
 			// allow --force to overwrite by treating it as a fresh record.
 			record = &Record{}
-		case errors.Is(err, ErrRecordNotFound) || errors.As(err, new(*RecordCorruptedError)):
+		} else if _, isCorrupted := errors.AsType[*RecordCorruptedError](err); errors.Is(err, ErrRecordNotFound) || isCorrupted {
 			// Create a new record if it's not found or if the existing one is corrupted.
 			record = &Record{}
-		default:
+		} else {
 			// For any other unknown error, fail safely.
 			return fmt.Errorf("failed to load existing record: %w", err)
 		}

--- a/internal/fileanalysis/file_analysis_store_test.go
+++ b/internal/fileanalysis/file_analysis_store_test.go
@@ -86,7 +86,7 @@ func TestStore_SchemaVersionMismatch(t *testing.T) {
 
 	// Manually write record with wrong schema version
 	recordPath := filepath.Join(analysisDir, "test.bin.json")
-	wrongVersionRecord := map[string]interface{}{
+	wrongVersionRecord := map[string]any{
 		"schema_version": 999,
 		"file_path":      testFile,
 		"content_hash":   "sha256:abc123",
@@ -118,7 +118,7 @@ func TestStore_Load_V21RejectedWithSchemaVersionMismatch(t *testing.T) {
 	require.NoError(t, err)
 
 	recordPath := filepath.Join(analysisDir, "test.bin.json")
-	v21Record := map[string]interface{}{
+	v21Record := map[string]any{
 		"schema_version": 21,
 		"file_path":      testFile,
 		"content_hash":   "sha256:abc123",
@@ -174,7 +174,7 @@ func TestStore_Load_V22RejectedWithSchemaVersionMismatch(t *testing.T) {
 	require.NoError(t, err)
 
 	recordPath := filepath.Join(analysisDir, "test.bin.json")
-	v22Record := map[string]interface{}{
+	v22Record := map[string]any{
 		"schema_version": 22,
 		"file_path":      testFile,
 		"content_hash":   "sha256:abc123",
@@ -277,7 +277,7 @@ func TestStore_Update_SchemaVersionMismatch(t *testing.T) {
 
 	// Manually write record with wrong schema version
 	recordPath := filepath.Join(analysisDir, "test.bin.json")
-	wrongVersionRecord := map[string]interface{}{
+	wrongVersionRecord := map[string]any{
 		"schema_version": 999,
 		"file_path":      testFile,
 		"content_hash":   "sha256:oldvalue",
@@ -298,7 +298,7 @@ func TestStore_Update_SchemaVersionMismatch(t *testing.T) {
 	// Original record should be preserved
 	data, err = os.ReadFile(recordPath)
 	require.NoError(t, err)
-	var preserved map[string]interface{}
+	var preserved map[string]any
 	err = json.Unmarshal(data, &preserved)
 	require.NoError(t, err)
 	assert.Equal(t, float64(999), preserved["schema_version"])
@@ -443,13 +443,13 @@ func TestStore_Load_V9DynLibDepsObjectFormat(t *testing.T) {
 
 	// Write a v9 record with dyn_lib_deps in the old {"libs":[...]} object format.
 	recordPath := filepath.Join(analysisDir, "test.bin.json")
-	v9Record := map[string]interface{}{
+	v9Record := map[string]any{
 		"schema_version": 9,
 		"file_path":      testFile,
 		"content_hash":   "sha256:abc123",
-		"dyn_lib_deps": map[string]interface{}{
-			"libs": []interface{}{
-				map[string]interface{}{
+		"dyn_lib_deps": map[string]any{
+			"libs": []any{
+				map[string]any{
 					"soname": "libssl.so.3",
 					"path":   "/usr/lib/x86_64-linux-gnu/libssl.so.3",
 					"hash":   "sha256:deadbeef",
@@ -488,7 +488,7 @@ func TestStore_Update_OldSchemaAllowsOverwrite(t *testing.T) {
 
 	// Write a record with the previous schema version (simulating a v1 record)
 	recordPath := filepath.Join(analysisDir, "test.bin.json")
-	oldVersionRecord := map[string]interface{}{
+	oldVersionRecord := map[string]any{
 		"schema_version": CurrentSchemaVersion - 1, // older schema
 		"file_path":      testFile,
 		"content_hash":   "sha256:oldvalue",

--- a/internal/filevalidator/benchmark_test.go
+++ b/internal/filevalidator/benchmark_test.go
@@ -23,7 +23,7 @@ func BenchmarkValidator_Verify(b *testing.B) {
 	}
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		err := validator.Verify(testFile)
 		if err != nil {
 			b.Fatalf("Verify failed: %v", err)

--- a/internal/groupmembership/membership_nocgo.go
+++ b/internal/groupmembership/membership_nocgo.go
@@ -26,13 +26,13 @@ func getGroupMembers(gid uint32) ([]string, error) {
 	}
 
 	// Start with explicit members from /etc/group
-	memberSet := make(map[string]bool)
+	memberSet := make(map[string]struct{})
 	if groupEntry.members != "" {
 		members := strings.Split(groupEntry.members, ",")
 		for _, member := range members {
 			member = strings.TrimSpace(member)
 			if member != "" {
-				memberSet[member] = true
+				memberSet[member] = struct{}{}
 			}
 		}
 	}
@@ -45,7 +45,7 @@ func getGroupMembers(gid uint32) ([]string, error) {
 
 	// Add primary group users to the member set
 	for _, user := range primaryUsers {
-		memberSet[user] = true
+		memberSet[user] = struct{}{}
 	}
 
 	// Convert map to slice

--- a/internal/libccache/adapters.go
+++ b/internal/libccache/adapters.go
@@ -1,12 +1,13 @@
 package libccache
 
 import (
+	"cmp"
 	"debug/elf"
 	"errors"
 	"fmt"
 	"log/slog"
 	"path/filepath"
-	"sort"
+	"slices"
 
 	"github.com/isseis/go-safe-cmd-runner/internal/common"
 	"github.com/isseis/go-safe-cmd-runner/internal/dynlib/machodylib"
@@ -254,6 +255,6 @@ func (a *MachoLibSystemAdapter) fallbackNameMatch(importSymbols []string) []comm
 	}
 
 	// Sort by Number.
-	sort.Slice(result, func(i, j int) bool { return result[i].Number < result[j].Number })
+	slices.SortFunc(result, func(a, b common.SyscallInfo) int { return cmp.Compare(a.Number, b.Number) })
 	return result
 }

--- a/internal/libccache/analyzer.go
+++ b/internal/libccache/analyzer.go
@@ -2,10 +2,11 @@
 package libccache
 
 import (
+	"cmp"
 	"debug/elf"
 	"errors"
 	"fmt"
-	"sort"
+	"slices"
 
 	"github.com/isseis/go-safe-cmd-runner/internal/common"
 	"github.com/isseis/go-safe-cmd-runner/internal/security/elfanalyzer"
@@ -123,11 +124,11 @@ func (a *LibcWrapperAnalyzer) Analyze(libcELFFile *elf.File) ([]WrapperEntry, er
 	}
 
 	// Sort by Number ascending, then Name ascending.
-	sort.Slice(entries, func(i, j int) bool {
-		if entries[i].Number != entries[j].Number {
-			return entries[i].Number < entries[j].Number
+	slices.SortFunc(entries, func(a, b WrapperEntry) int {
+		if a.Number != b.Number {
+			return cmp.Compare(a.Number, b.Number)
 		}
-		return entries[i].Name < entries[j].Name
+		return cmp.Compare(a.Name, b.Name)
 	})
 
 	return entries, nil

--- a/internal/libccache/macho_analyzer.go
+++ b/internal/libccache/macho_analyzer.go
@@ -1,11 +1,12 @@
 package libccache
 
 import (
+	"cmp"
 	"debug/macho"
 	"encoding/binary"
 	"fmt"
 	"log/slog"
-	"sort"
+	"slices"
 
 	"github.com/isseis/go-safe-cmd-runner/internal/arm64util"
 )
@@ -51,8 +52,8 @@ func (a *MachoLibSystemAnalyzer) Analyze(machoFile *macho.File) ([]WrapperEntry,
 
 	// Sort by address to estimate function sizes.
 	syms := filterFunctionSymbols(machoFile.Symtab.Syms)
-	sort.Slice(syms, func(i, j int) bool {
-		return syms[i].Value < syms[j].Value
+	slices.SortFunc(syms, func(a, b macho.Symbol) int {
+		return cmp.Compare(a.Value, b.Value)
 	})
 
 	textEnd := textBase + uint64(len(code))
@@ -101,11 +102,11 @@ func (a *MachoLibSystemAnalyzer) Analyze(machoFile *macho.File) ([]WrapperEntry,
 	}
 
 	// Sort by Number then by Name for deterministic output.
-	sort.Slice(entries, func(i, j int) bool {
-		if entries[i].Number != entries[j].Number {
-			return entries[i].Number < entries[j].Number
+	slices.SortFunc(entries, func(a, b WrapperEntry) int {
+		if a.Number != b.Number {
+			return cmp.Compare(a.Number, b.Number)
 		}
-		return entries[i].Name < entries[j].Name
+		return cmp.Compare(a.Name, b.Name)
 	})
 
 	return entries, nil

--- a/internal/libccache/macho_cache_test.go
+++ b/internal/libccache/macho_cache_test.go
@@ -61,7 +61,7 @@ func buildRawMachoBytes(t *testing.T, cpu macho.Cpu, textBytes []byte, syms []te
 	bo := make([]byte, 0, 512)
 	buf := bytes.NewBuffer(bo)
 
-	wr := func(v interface{}) {
+	wr := func(v any) {
 		require.NoError(t, writeLEValue(buf, v))
 	}
 
@@ -131,7 +131,7 @@ func buildRawMachoBytes(t *testing.T, cpu macho.Cpu, textBytes []byte, syms []te
 }
 
 // writeLEValue encodes v as little-endian bytes into buf.
-func writeLEValue(buf *bytes.Buffer, v interface{}) error {
+func writeLEValue(buf *bytes.Buffer, v any) error {
 	writeBytes := func(b []byte) { buf.Write(b) }
 	switch x := v.(type) {
 	case uint8:

--- a/internal/libccache/macos_syscall_table_test.go
+++ b/internal/libccache/macos_syscall_table_test.go
@@ -3,6 +3,7 @@
 package libccache
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -112,14 +113,7 @@ func TestNetworkSyscallWrapperNames(t *testing.T) {
 		"getpeername", "getsockname",
 	}
 	for _, name := range expected {
-		found := false
-		for _, n := range networkSyscallWrapperNames {
-			if n == name {
-				found = true
-				break
-			}
-		}
-		assert.True(t, found, "expected %s in networkSyscallWrapperNames", name)
+		assert.True(t, slices.Contains(networkSyscallWrapperNames, name), "expected %s in networkSyscallWrapperNames", name)
 	}
 
 	// sendmmsg and recvmmsg must not appear (Linux-specific).

--- a/internal/libccache/matcher.go
+++ b/internal/libccache/matcher.go
@@ -1,7 +1,8 @@
 package libccache
 
 import (
-	"sort"
+	"cmp"
+	"slices"
 
 	"github.com/isseis/go-safe-cmd-runner/internal/common"
 	"github.com/isseis/go-safe-cmd-runner/internal/security/elfanalyzer"
@@ -69,7 +70,7 @@ func (m *ImportSymbolMatcher) Match(importSymbols []string, wrappers []WrapperEn
 		}
 		result = append(result, info)
 	}
-	sort.Slice(result, func(i, j int) bool { return result[i].Number < result[j].Number })
+	slices.SortFunc(result, func(a, b common.SyscallInfo) int { return cmp.Compare(a.Number, b.Number) })
 
 	return result
 }
@@ -120,7 +121,7 @@ func (m *ImportSymbolMatcher) MatchWithMethod(
 		}
 		result = append(result, info)
 	}
-	sort.Slice(result, func(i, j int) bool { return result[i].Number < result[j].Number })
+	slices.SortFunc(result, func(a, b common.SyscallInfo) int { return cmp.Compare(a.Number, b.Number) })
 
 	return result
 }

--- a/internal/logging/log_line_tracker_test.go
+++ b/internal/logging/log_line_tracker_test.go
@@ -77,10 +77,10 @@ func TestDefaultLogLineTracker_ThreadSafety(t *testing.T) {
 	wg.Add(numGoroutines)
 
 	// Start multiple goroutines that increment the counter
-	for i := 0; i < numGoroutines; i++ {
+	for range numGoroutines {
 		go func() {
 			defer wg.Done()
-			for j := 0; j < incrementsPerGoroutine; j++ {
+			for range incrementsPerGoroutine {
 				tracker.IncrementLine()
 			}
 		}()
@@ -105,7 +105,7 @@ func TestDefaultLogLineTracker_ConcurrentReadWrite(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		for i := 0; i < numOperations; i++ {
+		for range numOperations {
 			tracker.IncrementLine()
 		}
 	}()
@@ -114,7 +114,7 @@ func TestDefaultLogLineTracker_ConcurrentReadWrite(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		for i := 0; i < numOperations; i++ {
+		for range numOperations {
 			line := tracker.GetCurrentLine()
 			// Line should never be negative
 			assert.GreaterOrEqual(t, line, 0, "GetCurrentLine() returned negative value")
@@ -125,7 +125,7 @@ func TestDefaultLogLineTracker_ConcurrentReadWrite(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		for i := 0; i < 10; i++ {
+		for range 10 {
 			tracker.Reset()
 		}
 	}()

--- a/internal/logging/message_formatter.go
+++ b/internal/logging/message_formatter.go
@@ -2,6 +2,7 @@ package logging
 
 import (
 	"log/slog"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -160,12 +161,7 @@ func (f *DefaultMessageFormatter) shouldSkipInteractiveAttr(key string) bool {
 		"interactive_mode", "color_support", "slack_enabled",
 	}
 
-	for _, skipKey := range skipKeys {
-		if key == skipKey {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(skipKeys, key)
 }
 
 // FormatLogFileHint formats a log file hint message for error-level logs.

--- a/internal/logging/safeopen_test.go
+++ b/internal/logging/safeopen_test.go
@@ -124,7 +124,7 @@ func TestGenerateRunID_Uniqueness(t *testing.T) {
 	ids := make(map[string]bool)
 	iterations := 100
 
-	for i := 0; i < iterations; i++ {
+	for range iterations {
 		id := GenerateRunID()
 
 		assert.NotEmpty(t, id, "GenerateRunID() returned empty string")

--- a/internal/logging/slack_handler_benchmark_test.go
+++ b/internal/logging/slack_handler_benchmark_test.go
@@ -30,7 +30,7 @@ func BenchmarkExtractCommandResults_CommandResults(b *testing.B) {
 
 	b.ResetTimer()
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = extractCommandResults(value)
 	}
 }
@@ -41,7 +41,7 @@ func BenchmarkExtractCommandResults_FromGroupValue(b *testing.B) {
 
 	b.ResetTimer()
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = extractCommandResultsFromGroup(groupValue)
 	}
 }
@@ -57,7 +57,7 @@ func BenchmarkExtractFromAttrs(b *testing.B) {
 
 	b.ResetTimer()
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = extractFromAttrs(attrs)
 	}
 }

--- a/internal/redaction/error_collector_test.go
+++ b/internal/redaction/error_collector_test.go
@@ -67,7 +67,7 @@ func TestInMemoryErrorCollector_MaxSize(t *testing.T) {
 	collector := NewInMemoryErrorCollector(maxSize)
 
 	// Record more failures than maxSize
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		collector.RecordFailure("key", errors.New("error"))
 	}
 
@@ -106,10 +106,10 @@ func TestInMemoryErrorCollector_ConcurrentAccess(t *testing.T) {
 	wg.Add(goroutines)
 
 	// Record failures concurrently
-	for i := 0; i < goroutines; i++ {
+	for range goroutines {
 		go func() {
 			defer wg.Done()
-			for j := 0; j < recordsPerGoroutine; j++ {
+			for range recordsPerGoroutine {
 				collector.RecordFailure("key", errors.New("error"))
 			}
 		}()
@@ -130,20 +130,20 @@ func TestInMemoryErrorCollector_ConcurrentReadWrite(_ *testing.T) {
 	wg.Add(goroutines * 2) // Writers + readers
 
 	// Writers
-	for i := 0; i < goroutines; i++ {
+	for range goroutines {
 		go func() {
 			defer wg.Done()
-			for j := 0; j < iterations; j++ {
+			for range iterations {
 				collector.RecordFailure("key", errors.New("error"))
 			}
 		}()
 	}
 
 	// Readers
-	for i := 0; i < goroutines; i++ {
+	for range goroutines {
 		go func() {
 			defer wg.Done()
-			for j := 0; j < iterations; j++ {
+			for range iterations {
 				_ = collector.GetFailures()
 				_ = collector.Count()
 				_ = collector.HasFailures()

--- a/internal/redaction/redactor_test.go
+++ b/internal/redaction/redactor_test.go
@@ -1890,7 +1890,7 @@ func BenchmarkRedactingHandler_String(b *testing.B) {
 	timestamp := time.Now().String()
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		logger.Info("test message",
 			"user", "testuser",
 			"action", "login",
@@ -1910,7 +1910,7 @@ func BenchmarkRedactingHandler_String_WithSensitiveData(b *testing.B) {
 	timestamp := time.Now().String()
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		logger.Info("test message",
 			"user", "testuser",
 			"credentials", "password=secret123 token=abc456",
@@ -1932,7 +1932,7 @@ func BenchmarkRedactingHandler_LogValuer(b *testing.B) {
 	timestamp := time.Now().String()
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		logger.Info("test message",
 			"user", "testuser",
 			"data", valuer,
@@ -1958,7 +1958,7 @@ func BenchmarkRedactingHandler_Slice(b *testing.B) {
 	timestamp := time.Now().String()
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		logger.Info("test message",
 			"user", "testuser",
 			"items", slice,
@@ -1983,7 +1983,7 @@ func BenchmarkRedactingHandler_Mixed(b *testing.B) {
 	timestamp := time.Now().String()
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		logger.Info("test message",
 			"user", "testuser",
 			"simple_string", "normal data",
@@ -2001,7 +2001,7 @@ func BenchmarkRedactText(b *testing.B) {
 	text := "User logged in with password=secret123 and token=abc456xyz"
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = config.RedactText(text)
 	}
 }
@@ -2012,7 +2012,7 @@ func BenchmarkRedactText_NoSensitiveData(b *testing.B) {
 	text := "User logged in successfully at 2024-01-01 12:00:00"
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = config.RedactText(text)
 	}
 }
@@ -2023,7 +2023,7 @@ func BenchmarkRedactLogAttribute_String(b *testing.B) {
 	attr := slog.String("message", "password=secret123")
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = config.RedactLogAttribute(attr)
 	}
 }
@@ -2038,7 +2038,7 @@ func BenchmarkRedactLogAttribute_Group(b *testing.B) {
 	)
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = config.RedactLogAttribute(attr)
 	}
 }
@@ -2050,7 +2050,7 @@ func BenchmarkRedactLogAttribute_Any_LogValuer(b *testing.B) {
 	attr := slog.Any("data", valuer)
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = config.RedactLogAttribute(attr)
 	}
 }

--- a/internal/redaction/reporter_test.go
+++ b/internal/redaction/reporter_test.go
@@ -86,7 +86,7 @@ func TestShutdownReporter_GroupsByKey(t *testing.T) {
 	collector := NewInMemoryErrorCollector(0)
 
 	// Record multiple failures for the same key
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		collector.RecordFailure("repeated_key", errors.New("same error"))
 		time.Sleep(5 * time.Millisecond)
 	}

--- a/internal/redaction/sensitive_patterns.go
+++ b/internal/redaction/sensitive_patterns.go
@@ -10,16 +10,16 @@ import (
 // SensitivePatterns contains compiled patterns for detecting sensitive information
 type SensitivePatterns struct {
 	// AllowedEnvVars contains environment variable names that are safe to log
-	AllowedEnvVars map[string]bool
+	AllowedEnvVars map[string]struct{}
 	// Combined patterns for efficient matching - always guaranteed to be non-nil
 	combinedCredentialPattern *regexp.Regexp
 	combinedEnvVarPattern     *regexp.Regexp
 }
 
 // NewSensitivePatterns creates a new SensitivePatterns with given pattern strings
-func NewSensitivePatterns(credentialPatterns, envVarPatterns []string, allowedEnvVars map[string]bool) (*SensitivePatterns, error) {
+func NewSensitivePatterns(credentialPatterns, envVarPatterns []string, allowedEnvVars map[string]struct{}) (*SensitivePatterns, error) {
 	if allowedEnvVars == nil {
-		allowedEnvVars = make(map[string]bool)
+		allowedEnvVars = make(map[string]struct{})
 	}
 
 	patterns := &SensitivePatterns{
@@ -62,22 +62,22 @@ func DefaultSensitivePatterns() *SensitivePatterns {
 	}
 
 	// Common safe environment variables
-	allowedEnvVars := map[string]bool{
-		"PATH":     true,
-		"HOME":     true,
-		"USER":     true,
-		"LANG":     true,
-		"SHELL":    true,
-		"TERM":     true,
-		"PWD":      true,
-		"OLDPWD":   true,
-		"HOSTNAME": true,
-		"LOGNAME":  true,
-		"TZ":       true,
-		"DISPLAY":  true,
-		"TMPDIR":   true,
-		"EDITOR":   true,
-		"PAGER":    true,
+	allowedEnvVars := map[string]struct{}{
+		"PATH":     {},
+		"HOME":     {},
+		"USER":     {},
+		"LANG":     {},
+		"SHELL":    {},
+		"TERM":     {},
+		"PWD":      {},
+		"OLDPWD":   {},
+		"HOSTNAME": {},
+		"LOGNAME":  {},
+		"TZ":       {},
+		"DISPLAY":  {},
+		"TMPDIR":   {},
+		"EDITOR":   {},
+		"PAGER":    {},
 	}
 
 	// Use constructor to ensure patterns are always properly initialized
@@ -137,7 +137,7 @@ func (sp *SensitivePatterns) IsSensitiveEnvVar(name string) bool {
 	upperName := strings.ToUpper(name)
 
 	// Check if it's explicitly allowed
-	if sp.AllowedEnvVars[upperName] {
+	if _, ok := sp.AllowedEnvVars[upperName]; ok {
 		return false
 	}
 	return sp.combinedEnvVarPattern.MatchString(upperName)

--- a/internal/redaction/sensitive_patterns_test.go
+++ b/internal/redaction/sensitive_patterns_test.go
@@ -84,7 +84,7 @@ func TestNewSensitivePatterns(t *testing.T) {
 		`(?i).*SECRET.*`,
 	}
 
-	allowedEnvVars := make(map[string]bool)
+	allowedEnvVars := make(map[string]struct{})
 
 	patterns, err := NewSensitivePatterns(credentialPatterns, envVarPatterns, allowedEnvVars)
 	require.NoError(t, err, "NewSensitivePatterns should succeed")
@@ -111,7 +111,7 @@ func TestNewSensitivePatterns_ErrorHandling(t *testing.T) {
 		`(?i).*PASSWORD.*`,
 	}
 
-	allowedEnvVars := make(map[string]bool)
+	allowedEnvVars := make(map[string]struct{})
 
 	patterns, err := NewSensitivePatterns(invalidCredentialPatterns, envVarPatterns, allowedEnvVars)
 	assert.Error(t, err, "NewSensitivePatterns should fail with invalid regex")
@@ -121,7 +121,7 @@ func TestNewSensitivePatterns_ErrorHandling(t *testing.T) {
 
 func TestNewSensitivePatterns_EmptyPatterns(t *testing.T) {
 	// Test with empty patterns (should succeed and create never-matching patterns)
-	allowedEnvVars := make(map[string]bool)
+	allowedEnvVars := make(map[string]struct{})
 
 	patterns, err := NewSensitivePatterns([]string{}, []string{}, allowedEnvVars)
 	require.NoError(t, err, "NewSensitivePatterns should succeed with empty patterns")
@@ -145,7 +145,7 @@ func BenchmarkIsSensitiveKey_IndividualPatterns(b *testing.B) {
 
 	testKey := "api_secret_key"
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		// Simulate original loop-based approach
 		found := false
 		for _, pattern := range credentialPatterns {
@@ -163,7 +163,7 @@ func BenchmarkIsSensitiveKey_Combined(b *testing.B) {
 	testKey := "api_secret_key"
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		patterns.IsSensitiveKey(testKey)
 	}
 }

--- a/internal/runner/base/executor/environment_bench_test.go
+++ b/internal/runner/base/executor/environment_bench_test.go
@@ -57,7 +57,7 @@ func BenchmarkBuildProcessEnvironment(b *testing.B) {
 		executortesting.WithExpandedEnv(cmdEnv))
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = executor.BuildProcessEnvironment(global, group, cmd)
 	}
 }
@@ -92,7 +92,7 @@ func BenchmarkBuildProcessEnvironment_Small(b *testing.B) {
 		}))
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = executor.BuildProcessEnvironment(global, group, cmd)
 	}
 }

--- a/internal/runner/base/output/integration_test.go
+++ b/internal/runner/base/output/integration_test.go
@@ -280,7 +280,7 @@ func TestOutputCaptureIntegration_UnlimitedSize(t *testing.T) {
 	}
 
 	// Write multiple times
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		err = manager.WriteOutput(capture, largeData)
 		require.NoError(t, err)
 	}
@@ -326,7 +326,7 @@ func TestOutputCaptureIntegration_ConcurrentWrites(t *testing.T) {
 	numWrites := 100
 
 	// Perform multiple writes sequentially
-	for i := 0; i < numWrites; i++ {
+	for range numWrites {
 		err = manager.WriteOutput(capture, testData)
 		require.NoError(t, err)
 	}

--- a/internal/runner/base/output/path.go
+++ b/internal/runner/base/output/path.go
@@ -108,19 +108,19 @@ func escapesWorkDirectory(relPath string) bool {
 }
 
 // dangerousCharLookup contains all single dangerous characters for fast lookup
-var dangerousCharLookup = map[rune]bool{
+var dangerousCharLookup = map[rune]struct{}{
 	// Shell metacharacters
-	';': true, '&': true, '|': true, '$': true, '`': true,
-	'>': true, '<': true,
+	';': {}, '&': {}, '|': {}, '$': {}, '`': {},
+	'>': {}, '<': {},
 	// Glob/expansion characters
-	'*': true, '?': true, '[': true, ']': true, '~': true, '!': true,
+	'*': {}, '?': {}, '[': {}, ']': {}, '~': {}, '!': {},
 	// Control characters
-	'\n': true, '\r': true, '\f': true, '\v': true, '\b': true, '\a': true, '\\': true,
+	'\n': {}, '\r': {}, '\f': {}, '\v': {}, '\b': {}, '\a': {}, '\\': {},
 }
 
 // dangerousSymbolLookup contains high-risk currency symbols
-var dangerousSymbolLookup = map[rune]bool{
-	'€': true, '¥': true, '£': true, '¢': true, '₹': true, '₽': true, '₩': true,
+var dangerousSymbolLookup = map[rune]struct{}{
+	'€': {}, '¥': {}, '£': {}, '¢': {}, '₹': {}, '₽': {}, '₩': {},
 }
 
 // multiCharPatternRegex is a pre-compiled regex for detecting multi-character dangerous patterns
@@ -132,13 +132,13 @@ var multiCharPatternRegex = regexp.MustCompile(`&&|\|\||\$\(|\$\{|>>|<<`)
 // Optimized version that scans the path only once with efficient lookups
 func containsDangerousCharacters(path string) []string {
 	var found []string
-	foundMap := make(map[string]bool) // To avoid duplicates
+	foundMap := make(map[string]struct{}) // To avoid duplicates
 
 	// Helper function to add unique dangerous characters
 	addDangerous := func(char string) {
-		if !foundMap[char] {
+		if _, ok := foundMap[char]; !ok {
 			found = append(found, char)
-			foundMap[char] = true
+			foundMap[char] = struct{}{}
 		}
 	}
 
@@ -153,12 +153,12 @@ func containsDangerousCharacters(path string) []string {
 		runeStr := string(r)
 
 		// Skip if already found
-		if foundMap[runeStr] {
+		if _, ok := foundMap[runeStr]; ok {
 			continue
 		}
 
 		// Check single-character lookup table first (most common case)
-		if dangerousCharLookup[r] {
+		if _, ok := dangerousCharLookup[r]; ok {
 			addDangerous(runeStr)
 			continue
 		}
@@ -170,7 +170,8 @@ func containsDangerousCharacters(path string) []string {
 		}
 
 		// Check for high-risk symbol characters
-		if unicode.IsSymbol(r) && dangerousSymbolLookup[r] {
+		_, inSymLookup := dangerousSymbolLookup[r]
+		if unicode.IsSymbol(r) && inSymLookup {
 			addDangerous(runeStr)
 			continue
 		}

--- a/internal/runner/base/privilege/metrics.go
+++ b/internal/runner/base/privilege/metrics.go
@@ -33,9 +33,7 @@ func (m *Metrics) RecordElevationSuccess(duration time.Duration) {
 		m.AverageElevationTime = m.TotalElevationTime / time.Duration(m.ElevationSuccesses)
 	}
 
-	if duration > m.MaxElevationTime {
-		m.MaxElevationTime = duration
-	}
+	m.MaxElevationTime = max(m.MaxElevationTime, duration)
 
 	m.LastElevationTime = time.Now()
 	m.updateSuccessRate()

--- a/internal/runner/base/privilege/metrics_test.go
+++ b/internal/runner/base/privilege/metrics_test.go
@@ -122,7 +122,7 @@ func TestMetrics_ConcurrentAccess(t *testing.T) {
 
 	// Writer goroutine
 	go func() {
-		for i := 0; i < 100; i++ {
+		for range 100 {
 			metrics.RecordElevationSuccess(time.Millisecond)
 		}
 		done <- true
@@ -130,7 +130,7 @@ func TestMetrics_ConcurrentAccess(t *testing.T) {
 
 	// Reader goroutine
 	go func() {
-		for i := 0; i < 100; i++ {
+		for range 100 {
 			snapshot := metrics.GetSnapshot()
 			// Just verify we can read without panicking
 			_ = snapshot.ElevationAttempts
@@ -182,7 +182,7 @@ func TestUpdateSuccessRate_AllCases(t *testing.T) {
 
 	t.Run("all_successes", func(t *testing.T) {
 		metrics := &privilege.Metrics{}
-		for i := 0; i < 10; i++ {
+		for range 10 {
 			metrics.RecordElevationSuccess(time.Millisecond)
 		}
 		snapshot := metrics.GetSnapshot()
@@ -192,7 +192,7 @@ func TestUpdateSuccessRate_AllCases(t *testing.T) {
 
 	t.Run("all_failures", func(t *testing.T) {
 		metrics := &privilege.Metrics{}
-		for i := 0; i < 10; i++ {
+		for range 10 {
 			metrics.RecordElevationFailure(errors.New("test error"))
 		}
 		snapshot := metrics.GetSnapshot()

--- a/internal/runner/base/privilege/race_test.go
+++ b/internal/runner/base/privilege/race_test.go
@@ -33,12 +33,12 @@ func TestUnixPrivilegeManager_ConcurrentAccess(t *testing.T) {
 	var results []error
 
 	// Launch multiple goroutines that try to use WithPrivileges concurrently
-	for i := 0; i < numGoroutines; i++ {
+	for range numGoroutines {
 		wg.Add(1)
-		go func(_ int) {
+		go func() {
 			defer wg.Done()
 
-			for j := 0; j < numOperationsPerGoroutine; j++ {
+			for range numOperationsPerGoroutine {
 				elevationCtx := runnertypes.ElevationContext{
 					Operation:   runnertypes.OperationFileAccess,
 					CommandName: "test_concurrent",
@@ -61,7 +61,7 @@ func TestUnixPrivilegeManager_ConcurrentAccess(t *testing.T) {
 				results = append(results, err)
 				mu.Unlock()
 			}
-		}(i)
+		}()
 	}
 
 	// Wait for all goroutines to complete
@@ -132,7 +132,7 @@ func TestUnixPrivilegeManager_RaceConditionProtection(t *testing.T) {
 	var errors []error
 
 	// Launch many goroutines simultaneously to try to trigger race conditions
-	for i := 0; i < numGoroutines; i++ {
+	for range numGoroutines {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -232,7 +232,7 @@ func TestUnixPrivilegeManager_ThreadSafety(t *testing.T) {
 	var wg sync.WaitGroup
 
 	// Test concurrent access to read-only methods
-	for i := 0; i < numGoroutines; i++ {
+	for range numGoroutines {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/internal/runner/base/security/command_analysis.go
+++ b/internal/runner/base/security/command_analysis.go
@@ -403,9 +403,9 @@ func formatDetectedSymbols(symbols []binaryanalyzer.DetectedSymbol) string {
 // Returns empty string if no subcommand is found.
 func findFirstSubcommand(args []string) string {
 	// Common git options that take a value (not exhaustive, but covers common cases)
-	optionsWithValue := map[string]bool{
-		"-c": true, "-C": true, "--work-tree": true, "--git-dir": true,
-		"--config": true, "--namespace": true,
+	optionsWithValue := map[string]struct{}{
+		"-c": {}, "-C": {}, "--work-tree": {}, "--git-dir": {},
+		"--config": {}, "--namespace": {},
 	}
 
 	skipNext := false
@@ -424,7 +424,7 @@ func findFirstSubcommand(args []string) string {
 			}
 
 			// Check if this option takes a value
-			if optionsWithValue[arg] {
+			if _, ok := optionsWithValue[arg]; ok {
 				skipNext = true
 			}
 			continue
@@ -484,15 +484,15 @@ func containsSSHStyleAddress(args []string) bool {
 
 // IsDestructiveFileOperation checks if the command performs destructive file operations
 func IsDestructiveFileOperation(cmd string, args []string) bool {
-	destructiveCommands := map[string]bool{
-		"rm":     true,
-		"rmdir":  true,
-		"unlink": true,
-		"shred":  true,
-		"dd":     true, // Can be dangerous when used incorrectly
+	destructiveCommands := map[string]struct{}{
+		"rm":     {},
+		"rmdir":  {},
+		"unlink": {},
+		"shred":  {},
+		"dd":     {}, // Can be dangerous when used incorrectly
 	}
 
-	if destructiveCommands[cmd] {
+	if _, ok := destructiveCommands[cmd]; ok {
 		return true
 	}
 
@@ -505,7 +505,7 @@ func IsDestructiveFileOperation(cmd string, args []string) bool {
 			if arg == "-exec" && i+1 < len(args) {
 				// Check if the command following -exec is destructive
 				execCmd := args[i+1]
-				if destructiveCommands[execCmd] {
+				if _, ok := destructiveCommands[execCmd]; ok {
 					return true
 				}
 			}
@@ -525,41 +525,41 @@ func IsDestructiveFileOperation(cmd string, args []string) bool {
 
 // IsSystemModification checks if the command modifies system settings
 func IsSystemModification(cmd string, args []string) bool {
-	systemCommands := map[string]bool{
-		"systemctl":   true,
-		"service":     true,
-		"chkconfig":   true,
-		"update-rc.d": true,
-		"mount":       true,
-		"umount":      true,
-		"fdisk":       true,
-		"parted":      true,
-		"mkfs":        true,
-		"fsck":        true,
-		"crontab":     true,
-		"at":          true,
-		"batch":       true,
+	systemCommands := map[string]struct{}{
+		"systemctl":   {},
+		"service":     {},
+		"chkconfig":   {},
+		"update-rc.d": {},
+		"mount":       {},
+		"umount":      {},
+		"fdisk":       {},
+		"parted":      {},
+		"mkfs":        {},
+		"fsck":        {},
+		"crontab":     {},
+		"at":          {},
+		"batch":       {},
 	}
 
-	if systemCommands[cmd] {
+	if _, ok := systemCommands[cmd]; ok {
 		return true
 	}
 
 	// Check for package management commands
-	packageManagers := map[string]bool{
-		"apt":     true,
-		"apt-get": true,
-		"yum":     true,
-		"dnf":     true,
-		"zypper":  true,
-		"pacman":  true,
-		"brew":    true,
-		"pip":     true,
-		"npm":     true,
-		"yarn":    true,
+	packageManagers := map[string]struct{}{
+		"apt":     {},
+		"apt-get": {},
+		"yum":     {},
+		"dnf":     {},
+		"zypper":  {},
+		"pacman":  {},
+		"brew":    {},
+		"pip":     {},
+		"npm":     {},
+		"yarn":    {},
 	}
 
-	if packageManagers[cmd] {
+	if _, ok := packageManagers[cmd]; ok {
 		// Only consider install/remove operations as medium risk
 		for _, arg := range args {
 			if arg == "install" || arg == "remove" || arg == "uninstall" ||

--- a/internal/runner/base/security/command_analysis_test.go
+++ b/internal/runner/base/security/command_analysis_test.go
@@ -1279,9 +1279,7 @@ func TestIsPrivilegeEscalationCommand(t *testing.T) {
 	// Test with actual symbolic link (integration test)
 	t.Run("symbolic link to sudo", func(t *testing.T) {
 		// Create a temporary directory
-		tempDir, err := os.MkdirTemp("", "sudo_symlink_test")
-		require.NoError(t, err)
-		defer os.RemoveAll(tempDir)
+		tempDir := commontesting.SafeTempDir(t)
 
 		// Create a symbolic link to sudo (if it exists)
 		sudoPath := "/usr/bin/sudo"
@@ -1302,14 +1300,12 @@ func TestIsPrivilegeEscalationCommand(t *testing.T) {
 	// Test symlink depth exceeded case
 	t.Run("symlink depth exceeded should return error", func(t *testing.T) {
 		// Create a temporary directory for deep symlink chain
-		tempDir, err := os.MkdirTemp("", "deep_sudo_symlink_test")
-		require.NoError(t, err)
-		defer os.RemoveAll(tempDir)
+		tempDir := commontesting.SafeTempDir(t)
 
 		// Create a deep chain of symlinks (more than MaxSymlinkDepth=40)
 		// Create initial target file
 		targetFile := filepath.Join(tempDir, "target_sudo")
-		err = os.WriteFile(targetFile, []byte("#!/bin/bash\necho sudo"), 0o755)
+		err := os.WriteFile(targetFile, []byte("#!/bin/bash\necho sudo"), 0o755)
 		require.NoError(t, err)
 
 		// Create 45 symlinks (exceeds MaxSymlinkDepth=40)
@@ -1359,9 +1355,7 @@ func TestAnalyzeCommandSecurityWithDeepSymlinks(t *testing.T) {
 
 func TestAnalyzeCommandSecuritySetuidSetgid(t *testing.T) {
 	// Create temporary directory for testing
-	tmpDir, err := os.MkdirTemp("", "setuid_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpDir)
+	tmpDir := commontesting.SafeTempDir(t)
 
 	t.Run("normal executable without setuid/setgid", func(t *testing.T) {
 		// Create a normal executable
@@ -1410,9 +1404,7 @@ func TestAnalyzeCommandSecuritySetuidSetgid(t *testing.T) {
 
 func TestHasSetuidOrSetgidBit(t *testing.T) {
 	// Create temporary directory for testing
-	tmpDir, err := os.MkdirTemp("", "setuid_helper_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpDir)
+	tmpDir := commontesting.SafeTempDir(t)
 
 	t.Run("normal file", func(t *testing.T) {
 		normalFile := filepath.Join(tmpDir, "normal")

--- a/internal/runner/base/security/network_analyzer.go
+++ b/internal/runner/base/security/network_analyzer.go
@@ -182,8 +182,7 @@ func (a *NetworkAnalyzer) analyzeBinarySignals(cmdPath string, contentHash strin
 				"path", cmdPath)
 			return true, true, nil
 		}
-		var schemaMismatch *fileanalysis.SchemaVersionMismatchError
-		if errors.As(loadErr, &schemaMismatch) {
+		if schemaMismatch, ok := errors.AsType[*fileanalysis.SchemaVersionMismatchError](loadErr); ok {
 			slog.Warn("Record has outdated schema; treating as high risk",
 				"path", cmdPath,
 				"expected_schema", schemaMismatch.Expected,

--- a/internal/runner/base/security/types.go
+++ b/internal/runner/base/security/types.go
@@ -272,7 +272,7 @@ func (c *Config) GetPathPatternsByRisk(level runnertypes.RiskLevel) []string {
 // GetSuspiciousFilePatterns returns patterns for suspicious files that should be flagged
 // This is derived dynamically from OutputCriticalPathPatterns to maintain consistency
 func (c *Config) GetSuspiciousFilePatterns() []string {
-	patterns := make(map[string]bool)
+	patterns := make(map[string]struct{})
 
 	// Extract file names from OutputCriticalPathPatterns
 	for _, pattern := range c.OutputCriticalPathPatterns {
@@ -281,11 +281,11 @@ func (c *Config) GetSuspiciousFilePatterns() []string {
 			// Extract basename from absolute paths
 			basename := filepath.Base(pattern)
 			if basename != "" && basename != "." && basename != "/" {
-				patterns[basename] = true
+				patterns[basename] = struct{}{}
 			}
 		} else if !strings.HasSuffix(pattern, "/") {
 			// Pattern is already a filename or relative path (not ending with "/")
-			patterns[pattern] = true
+			patterns[pattern] = struct{}{}
 		}
 		// Skip directory patterns ending with "/"
 	}

--- a/internal/runner/base/security/types_test.go
+++ b/internal/runner/base/security/types_test.go
@@ -289,10 +289,11 @@ func TestConfig_GetSuspiciousFilePatterns_Invariants(t *testing.T) {
 	assert.NotEmpty(t, patterns, "GetSuspiciousFilePatterns() returned empty list")
 
 	// Verify no duplicates
-	seen := make(map[string]bool)
+	seen := make(map[string]struct{})
 	for _, pattern := range patterns {
-		assert.False(t, seen[pattern], "Duplicate pattern found: %q", pattern)
-		seen[pattern] = true
+		_, dup := seen[pattern]
+		assert.False(t, dup, "Duplicate pattern found: %q", pattern)
+		seen[pattern] = struct{}{}
 	}
 
 	// Verify result is sorted

--- a/internal/runner/cli/filter_bench_test.go
+++ b/internal/runner/cli/filter_bench_test.go
@@ -15,7 +15,7 @@ func BenchmarkParseGroupNames(b *testing.B) {
 	input := strings.Repeat("group,", 5) + "group"
 	b.ReportAllocs()
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ParseGroupNames(input)
 	}
 }
@@ -31,7 +31,7 @@ func BenchmarkFilterGroups(b *testing.B) {
 	target := []string{"group1", "group5", "group9"}
 	b.ReportAllocs()
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		FilterGroups(target, config)
 	}
 }

--- a/internal/runner/config/expansion_bench_test.go
+++ b/internal/runner/config/expansion_bench_test.go
@@ -16,7 +16,7 @@ func BenchmarkExpandGlobal(b *testing.B) {
 	}
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_, _ = ExpandGlobal(spec)
 	}
 }
@@ -35,7 +35,7 @@ func BenchmarkExpandGlobalWithFromEnv(b *testing.B) {
 	b.Setenv("HOME", "/home/testuser")
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_, _ = ExpandGlobal(spec)
 	}
 }
@@ -59,7 +59,7 @@ func BenchmarkExpandGroup(b *testing.B) {
 	}
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_, _ = ExpandGroup(spec, rg)
 	}
 }
@@ -86,7 +86,7 @@ func BenchmarkExpandCommand(b *testing.B) {
 	rGlobal := &runnertypes.RuntimeGlobal{Spec: &runnertypes.GlobalSpec{}, ExpandedVars: map[string]string{}, ExpandedEnv: map[string]string{}}
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_, _ = ExpandCommand(spec, nil, rGroup, rGlobal, common.NewUnsetTimeout(), commontesting.NewUnsetOutputSizeLimit())
 	}
 }
@@ -117,7 +117,7 @@ func BenchmarkExpandGlobalComplex(b *testing.B) {
 	}
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_, _ = ExpandGlobal(spec)
 	}
 }
@@ -166,7 +166,7 @@ func BenchmarkExpandCommandWithEnvImport(b *testing.B) {
 	}
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_, _ = ExpandCommand(cmdSpec, nil, groupRuntime, globalRuntime, common.NewUnsetTimeout(), commontesting.NewUnsetOutputSizeLimit())
 	}
 }
@@ -219,7 +219,7 @@ func BenchmarkExpandMultipleCommandsWithEnvImport(b *testing.B) {
 	}
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		// Expand all commands (simulating loop in group_executor)
 		for _, cmdSpec := range cmdSpecs {
 			_, _ = ExpandCommand(cmdSpec, nil, groupRuntime, globalRuntime, common.NewUnsetTimeout(), commontesting.NewUnsetOutputSizeLimit())

--- a/internal/runner/config/loader.go
+++ b/internal/runner/config/loader.go
@@ -299,14 +299,14 @@ func ValidateTemplates(cfg *runnertypes.ConfigSpec) error {
 	}
 
 	// Track seen template names to detect duplicates
-	seen := make(map[string]bool)
+	seen := make(map[string]struct{})
 
 	for name, tmpl := range cfg.CommandTemplates {
 		// Check for duplicate names
-		if seen[name] {
+		if _, ok := seen[name]; ok {
 			return &ErrDuplicateTemplateName{Name: name}
 		}
-		seen[name] = true
+		seen[name] = struct{}{}
 
 		// Validate template name
 		if err := ValidateTemplateName(name); err != nil {

--- a/internal/runner/config/path_resolver_test.go
+++ b/internal/runner/config/path_resolver_test.go
@@ -19,7 +19,7 @@ func TestDefaultPathResolver_ResolvePath(t *testing.T) {
 		includePath  string
 		setupFiles   func(t *testing.T, baseDir string) string // Returns the file path created
 		wantErr      bool
-		errType      interface{}
+		errType      any
 		checkAbsPath bool
 	}{
 		{

--- a/internal/runner/config/template_expansion.go
+++ b/internal/runner/config/template_expansion.go
@@ -1057,14 +1057,12 @@ func ValidateTemplateVars(
 	// Check env_vars array
 	for i, envMapping := range template.EnvVars {
 		// Parse "KEY=value" format
-		const envSplitParts = 2
-		parts := strings.SplitN(envMapping, "=", envSplitParts)
-		if len(parts) != envSplitParts {
+		_, value, found := strings.Cut(envMapping, "=")
+		if !found {
 			// Invalid format - this should have been caught during parsing
 			// but we check here for defensive programming
 			continue
 		}
-		value := parts[1]
 
 		fieldName := fmt.Sprintf("env_vars[%d]", i)
 		if err := validateFieldVars(value, templateName, fieldName, globalVars); err != nil {

--- a/internal/runner/config/template_expansion_validation_test.go
+++ b/internal/runner/config/template_expansion_validation_test.go
@@ -19,7 +19,7 @@ func TestValidateTemplateVars(t *testing.T) {
 		templateName string
 		globalVars   map[string]string
 		wantErr      bool
-		errType      interface{}
+		errType      any
 	}{
 		{
 			name: "success: no variable references",
@@ -231,7 +231,7 @@ func TestValidateFieldVars(t *testing.T) {
 		fieldName    string
 		globalVars   map[string]string
 		wantErr      bool
-		errType      interface{}
+		errType      any
 	}{
 		{
 			name:         "success: no variables",
@@ -323,7 +323,7 @@ func TestValidateAllTemplates(t *testing.T) {
 		templates  map[string]runnertypes.CommandTemplate
 		globalVars map[string]string
 		wantErr    bool
-		errType    interface{}
+		errType    any
 	}{
 		{
 			name:       "success: no templates",

--- a/internal/runner/config/template_merger_test.go
+++ b/internal/runner/config/template_merger_test.go
@@ -16,7 +16,7 @@ func TestDefaultTemplateMerger_MergeTemplates(t *testing.T) {
 		sources       []TemplateSource
 		wantTemplates map[string]runnertypes.CommandTemplate
 		wantErr       bool
-		errType       interface{}
+		errType       any
 		errLocations  []string
 	}{
 		{

--- a/internal/runner/e2e_slack_webhook_separation_test.go
+++ b/internal/runner/e2e_slack_webhook_separation_test.go
@@ -422,11 +422,11 @@ func TestE2E_SlackWebhookSeparation_DryRunMode(t *testing.T) {
 
 // TestE2E_SlackWebhookSeparation_MessageFormat tests message formatting
 func TestE2E_SlackWebhookSeparation_MessageFormat(t *testing.T) {
-	var successPayloads []map[string]interface{}
+	var successPayloads []map[string]any
 
 	successServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
-		var payload map[string]interface{}
+		var payload map[string]any
 		if err := json.Unmarshal(body, &payload); err == nil {
 			successPayloads = append(successPayloads, payload)
 		}

--- a/internal/runner/group_executor_test.go
+++ b/internal/runner/group_executor_test.go
@@ -2268,7 +2268,7 @@ func BenchmarkNewDefaultGroupExecutor(b *testing.B) {
 
 	var ge *DefaultGroupExecutor
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ge = NewDefaultGroupExecutor(
 			nil, config, nil, nil, mockRM, "bench-test",
 			WithGroupNotificationFunc(nil),
@@ -2293,7 +2293,7 @@ func BenchmarkNewDefaultGroupExecutor_NoOptions(b *testing.B) {
 
 	var ge *DefaultGroupExecutor
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ge = NewDefaultGroupExecutor(
 			nil, config, nil, nil, mockRM, "bench-test",
 		)

--- a/internal/runner/resource/performance_test.go
+++ b/internal/runner/resource/performance_test.go
@@ -47,7 +47,7 @@ func BenchmarkDryRunPerformance(b *testing.B) {
 			ctx := context.Background()
 
 			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				dryRunOpts := &DryRunOptions{
 					DetailLevel:   DetailLevelDetailed,
 					OutputFormat:  OutputFormatText,
@@ -118,7 +118,7 @@ func BenchmarkFormatterPerformance(b *testing.B) {
 		}
 
 		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			_, err := formatter.FormatResult(result, opts)
 			if err != nil {
 				b.Fatalf("formatting error: %v", err)
@@ -135,7 +135,7 @@ func BenchmarkFormatterPerformance(b *testing.B) {
 		}
 
 		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			_, err := formatter.FormatResult(result, opts)
 			if err != nil {
 				b.Fatalf("formatting error: %v", err)
@@ -178,7 +178,7 @@ func BenchmarkResourceManagerModeSwitch(b *testing.B) {
 		require.NoError(b, err)
 
 		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			_, _, err := manager.ExecuteCommand(ctx, cmd, group, envVars)
 			if err != nil {
 				b.Fatalf("unexpected error: %v", err)
@@ -212,7 +212,7 @@ func BenchmarkMemoryUsage(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		dryRunOpts := &DryRunOptions{
 			DetailLevel:   DetailLevelDetailed,
 			OutputFormat:  OutputFormatText,

--- a/internal/safefileio/safe_file_test.go
+++ b/internal/safefileio/safe_file_test.go
@@ -676,12 +676,10 @@ func TestEnsureParentDirsNoSymlinks(t *testing.T) {
 		// os.TempDir() on macOS resolves through /tmp -> /private/tmp.
 		// ensureParentDirsNoSymlinks must accept that root-owned symlink so
 		// that writing to the system temp directory works correctly.
-		subDir, err := os.MkdirTemp("", "safefileio-test-*")
-		require.NoError(t, err)
-		defer func() { _ = os.RemoveAll(subDir) }()
+		subDir := commontesting.SafeTempDir(t)
 
 		targetPath := filepath.Join(subDir, "file.txt")
-		err = ensureParentDirsNoSymlinks(targetPath)
+		err := ensureParentDirsNoSymlinks(targetPath)
 		assert.NoError(t, err, "path under os.TempDir must be accepted")
 	})
 }

--- a/internal/security/elfanalyzer/analyzer_benchmark_test.go
+++ b/internal/security/elfanalyzer/analyzer_benchmark_test.go
@@ -33,7 +33,7 @@ func BenchmarkAnalyzeNetworkSymbols(b *testing.B) {
 		b.Run(bin.name, func(b *testing.B) {
 			analyzer := NewStandardELFAnalyzer(nil)
 			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				_ = analyzer.AnalyzeNetworkSymbols(absPath, "sha256:dummy")
 			}
 		})
@@ -69,7 +69,7 @@ func BenchmarkAnalyzeNetworkSymbols_TestdataFixtures(b *testing.B) {
 		b.Run(fixture, func(b *testing.B) {
 			analyzer := NewStandardELFAnalyzer(nil)
 			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				_ = analyzer.AnalyzeNetworkSymbols(absPath, "sha256:dummy")
 			}
 		})

--- a/internal/security/elfanalyzer/arm64_go_wrapper_resolver.go
+++ b/internal/security/elfanalyzer/arm64_go_wrapper_resolver.go
@@ -1,9 +1,10 @@
 package elfanalyzer
 
 import (
+	"cmp"
 	"debug/elf"
 	"encoding/binary"
-	"sort"
+	"slices"
 
 	"golang.org/x/arch/arm64/arm64asm"
 )
@@ -198,11 +199,11 @@ func (r *ARM64GoWrapperResolver) sortAndDedupWrapperRanges() {
 	if len(r.wrapperRanges) <= 1 {
 		return
 	}
-	sort.Slice(r.wrapperRanges, func(i, j int) bool {
-		if r.wrapperRanges[i].start == r.wrapperRanges[j].start {
-			return r.wrapperRanges[i].end < r.wrapperRanges[j].end
+	slices.SortFunc(r.wrapperRanges, func(a, b wrapperRange) int {
+		if a.start == b.start {
+			return cmp.Compare(a.end, b.end)
 		}
-		return r.wrapperRanges[i].start < r.wrapperRanges[j].start
+		return cmp.Compare(a.start, b.start)
 	})
 	dedup := r.wrapperRanges[:0]
 	for i := range r.wrapperRanges {

--- a/internal/security/elfanalyzer/go_wrapper_resolver.go
+++ b/internal/security/elfanalyzer/go_wrapper_resolver.go
@@ -1,9 +1,11 @@
 package elfanalyzer
 
 import (
+	"cmp"
 	"debug/elf"
 	"fmt"
 	"log/slog"
+	"slices"
 	"sort"
 )
 
@@ -214,8 +216,8 @@ func (b *goWrapperBase) loadFromPclntab(elfFile *elf.File) error {
 	}
 
 	// Sort wrapperRanges by start address so IsInsideWrapper can use binary search.
-	sort.Slice(b.wrapperRanges, func(i, j int) bool {
-		return b.wrapperRanges[i].start < b.wrapperRanges[j].start
+	slices.SortFunc(b.wrapperRanges, func(a, b wrapperRange) int {
+		return cmp.Compare(a.start, b.start)
 	})
 
 	return nil

--- a/internal/security/elfanalyzer/go_wrapper_resolver_test.go
+++ b/internal/security/elfanalyzer/go_wrapper_resolver_test.go
@@ -3,8 +3,9 @@
 package elfanalyzer
 
 import (
+	"cmp"
 	"debug/elf"
-	"sort"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -306,8 +307,8 @@ func TestX86GoWrapperResolver_IsInsideWrapper(t *testing.T) {
 	}
 
 	// Sort as loadFromPclntab would.
-	sort.Slice(resolver.wrapperRanges, func(i, j int) bool {
-		return resolver.wrapperRanges[i].start < resolver.wrapperRanges[j].start
+	slices.SortFunc(resolver.wrapperRanges, func(a, b wrapperRange) int {
+		return cmp.Compare(a.start, b.start)
 	})
 
 	for _, tt := range tests {

--- a/internal/security/elfanalyzer/syscall_analyzer.go
+++ b/internal/security/elfanalyzer/syscall_analyzer.go
@@ -835,10 +835,7 @@ func (a *SyscallAnalyzer) backwardScanX86WithRegCopy(
 		return number, method, detail
 	}
 
-	probeLimit := windowStart + x86Decoder.MaxInstructionLength()
-	if probeLimit > syscallOffset {
-		probeLimit = syscallOffset
-	}
+	probeLimit := min(windowStart+x86Decoder.MaxInstructionLength(), syscallOffset)
 	for candidateStart := windowStart + 1; candidateStart <= probeLimit; candidateStart++ {
 		candidateNumber, candidateMethod, candidateDetail, _ := a.backwardScanX86WithWindow(
 			code,

--- a/internal/security/elfanalyzer/syscall_analyzer_integration_test.go
+++ b/internal/security/elfanalyzer/syscall_analyzer_integration_test.go
@@ -387,12 +387,12 @@ func main() {
 		dynsyms, err := elfFile.DynamicSymbols()
 		require.NoError(t, err, ".dynsym must be present in a CGO binary")
 
-		networkSyms := map[string]bool{
-			"socket": true, "connect": true, "bind": true,
-			"sendto": true, "recvfrom": true, "getaddrinfo": true,
+		networkSyms := map[string]struct{}{
+			"socket": {}, "connect": {}, "bind": {},
+			"sendto": {}, "recvfrom": {}, "getaddrinfo": {},
 		}
 		for _, sym := range dynsyms {
-			if networkSyms[sym.Name] {
+			if _, found := networkSyms[sym.Name]; found {
 				t.Errorf(".dynsym contains network symbol %q; CGO binary should not have it", sym.Name)
 			}
 		}

--- a/internal/security/elfanalyzer/x86_syscall_numbers_test.go
+++ b/internal/security/elfanalyzer/x86_syscall_numbers_test.go
@@ -1,6 +1,7 @@
 package elfanalyzer
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -42,12 +43,13 @@ func TestX86_64SyscallTable_NetworkSyscalls(t *testing.T) {
 
 	// Verify all required syscalls appear in GetNetworkSyscalls()
 	networkNums := table.GetNetworkSyscalls()
-	networkNumSet := make(map[int]bool, len(networkNums))
+	networkNumSet := make(map[int]struct{}, len(networkNums))
 	for _, n := range networkNums {
-		networkNumSet[n] = true
+		networkNumSet[n] = struct{}{}
 	}
 	for _, tc := range requiredNetworkSyscalls {
-		assert.True(t, networkNumSet[tc.number],
+		_, inSet := networkNumSet[tc.number]
+		assert.True(t, inSet,
 			"syscall %d (%s) should appear in GetNetworkSyscalls()", tc.number, tc.name)
 	}
 	assert.Equal(t, len(requiredNetworkSyscalls), len(networkNums),
@@ -110,29 +112,22 @@ func TestX86_64SyscallTable_GetExecSyscalls(t *testing.T) {
 	table := NewX86_64SyscallTable()
 
 	execNums := table.GetExecSyscalls()
-	execNumSet := make(map[int]bool, len(execNums))
+	execNumSet := make(map[int]struct{}, len(execNums))
 	for _, n := range execNums {
-		execNumSet[n] = true
+		execNumSet[n] = struct{}{}
 	}
 
-	assert.True(t, execNumSet[59], "GetExecSyscalls() should include execve(59)")
-	assert.True(t, execNumSet[322], "GetExecSyscalls() should include execveat(322)")
+	_, hasExecve := execNumSet[59]
+	assert.True(t, hasExecve, "GetExecSyscalls() should include execve(59)")
+	_, hasExecveat := execNumSet[322]
+	assert.True(t, hasExecveat, "GetExecSyscalls() should include execveat(322)")
 	assert.Len(t, execNums, 2, "GetExecSyscalls() should include only exec syscalls")
 
 	// Mutating the returned slice must not affect subsequent calls.
 	if len(execNums) > 0 {
 		execNums[0] = -1
 		execNums2 := table.GetExecSyscalls()
-		assert.True(t, contains(execNums2, 59))
-		assert.True(t, contains(execNums2, 322))
+		assert.True(t, slices.Contains(execNums2, 59))
+		assert.True(t, slices.Contains(execNums2, 322))
 	}
-}
-
-func contains(nums []int, target int) bool {
-	for _, n := range nums {
-		if n == target {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/security/machoanalyzer/pass1_scanner.go
+++ b/internal/security/machoanalyzer/pass1_scanner.go
@@ -1,7 +1,8 @@
 package machoanalyzer
 
 import (
-	"sort"
+	"cmp"
+	"slices"
 
 	"github.com/isseis/go-safe-cmd-runner/internal/arm64util"
 	"github.com/isseis/go-safe-cmd-runner/internal/common"
@@ -50,8 +51,8 @@ func buildStubRanges(funcs map[string]MachoPclntabFunc) []funcRange {
 		}
 	}
 	// Sort by start address for binary search in isInsideRange.
-	sort.Slice(ranges, func(i, j int) bool {
-		return ranges[i].start < ranges[j].start
+	slices.SortFunc(ranges, func(a, b funcRange) int {
+		return cmp.Compare(a.start, b.start)
 	})
 	return ranges
 }

--- a/internal/shebang/parser.go
+++ b/internal/shebang/parser.go
@@ -157,14 +157,15 @@ func Parse(filePath string, fs safefileio.FileSystem) (*Info, error) {
 // trustedEnvPaths is the set of absolute paths recognised as the system env(1)
 // binary. Keyed on the raw (pre-symlink-resolution) shebang token so that
 // systems where /usr/bin/env is a symlink (e.g., to busybox) work correctly.
-var trustedEnvPaths = map[string]bool{
-	"/usr/bin/env": true,
-	"/bin/env":     true,
+var trustedEnvPaths = map[string]struct{}{
+	"/usr/bin/env": {},
+	"/bin/env":     {},
 }
 
 // isTrustedEnvBinary reports whether path is a known system env(1) binary.
 func isTrustedEnvBinary(path string) bool {
-	return trustedEnvPaths[path]
+	_, ok := trustedEnvPaths[path]
+	return ok
 }
 
 // parseEnvForm handles "#!/usr/bin/env <cmd>" shebangs.

--- a/internal/terminal/color.go
+++ b/internal/terminal/color.go
@@ -5,6 +5,7 @@ package terminal
 
 import (
 	"os"
+	"slices"
 	"strings"
 )
 
@@ -54,14 +55,7 @@ func (d *DefaultColorDetector) SupportsColor() bool {
 	}
 
 	// Check for exact matches or prefixes using package-level list
-	for _, colorTerm := range colorTerminals {
-		if term == colorTerm || strings.HasPrefix(term, colorTerm+"-") {
-			return true
-		}
-	}
-
-	// For unknown terminals, default to no color for safety
-	// This is a conservative approach - better to miss color support
-	// than to output escape sequences to terminals that don't support them
-	return false
+	return slices.ContainsFunc(colorTerminals, func(colorTerm string) bool {
+		return term == colorTerm || strings.HasPrefix(term, colorTerm+"-")
+	})
 }

--- a/internal/verification/manager_macho_test.go
+++ b/internal/verification/manager_macho_test.go
@@ -224,7 +224,7 @@ func TestVerify_MachOOldSchema(t *testing.T) {
 	require.NoError(t, err)
 
 	oldSchema := fileanalysis.CurrentSchemaVersion - 1
-	rawRecord := map[string]interface{}{
+	rawRecord := map[string]any{
 		"schema_version": oldSchema,
 		"content_hash":   "sha256:aabbcc",
 	}
@@ -240,7 +240,7 @@ func TestVerify_MachOOldSchema(t *testing.T) {
 
 // writeRawJSONRecord writes a raw JSON object to the given path, creating
 // parent directories as needed. Used to inject records with arbitrary schema versions.
-func writeRawJSONRecord(t *testing.T, path string, record interface{}) {
+func writeRawJSONRecord(t *testing.T, path string, record any) {
 	t.Helper()
 	data, err := json.MarshalIndent(record, "", "  ")
 	require.NoError(t, err)

--- a/internal/verification/manager_test.go
+++ b/internal/verification/manager_test.go
@@ -1460,7 +1460,7 @@ func createOldSchemaRecord(t *testing.T, hashDir, filePath string) string {
 	recordFilePath, err := getter.GetHashFilePath(resolvedHashDir, resolvedPath)
 	require.NoError(t, err)
 
-	record := map[string]interface{}{
+	record := map[string]any{
 		"schema_version": fileanalysis.CurrentSchemaVersion - 1, // older schema triggers the overwrite path (Actual < Expected)
 		"file_path":      filePath,
 		"content_hash":   "sha256:aabbcc",
@@ -1583,7 +1583,7 @@ func createFutureSchemaRecord(t *testing.T, hashDir, filePath string) string {
 	recordFilePath, err := getter.GetHashFilePath(resolvedHashDir, resolvedPath)
 	require.NoError(t, err)
 
-	record := map[string]interface{}{
+	record := map[string]any{
 		"schema_version": fileanalysis.CurrentSchemaVersion + 1, // future schema (> CurrentSchemaVersion)
 		"file_path":      filePath,
 		"content_hash":   "sha256:aabbcc",

--- a/internal/verification/result_collector_test.go
+++ b/internal/verification/result_collector_test.go
@@ -118,7 +118,7 @@ func TestResultCollector_Concurrency(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(numGoroutines)
 
-	for i := 0; i < numGoroutines; i++ {
+	for range numGoroutines {
 		go func() {
 			defer wg.Done()
 

--- a/scripts/verification/compare_doc_structure.go
+++ b/scripts/verification/compare_doc_structure.go
@@ -190,25 +190,25 @@ func compareFiles(jaFile, enFile string) (*StructureComparison, error) {
 	}
 
 	// Find headings that appear in one file but not the other
-	jaHeadingMap := make(map[int]map[string]bool)
-	enHeadingMap := make(map[int]map[string]bool)
+	jaHeadingMap := make(map[int]map[string]struct{})
+	enHeadingMap := make(map[int]map[string]struct{})
 
 	for _, h := range jaStructure.Headings {
 		if jaHeadingMap[h.Level] == nil {
-			jaHeadingMap[h.Level] = make(map[string]bool)
+			jaHeadingMap[h.Level] = make(map[string]struct{})
 		}
-		jaHeadingMap[h.Level][normalizeHeading(h.Text)] = true
+		jaHeadingMap[h.Level][normalizeHeading(h.Text)] = struct{}{}
 	}
 
 	for _, h := range enStructure.Headings {
 		if enHeadingMap[h.Level] == nil {
-			enHeadingMap[h.Level] = make(map[string]bool)
+			enHeadingMap[h.Level] = make(map[string]struct{})
 		}
 		normalized := normalizeHeading(h.Text)
-		enHeadingMap[h.Level][normalized] = true
+		enHeadingMap[h.Level][normalized] = struct{}{}
 
 		// Check if this heading exists in Japanese
-		if !jaHeadingMap[h.Level][normalized] {
+		if _, ok := jaHeadingMap[h.Level][normalized]; !ok {
 			comparison.MissingInJa = append(comparison.MissingInJa,
 				fmt.Sprintf("Level %d: %s", h.Level, h.Text))
 		}
@@ -216,7 +216,7 @@ func compareFiles(jaFile, enFile string) (*StructureComparison, error) {
 
 	for _, h := range jaStructure.Headings {
 		normalized := normalizeHeading(h.Text)
-		if !enHeadingMap[h.Level][normalized] {
+		if _, ok := enHeadingMap[h.Level][normalized]; !ok {
 			comparison.MissingInEn = append(comparison.MissingInEn,
 				fmt.Sprintf("Level %d: %s", h.Level, h.Text))
 		}
@@ -308,10 +308,7 @@ func parseDocStructure(filePath, lang string) (*DocStructure, error) {
 func compareHeadings(jaHeadings, enHeadings []Heading) []HeadingMatch {
 	matches := []HeadingMatch{}
 
-	maxLen := len(jaHeadings)
-	if len(enHeadings) > maxLen {
-		maxLen = len(enHeadings)
-	}
+	maxLen := max(len(jaHeadings), len(enHeadings))
 
 	for i := 0; i < maxLen; i++ {
 		match := HeadingMatch{}

--- a/scripts/verification/verify_cli_args.go
+++ b/scripts/verification/verify_cli_args.go
@@ -10,6 +10,7 @@ package main
 
 import (
 	"bufio"
+	"cmp"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -19,7 +20,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"sort"
+	"slices"
 	"strings"
 )
 
@@ -276,8 +277,8 @@ func extractCommandFromFilename(path string) string {
 	// docs/user/runner_command.ja.md -> runner
 	// docs/user/record_command.ja.md -> record
 	filename := filepath.Base(path)
-	if strings.HasSuffix(filename, "_command.ja.md") {
-		return strings.TrimSuffix(filename, "_command.ja.md")
+	if base, ok := strings.CutSuffix(filename, "_command.ja.md"); ok {
+		return base
 	}
 	return "unknown"
 }
@@ -294,10 +295,8 @@ func isValidArgName(name string) bool {
 		"h", "help", "version", "v",
 	}
 
-	for _, exclude := range excludeList {
-		if name == exclude {
-			return false // Filter out these common arguments
-		}
+	if slices.Contains(excludeList, name) {
+		return false // Filter out these common arguments
 	}
 
 	return true
@@ -340,15 +339,13 @@ func compareArgs(codeArgs map[string]*CLIArg, docArgs map[string][]string) *Comp
 	}
 
 	// Sort for consistent output
-	sort.Slice(report.InCodeOnly, func(i, j int) bool {
-		return report.InCodeOnly[i].Command+":"+report.InCodeOnly[i].Name <
-			report.InCodeOnly[j].Command+":"+report.InCodeOnly[j].Name
+	slices.SortFunc(report.InCodeOnly, func(a, b *CLIArg) int {
+		return cmp.Compare(a.Command+":"+a.Name, b.Command+":"+b.Name)
 	})
-	sort.Slice(report.InBoth, func(i, j int) bool {
-		return report.InBoth[i].Command+":"+report.InBoth[i].Name <
-			report.InBoth[j].Command+":"+report.InBoth[j].Name
+	slices.SortFunc(report.InBoth, func(a, b *CLIArg) int {
+		return cmp.Compare(a.Command+":"+a.Name, b.Command+":"+b.Name)
 	})
-	sort.Strings(report.InDocsOnly)
+	slices.Sort(report.InDocsOnly)
 
 	return report
 }

--- a/scripts/verification/verify_links.go
+++ b/scripts/verification/verify_links.go
@@ -53,30 +53,30 @@ type Config struct {
 // allowedHosts is a map of trusted domains for external link checking.
 // SECURITY: Only these hosts can be checked to prevent SSRF attacks.
 // Add new trusted domains here as needed.
-var allowedHosts = map[string]bool{
+var allowedHosts = map[string]struct{}{
 	// Go ecosystem
-	"golang.org":          true,
-	"go.dev":              true,
-	"pkg.go.dev":          true,
-	"go.googlesource.com": true,
+	"golang.org":          {},
+	"go.dev":              {},
+	"pkg.go.dev":          {},
+	"go.googlesource.com": {},
 
 	// Documentation and references
-	"en.wikipedia.org": true,
-	"ja.wikipedia.org": true,
-	"owasp.org":        true,
-	"cwe.mitre.org":    true,
+	"en.wikipedia.org": {},
+	"ja.wikipedia.org": {},
+	"owasp.org":        {},
+	"cwe.mitre.org":    {},
 
 	// Code hosting
-	"github.com": true,
-	"gitlab.com": true,
+	"github.com": {},
+	"gitlab.com": {},
 
 	// Rust ecosystem (if needed)
-	"docs.rs":   true,
-	"crates.io": true,
+	"docs.rs":   {},
+	"crates.io": {},
 
 	// Standards and RFCs
-	"www.rfc-editor.org":   true,
-	"datatracker.ietf.org": true,
+	"www.rfc-editor.org":   {},
+	"datatracker.ietf.org": {},
 }
 
 func main() {
@@ -274,8 +274,7 @@ func isExternalURL(url string) bool {
 // verifyInternalLink verifies an internal link
 func verifyInternalLink(url, sourceFile string) bool {
 	// Remove anchor if present
-	parts := strings.SplitN(url, "#", 2)
-	filePath := parts[0]
+	filePath, _, _ := strings.Cut(url, "#")
 
 	// Skip empty paths (anchor-only links)
 	if filePath == "" {
@@ -345,7 +344,7 @@ func isAllowedHost(urlStr string) error {
 	}
 
 	// Check against allowlist
-	if !allowedHosts[u.Host] {
+	if _, ok := allowedHosts[u.Host]; !ok {
 		return fmt.Errorf("host not in allowlist: %s (add to allowedHosts if trusted)", u.Host)
 	}
 

--- a/scripts/verification/verify_toml_keys.go
+++ b/scripts/verification/verify_toml_keys.go
@@ -9,6 +9,7 @@ package main
 
 import (
 	"bufio"
+	"cmp"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -18,7 +19,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"sort"
+	"slices"
 	"strings"
 )
 
@@ -197,10 +198,10 @@ func extractKeysFromDocs(docsRoot string) (map[string][]string, error) {
 			line := scanner.Text()
 
 			// Track code block state
-			if strings.HasPrefix(line, "```") {
+			if rest, ok := strings.CutPrefix(line, "```"); ok {
 				if !inCodeBlock {
 					inCodeBlock = true
-					codeBlockType = strings.TrimPrefix(line, "```")
+					codeBlockType = rest
 				} else {
 					inCodeBlock = false
 					codeBlockType = ""
@@ -247,13 +248,7 @@ func isValidTOMLKey(key string) bool {
 		"true", "false", "yes", "no",
 	}
 
-	for _, exclude := range excludeList {
-		if key == exclude {
-			return false
-		}
-	}
-
-	return true
+	return !slices.Contains(excludeList, key)
 }
 
 // ComparisonReport contains the comparison results
@@ -293,13 +288,13 @@ func compareKeys(codeKeys map[string]*TOMLKey, docKeys map[string][]string) *Com
 	}
 
 	// Sort for consistent output
-	sort.Slice(report.InCodeOnly, func(i, j int) bool {
-		return report.InCodeOnly[i].Key < report.InCodeOnly[j].Key
+	slices.SortFunc(report.InCodeOnly, func(a, b *TOMLKey) int {
+		return cmp.Compare(a.Key, b.Key)
 	})
-	sort.Slice(report.InBoth, func(i, j int) bool {
-		return report.InBoth[i].Key < report.InBoth[j].Key
+	slices.SortFunc(report.InBoth, func(a, b *TOMLKey) int {
+		return cmp.Compare(a.Key, b.Key)
 	})
-	sort.Strings(report.InDocsOnly)
+	slices.Sort(report.InDocsOnly)
 
 	return report
 }


### PR DESCRIPTION
This pull request modernizes Go code throughout the repository by adopting newer language features and standard library improvements introduced in recent Go versions (1.18+). It updates documentation to encourage these idioms, refactors tests and core logic to use them, and improves code readability and maintainability. The most significant changes are grouped below:

**Adoption of Modern Go Idioms and Standard Library Features:**

* Added a "Modern Go Idioms" section to `CLAUDE.md`, recommending the use of features such as `any`, `slices` and `maps` packages, `cmp.Compare`, `strings.CutPrefix`, and more, to improve code clarity and reduce boilerplate.
* Replaced `interface{}` with `any` in test files for type safety and clarity. [[1]](diffhunk://#diff-85d06c70c208052f065bb838153cc20d1817e0254e56222b776160ea441f7d8fL89-R89) [[2]](diffhunk://#diff-85d06c70c208052f065bb838153cc20d1817e0254e56222b776160ea441f7d8fL121-R121) [[3]](diffhunk://#diff-85d06c70c208052f065bb838153cc20d1817e0254e56222b776160ea441f7d8fL177-R177) [[4]](diffhunk://#diff-85d06c70c208052f065bb838153cc20d1817e0254e56222b776160ea441f7d8fL280-R280) [[5]](diffhunk://#diff-85d06c70c208052f065bb838153cc20d1817e0254e56222b776160ea441f7d8fL301-R301) [[6]](diffhunk://#diff-85d06c70c208052f065bb838153cc20d1817e0254e56222b776160ea441f7d8fL446-R452) [[7]](diffhunk://#diff-85d06c70c208052f065bb838153cc20d1817e0254e56222b776160ea441f7d8fL491-R491)

**Refactoring to Use New Collection and Comparison Utilities:**

* Replaced manual sorting using `sort.Slice` with the type-safe and faster `slices.SortFunc` and `cmp.Compare` in multiple files, including ELF/Mach-O dynamic library analyzers and ccache adapters. [[1]](diffhunk://#diff-554870805056553cb3d5aefd16a6e0fef13ea375aa13de795da31c360b8ac147L13-R14) [[2]](diffhunk://#diff-554870805056553cb3d5aefd16a6e0fef13ea375aa13de795da31c360b8ac147L238-R243) [[3]](diffhunk://#diff-5476e31a73649e02ee95d22db9d051f2016b99d7696a8e3c94b427088d5b0345L16-R17) [[4]](diffhunk://#diff-5476e31a73649e02ee95d22db9d051f2016b99d7696a8e3c94b427088d5b0345L243-R248) [[5]](diffhunk://#diff-16dc9f8910069eea8f11758fff9669d62c28b884bc6c6051381299d91ff04c40R7-R15) [[6]](diffhunk://#diff-16dc9f8910069eea8f11758fff9669d62c28b884bc6c6051381299d91ff04c40L336-R338) [[7]](diffhunk://#diff-652de21beeb175d744858c47df32cce5d44e82ac33e80f33f234f4964f5ea6e5R4-R10) [[8]](diffhunk://#diff-652de21beeb175d744858c47df32cce5d44e82ac33e80f33f234f4964f5ea6e5L257-R258) [[9]](diffhunk://#diff-99be5e98da06786bc9e1d7ccb2be5d22bc93e5a095319413ebe5109952d3bbdeR5-R9)
* Updated map set idioms from `map[T]bool` to `map[T]struct{}` for memory efficiency in test utilities and group membership logic. [[1]](diffhunk://#diff-bbf50186161a71483d9c2fab9cccd59f31932232d619669b6c82b261a84edd6cL39-R39) [[2]](diffhunk://#diff-bbf50186161a71483d9c2fab9cccd59f31932232d619669b6c82b261a84edd6cL95-R95) [[3]](diffhunk://#diff-bbf50186161a71483d9c2fab9cccd59f31932232d619669b6c82b261a84edd6cL113-R113) [[4]](diffhunk://#diff-bbf50186161a71483d9c2fab9cccd59f31932232d619669b6c82b261a84edd6cL343-R343) [[5]](diffhunk://#diff-bbf50186161a71483d9c2fab9cccd59f31932232d619669b6c82b261a84edd6cL438-R438) [[6]](diffhunk://#diff-62ef9bffdd48cccb8e6712fa369aa0fbb4bafc3f0d7658c7afc020eba4da1111L29-R35) [[7]](diffhunk://#diff-62ef9bffdd48cccb8e6712fa369aa0fbb4bafc3f0d7658c7afc020eba4da1111L48-R48)

**Test and Temporary Directory Improvements:**

* Refactored tests to use `t.TempDir()` or a common `SafeTempDir` helper for temporary directories, improving test isolation and cleanup. [[1]](diffhunk://#diff-51fc2c1f179c42eddc608b5f449f482f0b42704db54e8e3f63b9d2b9936ceca2L124-R124) [[2]](diffhunk://#diff-51fc2c1f179c42eddc608b5f449f482f0b42704db54e8e3f63b9d2b9936ceca2L451-R447) [[3]](diffhunk://#diff-b11d640534824c8fc014ec5029eb76f4964dffd3d25846499af0d5c8970e3f4bL20-R24)

**Other Idiomatic Improvements:**

* Updated a benchmark to use `for range b.N` instead of a traditional for loop, aligning with modern Go benchmarking idioms.
* Replaced string prefix checks and trimming with the more concise `strings.CutPrefix` in path expansion logic.

These updates collectively modernize the codebase, reduce boilerplate, and make use of recent Go enhancements for better performance and readability.