### PR TITLE
fix(sample): replace outdated SLACK_WEBHOOK_URL with slack_allowed_host

### DIFF
--- a/docs/user/README.ja.md
+++ b/docs/user/README.ja.md
@@ -40,6 +40,7 @@ runner -c config.toml  # 短い形式
 # ドライラン（実行内容の確認）
 runner -config config.toml -dry-run
 runner -c config.toml -n  # 短い形式
+
 ```
 
 **こんな時に:**

--- a/docs/user/README.ja.md
+++ b/docs/user/README.ja.md
@@ -40,7 +40,6 @@ runner -c config.toml  # 短い形式
 # ドライラン（実行内容の確認）
 runner -config config.toml -dry-run
 runner -c config.toml -n  # 短い形式
-
 ```
 
 **こんな時に:**

--- a/sample/comprehensive.toml
+++ b/sample/comprehensive.toml
@@ -20,8 +20,9 @@ env_allowed = [
     "NODE_ENV",
     "DEBUG_MODE",
     "GOTRACEBACK",
-    "SLACK_WEBHOOK_URL",
 ]
+# Slack webhook URL host allowlist (required when GSCR_SLACK_WEBHOOK_URL_* env vars are set)
+slack_allowed_host = "hooks.slack.com"
 verify_files = ["/etc/passwd", "/bin/sh"]
 
 # Global internal variables available for TOML expansion

--- a/sample/comprehensive.toml
+++ b/sample/comprehensive.toml
@@ -22,6 +22,8 @@ env_allowed = [
     "GOTRACEBACK",
 ]
 # Slack webhook URL host allowlist (required when GSCR_SLACK_WEBHOOK_URL_* env vars are set)
+# Set GSCR_SLACK_WEBHOOK_URL_ERROR (and optionally GSCR_SLACK_WEBHOOK_URL_SUCCESS)
+# in the environment before running to enable Slack notifications.
 slack_allowed_host = "hooks.slack.com"
 verify_files = ["/etc/passwd", "/bin/sh"]
 

--- a/sample/slack-group-notification-test.toml
+++ b/sample/slack-group-notification-test.toml
@@ -6,13 +6,13 @@ version = "1.0"
 
 [global]
 timeout = 30
-
-# Environment variables needed for Slack notifications
-# The SLACK_WEBHOOK_URL should be set in the environment before running
+# Slack webhook URL host allowlist (required when GSCR_SLACK_WEBHOOK_URL_* env vars are set)
+# Set GSCR_SLACK_WEBHOOK_URL_ERROR (and optionally GSCR_SLACK_WEBHOOK_URL_SUCCESS)
+# in the environment before running to enable Slack notifications.
+slack_allowed_host = "hooks.slack.com"
 env_allowed = [
     "PATH",
     "LANG",
-    "SLACK_WEBHOOK_URL",
 ]
 
 # Group 1: Successful command group

--- a/sample/slack-notify.toml
+++ b/sample/slack-notify.toml
@@ -4,12 +4,14 @@ version = "1.0"
 
 [global]
 timeout = 30
-# Environment variables for Slack notification testing
+# Slack webhook URL host allowlist (required when GSCR_SLACK_WEBHOOK_URL_* env vars are set)
+# Set GSCR_SLACK_WEBHOOK_URL_ERROR (and optionally GSCR_SLACK_WEBHOOK_URL_SUCCESS)
+# in the environment before running to enable Slack notifications.
+slack_allowed_host = "hooks.slack.com"
 env_allowed = [
     "PATH",
     "HOME",
     "LANG",
-    "SLACK_WEBHOOK_URL",
     "GOTRACEBACK",
 ]
 verify_files = ["/etc/passwd"]


### PR DESCRIPTION
Remove the obsolete SLACK_WEBHOOK_URL from env_allowed in three sample files (slack-notify.toml, slack-group-notification-test.toml, comprehensive.toml). The runner reads GSCR_SLACK_WEBHOOK_URL_SUCCESS / GSCR_SLACK_WEBHOOK_URL_ERROR directly from the OS environment, so listing the old name in env_allowed had no effect. Add the required slack_allowed_host field to each [global] section so the samples are valid when Slack notifications are enabled.