### PR TITLE
docs: add command risk evaluation guide (JA/EN)

### DIFF
--- a/docs/dev/architecture_design/command-risk-evaluation.ja.md
+++ b/docs/dev/architecture_design/command-risk-evaluation.ja.md
@@ -4,9 +4,11 @@
 
 本文書は、`runner` がコマンドを **実行する時点** で行う「リスク判定（risk evaluation）」の仕組みを、開発者向けに解説するものである。
 
-`runner` は設定ファイル（TOML）に記述された各コマンドを実行する前に、そのコマンドが持つセキュリティ上の危険度を **リスクレベル** として算出する。算出されたリスクレベルが、コマンドまたはグループに設定された **最大許容リスクレベル（`risk_level`）** を超える場合、そのコマンドの実行を拒否する。これにより「設定で明示的に許可した範囲を超える危険な操作」を実行前に遮断する。
+`runner` は設定ファイル（TOML）に記述された各コマンドを実行する前に、そのコマンドが持つセキュリティ上の危険度を **リスクレベル** として算出する。算出されたリスクレベル（実効リスク）が、コマンドに設定された **最大許容リスクレベル（`risk_level`）** を超える場合、そのコマンドの実行を拒否する。また、判定が確実に行えない場合（バイナリの同一性が未検証、シンボリックリンク解決の失敗、間接実行で束縛不能な対象など）は、許容レベルとは無関係に **ブロッキング（Blocking）拒否** とする。これにより「設定で明示的に許可した範囲を超える危険な操作」と「安全性を確認できない操作」を実行前に遮断する。
 
-この判定は、ハッシュ検証（ファイル整合性検証）やバイナリ静的解析といった他のセキュリティ層と組み合わさって動作する。本文書ではそれらの詳細には立ち入らず、**リスクレベルの決定ロジック** に焦点を当てる。
+リスク判定の結果は、単なるリスクレベルではなく **検証済み実行計画（`VerifiedCommandPlan`）** として返される。計画は、評価したバイナリの同一性（解決済みパス・content hash・fd）を実行時の同一性と束縛し、実行器はこの計画にもとづいて実行する（評価した実体と実行する実体が一致することを保証する）。
+
+この判定は、ハッシュ検証（ファイル整合性検証）やバイナリ静的解析といった他のセキュリティ層と密接に連動して動作する。本文書では **リスクレベルの決定ロジック** に焦点を当てる。
 
 ### 対象読者
 
@@ -18,10 +20,12 @@
 
 | パッケージ | 役割 |
 |-----------|------|
-| `internal/runner/base/risk` | 実行時リスク判定のエントリポイント（`Evaluator`） |
-| `internal/runner/base/security` | 個別判定ロジック（特権昇格・破壊操作・ネットワーク・coreutils 等） |
-| `internal/runner/resource` | リスク判定の呼び出しと許容レベルとの比較（実行可否の判断） |
-| `internal/runner/base/runnertypes` | `RiskLevel` 型と設定値のパース |
+| `internal/runner/base/risk` | 実行時リスク判定のエントリポイント（`StandardEvaluator.EvaluateRisk`） |
+| `internal/runner/base/security` | 個別判定ロジック（特権昇格・破壊操作・システム変更・coreutils・間接実行・任意コード実行・バイナリ解析など） |
+| `internal/runner/base/risktypes` | 評価結果の DTO（`VerifiedCommandPlan` / `RiskAssessment` / `ReasonCode` / `BinaryAnalysisResult` など） |
+| `internal/runner/base/runnertypes` | `RiskLevel` 型と設定値のパース、`RuntimeCommand` |
+| `internal/runner/base/audit` | リスク判定結果の監査ログ出力（`Logger.LogRiskProfile`） |
+| `internal/runner/resource` | リスク判定の呼び出しと許容レベルとの比較（実行可否の判断、`NormalResourceManager` / `DryRunResourceManager`） |
 
 ## リスクレベルの定義
 
@@ -43,19 +47,19 @@ flowchart LR
 | 0 | `RiskLevelUnknown` | `unknown` | リスクを判定できなかった／分類対象外（**Low より安全という意味ではない**） |
 | 1 | `RiskLevelLow` | `low` | セキュリティリスクが最小限のコマンド |
 | 2 | `RiskLevelMedium` | `medium` | 中程度のリスク（ネットワーク操作・システム変更など） |
-| 3 | `RiskLevelHigh` | `high` | 高リスク（破壊的操作・動的ロード・exec シグナルなど） |
+| 3 | `RiskLevelHigh` | `high` | 高リスク（破壊的操作・任意コード実行・動的ロード・exec シグナルなど） |
 | 4 | `RiskLevelCritical` | `critical` | 実行を遮断すべきコマンド（特権昇格など） |
 
 **重要な性質**：
 
 - `Low` 〜 `Critical` は整数として **大小比較可能** であり、複数の要因がある場合は原則として **最大値** が採用される（`max(...)`）。
-- `Unknown`（値 0）は数値としては最小だが、意味は「判定不能／分類対象外」であって **`Low` より安全という意味ではない**。実装上、`Unknown` が「最も低いリスク」として許容比較（`effectiveRisk > maxAllowedRisk`）を通過してしまうことはない。実行時パス（`EvaluateRisk`）が `Unknown` を返すのは **エラーと同時の場合のみ** で、その際はエラーが呼び出し元へ伝播して **フェイルクローズド**（実行中止）になるためである。`Unknown` は主に「この判定では確定できないので後続の判定に委ねる」という内部シグナルとして使われる（例：`getDefaultRiskByDirectory` や `AnalyzeCommandSecurity` の中間結果）。
-- `critical` は **設定ファイルでは指定できない**（`ParseRiskLevel` がエラーを返す）。内部利用専用であり、特権昇格コマンドのように「必ず遮断すべき」ものに割り当てられる。
+- `Unknown`（値 0）は数値としては最小だが、意味は「判定不能／分類対象外」であって **`Low` より安全という意味ではない**。実装上、判定不能なケースは数値比較ではなく `RiskAssessment.Blocking`（ブロッキング拒否）として表現され、許容レベル比較を素通りすることはない（**フェイルクローズド**）。`Unknown` は主に「この判定では確定できないので後続の判定に委ねる」という内部シグナルとして使われる（例：`SystemModificationRisk` や `ProfileFactorRisk` の「該当なし」を表す戻り値）。
+- `critical` と `unknown` は **設定ファイルでは指定できない**（`ParseRiskLevel` がいずれもエラーを返す）。`critical` は内部利用専用であり、特権昇格コマンドのように「必ず遮断すべき」ものに割り当てられる。
 - 設定で `risk_level` を省略した場合の既定値は `low` である（`CommandSpec.GetRiskLevel` が `RiskLevelLow` を返す）。
 
 ## 実行時の全体フロー
 
-リスク判定は通常実行モード（`NormalResourceManager.ExecuteCommand`）の中で行われる。配線は `runner.go` で行われ、`NetworkAnalyzer` → `StandardEvaluator` → `ResourceManager` の順に組み立てられる。
+リスク判定は通常実行モード（`NormalResourceManager.ExecuteCommand`）の中で行われる。評価器の配線は `runner.go` で行われ、検証マネージャから得た解析依存（`AnalysisDeps`）を `NetworkAnalyzer` に渡し、それを `StandardEvaluator` に渡して組み立てる（`security.NewNetworkAnalyzer` → `risk.NewStandardEvaluator`）。
 
 ```mermaid
 flowchart TD
@@ -63,16 +67,18 @@ flowchart TD
     classDef process fill:#fff1e6,stroke:#ff7f0e,stroke-width:1px,color:#8a3e00;
     classDef decision fill:#fde6e6,stroke:#c0392b,stroke-width:1px,color:#7b0a0a;
 
-    A[("RuntimeCommand<br>(展開済みコマンド/引数)")] --> B["NormalResourceManager<br>ExecuteCommand"]
-    B --> C["Evaluator.EvaluateRisk<br>(実効リスクを算出)"]
-    C -->|"effectiveRisk"| D{"effectiveRisk ><br>maxAllowedRisk ?"}
-    E[("設定 risk_level<br>(最大許容リスク)")] -->|"GetRiskLevel"| D
-    D -->|"Yes"| F["実行拒否<br>ErrCommandSecurityViolation"]
-    D -->|"No"| G["コマンド実行"]
+    A[("RuntimeCommand<br>(展開済みコマンド/引数/content hash)")] --> B["NormalResourceManager<br>ExecuteCommand"]
+    B --> C["Evaluator.EvaluateRisk<br>(VerifiedCommandPlanを算出)"]
+    C -->|"Assessment.Blocking"| D1{"Blocking ?"}
+    D1 -->|"Yes"| F["実行拒否<br>ErrCommandSecurityViolation"]
+    D1 -->|"No"| D2{"effectiveRisk ><br>maxAllowedRisk ?"}
+    E[("設定 risk_level<br>(最大許容リスク)")] -->|"GetRiskLevel"| D2
+    D2 -->|"Yes"| F
+    D2 -->|"No"| G["コマンド実行<br>(計画の同一性に束縛)"]
 
     class A,E data;
     class B,C,G process;
-    class D decision;
+    class D1,D2 decision;
     class F decision;
 ```
 
@@ -93,28 +99,35 @@ flowchart LR
 実行可否の比較は `internal/runner/resource/normal_manager.go` で行われる。
 
 ```go
-// Step 1: 実効リスクを算出
-effectiveRisk, err := n.riskEvaluator.EvaluateRisk(cmd)
+// Step 1: 検証済み実行計画を算出（実効リスク・拒否理由・検証済み同一性を含む）
+plan, err := n.riskEvaluator.EvaluateRisk(cmd)
+// err は「予期しない内部エラー（分類不能なレコード読込失敗）」のみ。
+// ポリシー上の拒否はエラーではなく plan.Assessment.Blocking で表現される。
+
+effectiveRisk := plan.Assessment.Level
 
 // Step 2: 設定から最大許容リスクを取得（既定は low）
 maxAllowedRisk, err := cmd.GetRiskLevel()
 
-// Step 3: 比較。超過していれば実行を拒否する
-if effectiveRisk > maxAllowedRisk {
-    return ..., fmt.Errorf("%w: command %s (effective risk: %s) exceeds maximum allowed risk level (%s)",
-        runnertypes.ErrCommandSecurityViolation, ...)
-}
+// Step 3: 統一リスクゲート。Blocking なら許容レベルに関わらず拒否、
+//         そうでなければ実効リスクが許容上限を超えていれば拒否する。
+denied := plan.Assessment.Blocking || effectiveRisk > maxAllowedRisk
 ```
 
 ポイント：
 
-- **実効リスク（effectiveRisk）**：コマンドの内容から算出される実際の危険度。
+- **実効リスク（effectiveRisk）**：コマンドの内容から算出される実際の危険度（`Assessment.Level`）。
+- **ブロッキング（Blocking）**：許容レベルに関係なく拒否すべき状態（同一性未検証、解析不能、間接実行で束縛不能など）。`Assessment.Blocking` で表現され、`effectiveRisk > maxAllowedRisk` の比較より優先される。
 - **最大許容リスク（maxAllowedRisk）**：利用者が設定で許可した上限。
 - `critical` は設定に書けないため、特権昇格コマンドのように実効リスクが `critical` になるものは **どんな設定でも必ず拒否される**（既定の `low` はもちろん、最大の `high` を設定しても `critical > high` となる）。
+- 計画が開いた検証済みファイルディスクリプタは、許可・拒否・エラーのいずれの経路でも `plan.Close()` で必ず解放される（ディスクリプタ漏れ防止）。
 
 ## リスク判定アルゴリズム（`EvaluateRisk`）
 
-実行時リスクの中核は `risk.StandardEvaluator.EvaluateRisk`（`internal/runner/base/risk/evaluator.go`）である。判定は **早期リターン方式** で、上位（より危険な）判定から順に評価し、最初に該当したレベルを返す。
+実行時リスクの中核は `risk.StandardEvaluator.EvaluateRisk`（`internal/runner/base/risk/evaluator.go`）である。判定は **ランク付けされた拒否ゲートで短絡（ショートサーキット）した後、残りの判定軸の最大値をとる** 構成になっている。すなわち以下の 2 段構えである。
+
+1. **短絡する拒否ゲート（ランク1〜3）**：同一性ゲート・間接実行・特権昇格。いずれかに該当すると即座に拒否（Blocking）または Critical を返す。
+2. **順序非依存の最大値（ランク4〜8）**：残りの判定軸を **すべて評価** し、その **最大値** を実効リスクとする。「最初に該当したものを返す」早期リターン方式ではない点に注意する。
 
 ```mermaid
 flowchart TD
@@ -122,149 +135,90 @@ flowchart TD
     classDef decision fill:#fde6e6,stroke:#c0392b,stroke-width:1px,color:#7b0a0a;
     classDef result fill:#e8f5e8,stroke:#2e8b57,stroke-width:2px,color:#006400;
 
-    S["EvaluateRisk(cmd)"] --> P1{"特権昇格コマンド?<br>(sudo/su/doas)"}
-    P1 -->|"Yes"| RC["Critical"]
-    P1 -->|"No"| P2{"破壊的ファイル操作?<br>(rm/dd/shred/find -delete 等)"}
-    P2 -->|"Yes"| RH1["High"]
-    P2 -->|"No"| P3{"coreutils 単一バイナリ<br>配下のコマンド?"}
-    P3 -->|"handled"| RCU["coreutils 分類結果<br>(Low/Medium/High)"]
-    P3 -->|"No"| P4{"ネットワーク操作 /<br>高リスクバイナリシグナル?<br>(プロファイル/バイナリ解析/引数)"}
-    P4 -->|"高リスク signal<br>(動的ロード/exec/svc/mprotect PROT_EXEC)"| RH2["High"]
-    P4 -->|"ネットワークのみ"| RM1["Medium"]
-    P4 -->|"No"| P5{"システム変更?<br>(systemctl/mount/apt install 等)"}
-    P5 -->|"Yes"| RM2["Medium"]
-    P5 -->|"No"| RL["Low (既定)"]
+    S["EvaluateRisk(cmd)"] --> G0{"絶対パス? & シンボリックリンク<br>解決成功?"}
+    G0 -->|"No"| BR0["Blocking 拒否"]
+    G0 -->|"Yes"| G1{"ランク1: 同一性ゲート<br>content hash あり & 解析有効?"}
+    G1 -->|"No"| BR1["Blocking 拒否"]
+    G1 -->|"Yes"| G2{"ランク2: 間接実行?<br>(wrapper/inline/find/loader等)"}
+    G2 -->|"Critical (特権トークン)"| RC["Critical"]
+    G2 -->|"Reject (束縛不能)"| BR2["Blocking 拒否"]
+    G2 -->|"Floor / None"| G3{"ランク3: 特権昇格?<br>(プロファイルで判定)"}
+    G3 -->|"Yes"| RC
+    G3 -->|"No"| DIM["ランク4〜8: 判定軸の最大値<br>(coreutils / 破壊操作 / システム変更 /<br>プロファイル要因 / 危険引数 /<br>任意コード実行 / ネットワーク引数 /<br>バイナリ解析)"]
+    DIM --> FLOOR["ランク2 Floor を最大値に合成"]
+    FLOOR --> RES["実効リスク (Low〜High)<br>または軸の Blocking 拒否"]
 
-    class S process;
-    class P1,P2,P3,P4,P5 decision;
-    class RC,RH1,RH2,RM1,RM2,RCU,RL result;
+    class S,DIM,FLOOR process;
+    class G0,G1,G2,G3 decision;
+    class RC,RES,BR0,BR1,BR2 result;
 ```
 
-判定順序（コードのステップに対応）：
+### 前処理: 絶対パスとシンボリックリンク解決
 
-### Step 1: 特権昇格コマンド → Critical
+判定軸に入る前に、次の前提を満たすことを確認する。満たさなければ **Blocking 拒否** となる。
 
-`security.IsPrivilegeEscalationCommand` がコマンド名を検査する。`sudo` / `su` / `doas` に該当すると **Critical** を返す。
+- コマンドパスは評価器到達時点で **絶対パス** でなければならない（呼び出し側が解決済み）。相対パスは同一性が確立できず、バイナリ解析が暗黙にスキップされてしまうため拒否する（`ReasonNonAbsolutePath`）。
+- シンボリックリンク連鎖は `security.ResolveCommandNames`（**strict**）で一度だけ解決する。解決失敗・深さ上限超過（`MaxSymlinkDepth = 40`、`ErrSymlinkDepthExceeded`）・循環は `ReasonSymlinkResolutionFailed` で **フェイルクローズド** 拒否する。部分解決された連鎖で評価して危険な実体を見逃すことを防ぐためである。
 
-- シンボリックリンクを辿って判定する（`extractAllCommandNames`）。`/usr/bin/foo` が実体として `sudo` を指していても検出する。
-- シンボリックリンクの深さが上限（`MaxSymlinkDepth`）を超えた場合はエラー（`ErrSymlinkDepthExceeded`）を返し、リスクは `Unknown` となる。`EvaluateRisk` はエラーを呼び出し元へ伝播し、**フェイルクローズド**（コマンドは実行されない）。
+解決によって得られる「名前集合」（元の名前・basename・連鎖中の各リンク先とその basename）は、以降の名前ベース判定（特権・破壊操作・システム変更など）で共有される。
 
-特権昇格コマンドは `commandRiskProfiles` 上で `PrivilegeRisk = Critical` として定義されている（後述のプロファイル参照）。
+### ランク1: 同一性ゲート → Blocking 拒否
 
-### Step 2: 破壊的ファイル操作 → High
+バイナリの同一性を確認できない場合は、設定された `risk_level` に関わらず拒否する（`identityGate`）。これは他のどの判定軸よりも前に評価され、未検証バイナリが後続の軸で「Low/High 許容可」と判定されて通過することを防ぐ。
 
-`security.IsDestructiveFileOperation` が以下を **High** と判定する：
+- `cmd.ExpandedCmdContentHash` が空（ハッシュ検証で同一性が確立されていない）→ `ReasonUncertainUnverifiedIdentity` で Blocking。
+- バイナリ解析が無効（`NetworkAnalyzer.AnalysisEnabled()` が false、すなわち `RecordStore` 未設定）→ `ReasonAnalysisDisabled` で Blocking。解析無効はフェイルオープンではなくフェイルクローズドである。
 
-- コマンド名が `rm` / `rmdir` / `unlink` / `shred` / `dd` のいずれか。
-- `find` の引数に `-delete`、または `-exec` の直後に破壊的コマンドがある。
-- `rsync` の引数に `--delete` 系オプションがある。
+### ランク2: 間接実行（indirect execution）の解析
 
-### Step 3: coreutils 単一バイナリの分類
+検証済みバイナリ以外の実体を実行・ロードする形態を検出する（`security.AnalyzeIndirectExecution`）。詳細は後述の「間接実行の解析」を参照。結果（`IndirectExecutionResult.Kind`）に応じて以下のように扱う。
 
-Rust 製 coreutils のように、すべてのサブコマンドが **1 つのバイナリ** を共有する実装に対応するための特別処理である。`security.CoreutilsCommandRisk` が判定する。
+- `IndirectCritical`：実効ターゲットに特権昇格トークン（sudo/su/doas）がある → **Critical**（短絡）。
+- `IndirectReject`：実行時まで同一性を束縛できない形態（抽出不能なラッパー、禁止されたローダ制御変数、find/xargs の子プロセス exec、動的ローダ直接起動、リモートシェルヘルパー）→ **Blocking 拒否**（短絡）。
+- `IndirectFloor`：許容されるが最小リスクレベルを持つ形態（ラッパー内の危険な内側コマンド、インラインシェル、パッケージスクリプトランナーなど）→ そのレベルを **リスクの下限（floor）** として、後続の判定軸の最大値に合成する。
+- `IndirectNone`：間接実行形態ではない。
 
-通常のバイナリ静的解析（Step 4 のネットワーク解析内）では、coreutils は単一バイナリ内に全サブコマンドのシンボルを含むため誤分類されてしまう。これを避けるために、解析より前に専用ロジックで分類する。
+連鎖中に実行・ロードされる各実体（`ExecutedArtifact`）は、監査と後段の同一性束縛のために計画へ記録される。
 
-判定条件と挙動：
+### ランク3: 特権昇格 → Critical
 
-- 対象は、解決済みパスの **親ディレクトリが coreutils ディレクトリ（`common.CoreutilsDir`）と完全一致** するコマンドのみ。一致しない場合は `handled=false` を返し、後続のステップへ進む。
-- setuid/setgid ビットが立っていれば **High**（coreutils のハードリンクが setuid であることは通常ありえず、パッケージング不備か改ざんの兆候）。
-- 実効サブコマンドの決定：
-  - 通常はパスの basename（例：`/opt/coreutils/rm` → `rm`）。
-  - マルチコール・エントリポイント（basename が `coreutils`）の場合は、引数の最初の非オプション要素を採用（`coreutils rm -rf ...` → `rm`）。
-- 実効サブコマンドによる分類：
-  - 破壊系（`dd`, `rm`, `rmdir`, `shred`, `truncate`, `unlink`）→ **High**
-  - 既知の安全系（`ls`, `cat`, `mkdir`, `sha256sum` 等の読み取り・情報取得・テキスト処理・新規作成系）→ **Low**
-  - それ以外（ディレクトリ配下だが分類不明）→ **Medium**（フェイルセーフの既定）
-- setuid チェックの stat がエラーになった場合、実行時パス（`EvaluateRisk`）では **エラーを伝播してフェイルクローズド**（実行しない）。
+解決済みプロファイルが特権昇格を示す場合は **Critical**（常に拒否）。`security.ResolveProfile(names)` でプロファイルを引き、`profile.IsPrivilege()`（`PrivilegeRisk >= High`）が真なら該当する。プロファイル上では `sudo` / `su` / `doas` が `PrivilegeRisk = Critical` として定義されている。シンボリックリンクを辿った名前集合で照合するため、別名（`/usr/bin/foo` が `sudo` を指す等）でも検出する。
 
-### Step 4: ネットワーク操作 / 高リスクバイナリシグナル → High / Medium
+### ランク4〜8: 判定軸の最大値（`evaluateDimensions`）
 
-`NetworkAnalyzer.IsNetworkOperation` が判定する。関数名は "Network" だが、戻り値は `(isNetwork, isHighRisk, error)` であり、**ネットワーク操作とは限らない高リスクバイナリシグナルも `isHighRisk` 側で報告する**。具体的には、動的ロードシンボル（`dlopen`/`dlsym`/`dlvsym`）、exec シスコール、`svc #0x80` 直接シスコール、**mprotect 系の `PROT_EXEC`** がこれに含まれる（詳細は 4-2 を参照）。
+ここからは **順序非依存** で、該当するすべての軸を評価し最大値をとる（`addDimension` が `max` をとりつつ理由コードを蓄積する）。初期値は `Low`。途中でフェイルクローズドが必要な軸（coreutils のファイル情報取得失敗、バイナリ解析の不確実）に当たった場合は **Blocking 拒否** を返す。
 
-- `isHighRisk == true` → **High**（ネットワークか否かによらず High。mprotect `PROT_EXEC` 等はここに入る）
-- `isNetwork == true`（高リスクでない）→ **Medium**
-- どちらも false → 次のステップへ
+- **ランク4: coreutils 単一バイナリ分類**（`security.CoreutilsCommandRisk`）。該当する場合は権威的に扱い、バイナリ解析軸（ランク8）を抑止する。ただし他の軸は引き続き寄与する。
+- **破壊的ファイル操作**（`security.IsDestructiveFileOperation`）→ High。
+- **システム変更**（`security.SystemModificationRisk`）→ Medium/High（後述）。
+- **ランク5: プロファイル要因**（`applyProfileFactors` → `security.ProfileFactorRisk`）。特権はランク3、システム変更は上記で扱うため、ここでは破壊・データ持ち出し・該当するネットワークの 3 要因のみを合成する。プロファイルの人間可読な理由（`GetRiskReasons`）と `NetworkType` も記録する。
+- **ランク6: 危険な引数パターン**（`security.CheckDangerousArgPatterns`）：`rm -rf`、`dd if=`、`chmod 777`、`mkfs.*` など。
+- **ランク7: 任意コード実行ランナー**（`security.IsArbitraryCodeExecutionRunner`）→ 引数によらず High（後述）。
+- **ネットワーク引数**：プロファイル未登録のコマンドで、引数に URL や SSH 形式アドレスがあれば（`security.HasNetworkArguments`）→ Medium。
+- **ランク8: バイナリ静的解析**（coreutils 該当時は抑止）。`NetworkAnalyzer.Classify` の結果を合成する（後述）。`BinaryAnalysisUncertain` は **Blocking 拒否**。
 
-検出は以下の優先順位で行われる：
+最後に、ランク2の `IndirectFloor` のレベルを最大値へ合成し（ラップされた危険コマンドが過小評価されないように）、理由コード・理由文字列を追記して重複排除する。
 
-```mermaid
-flowchart TD
-    classDef process fill:#fff1e6,stroke:#ff7f0e,stroke-width:1px,color:#8a3e00;
-    classDef decision fill:#fde6e6,stroke:#c0392b,stroke-width:1px,color:#7b0a0a;
-    classDef result fill:#e8f5e8,stroke:#2e8b57,stroke-width:2px,color:#006400;
+最終的に Blocking でなければ、`allowedPlan` が検証済み実体を fd 束縛で開いて実行可能な計画を返す（開けない場合は `ReasonIdentityUnbound` で Blocking 拒否）。
 
-    A["IsNetworkOperation"] --> B{"コマンドプロファイルに<br>登録あり?"}
-    B -->|"NetworkTypeAlways"| R1["network=true"]
-    B -->|"NetworkTypeConditional"| C{"サブコマンド/引数が<br>ネットワーク該当?"}
-    C -->|"Yes"| R1
-    C -->|"No"| R0["network=false"]
-    B -->|"登録なし & 絶対パス"| D["バイナリ静的解析<br>(analyzeBinarySignals)"]
-    D --> E{"ネットワーク/動的ロード/<br>exec シグナル?"}
-    E -->|"Yes"| R2["network/highRisk"]
-    E -->|"No"| F{"引数に URL や<br>SSH 形式アドレス?"}
-    B -->|"登録なし"| F
-    F -->|"Yes"| R1
-    F -->|"No"| R0
+## 間接実行（indirect execution）の解析
 
-    class A,D process;
-    class B,C,E,F decision;
-    class R0,R1,R2 result;
-```
+`security.AnalyzeIndirectExecution`（`internal/runner/base/security/indirect_execution.go`）は、**検証したバイナリとは別の実体を実行・ロードする形態** を検出し、評価器がどう扱うべきか（Critical / Reject / Floor / None）を返す。検出は basename と解決済みシンボリックリンクで行い、ラッパーがラッパーをラップする入れ子は再帰的に解析する（深さ上限 `indirectExecMaxDepth = 16`）。
 
-#### 4-1. コマンドプロファイルによる判定（最優先）
+主な検出対象：
 
-`commandProfileDefinitions`（`internal/runner/base/security/command_analysis.go`）にハードコードされた既知コマンドの一覧を参照する。各プロファイルは `NetworkType` を持つ：
+- **シェバン（shebang）スクリプト**：`#!/usr/bin/env python` のように、カーネルがシェバンのインタプリタ（別実体）を起動するため、インタプリタ連鎖を評価しゲートする。basename ベースのラッパー照合より前に判定する。
+- **ラッパー**（`env`, `timeout`, `nice`, `ionice`, `nohup`, `stdbuf`, `setsid`, `time`, `chrt`, `taskset`）：runner はこれらを再実装し、抽出した内側コマンド自体を exec するため、内側コマンドを同一性束縛できる。よって reject ではなく内側コマンドを評価する。内側コマンドが特権トークンなら Critical。`env` は `NAME=VALUE` 代入・`-S` 分割文字列・`-C/--chdir`（拒否）を個別に解析し、ローダ制御変数（`LD_*` / `DYLD_*`）の指定や PATH 上書き＋裸の内側名は拒否する。
+- **find / xargs の子プロセス exec**（`-exec`/`-execdir`/`-ok`/`-okdir`、xargs のヘルパー）：runner の子プロセスではなく find/xargs 自身の子プロセスから実行されるため同一性束縛できない。特権トークンなら Critical、それ以外は Reject。
+- **動的ローダ直接起動**（`ld-linux*.so --preload ...` 等）：任意ライブラリをロードできるため Reject。
+- **リモートシェル／出力フィルタヘルパー**（`rsync -e`、`tar --to-command` / `--checkpoint-action`）：ツールの子プロセスからヘルパーが走るため Reject。
+- **パッケージスクリプトランナー**（`npm run` / `npx` / `yarn <script>` / `pnpm run` / `bunx` 等）：未検証のマニフェストからスクリプトを実行するため High の Floor。
+- **インラインコード**（`bash -c`、`python -c`/`-e` など）：High の Floor。
+- **SysV service**：未検証の init スクリプト（`/etc/init.d/<name>`）を実行するため、init スクリプトを連鎖実体として記録しつつ High の Floor。
 
-- `NetworkTypeAlways`：常にネットワーク操作を行う。該当すると即 `network=true`。
-  - 例：`curl`, `wget`, `ssh`, `scp`, `nc`, `aws`、AI 系（`claude`, `gemini` 等）。
-  - **スクリプト言語・シェルも含む**：`bash`, `python`, `node`, `ruby`, `java`, `perl` などは、本体バイナリにネットワークシンボルが無くても任意のネットワークツールを内部で呼び出せるため `Always` として扱う（フェイルセーフ）。
-- `NetworkTypeConditional`：引数によってネットワーク操作になるかが決まる。
-  - `git`：サブコマンドが `clone` / `fetch` / `pull` / `push` / `remote` の場合（`findFirstSubcommand` でオプションを読み飛ばして判定）。
-  - `rsync`：リモート指定がある場合。
-  - 加えて、引数に URL や SSH 形式アドレスがあればネットワークと判定。
+内側コマンドの評価（`evaluateInnerAs`）では、特権・破壊操作・coreutils・システム変更・任意コード実行ランナー・危険引数パターン・リスクプロファイル要因をすべて折り込み、ラップされたコマンドが直接起動の場合より過小評価されないようにする。連鎖中の実体は、Floor/Critical/Reject のいずれの結果でも監査のために記録される。
 
-これらの判定もシンボリックリンクを辿って行う。
-
-#### 4-2. バイナリ静的解析（プロファイル未登録かつ絶対パス）
-
-プロファイルに無い未知コマンドは、事前計算された解析レコード（`RecordStore`）を用いて静的解析する（`analyzeBinarySignals`）。レコードには ELF/Mach-O のシンボル解析・シスコール解析の結果が含まれる。
-
-検出されるシグナルと扱い：
-
-| シグナル | 結果 |
-|----------|------|
-| ネットワークシンボル（socket/DNS）・ネットワークシスコール | `isNetwork = true`（Medium 相当） |
-| 動的ロードシンボル（`dlopen`/`dlsym`/`dlvsym`） | `isHighRisk = true`（High） |
-| exec シスコール | `isHighRisk = true`（High） |
-| `svc #0x80` 直接シスコール（未解決） | `isHighRisk = true`（High） |
-| mprotect 系で `PROT_EXEC` が確定または不明 | `isHighRisk = true`（High） |
-
-**フェイルクローズドの設計**：解析の確実性が担保できない場合は安全側（高リスク）に倒す。
-
-- `RecordStore` が nil（解析機能なし）→ `(false, false)`。
-- `contentHash` が空（バイナリの同一性が未検証）→ `(true, true)` = High。
-- 解析レコードが見つからない／スキーマ不一致／content hash 不一致／解析エラー／未知の結果 → いずれも High 扱い。
-
-> 注：`contentHash` はハッシュ検証で得た「algo:hex」形式の事前計算ハッシュであり、解析レコードがディスク上のバイナリと一致することを保証する。リスク判定はファイル整合性検証と密接に連動している。
-
-#### 4-3. 引数ベースの検出
-
-プロファイル・バイナリ解析で確定しない場合でも、引数に以下が含まれればネットワークと判定する（`hasNetworkArguments`）：
-
-- `://` を含む URL。
-- SSH 形式アドレス（`[user@]host:path`）。メールアドレスやポート番号、時刻表記との誤検出を避けるため、正規表現で厳密に判定する。
-
-### Step 5: システム変更 → Medium
-
-`security.IsSystemModification` が以下を **Medium** と判定する：
-
-- システム管理系コマンド：`systemctl`, `service`, `mount`, `umount`, `fdisk`, `mkfs`, `crontab` 等。
-- パッケージ管理コマンド（`apt`, `yum`, `npm`, `pip` 等）で、引数に `install` / `remove` / `uninstall` / `upgrade` / `update` を伴う場合のみ。
-
-### Step 6: 既定 → Low
-
-上記いずれにも該当しないコマンドは **Low** とする。
+> 設計意図：これらの「束縛不能な実行形態」を拒否するのは、ハッシュ検証で確認した実体とは異なる実体が実行されてしまう経路を塞ぐためである。runner が自身で再実装できるラッパー（内側コマンドを抽出して exec する）だけが許容され、他者のプロセスがヘルパーを起動する形態は束縛できないため拒否される。
 
 ## コマンドリスクプロファイル
 
@@ -280,17 +234,26 @@ flowchart TD
     P --> F3["DestructionRisk<br>(破壊操作)"]
     P --> F4["DataExfilRisk<br>(データ持ち出し)"]
     P --> F5["SystemModRisk<br>(システム変更)"]
-    F1 --> M["BaseRiskLevel()<br>= max(全要因)"]
-    F2 --> M
-    F3 --> M
-    F4 --> M
-    F5 --> M
+
+    F2 --> PF["ProfileFactorRisk()<br>= max(破壊 / データ持ち出し /<br>該当するネットワーク)"]
+    F3 --> PF
+    F4 --> PF
 
     class P,F1,F2,F3,F4,F5 process;
-    class M result;
+    class PF result;
 ```
 
-各要因は `RiskFactor`（`Level` と人間可読の `Reason`）を持つ。総合リスクは全要因の **最大値**（`BaseRiskLevel`）として計算される。
+各要因は `RiskFactor`（`Level` と人間可読の `Reason`）を持つ。
+
+リスク評価への寄与の仕方は要因ごとに異なる：
+
+- `PrivilegeRisk` は専用の特権ゲート（ランク3、`IsPrivilege()`）で処理する。
+- `SystemModRisk` は `SystemModificationRisk`（後述）で処理する。
+- 残りの `DestructionRisk` / `DataExfilRisk` / `NetworkRisk`（該当する場合）は `ProfileFactorRisk` で 1 つのレベルに折り込み、ランク5の判定軸として最大値に寄与する。
+
+そのため、`CommandRiskProfile.BaseRiskLevel()`（全要因の単純最大値）は **現在の評価経路では使用されておらず**、プロファイル検査・テスト向けの補助関数として残されている。
+
+プロファイルの解決は `ResolveProfile(names)` が行う。シンボリックリンクで複数の名前がプロファイルに一致した場合は、各要因の最大値をとってマージする（`mergeProfilesMax`）。
 
 プロファイルはビルダーパターン（`NewProfile(...).XxxRisk(...).Build()`）で定義する。例：
 
@@ -301,14 +264,45 @@ NewProfile("sudo", "su", "doas").
     Build(),
 
 // AI サービス（ネットワーク + データ持ち出しの 2 要因）
-NewProfile("claude", "gemini", "chatgpt", ...).
+NewProfile("claude", "gemini", "chatgpt", "gpt", "openai", "anthropic").
     NetworkRisk(runnertypes.RiskLevelHigh, "Always communicates with external AI API").
     DataExfilRisk(runnertypes.RiskLevelHigh, "May send sensitive data to external service").
     AlwaysNetwork().
     Build(),
 ```
 
-`Validate()` により整合性が検証される（例：`NetworkTypeAlways` なら `NetworkRisk >= Medium` であること）。
+`NetworkType` は次の 3 種である（`ProfileNetworkApplies` が適用可否を判定する）：
+
+- `NetworkTypeAlways`：常にネットワーク操作を行う。
+  - 例：`curl`, `wget`（Medium）, `ssh`, `scp`, `nc`, `aws`、AI 系（`claude` 等、High）。
+  - **スクリプト言語・シェルも含む**：`bash`, `python`, `node`, `ruby`, `java`, `perl`、その他多数の言語ランタイム（Lua/Tcl/R/Julia/Guile/Erlang/JVM 系/.NET 系/PowerShell など）は、本体バイナリにネットワークシンボルが無くても任意のネットワークツールを内部で呼び出せるため `Always`（Medium）として扱う。なおこれらの多くは後述の **任意コード実行ランナー** にも該当し、その場合は High となる。
+- `NetworkTypeConditional`：引数によってネットワーク操作になるかが決まる。
+  - `git`：サブコマンドが `clone` / `fetch` / `pull` / `push` / `remote` の場合（グローバルオプションを読み飛ばして判定）。
+  - `rsync`：リモート指定がある場合。
+  - 加えて、引数に URL や SSH 形式アドレスがあればネットワークと判定。
+- `NetworkTypeNone`：ネットワークプロファイルなし。
+
+`Validate()` により整合性が検証される（例：`NetworkTypeAlways` なら `NetworkRisk >= Medium` であること、`NetworkSubcommands` は `Conditional` のみで指定可）。
+
+### システム変更リスク（`SystemModificationRisk`）
+
+システム変更は専用関数 `SystemModificationRisk(names, args)` が判定する（プロファイルの `SystemModRisk` ではなくこちらが評価経路の単一の情報源）。
+
+- `systemctl`：サブコマンドにより条件分岐（`SystemctlSubcommandRisk`）。変更系の動詞（start/stop/enable/mask など）と未知・識別不能な動詞は **High**、読み取り専用の動詞（status/show/list-* など）とサブコマンド省略は **Medium** の下限（Low にはしない。構成情報を露出しうるため）。
+- `service`：未検証の init スクリプトを実行するため常に **High**。
+- その他のシステム管理系コマンド（`mount`, `umount`, `fdisk`, `mkfs`, `crontab`, `at` 等）→ **Medium**。
+- パッケージ管理コマンド（`apt`, `yum`, `dnf`, `npm`, `pip`, `pacman` 等）で、引数に `install` / `remove` / `upgrade` 等の変更系の動詞を伴う場合のみ → **Medium**（`apt list` のような照会は対象外）。
+
+該当しない場合は `RiskLevelUnknown` を返し、システム変更軸は寄与しない。
+
+### 任意コード実行ランナー（`IsArbitraryCodeExecutionRunner`）
+
+`arbitrary_code.go` の `arbitraryCodeExecutionRunners` に列挙されたコマンドは、本ツールのリスク評価・ハッシュ検証の外部にある入力（スクリプト・レシピ・ビルド定義）から任意のコードを実行しうるため、**引数によらず High** とする。
+
+- シェル（`bash`, `sh`, `zsh` 等）、スクリプトインタプリタ・ランタイム（`python`, `node`, `ruby`, `perl`, `php`, `lua`, `java`, `dotnet`, `pwsh` 等、別名を含む）。
+- ビルド・タスクランナー（`make`, `cmake`, `gradle`, `mvn`, `bazel`, `rake`, `just`, `go`, `cargo` 等）。
+
+`--version` や `--help` のような無害な起動も区別せず High とする（網羅的に安全な起動を判別するのは安全でないため）。
 
 ### 新しいコマンドのプロファイルを追加する
 
@@ -316,52 +310,117 @@ NewProfile("claude", "gemini", "chatgpt", ...).
 2. 該当するリスク要因（`PrivilegeRisk` / `NetworkRisk` / `DestructionRisk` / `DataExfilRisk` / `SystemModRisk`）を設定する。
 3. ネットワークの種別（`AlwaysNetwork()` / `ConditionalNetwork(...)`）を必要に応じて指定する。
 4. 各リスク要因には根拠（`Reason`）を必ず記述する（監査ログに出力される）。
+5. インタプリタ・ビルドランナーを追加する場合は、`arbitrary_code.go` の `arbitraryCodeExecutionRunners` にも追加し、別名が過小評価されないようにする。
+
+## バイナリ静的解析（`NetworkAnalyzer.Classify`）
+
+プロファイルに無い未知コマンドは、事前計算された解析レコード（`RecordStore`）を用いて静的解析する（`NetworkAnalyzer.Classify`、`internal/runner/base/security/network_analyzer.go`）。レコードには ELF/Mach-O のシンボル解析・シスコール解析の結果が含まれる。`Classify` は **4 つのクラス** のいずれかを返す（`risktypes.BinaryAnalysisResult`）。
+
+| クラス | 意味 | 評価器での扱い |
+|--------|------|----------------|
+| `BinaryAnalysisClean` | 危険・ネットワークいずれのシグナルも無し | 寄与なし（Low） |
+| `BinaryAnalysisNetwork` | ネットワークシグナルのみ | Medium |
+| `BinaryAnalysisHighRisk` | 動的ロード/exec/svc/mprotect シグナル | High |
+| `BinaryAnalysisUncertain` | シグナルを確実に取得できない | **Blocking 拒否**（フェイルクローズド） |
+
+検出されるシグナルと理由コード：
+
+| シグナル | 扱い | 理由コード |
+|----------|------|-----------|
+| ネットワークシンボル（socket/DNS）・ネットワークシスコール | Network | `binary_analysis_network` |
+| 動的ロードシンボル（`dlopen`/`dlsym`/`dlvsym`） | HighRisk | `binary_analysis_dynamic_load` |
+| exec シスコール | HighRisk | `binary_analysis_exec` |
+| `svc #0x80` 直接シスコール（未解決） | HighRisk | `binary_analysis_svc` |
+| mprotect 系で `PROT_EXEC` が確定または不明 | HighRisk | `binary_analysis_mprotect_exec` |
+
+**フェイルクローズドの設計**：解析の確実性が担保できない場合は `Uncertain`（Blocking 拒否）に倒す。具体的には次のいずれも `Uncertain` となる。
+
+- `RecordStore` が nil（解析機能なし）→ `analysis_disabled`（通常はランク1の同一性ゲートで先に拒否される）。
+- `contentHash` が空（バイナリの同一性が未検証）→ `uncertain_unverified_identity`。
+- 解析レコードが見つからない → `uncertain_missing_record`。
+- スキーマ不一致 → `uncertain_schema_mismatch`。
+- content hash 不一致 → `uncertain_hash_mismatch`。
+
+なお、分類不能な真の I/O 失敗（レコード読込失敗）だけは `Classify` が **エラー** を返し、評価器はそれを呼び出し元へ伝播する（`NormalResourceManager` は最小限の deny 監査を出してから処理を中止する）。
+
+> 注：`contentHash` はハッシュ検証で得た「algo:hex」形式の事前計算ハッシュであり、解析レコードがディスク上のバイナリと一致することを保証する。リスク判定はファイル整合性検証と密接に連動している。
+
+### ネットワーク引数の検出（`HasNetworkArguments`）
+
+プロファイル・バイナリ解析とは別に、引数に以下が含まれればネットワーク操作とみなす（プロファイル未登録のコマンドに対してランク4〜8の軸として Medium を寄与）。
+
+- `://` を含む URL。
+- SSH 形式アドレス（`[user@]host:path`）。メールアドレスやポート番号、時刻表記との誤検出を避けるため、正規表現で厳密に判定する。
+
+## coreutils 単一バイナリの分類
+
+Rust 製 coreutils のように、すべてのサブコマンドが **1 つのバイナリ** を共有する実装に対応するための特別処理である（`security.CoreutilsCommandRisk`、`coreutils.go`）。通常のバイナリ静的解析では、単一バイナリ内に全サブコマンドのシンボルを含むため誤分類されてしまう。これを避けるため、ランク4で専用ロジックにより分類し、該当時はバイナリ解析軸を抑止する。
+
+判定条件と挙動：
+
+- 対象は、解決済みパスの **親ディレクトリが coreutils ディレクトリ（`common.CoreutilsDir = /usr/lib/cargo/bin/coreutils`）と完全一致** するコマンドのみ。一致しない場合は `handled=false` を返し、他の軸（バイナリ解析を含む）で評価される。
+- setuid/setgid ビットが立っていれば **High**（coreutils のハードリンクが setuid であることは通常ありえず、パッケージング不備か改ざんの兆候）。
+- 実効サブコマンドの決定：
+  - 通常はパスの basename（例：`/usr/lib/cargo/bin/coreutils/rm` → `rm`）。
+  - マルチコール・エントリポイント（basename が `coreutils`）の場合は、引数の最初の非オプション要素を採用（`coreutils rm -rf ...` → `rm`）。
+- 実効サブコマンドによる分類：
+  - 破壊系（`dd`, `rm`, `rmdir`, `shred`, `truncate`, `unlink`）→ **High**
+  - 既知の安全系（`ls`, `cat`, `mkdir`, `sha256sum` 等の読み取り・情報取得・テキスト処理・新規作成系）→ **Low**
+  - それ以外（ディレクトリ配下だが分類不明・識別不能）→ **High**（フェイルセーフの既定。`coreutils <subcmd>` が解析不能な場合に破壊系サブコマンドを隠せないよう、Medium ではなく High に倒す）
+- setuid チェックの stat がエラーになった場合、実行時パスでは **エラーを伝播してフェイルクローズド**（Blocking 拒否）。
 
 ## 実行時パスとドライランパスの違い
 
-リスク判定には 2 つの入口があり、**目的が異なる** ことに注意する。
+リスク判定には 2 つの入口があるが、**いずれも同一の `EvaluateRisk` を共有** する。差異は「結果をどう扱うか」だけである（以前存在した `AnalyzeCommandSecurity` のような別系統のドライラン専用ロジックは廃止された）。
 
 | 観点 | 実行時パス | ドライランパス |
 |------|-----------|---------------|
-| 関数 | `risk.StandardEvaluator.EvaluateRisk` | `security.AnalyzeCommandSecurity` |
-| 呼び出し元 | `NormalResourceManager.ExecuteCommand` | `dryrun_manager.go` |
-| 目的 | 実行可否の判断（許容レベルと比較） | リスクの **表示・説明** |
-| エラー時の挙動 | フェイルクローズド（実行を中止） | フェイルセーフ（High として表示を継続） |
-| 追加の判定 | なし | ディレクトリ既定リスク、ハッシュ検証、setuid、危険パターン照合 など |
+| 評価関数 | `risk.StandardEvaluator.EvaluateRisk`（共通） | 同左（共通） |
+| 呼び出し元 | `NormalResourceManager.ExecuteCommand` | `DryRunResourceManager.evaluateCommandRisk` |
+| 目的 | 実行可否の判断（許容レベルと比較） | リスクの **表示・説明**（実行はしない） |
+| ポリシー拒否時の挙動 | 実行を中止（エラー） | 拒否を記録して **継続**（プレビュー継続） |
+| 同一性未検証／解析不能の扱い | Blocking 拒否（中止） | Blocking 拒否として記録。`verification_unavailable`（同一性未検証・解析無効）は別扱いし、専用の終了コードで報告 |
+| 内部エラー（レコード読込失敗等） | 監査を出して中止 | 監査を出して中止（ハードエラー） |
 
-`AnalyzeCommandSecurity` はドライラン時により詳細な情報を提供するために、以下の追加判定を含む（実行時パスとは別系統）：
-
-- **ディレクトリベースの既定リスク**（`getDefaultRiskByDirectory`）：`/bin`, `/usr/bin` などは Low、`/sbin`, `/usr/sbin` などは Medium。
-- **ハッシュ検証失敗** → Critical。
-- **setuid/setgid ビット** → High。
-- **危険コマンドパターン照合**（`rm -rf`, `dd if=`, `mkfs` 等）。
-
-> 補足：両パスは共通の `security` パッケージ関数（特権昇格・破壊操作・coreutils・ネットワーク解析）を再利用しているが、判定の組み立てと最終的な扱いは独立している。ロジックを変更する際は **両方への影響** を確認すること。
+両パスとも、判定の確実性（同一性・解析の可用性）が担保できない場合はフェイルクローズドに倒す点は共通である。ドライランは「この環境では検証できないため拒否されるが、検証可能な本番環境での結果を予測する」ための表示を付加する点が異なる。
 
 ## 監査ログ
 
-リスク判定の結果は監査ログに記録される（`internal/runner/base/audit/logger.go` の `LogRiskProfile`）。
+リスク判定の結果は監査ログに記録される（`internal/runner/base/audit/logger.go` の `Logger.LogRiskProfile`）。許可・拒否のいずれの決定でも、また内部エラーで中止する経路でも、必ず 1 件のエントリが出力される。入力は `risktypes.RiskAuditEntry`（DTO）である。
+
+主なフィールド：
 
 - `audit_type`: `command_risk_profile`
-- `risk_level`: 算出されたリスクレベル
-- `risk_factors`: 各リスク要因の `Reason` の配列
-- `network_type`: ネットワーク種別
+- `mode`: `normal` / `dry-run`
+- `decision`: `allow` / `deny`
+- `risk_level`: 算出された実効リスクレベル
+- `max_allowed_risk`: 設定された最大許容リスク
+- `resolved_path` / `content_hash` / `record_id`: 相関用の識別情報（未取得なら欠落マーカー）
+- `network_type`: ネットワーク種別（none/always/conditional）
+- `reason_codes`: 機械可読の理由コード（`ReasonCode` の配列）
+- `risk_factors`: 各リスク要因の人間可読な `Reason` の配列
+- `blocking_reason`: 拒否理由コード（Blocking・Critical いずれの拒否でも設定）
+- `error_class`: 失敗起因の拒否の分類（シンボリックリンク解決失敗・coreutils ファイル情報失敗・レコード読込失敗・パス解決失敗・risk_level 設定不正など）
+- `verification_unavailable`: ドライランで検証/解析が利用不能だったことを示す
+- `command_args`: マスク済みのコマンド引数
+- `chain`: 間接実行で実行・ロードされた各実体（path / role / disposition / content_hash）
 
-ログレベルはリスクレベルに対応する：
+ログレベルはリスクレベルに対応し、さらに **拒否の場合は最低でも Warn** に引き上げられる（Low ceiling で拒否された Medium コマンドも Warn/Error 検索で見つかるように）。
 
 | リスクレベル | ログレベル |
 |-------------|-----------|
 | Critical | Error |
 | High | Warn |
-| Medium | Info |
-| Low / Unknown | Debug |
+| Medium | Info（拒否時は Warn 以上） |
+| Low / Unknown | Debug（拒否時は Warn 以上） |
 
-これにより、なぜそのコマンドが特定のリスクレベルと判定されたかを事後に追跡できる。
+これにより、なぜそのコマンドが特定のリスクレベルと判定されたか、どの理由コードで拒否されたかを事後に追跡できる。
 
 ## まとめ
 
-- `runner` は実行時に各コマンドの **実効リスクレベル** を算出し、設定の **最大許容リスクレベル** と比較して実行可否を決める。
-- 判定は危険度の高い順（特権昇格 → 破壊操作 → coreutils → ネットワーク → システム変更 → 既定 Low）で早期リターンする。
-- 複数要因を持つコマンドは、要因の **最大値** が総合リスクとなる。
-- 判定が確実でない場合（シンボリックリンク異常、解析レコード欠落、ハッシュ未検証など）は、実行時パスでは **フェイルクローズド**（実行しない）で安全側に倒す。
-- `critical` は設定で指定できず、特権昇格などの「必ず遮断すべき」コマンドに内部的に割り当てられる。
+- `runner` は実行時に各コマンドの **検証済み実行計画（`VerifiedCommandPlan`）** を算出し、その実効リスクレベルを設定の **最大許容リスクレベル** と比較して実行可否を決める。判定不能・束縛不能なケースは許容レベルに関わらず **Blocking 拒否** とする。
+- 判定はまず短絡する拒否ゲート（同一性ゲート → 間接実行 → 特権昇格）を評価し、続いて残りの判定軸（coreutils・破壊操作・システム変更・プロファイル要因・危険引数・任意コード実行・ネットワーク引数・バイナリ解析）の **最大値** をとる。早期リターンではなく順序非依存の最大値である。
+- 検証済みバイナリ以外を実行・ロードする **間接実行形態** は、runner が再実装できるラッパーを除き拒否される。
+- 判定が確実でない場合（同一性未検証、解析無効、シンボリックリンク異常、解析レコード欠落・不一致など）は **フェイルクローズド**（Blocking 拒否）で安全側に倒す。
+- `critical`（および `unknown`）は設定で指定できず、`critical` は特権昇格などの「必ず遮断すべき」コマンドに内部的に割り当てられる。
+- 実行時パスとドライランパスは同一の `EvaluateRisk` を共有し、結果の扱い（中止するか、表示して継続するか）だけが異なる。

--- a/docs/dev/architecture_design/command-risk-evaluation.ja.md
+++ b/docs/dev/architecture_design/command-risk-evaluation.ja.md
@@ -1,0 +1,367 @@
+# コマンドリスク判定 技術解説
+
+## 概要
+
+本文書は、`runner` がコマンドを **実行する時点** で行う「リスク判定（risk evaluation）」の仕組みを、開発者向けに解説するものである。
+
+`runner` は設定ファイル（TOML）に記述された各コマンドを実行する前に、そのコマンドが持つセキュリティ上の危険度を **リスクレベル** として算出する。算出されたリスクレベルが、コマンドまたはグループに設定された **最大許容リスクレベル（`risk_level`）** を超える場合、そのコマンドの実行を拒否する。これにより「設定で明示的に許可した範囲を超える危険な操作」を実行前に遮断する。
+
+この判定は、ハッシュ検証（ファイル整合性検証）やバイナリ静的解析といった他のセキュリティ層と組み合わさって動作する。本文書ではそれらの詳細には立ち入らず、**リスクレベルの決定ロジック** に焦点を当てる。
+
+### 対象読者
+
+- リスク判定ロジックを変更・拡張する開発者
+- 新しいコマンドのリスクプロファイルを追加する開発者
+- `risk_level` 設定の挙動を理解したい利用者
+
+### 関連パッケージ
+
+| パッケージ | 役割 |
+|-----------|------|
+| `internal/runner/base/risk` | 実行時リスク判定のエントリポイント（`Evaluator`） |
+| `internal/runner/base/security` | 個別判定ロジック（特権昇格・破壊操作・ネットワーク・coreutils 等） |
+| `internal/runner/resource` | リスク判定の呼び出しと許容レベルとの比較（実行可否の判断） |
+| `internal/runner/base/runnertypes` | `RiskLevel` 型と設定値のパース |
+
+## リスクレベルの定義
+
+リスクレベルは `runnertypes.RiskLevel`（`internal/runner/base/runnertypes/config.go`）で定義される列挙型である。**危険度の順序を持つのは `Low` 以上の 4 段階** であり、`Unknown`（値 0）はこの順序の一部ではなく「リスクを判定できなかった／分類対象外」を表す特別な値である点に注意する。
+
+```mermaid
+flowchart LR
+    classDef level fill:#fff1e6,stroke:#ff7f0e,stroke-width:1px,color:#8a3e00;
+    classDef special fill:#eeeeee,stroke:#888,stroke-width:1px,color:#333;
+
+    L["Low<br>(低)"] --> M["Medium<br>(中)"] --> H["High<br>(高)"] --> C["Critical<br>(致命的)"]
+    U["Unknown (値0)<br>判定不能 / 分類対象外<br>※「Lowより安全」ではない"]
+    class L,M,H,C level;
+    class U special;
+```
+
+| レベル | 定数 | 文字列 | 意味 |
+|--------|------|--------|------|
+| 0 | `RiskLevelUnknown` | `unknown` | リスクを判定できなかった／分類対象外（**Low より安全という意味ではない**） |
+| 1 | `RiskLevelLow` | `low` | セキュリティリスクが最小限のコマンド |
+| 2 | `RiskLevelMedium` | `medium` | 中程度のリスク（ネットワーク操作・システム変更など） |
+| 3 | `RiskLevelHigh` | `high` | 高リスク（破壊的操作・動的ロード・exec シグナルなど） |
+| 4 | `RiskLevelCritical` | `critical` | 実行を遮断すべきコマンド（特権昇格など） |
+
+**重要な性質**：
+
+- `Low` 〜 `Critical` は整数として **大小比較可能** であり、複数の要因がある場合は原則として **最大値** が採用される（`max(...)`）。
+- `Unknown`（値 0）は数値としては最小だが、意味は「判定不能／分類対象外」であって **`Low` より安全という意味ではない**。実装上、`Unknown` が「最も低いリスク」として許容比較（`effectiveRisk > maxAllowedRisk`）を通過してしまうことはない。実行時パス（`EvaluateRisk`）が `Unknown` を返すのは **エラーと同時の場合のみ** で、その際はエラーが呼び出し元へ伝播して **フェイルクローズド**（実行中止）になるためである。`Unknown` は主に「この判定では確定できないので後続の判定に委ねる」という内部シグナルとして使われる（例：`getDefaultRiskByDirectory` や `AnalyzeCommandSecurity` の中間結果）。
+- `critical` は **設定ファイルでは指定できない**（`ParseRiskLevel` がエラーを返す）。内部利用専用であり、特権昇格コマンドのように「必ず遮断すべき」ものに割り当てられる。
+- 設定で `risk_level` を省略した場合の既定値は `low` である（`CommandSpec.GetRiskLevel` が `RiskLevelLow` を返す）。
+
+## 実行時の全体フロー
+
+リスク判定は通常実行モード（`NormalResourceManager.ExecuteCommand`）の中で行われる。配線は `runner.go` で行われ、`NetworkAnalyzer` → `StandardEvaluator` → `ResourceManager` の順に組み立てられる。
+
+```mermaid
+flowchart TD
+    classDef data fill:#e6f7ff,stroke:#1f77b4,stroke-width:1px,color:#0b3d91;
+    classDef process fill:#fff1e6,stroke:#ff7f0e,stroke-width:1px,color:#8a3e00;
+    classDef decision fill:#fde6e6,stroke:#c0392b,stroke-width:1px,color:#7b0a0a;
+
+    A[("RuntimeCommand<br>(展開済みコマンド/引数)")] --> B["NormalResourceManager<br>ExecuteCommand"]
+    B --> C["Evaluator.EvaluateRisk<br>(実効リスクを算出)"]
+    C -->|"effectiveRisk"| D{"effectiveRisk ><br>maxAllowedRisk ?"}
+    E[("設定 risk_level<br>(最大許容リスク)")] -->|"GetRiskLevel"| D
+    D -->|"Yes"| F["実行拒否<br>ErrCommandSecurityViolation"]
+    D -->|"No"| G["コマンド実行"]
+
+    class A,E data;
+    class B,C,G process;
+    class D decision;
+    class F decision;
+```
+
+**凡例（Legend）**
+
+```mermaid
+flowchart LR
+    classDef data fill:#e6f7ff,stroke:#1f77b4,stroke-width:1px,color:#0b3d91;
+    classDef process fill:#fff1e6,stroke:#ff7f0e,stroke-width:1px,color:#8a3e00;
+    classDef decision fill:#fde6e6,stroke:#c0392b,stroke-width:1px,color:#7b0a0a;
+
+    D1[("データ")] --> P1["処理"] --> X1{"判定"}
+    class D1 data
+    class P1 process
+    class X1 decision
+```
+
+実行可否の比較は `internal/runner/resource/normal_manager.go` で行われる。
+
+```go
+// Step 1: 実効リスクを算出
+effectiveRisk, err := n.riskEvaluator.EvaluateRisk(cmd)
+
+// Step 2: 設定から最大許容リスクを取得（既定は low）
+maxAllowedRisk, err := cmd.GetRiskLevel()
+
+// Step 3: 比較。超過していれば実行を拒否する
+if effectiveRisk > maxAllowedRisk {
+    return ..., fmt.Errorf("%w: command %s (effective risk: %s) exceeds maximum allowed risk level (%s)",
+        runnertypes.ErrCommandSecurityViolation, ...)
+}
+```
+
+ポイント：
+
+- **実効リスク（effectiveRisk）**：コマンドの内容から算出される実際の危険度。
+- **最大許容リスク（maxAllowedRisk）**：利用者が設定で許可した上限。
+- `critical` は設定に書けないため、特権昇格コマンドのように実効リスクが `critical` になるものは **どんな設定でも必ず拒否される**（既定の `low` はもちろん、最大の `high` を設定しても `critical > high` となる）。
+
+## リスク判定アルゴリズム（`EvaluateRisk`）
+
+実行時リスクの中核は `risk.StandardEvaluator.EvaluateRisk`（`internal/runner/base/risk/evaluator.go`）である。判定は **早期リターン方式** で、上位（より危険な）判定から順に評価し、最初に該当したレベルを返す。
+
+```mermaid
+flowchart TD
+    classDef process fill:#fff1e6,stroke:#ff7f0e,stroke-width:1px,color:#8a3e00;
+    classDef decision fill:#fde6e6,stroke:#c0392b,stroke-width:1px,color:#7b0a0a;
+    classDef result fill:#e8f5e8,stroke:#2e8b57,stroke-width:2px,color:#006400;
+
+    S["EvaluateRisk(cmd)"] --> P1{"特権昇格コマンド?<br>(sudo/su/doas)"}
+    P1 -->|"Yes"| RC["Critical"]
+    P1 -->|"No"| P2{"破壊的ファイル操作?<br>(rm/dd/shred/find -delete 等)"}
+    P2 -->|"Yes"| RH1["High"]
+    P2 -->|"No"| P3{"coreutils 単一バイナリ<br>配下のコマンド?"}
+    P3 -->|"handled"| RCU["coreutils 分類結果<br>(Low/Medium/High)"]
+    P3 -->|"No"| P4{"ネットワーク操作 /<br>高リスクバイナリシグナル?<br>(プロファイル/バイナリ解析/引数)"}
+    P4 -->|"高リスク signal<br>(動的ロード/exec/svc/mprotect PROT_EXEC)"| RH2["High"]
+    P4 -->|"ネットワークのみ"| RM1["Medium"]
+    P4 -->|"No"| P5{"システム変更?<br>(systemctl/mount/apt install 等)"}
+    P5 -->|"Yes"| RM2["Medium"]
+    P5 -->|"No"| RL["Low (既定)"]
+
+    class S process;
+    class P1,P2,P3,P4,P5 decision;
+    class RC,RH1,RH2,RM1,RM2,RCU,RL result;
+```
+
+判定順序（コードのステップに対応）：
+
+### Step 1: 特権昇格コマンド → Critical
+
+`security.IsPrivilegeEscalationCommand` がコマンド名を検査する。`sudo` / `su` / `doas` に該当すると **Critical** を返す。
+
+- シンボリックリンクを辿って判定する（`extractAllCommandNames`）。`/usr/bin/foo` が実体として `sudo` を指していても検出する。
+- シンボリックリンクの深さが上限（`MaxSymlinkDepth`）を超えた場合はエラー（`ErrSymlinkDepthExceeded`）を返し、リスクは `Unknown` となる。`EvaluateRisk` はエラーを呼び出し元へ伝播し、**フェイルクローズド**（コマンドは実行されない）。
+
+特権昇格コマンドは `commandRiskProfiles` 上で `PrivilegeRisk = Critical` として定義されている（後述のプロファイル参照）。
+
+### Step 2: 破壊的ファイル操作 → High
+
+`security.IsDestructiveFileOperation` が以下を **High** と判定する：
+
+- コマンド名が `rm` / `rmdir` / `unlink` / `shred` / `dd` のいずれか。
+- `find` の引数に `-delete`、または `-exec` の直後に破壊的コマンドがある。
+- `rsync` の引数に `--delete` 系オプションがある。
+
+### Step 3: coreutils 単一バイナリの分類
+
+Rust 製 coreutils のように、すべてのサブコマンドが **1 つのバイナリ** を共有する実装に対応するための特別処理である。`security.CoreutilsCommandRisk` が判定する。
+
+通常のバイナリ静的解析（Step 4 のネットワーク解析内）では、coreutils は単一バイナリ内に全サブコマンドのシンボルを含むため誤分類されてしまう。これを避けるために、解析より前に専用ロジックで分類する。
+
+判定条件と挙動：
+
+- 対象は、解決済みパスの **親ディレクトリが coreutils ディレクトリ（`common.CoreutilsDir`）と完全一致** するコマンドのみ。一致しない場合は `handled=false` を返し、後続のステップへ進む。
+- setuid/setgid ビットが立っていれば **High**（coreutils のハードリンクが setuid であることは通常ありえず、パッケージング不備か改ざんの兆候）。
+- 実効サブコマンドの決定：
+  - 通常はパスの basename（例：`/opt/coreutils/rm` → `rm`）。
+  - マルチコール・エントリポイント（basename が `coreutils`）の場合は、引数の最初の非オプション要素を採用（`coreutils rm -rf ...` → `rm`）。
+- 実効サブコマンドによる分類：
+  - 破壊系（`dd`, `rm`, `rmdir`, `shred`, `truncate`, `unlink`）→ **High**
+  - 既知の安全系（`ls`, `cat`, `mkdir`, `sha256sum` 等の読み取り・情報取得・テキスト処理・新規作成系）→ **Low**
+  - それ以外（ディレクトリ配下だが分類不明）→ **Medium**（フェイルセーフの既定）
+- setuid チェックの stat がエラーになった場合、実行時パス（`EvaluateRisk`）では **エラーを伝播してフェイルクローズド**（実行しない）。
+
+### Step 4: ネットワーク操作 / 高リスクバイナリシグナル → High / Medium
+
+`NetworkAnalyzer.IsNetworkOperation` が判定する。関数名は "Network" だが、戻り値は `(isNetwork, isHighRisk, error)` であり、**ネットワーク操作とは限らない高リスクバイナリシグナルも `isHighRisk` 側で報告する**。具体的には、動的ロードシンボル（`dlopen`/`dlsym`/`dlvsym`）、exec シスコール、`svc #0x80` 直接シスコール、**mprotect 系の `PROT_EXEC`** がこれに含まれる（詳細は 4-2 を参照）。
+
+- `isHighRisk == true` → **High**（ネットワークか否かによらず High。mprotect `PROT_EXEC` 等はここに入る）
+- `isNetwork == true`（高リスクでない）→ **Medium**
+- どちらも false → 次のステップへ
+
+検出は以下の優先順位で行われる：
+
+```mermaid
+flowchart TD
+    classDef process fill:#fff1e6,stroke:#ff7f0e,stroke-width:1px,color:#8a3e00;
+    classDef decision fill:#fde6e6,stroke:#c0392b,stroke-width:1px,color:#7b0a0a;
+    classDef result fill:#e8f5e8,stroke:#2e8b57,stroke-width:2px,color:#006400;
+
+    A["IsNetworkOperation"] --> B{"コマンドプロファイルに<br>登録あり?"}
+    B -->|"NetworkTypeAlways"| R1["network=true"]
+    B -->|"NetworkTypeConditional"| C{"サブコマンド/引数が<br>ネットワーク該当?"}
+    C -->|"Yes"| R1
+    C -->|"No"| R0["network=false"]
+    B -->|"登録なし & 絶対パス"| D["バイナリ静的解析<br>(analyzeBinarySignals)"]
+    D --> E{"ネットワーク/動的ロード/<br>exec シグナル?"}
+    E -->|"Yes"| R2["network/highRisk"]
+    E -->|"No"| F{"引数に URL や<br>SSH 形式アドレス?"}
+    B -->|"登録なし"| F
+    F -->|"Yes"| R1
+    F -->|"No"| R0
+
+    class A,D process;
+    class B,C,E,F decision;
+    class R0,R1,R2 result;
+```
+
+#### 4-1. コマンドプロファイルによる判定（最優先）
+
+`commandProfileDefinitions`（`internal/runner/base/security/command_analysis.go`）にハードコードされた既知コマンドの一覧を参照する。各プロファイルは `NetworkType` を持つ：
+
+- `NetworkTypeAlways`：常にネットワーク操作を行う。該当すると即 `network=true`。
+  - 例：`curl`, `wget`, `ssh`, `scp`, `nc`, `aws`、AI 系（`claude`, `gemini` 等）。
+  - **スクリプト言語・シェルも含む**：`bash`, `python`, `node`, `ruby`, `java`, `perl` などは、本体バイナリにネットワークシンボルが無くても任意のネットワークツールを内部で呼び出せるため `Always` として扱う（フェイルセーフ）。
+- `NetworkTypeConditional`：引数によってネットワーク操作になるかが決まる。
+  - `git`：サブコマンドが `clone` / `fetch` / `pull` / `push` / `remote` の場合（`findFirstSubcommand` でオプションを読み飛ばして判定）。
+  - `rsync`：リモート指定がある場合。
+  - 加えて、引数に URL や SSH 形式アドレスがあればネットワークと判定。
+
+これらの判定もシンボリックリンクを辿って行う。
+
+#### 4-2. バイナリ静的解析（プロファイル未登録かつ絶対パス）
+
+プロファイルに無い未知コマンドは、事前計算された解析レコード（`RecordStore`）を用いて静的解析する（`analyzeBinarySignals`）。レコードには ELF/Mach-O のシンボル解析・シスコール解析の結果が含まれる。
+
+検出されるシグナルと扱い：
+
+| シグナル | 結果 |
+|----------|------|
+| ネットワークシンボル（socket/DNS）・ネットワークシスコール | `isNetwork = true`（Medium 相当） |
+| 動的ロードシンボル（`dlopen`/`dlsym`/`dlvsym`） | `isHighRisk = true`（High） |
+| exec シスコール | `isHighRisk = true`（High） |
+| `svc #0x80` 直接シスコール（未解決） | `isHighRisk = true`（High） |
+| mprotect 系で `PROT_EXEC` が確定または不明 | `isHighRisk = true`（High） |
+
+**フェイルクローズドの設計**：解析の確実性が担保できない場合は安全側（高リスク）に倒す。
+
+- `RecordStore` が nil（解析機能なし）→ `(false, false)`。
+- `contentHash` が空（バイナリの同一性が未検証）→ `(true, true)` = High。
+- 解析レコードが見つからない／スキーマ不一致／content hash 不一致／解析エラー／未知の結果 → いずれも High 扱い。
+
+> 注：`contentHash` はハッシュ検証で得た「algo:hex」形式の事前計算ハッシュであり、解析レコードがディスク上のバイナリと一致することを保証する。リスク判定はファイル整合性検証と密接に連動している。
+
+#### 4-3. 引数ベースの検出
+
+プロファイル・バイナリ解析で確定しない場合でも、引数に以下が含まれればネットワークと判定する（`hasNetworkArguments`）：
+
+- `://` を含む URL。
+- SSH 形式アドレス（`[user@]host:path`）。メールアドレスやポート番号、時刻表記との誤検出を避けるため、正規表現で厳密に判定する。
+
+### Step 5: システム変更 → Medium
+
+`security.IsSystemModification` が以下を **Medium** と判定する：
+
+- システム管理系コマンド：`systemctl`, `service`, `mount`, `umount`, `fdisk`, `mkfs`, `crontab` 等。
+- パッケージ管理コマンド（`apt`, `yum`, `npm`, `pip` 等）で、引数に `install` / `remove` / `uninstall` / `upgrade` / `update` を伴う場合のみ。
+
+### Step 6: 既定 → Low
+
+上記いずれにも該当しないコマンドは **Low** とする。
+
+## コマンドリスクプロファイル
+
+`CommandRiskProfile`（`internal/runner/base/security/command_risk_profile.go`）は、1 つのコマンドに対する **複数のリスク要因** を分離して保持する構造体である。
+
+```mermaid
+flowchart TD
+    classDef process fill:#fff1e6,stroke:#ff7f0e,stroke-width:1px,color:#8a3e00;
+    classDef result fill:#e8f5e8,stroke:#2e8b57,stroke-width:2px,color:#006400;
+
+    P["CommandRiskProfile"] --> F1["PrivilegeRisk<br>(特権昇格)"]
+    P --> F2["NetworkRisk<br>(ネットワーク)"]
+    P --> F3["DestructionRisk<br>(破壊操作)"]
+    P --> F4["DataExfilRisk<br>(データ持ち出し)"]
+    P --> F5["SystemModRisk<br>(システム変更)"]
+    F1 --> M["BaseRiskLevel()<br>= max(全要因)"]
+    F2 --> M
+    F3 --> M
+    F4 --> M
+    F5 --> M
+
+    class P,F1,F2,F3,F4,F5 process;
+    class M result;
+```
+
+各要因は `RiskFactor`（`Level` と人間可読の `Reason`）を持つ。総合リスクは全要因の **最大値**（`BaseRiskLevel`）として計算される。
+
+プロファイルはビルダーパターン（`NewProfile(...).XxxRisk(...).Build()`）で定義する。例：
+
+```go
+// 特権昇格コマンド
+NewProfile("sudo", "su", "doas").
+    PrivilegeRisk(runnertypes.RiskLevelCritical, "...").
+    Build(),
+
+// AI サービス（ネットワーク + データ持ち出しの 2 要因）
+NewProfile("claude", "gemini", "chatgpt", ...).
+    NetworkRisk(runnertypes.RiskLevelHigh, "Always communicates with external AI API").
+    DataExfilRisk(runnertypes.RiskLevelHigh, "May send sensitive data to external service").
+    AlwaysNetwork().
+    Build(),
+```
+
+`Validate()` により整合性が検証される（例：`NetworkTypeAlways` なら `NetworkRisk >= Medium` であること）。
+
+### 新しいコマンドのプロファイルを追加する
+
+1. `command_analysis.go` の `commandProfileDefinitions` にエントリを追加する。
+2. 該当するリスク要因（`PrivilegeRisk` / `NetworkRisk` / `DestructionRisk` / `DataExfilRisk` / `SystemModRisk`）を設定する。
+3. ネットワークの種別（`AlwaysNetwork()` / `ConditionalNetwork(...)`）を必要に応じて指定する。
+4. 各リスク要因には根拠（`Reason`）を必ず記述する（監査ログに出力される）。
+
+## 実行時パスとドライランパスの違い
+
+リスク判定には 2 つの入口があり、**目的が異なる** ことに注意する。
+
+| 観点 | 実行時パス | ドライランパス |
+|------|-----------|---------------|
+| 関数 | `risk.StandardEvaluator.EvaluateRisk` | `security.AnalyzeCommandSecurity` |
+| 呼び出し元 | `NormalResourceManager.ExecuteCommand` | `dryrun_manager.go` |
+| 目的 | 実行可否の判断（許容レベルと比較） | リスクの **表示・説明** |
+| エラー時の挙動 | フェイルクローズド（実行を中止） | フェイルセーフ（High として表示を継続） |
+| 追加の判定 | なし | ディレクトリ既定リスク、ハッシュ検証、setuid、危険パターン照合 など |
+
+`AnalyzeCommandSecurity` はドライラン時により詳細な情報を提供するために、以下の追加判定を含む（実行時パスとは別系統）：
+
+- **ディレクトリベースの既定リスク**（`getDefaultRiskByDirectory`）：`/bin`, `/usr/bin` などは Low、`/sbin`, `/usr/sbin` などは Medium。
+- **ハッシュ検証失敗** → Critical。
+- **setuid/setgid ビット** → High。
+- **危険コマンドパターン照合**（`rm -rf`, `dd if=`, `mkfs` 等）。
+
+> 補足：両パスは共通の `security` パッケージ関数（特権昇格・破壊操作・coreutils・ネットワーク解析）を再利用しているが、判定の組み立てと最終的な扱いは独立している。ロジックを変更する際は **両方への影響** を確認すること。
+
+## 監査ログ
+
+リスク判定の結果は監査ログに記録される（`internal/runner/base/audit/logger.go` の `LogRiskProfile`）。
+
+- `audit_type`: `command_risk_profile`
+- `risk_level`: 算出されたリスクレベル
+- `risk_factors`: 各リスク要因の `Reason` の配列
+- `network_type`: ネットワーク種別
+
+ログレベルはリスクレベルに対応する：
+
+| リスクレベル | ログレベル |
+|-------------|-----------|
+| Critical | Error |
+| High | Warn |
+| Medium | Info |
+| Low / Unknown | Debug |
+
+これにより、なぜそのコマンドが特定のリスクレベルと判定されたかを事後に追跡できる。
+
+## まとめ
+
+- `runner` は実行時に各コマンドの **実効リスクレベル** を算出し、設定の **最大許容リスクレベル** と比較して実行可否を決める。
+- 判定は危険度の高い順（特権昇格 → 破壊操作 → coreutils → ネットワーク → システム変更 → 既定 Low）で早期リターンする。
+- 複数要因を持つコマンドは、要因の **最大値** が総合リスクとなる。
+- 判定が確実でない場合（シンボリックリンク異常、解析レコード欠落、ハッシュ未検証など）は、実行時パスでは **フェイルクローズド**（実行しない）で安全側に倒す。
+- `critical` は設定で指定できず、特権昇格などの「必ず遮断すべき」コマンドに内部的に割り当てられる。

--- a/docs/dev/architecture_design/command-risk-evaluation.md
+++ b/docs/dev/architecture_design/command-risk-evaluation.md
@@ -4,9 +4,11 @@
 
 This document explains, for developers, the mechanism of the "risk evaluation" that `runner` performs at the point when it **executes** a command.
 
-Before executing each command described in the configuration file (TOML), `runner` computes the security danger level that the command carries as a **risk level**. If the computed risk level exceeds the **maximum allowed risk level (`risk_level`)** configured on the command or group, it rejects execution of that command. This blocks, before execution, "dangerous operations that exceed the range explicitly allowed by the configuration."
+Before executing each command described in the configuration file (TOML), `runner` computes the security danger level that the command carries as a **risk level**. If the computed risk level (the effective risk) exceeds the **maximum allowed risk level (`risk_level`)** configured on the command, it rejects execution of that command. In addition, when the evaluation cannot be performed with certainty (the binary's identity is unverified, symlink resolution failed, an indirect-execution target cannot be bound, etc.), it is a **Blocking deny** regardless of the allowed level. This blocks, before execution, both "dangerous operations that exceed the range explicitly allowed by the configuration" and "operations whose safety cannot be confirmed."
 
-This evaluation works in combination with other security layers such as hash verification (file integrity verification) and binary static analysis. This document does not go into the details of those, and focuses on the **logic that determines the risk level**.
+The result of risk evaluation is returned not as a mere risk level but as a **verified command plan (`VerifiedCommandPlan`)**. The plan binds the identity of the evaluated binary (resolved path, content hash, fd) to the identity at execution time, and the executor executes based on this plan (guaranteeing that the entity that was evaluated and the entity that is executed are identical).
+
+This evaluation works closely in concert with other security layers such as hash verification (file integrity verification) and binary static analysis. This document focuses on the **logic that determines the risk level**.
 
 ### Intended Audience
 
@@ -18,10 +20,12 @@ This evaluation works in combination with other security layers such as hash ver
 
 | Package | Role |
 |-----------|------|
-| `internal/runner/base/risk` | Entry point for runtime risk evaluation (`Evaluator`) |
-| `internal/runner/base/security` | Individual decision logic (privilege escalation, destructive operations, network, coreutils, etc.) |
-| `internal/runner/resource` | Invocation of risk evaluation and comparison with the allowed level (decision of whether execution is allowed) |
-| `internal/runner/base/runnertypes` | The `RiskLevel` type and parsing of configuration values |
+| `internal/runner/base/risk` | Entry point for runtime risk evaluation (`StandardEvaluator.EvaluateRisk`) |
+| `internal/runner/base/security` | Individual decision logic (privilege escalation, destructive operations, system modification, coreutils, indirect execution, arbitrary code execution, binary analysis, etc.) |
+| `internal/runner/base/risktypes` | DTOs for the evaluation result (`VerifiedCommandPlan` / `RiskAssessment` / `ReasonCode` / `BinaryAnalysisResult`, etc.) |
+| `internal/runner/base/runnertypes` | The `RiskLevel` type, parsing of configuration values, and `RuntimeCommand` |
+| `internal/runner/base/audit` | Audit logging of the risk evaluation result (`Logger.LogRiskProfile`) |
+| `internal/runner/resource` | Invocation of risk evaluation and comparison with the allowed level (decision of whether execution is allowed, `NormalResourceManager` / `DryRunResourceManager`) |
 
 ## Definition of Risk Levels
 
@@ -43,19 +47,19 @@ flowchart LR
 | 0 | `RiskLevelUnknown` | `unknown` | Risk could not be determined / not classified (**does not mean safer than Low**) |
 | 1 | `RiskLevelLow` | `low` | Command with minimal security risk |
 | 2 | `RiskLevelMedium` | `medium` | Moderate risk (network operations, system modification, etc.) |
-| 3 | `RiskLevelHigh` | `high` | High risk (destructive operations, dynamic load, exec signal, etc.) |
+| 3 | `RiskLevelHigh` | `high` | High risk (destructive operations, arbitrary code execution, dynamic load, exec signal, etc.) |
 | 4 | `RiskLevelCritical` | `critical` | Command that should be blocked (privilege escalation, etc.) |
 
 **Important properties**:
 
 - `Low` through `Critical` are **comparable** as integers, and when there are multiple factors the **maximum** is adopted as a rule (`max(...)`).
-- `Unknown` (value 0) is the smallest as a number, but its meaning is "indeterminate / not classified," and it **does not mean safer than `Low`**. In the implementation, `Unknown` never passes the allowed-level comparison (`effectiveRisk > maxAllowedRisk`) as "the lowest risk." This is because the runtime path (`EvaluateRisk`) returns `Unknown` **only together with an error**, and in that case the error propagates to the caller and the result is **fail-closed** (execution is aborted). `Unknown` is mainly used as an internal signal meaning "this evaluation cannot determine it, so defer to the subsequent evaluation" (e.g., intermediate results of `getDefaultRiskByDirectory` or `AnalyzeCommandSecurity`).
-- `critical` **cannot be specified in the configuration file** (`ParseRiskLevel` returns an error). It is reserved for internal use only and is assigned to things that "must be blocked," such as privilege escalation commands.
+- `Unknown` (value 0) is the smallest as a number, but its meaning is "indeterminate / not classified," and it **does not mean safer than `Low`**. In the implementation, an indeterminate case is represented not by a numeric comparison but as `RiskAssessment.Blocking` (a Blocking deny), and it never slips past the allowed-level comparison (**fail-closed**). `Unknown` is mainly used as an internal signal meaning "this evaluation cannot determine it, so defer to the subsequent evaluation" (e.g., the return value of `SystemModificationRisk` or `ProfileFactorRisk` representing "not applicable").
+- `critical` and `unknown` **cannot be specified in the configuration file** (`ParseRiskLevel` returns an error for both). `critical` is reserved for internal use only and is assigned to things that "must be blocked," such as privilege escalation commands.
 - When `risk_level` is omitted in the configuration, the default value is `low` (`CommandSpec.GetRiskLevel` returns `RiskLevelLow`).
 
 ## Overall Runtime Flow
 
-Risk evaluation is performed within the normal execution mode (`NormalResourceManager.ExecuteCommand`). The wiring is done in `runner.go`, where `NetworkAnalyzer` → `StandardEvaluator` → `ResourceManager` are assembled in this order.
+Risk evaluation is performed within the normal execution mode (`NormalResourceManager.ExecuteCommand`). The wiring of the evaluator is done in `runner.go`, where the analysis dependencies (`AnalysisDeps`) obtained from the verification manager are passed to `NetworkAnalyzer`, which in turn is passed to `StandardEvaluator` to assemble it (`security.NewNetworkAnalyzer` → `risk.NewStandardEvaluator`).
 
 ```mermaid
 flowchart TD
@@ -63,16 +67,18 @@ flowchart TD
     classDef process fill:#fff1e6,stroke:#ff7f0e,stroke-width:1px,color:#8a3e00;
     classDef decision fill:#fde6e6,stroke:#c0392b,stroke-width:1px,color:#7b0a0a;
 
-    A[("RuntimeCommand<br>(expanded command/arguments)")] --> B["NormalResourceManager<br>ExecuteCommand"]
-    B --> C["Evaluator.EvaluateRisk<br>(compute effective risk)"]
-    C -->|"effectiveRisk"| D{"effectiveRisk ><br>maxAllowedRisk ?"}
-    E[("Configured risk_level<br>(maximum allowed risk)")] -->|"GetRiskLevel"| D
-    D -->|"Yes"| F["Reject execution<br>ErrCommandSecurityViolation"]
-    D -->|"No"| G["Execute command"]
+    A[("RuntimeCommand<br>(expanded command/arguments/content hash)")] --> B["NormalResourceManager<br>ExecuteCommand"]
+    B --> C["Evaluator.EvaluateRisk<br>(compute VerifiedCommandPlan)"]
+    C -->|"Assessment.Blocking"| D1{"Blocking ?"}
+    D1 -->|"Yes"| F["Reject execution<br>ErrCommandSecurityViolation"]
+    D1 -->|"No"| D2{"effectiveRisk ><br>maxAllowedRisk ?"}
+    E[("Configured risk_level<br>(maximum allowed risk)")] -->|"GetRiskLevel"| D2
+    D2 -->|"Yes"| F
+    D2 -->|"No"| G["Execute command<br>(bound to the plan's identity)"]
 
     class A,E data;
     class B,C,G process;
-    class D decision;
+    class D1,D2 decision;
     class F decision;
 ```
 
@@ -93,28 +99,35 @@ flowchart LR
 The comparison of whether execution is allowed is performed in `internal/runner/resource/normal_manager.go`.
 
 ```go
-// Step 1: Compute the effective risk
-effectiveRisk, err := n.riskEvaluator.EvaluateRisk(cmd)
+// Step 1: Compute the verified command plan (includes the effective risk, the deny reason, and the verified identity)
+plan, err := n.riskEvaluator.EvaluateRisk(cmd)
+// err is only for an "unexpected internal error (an unclassifiable record-load failure)".
+// A policy deny is not an error; it is represented by plan.Assessment.Blocking.
+
+effectiveRisk := plan.Assessment.Level
 
 // Step 2: Get the maximum allowed risk from the configuration (default is low)
 maxAllowedRisk, err := cmd.GetRiskLevel()
 
-// Step 3: Compare. If it exceeds, reject execution
-if effectiveRisk > maxAllowedRisk {
-    return ..., fmt.Errorf("%w: command %s (effective risk: %s) exceeds maximum allowed risk level (%s)",
-        runnertypes.ErrCommandSecurityViolation, ...)
-}
+// Step 3: Unified risk gate. If Blocking, deny regardless of the allowed level;
+//         otherwise, deny if the effective risk exceeds the allowed upper limit.
+denied := plan.Assessment.Blocking || effectiveRisk > maxAllowedRisk
 ```
 
 Key points:
 
-- **Effective risk (effectiveRisk)**: the actual danger level computed from the content of the command.
+- **Effective risk (effectiveRisk)**: the actual danger level computed from the content of the command (`Assessment.Level`).
+- **Blocking**: a state that should be denied regardless of the allowed level (unverified identity, analysis impossible, an indirect execution that cannot be bound, etc.). It is represented by `Assessment.Blocking` and takes precedence over the `effectiveRisk > maxAllowedRisk` comparison.
 - **Maximum allowed risk (maxAllowedRisk)**: the upper limit the user has allowed in the configuration.
 - Because `critical` cannot be written in the configuration, anything whose effective risk becomes `critical`, such as a privilege escalation command, is **always rejected under any configuration** (of course with the default `low`, but even if you configure the maximum `high`, it becomes `critical > high`).
+- The verified file descriptor opened by the plan is always released via `plan.Close()` on every path—allow, deny, or error (to prevent descriptor leaks).
 
 ## Risk Evaluation Algorithm (`EvaluateRisk`)
 
-The core of runtime risk is `risk.StandardEvaluator.EvaluateRisk` (`internal/runner/base/risk/evaluator.go`). The evaluation is an **early-return scheme**: it evaluates in order from the higher (more dangerous) checks and returns the level that matches first.
+The core of runtime risk is `risk.StandardEvaluator.EvaluateRisk` (`internal/runner/base/risk/evaluator.go`). The evaluation is structured to **short-circuit at ranked deny gates and then take the maximum of the remaining decision dimensions**. That is, it has the following two stages:
+
+1. **Short-circuiting deny gates (ranks 1–3)**: the identity gate, indirect execution, and privilege escalation. If any of these match, it immediately returns a deny (Blocking) or Critical.
+2. **Order-independent maximum (ranks 4–8)**: it evaluates **all** of the remaining decision dimensions and takes their **maximum** as the effective risk. Note that this is not an early-return scheme of "return the first one that matches."
 
 ```mermaid
 flowchart TD
@@ -122,149 +135,90 @@ flowchart TD
     classDef decision fill:#fde6e6,stroke:#c0392b,stroke-width:1px,color:#7b0a0a;
     classDef result fill:#e8f5e8,stroke:#2e8b57,stroke-width:2px,color:#006400;
 
-    S["EvaluateRisk(cmd)"] --> P1{"Privilege escalation command?<br>(sudo/su/doas)"}
-    P1 -->|"Yes"| RC["Critical"]
-    P1 -->|"No"| P2{"Destructive file operation?<br>(rm/dd/shred/find -delete, etc.)"}
-    P2 -->|"Yes"| RH1["High"]
-    P2 -->|"No"| P3{"Command under the coreutils<br>single binary?"}
-    P3 -->|"handled"| RCU["coreutils classification result<br>(Low/Medium/High)"]
-    P3 -->|"No"| P4{"Network operation /<br>high-risk binary signal?<br>(profile/binary analysis/arguments)"}
-    P4 -->|"high-risk signal<br>(dynamic load/exec/svc/mprotect PROT_EXEC)"| RH2["High"]
-    P4 -->|"network only"| RM1["Medium"]
-    P4 -->|"No"| P5{"System modification?<br>(systemctl/mount/apt install, etc.)"}
-    P5 -->|"Yes"| RM2["Medium"]
-    P5 -->|"No"| RL["Low (default)"]
+    S["EvaluateRisk(cmd)"] --> G0{"Absolute path? & symlink<br>resolution succeeded?"}
+    G0 -->|"No"| BR0["Blocking deny"]
+    G0 -->|"Yes"| G1{"Rank 1: identity gate<br>content hash present & analysis enabled?"}
+    G1 -->|"No"| BR1["Blocking deny"]
+    G1 -->|"Yes"| G2{"Rank 2: indirect execution?<br>(wrapper/inline/find/loader, etc.)"}
+    G2 -->|"Critical (privilege token)"| RC["Critical"]
+    G2 -->|"Reject (cannot bind)"| BR2["Blocking deny"]
+    G2 -->|"Floor / None"| G3{"Rank 3: privilege escalation?<br>(decided by profile)"}
+    G3 -->|"Yes"| RC
+    G3 -->|"No"| DIM["Ranks 4–8: maximum of decision dimensions<br>(coreutils / destructive operation / system modification /<br>profile factors / dangerous arguments /<br>arbitrary code execution / network arguments /<br>binary analysis)"]
+    DIM --> FLOOR["Fold the Rank 2 Floor into the maximum"]
+    FLOOR --> RES["Effective risk (Low–High)<br>or a dimension's Blocking deny"]
 
-    class S process;
-    class P1,P2,P3,P4,P5 decision;
-    class RC,RH1,RH2,RM1,RM2,RCU,RL result;
+    class S,DIM,FLOOR process;
+    class G0,G1,G2,G3 decision;
+    class RC,RES,BR0,BR1,BR2 result;
 ```
 
-Evaluation order (corresponding to the steps in the code):
+### Preprocessing: Absolute Path and Symlink Resolution
 
-### Step 1: Privilege escalation command → Critical
+Before entering the decision dimensions, it confirms that the following prerequisites are met. If they are not met, it becomes a **Blocking deny**.
 
-`security.IsPrivilegeEscalationCommand` inspects the command name. If it matches `sudo` / `su` / `doas`, it returns **Critical**.
+- The command path must be an **absolute path** by the time it reaches the evaluator (the caller resolves it). A relative path is denied because the identity cannot be established and binary analysis would be silently skipped (`ReasonNonAbsolutePath`).
+- The symlink chain is resolved once with `security.ResolveCommandNames` (**strict**). A resolution failure, exceeding the depth limit (`MaxSymlinkDepth = 40`, `ErrSymlinkDepthExceeded`), or a cycle is denied **fail-closed** with `ReasonSymlinkResolutionFailed`. This is to prevent evaluating a partially resolved chain and missing a dangerous entity.
 
-- The decision follows symlinks (`extractAllCommandNames`). Even if `/usr/bin/foo` actually points to `sudo`, it is detected.
-- If the symlink depth exceeds the limit (`MaxSymlinkDepth`), it returns an error (`ErrSymlinkDepthExceeded`) and the risk becomes `Unknown`. `EvaluateRisk` propagates the error to the caller, and the result is **fail-closed** (the command is not executed).
+The "name set" obtained by resolution (the original name, the basename, and each link target in the chain together with its basename) is shared by the subsequent name-based decisions (privilege, destructive operations, system modification, etc.).
 
-Privilege escalation commands are defined as `PrivilegeRisk = Critical` in `commandRiskProfiles` (see the profile section below).
+### Rank 1: Identity Gate → Blocking Deny
 
-### Step 2: Destructive file operation → High
+When the binary's identity cannot be confirmed, it is denied regardless of the configured `risk_level` (`identityGate`). This is evaluated before any other decision dimension, preventing an unverified binary from being judged "allowable for Low/High" by a subsequent dimension and passing through.
 
-`security.IsDestructiveFileOperation` evaluates the following as **High**:
+- `cmd.ExpandedCmdContentHash` is empty (identity has not been established by hash verification) → Blocking with `ReasonUncertainUnverifiedIdentity`.
+- Binary analysis is disabled (`NetworkAnalyzer.AnalysisEnabled()` is false, i.e., `RecordStore` is not configured) → Blocking with `ReasonAnalysisDisabled`. Disabled analysis is fail-closed, not fail-open.
 
-- The command name is one of `rm` / `rmdir` / `unlink` / `shred` / `dd`.
-- The arguments of `find` contain `-delete`, or a destructive command immediately follows `-exec`.
-- The arguments of `rsync` contain a `--delete`-family option.
+### Rank 2: Analysis of Indirect Execution
 
-### Step 3: Classification of the coreutils single binary
+It detects forms that execute or load an entity other than the verified binary (`security.AnalyzeIndirectExecution`). See "Analysis of Indirect Execution" below for details. Depending on the result (`IndirectExecutionResult.Kind`), it is handled as follows.
 
-This is special handling to support implementations, such as the Rust-based coreutils, where all subcommands share **a single binary**. `security.CoreutilsCommandRisk` makes the decision.
+- `IndirectCritical`: the effective target has a privilege escalation token (sudo/su/doas) → **Critical** (short-circuit).
+- `IndirectReject`: a form whose identity cannot be bound until execution time (a wrapper that cannot be extracted, a forbidden loader-control variable, a find/xargs child-process exec, a direct dynamic-loader invocation, a remote-shell helper) → **Blocking deny** (short-circuit).
+- `IndirectFloor`: an allowable form that has a minimum risk level (a dangerous inner command within a wrapper, an inline shell, a package script runner, etc.) → that level is folded into the maximum of the subsequent decision dimensions as a **risk floor**.
+- `IndirectNone`: not an indirect-execution form.
 
-In ordinary binary static analysis (within the network analysis of Step 4), coreutils is misclassified because the single binary contains the symbols of all subcommands. To avoid this, it is classified by dedicated logic before the analysis.
+Each entity executed or loaded within the chain (`ExecutedArtifact`) is recorded in the plan for auditing and for the later identity binding.
 
-Decision conditions and behavior:
+### Rank 3: Privilege Escalation → Critical
 
-- The target is only a command whose resolved path **has a parent directory that exactly matches the coreutils directory (`common.CoreutilsDir`)**. If it does not match, it returns `handled=false` and proceeds to the subsequent steps.
-- If the setuid/setgid bit is set, it is **High** (a coreutils hardlink being setuid is normally impossible, and a set bit is a sign of a packaging defect or tampering).
-- Determination of the effective subcommand:
-  - Normally the basename of the path (e.g., `/opt/coreutils/rm` → `rm`).
-  - For the multicall entry point (basename is `coreutils`), the first non-option element of the arguments is adopted (`coreutils rm -rf ...` → `rm`).
-- Classification by the effective subcommand:
-  - Destructive commands (`dd`, `rm`, `rmdir`, `shred`, `truncate`, `unlink`) → **High**
-  - Known safe commands (`ls`, `cat`, `mkdir`, `sha256sum`, etc., which read, retrieve information, process text, or create new files) → **Low**
-  - Everything else (under the directory but unclassified) → **Medium** (the fail-safe default)
-- If the stat of the setuid check results in an error, the runtime path (`EvaluateRisk`) **propagates the error and is fail-closed** (does not execute).
+When the resolved profile indicates privilege escalation, it is **Critical** (always denied). It looks up the profile with `security.ResolveProfile(names)`, and if `profile.IsPrivilege()` (`PrivilegeRisk >= High`) is true, it matches. In the profiles, `sudo` / `su` / `doas` are defined as `PrivilegeRisk = Critical`. Because matching uses the name set obtained by following symlinks, it is also detected under an alias (e.g., `/usr/bin/foo` pointing to `sudo`).
 
-### Step 4: Network operation / high-risk binary signal → High / Medium
+### Ranks 4–8: Maximum of Decision Dimensions (`evaluateDimensions`)
 
-`NetworkAnalyzer.IsNetworkOperation` makes the decision. Although the function name is "Network," its return value is `(isNetwork, isHighRisk, error)`, and it **also reports, via the `isHighRisk` side, high-risk binary signals that are not necessarily network operations**. Specifically, dynamic load symbols (`dlopen`/`dlsym`/`dlvsym`), exec syscalls, the `svc #0x80` direct syscall, and the **`PROT_EXEC` of the mprotect family** are included in this (see 4-2 for details).
+From here on, it is **order-independent**: it evaluates all applicable dimensions and takes the maximum (`addDimension` takes the `max` while accumulating reason codes). The initial value is `Low`. If it hits a dimension that requires fail-closed handling along the way (a coreutils file-info retrieval failure, or an uncertain binary analysis), it returns a **Blocking deny**.
 
-- `isHighRisk == true` → **High** (High regardless of whether it is network; mprotect `PROT_EXEC`, etc. fall here)
-- `isNetwork == true` (not high-risk) → **Medium**
-- Both false → proceed to the next step
+- **Rank 4: coreutils single-binary classification** (`security.CoreutilsCommandRisk`). When it applies, it is treated as authoritative and suppresses the binary-analysis dimension (Rank 8). However, the other dimensions still contribute.
+- **Destructive file operation** (`security.IsDestructiveFileOperation`) → High.
+- **System modification** (`security.SystemModificationRisk`) → Medium/High (see below).
+- **Rank 5: profile factors** (`applyProfileFactors` → `security.ProfileFactorRisk`). Because privilege is handled in Rank 3 and system modification is handled above, only the three factors of destruction, data exfiltration, and applicable network are folded here. The human-readable reasons of the profile (`GetRiskReasons`) and the `NetworkType` are also recorded.
+- **Rank 6: dangerous argument patterns** (`security.CheckDangerousArgPatterns`): `rm -rf`, `dd if=`, `chmod 777`, `mkfs.*`, etc.
+- **Rank 7: arbitrary-code-execution runner** (`security.IsArbitraryCodeExecutionRunner`) → High regardless of arguments (see below).
+- **Network arguments**: for a command not registered in a profile, if the arguments contain a URL or an SSH-style address (`security.HasNetworkArguments`) → Medium.
+- **Rank 8: binary static analysis** (suppressed when coreutils applies). It folds in the result of `NetworkAnalyzer.Classify` (see below). `BinaryAnalysisUncertain` is a **Blocking deny**.
 
-Detection is performed in the following priority order:
+Finally, the level of the Rank 2 `IndirectFloor` is folded into the maximum (so that a wrapped dangerous command is not under-evaluated), and the reason codes and reason strings are appended and deduplicated.
 
-```mermaid
-flowchart TD
-    classDef process fill:#fff1e6,stroke:#ff7f0e,stroke-width:1px,color:#8a3e00;
-    classDef decision fill:#fde6e6,stroke:#c0392b,stroke-width:1px,color:#7b0a0a;
-    classDef result fill:#e8f5e8,stroke:#2e8b57,stroke-width:2px,color:#006400;
+In the end, if it is not Blocking, `allowedPlan` opens the verified entity with fd binding and returns an executable plan (if it cannot be opened, it is a Blocking deny with `ReasonIdentityUnbound`).
 
-    A["IsNetworkOperation"] --> B{"Registered in a<br>command profile?"}
-    B -->|"NetworkTypeAlways"| R1["network=true"]
-    B -->|"NetworkTypeConditional"| C{"Subcommand/argument<br>matches network?"}
-    C -->|"Yes"| R1
-    C -->|"No"| R0["network=false"]
-    B -->|"not registered & absolute path"| D["Binary static analysis<br>(analyzeBinarySignals)"]
-    D --> E{"Network/dynamic load/<br>exec signal?"}
-    E -->|"Yes"| R2["network/highRisk"]
-    E -->|"No"| F{"URL or SSH-style<br>address in arguments?"}
-    B -->|"not registered"| F
-    F -->|"Yes"| R1
-    F -->|"No"| R0
+## Analysis of Indirect Execution
 
-    class A,D process;
-    class B,C,E,F decision;
-    class R0,R1,R2 result;
-```
+`security.AnalyzeIndirectExecution` (`internal/runner/base/security/indirect_execution.go`) detects **forms that execute or load an entity other than the verified binary** and returns how the evaluator should handle it (Critical / Reject / Floor / None). Detection is done by basename and resolved symlinks, and a nesting where a wrapper wraps a wrapper is analyzed recursively (depth limit `indirectExecMaxDepth = 16`).
 
-#### 4-1. Decision by command profile (highest priority)
+Main detection targets:
 
-It refers to the list of known commands hardcoded in `commandProfileDefinitions` (`internal/runner/base/security/command_analysis.go`). Each profile has a `NetworkType`:
+- **Shebang script**: as in `#!/usr/bin/env python`, the kernel launches the shebang interpreter (a separate entity), so the interpreter chain is evaluated and gated. This is decided before the basename-based wrapper matching.
+- **Wrappers** (`env`, `timeout`, `nice`, `ionice`, `nohup`, `stdbuf`, `setsid`, `time`, `chrt`, `taskset`): because `runner` re-implements these and execs the extracted inner command itself, the inner command can be identity-bound. Therefore, instead of rejecting, it evaluates the inner command. If the inner command is a privilege token, it is Critical. `env` separately analyzes `NAME=VALUE` assignments, the `-S` split-string, and `-C/--chdir` (rejected), and it rejects the specification of a loader-control variable (`LD_*` / `DYLD_*`) or a PATH override combined with a bare inner name.
+- **find / xargs child-process exec** (`-exec`/`-execdir`/`-ok`/`-okdir`, the xargs helper): because it is executed from find/xargs's own child process rather than `runner`'s child process, the identity cannot be bound. If it is a privilege token, Critical; otherwise, Reject.
+- **Direct dynamic-loader invocation** (`ld-linux*.so --preload ...`, etc.): because it can load arbitrary libraries, Reject.
+- **Remote-shell / output-filter helpers** (`rsync -e`, `tar --to-command` / `--checkpoint-action`): because the helper runs from the tool's child process, Reject.
+- **Package script runners** (`npm run` / `npx` / `yarn <script>` / `pnpm run` / `bunx`, etc.): because they run a script from an unverified manifest, a High Floor.
+- **Inline code** (`bash -c`, `python -c`/`-e`, etc.): a High Floor.
+- **SysV service**: because it runs an unverified init script (`/etc/init.d/<name>`), it records the init script as a chain entity while applying a High Floor.
 
-- `NetworkTypeAlways`: always performs network operations. If it matches, `network=true` immediately.
-  - Examples: `curl`, `wget`, `ssh`, `scp`, `nc`, `aws`, and AI-related ones (`claude`, `gemini`, etc.).
-  - **Script languages and shells are also included**: `bash`, `python`, `node`, `ruby`, `java`, `perl`, etc. are treated as `Always` (fail-safe), because even if the main binary has no network symbols, they can invoke arbitrary network tools internally.
-- `NetworkTypeConditional`: whether it becomes a network operation is determined by the arguments.
-  - `git`: when the subcommand is `clone` / `fetch` / `pull` / `push` / `remote` (decided after skipping options with `findFirstSubcommand`).
-  - `rsync`: when a remote is specified.
-  - In addition, if the arguments contain a URL or an SSH-style address, it is evaluated as network.
+In the evaluation of the inner command (`evaluateInnerAs`), it folds in all of privilege, destructive operations, coreutils, system modification, arbitrary-code-execution runner, dangerous argument patterns, and risk profile factors, so that a wrapped command is not under-evaluated compared to a direct invocation. The entities within the chain are recorded for auditing under any result of Floor/Critical/Reject.
 
-These decisions are also made following symlinks.
-
-#### 4-2. Binary static analysis (not registered in a profile and absolute path)
-
-An unknown command that is not in a profile is statically analyzed using a precomputed analysis record (`RecordStore`) (`analyzeBinarySignals`). The record contains the results of symbol analysis and syscall analysis of the ELF/Mach-O.
-
-Detected signals and their handling:
-
-| Signal | Result |
-|----------|------|
-| Network symbol (socket/DNS) / network syscall | `isNetwork = true` (equivalent to Medium) |
-| Dynamic load symbol (`dlopen`/`dlsym`/`dlvsym`) | `isHighRisk = true` (High) |
-| exec syscall | `isHighRisk = true` (High) |
-| `svc #0x80` direct syscall (unresolved) | `isHighRisk = true` (High) |
-| `PROT_EXEC` in the mprotect family is confirmed or unknown | `isHighRisk = true` (High) |
-
-**Fail-closed design**: when the certainty of the analysis cannot be guaranteed, it falls to the safe side (high risk).
-
-- `RecordStore` is nil (no analysis capability) → `(false, false)`.
-- `contentHash` is empty (the binary's identity is unverified) → `(true, true)` = High.
-- The analysis record is not found / schema mismatch / content hash mismatch / analysis error / unknown result → all treated as High.
-
-> Note: `contentHash` is a precomputed hash in the "algo:hex" format obtained from hash verification, and it guarantees that the analysis record matches the binary on disk. Risk evaluation is closely linked with file integrity verification.
-
-#### 4-3. Argument-based detection
-
-Even when it is not determined by the profile or binary analysis, if the arguments contain the following, it is evaluated as network (`hasNetworkArguments`):
-
-- A URL containing `://`.
-- An SSH-style address (`[user@]host:path`). To avoid false positives with email addresses, port numbers, and time formats, it is evaluated strictly with a regex.
-
-### Step 5: System modification → Medium
-
-`security.IsSystemModification` evaluates the following as **Medium**:
-
-- System administration commands: `systemctl`, `service`, `mount`, `umount`, `fdisk`, `mkfs`, `crontab`, etc.
-- Package management commands (`apt`, `yum`, `npm`, `pip`, etc.), only when the arguments include `install` / `remove` / `uninstall` / `upgrade` / `update`.
-
-### Step 6: Default → Low
-
-A command that matches none of the above is treated as **Low**.
+> Design intent: these "execution forms that cannot be bound" are rejected in order to close off paths by which an entity different from the one confirmed by hash verification ends up being executed. Only wrappers that `runner` can re-implement itself (extracting the inner command and exec-ing it) are allowed; forms in which another process launches the helper cannot be bound and are therefore rejected.
 
 ## Command Risk Profile
 
@@ -280,17 +234,26 @@ flowchart TD
     P --> F3["DestructionRisk<br>(destructive operation)"]
     P --> F4["DataExfilRisk<br>(data exfiltration)"]
     P --> F5["SystemModRisk<br>(system modification)"]
-    F1 --> M["BaseRiskLevel()<br>= max(all factors)"]
-    F2 --> M
-    F3 --> M
-    F4 --> M
-    F5 --> M
+
+    F2 --> PF["ProfileFactorRisk()<br>= max(destruction / data exfiltration /<br>applicable network)"]
+    F3 --> PF
+    F4 --> PF
 
     class P,F1,F2,F3,F4,F5 process;
-    class M result;
+    class PF result;
 ```
 
-Each factor has a `RiskFactor` (a `Level` and a human-readable `Reason`). The overall risk is computed as the **maximum** of all factors (`BaseRiskLevel`).
+Each factor has a `RiskFactor` (a `Level` and a human-readable `Reason`).
+
+The way each factor contributes to the risk evaluation differs:
+
+- `PrivilegeRisk` is handled by the dedicated privilege gate (Rank 3, `IsPrivilege()`).
+- `SystemModRisk` is handled by `SystemModificationRisk` (see below).
+- The remaining `DestructionRisk` / `DataExfilRisk` / `NetworkRisk` (when applicable) are folded into a single level by `ProfileFactorRisk` and contribute to the maximum as the Rank 5 decision dimension.
+
+For that reason, `CommandRiskProfile.BaseRiskLevel()` (the simple maximum of all factors) is **not used on the current evaluation path**; it is retained as a helper for profile inspection and tests.
+
+Profile resolution is performed by `ResolveProfile(names)`. When multiple names match a profile via symlinks, it merges them by taking the maximum of each factor (`mergeProfilesMax`).
 
 The profile is defined with the builder pattern (`NewProfile(...).XxxRisk(...).Build()`). Example:
 
@@ -301,14 +264,45 @@ NewProfile("sudo", "su", "doas").
     Build(),
 
 // AI service (two factors: network + data exfiltration)
-NewProfile("claude", "gemini", "chatgpt", ...).
+NewProfile("claude", "gemini", "chatgpt", "gpt", "openai", "anthropic").
     NetworkRisk(runnertypes.RiskLevelHigh, "Always communicates with external AI API").
     DataExfilRisk(runnertypes.RiskLevelHigh, "May send sensitive data to external service").
     AlwaysNetwork().
     Build(),
 ```
 
-Consistency is verified by `Validate()` (for example, if `NetworkTypeAlways`, then `NetworkRisk >= Medium`).
+`NetworkType` is one of the following three kinds (`ProfileNetworkApplies` decides whether it applies):
+
+- `NetworkTypeAlways`: always performs network operations.
+  - Examples: `curl`, `wget` (Medium), `ssh`, `scp`, `nc`, `aws`, and AI-related ones (`claude`, etc., High).
+  - **Script languages and shells are also included**: `bash`, `python`, `node`, `ruby`, `java`, `perl`, and many other language runtimes (Lua/Tcl/R/Julia/Guile/Erlang, JVM-based, .NET-based, PowerShell, etc.) are treated as `Always` (Medium), because even if the main binary has no network symbols, they can invoke arbitrary network tools internally. Note that many of these also match the **arbitrary-code-execution runner** described below, in which case they become High.
+- `NetworkTypeConditional`: whether it becomes a network operation is determined by the arguments.
+  - `git`: when the subcommand is `clone` / `fetch` / `pull` / `push` / `remote` (decided after skipping the global options).
+  - `rsync`: when a remote is specified.
+  - In addition, if the arguments contain a URL or an SSH-style address, it is evaluated as network.
+- `NetworkTypeNone`: no network profile.
+
+Consistency is verified by `Validate()` (for example, if `NetworkTypeAlways`, then `NetworkRisk >= Medium`; `NetworkSubcommands` can be specified only for `Conditional`).
+
+### System Modification Risk (`SystemModificationRisk`)
+
+System modification is decided by the dedicated function `SystemModificationRisk(names, args)` (this, not the profile's `SystemModRisk`, is the single source of truth on the evaluation path).
+
+- `systemctl`: branches by subcommand (`SystemctlSubcommandRisk`). Change verbs (start/stop/enable/mask, etc.) and unknown / unidentifiable verbs are **High**; read-only verbs (status/show/list-*, etc.) and an omitted subcommand are a **Medium** floor (not Low, because they can expose configuration information).
+- `service`: because it runs an unverified init script, always **High**.
+- Other system administration commands (`mount`, `umount`, `fdisk`, `mkfs`, `crontab`, `at`, etc.) → **Medium**.
+- Package management commands (`apt`, `yum`, `dnf`, `npm`, `pip`, `pacman`, etc.), only when the arguments include a change verb such as `install` / `remove` / `upgrade` → **Medium** (a query such as `apt list` is not a target).
+
+When none of these applies, it returns `RiskLevelUnknown` and the system-modification dimension does not contribute.
+
+### Arbitrary-Code-Execution Runner (`IsArbitraryCodeExecutionRunner`)
+
+Commands listed in `arbitraryCodeExecutionRunners` in `arbitrary_code.go` can execute arbitrary code from inputs (scripts, recipes, build definitions) that are outside this tool's risk evaluation and hash verification, so they are treated as **High regardless of arguments**.
+
+- Shells (`bash`, `sh`, `zsh`, etc.), and script interpreters / runtimes (`python`, `node`, `ruby`, `perl`, `php`, `lua`, `java`, `dotnet`, `pwsh`, etc., including aliases).
+- Build / task runners (`make`, `cmake`, `gradle`, `mvn`, `bazel`, `rake`, `just`, `go`, `cargo`, etc.).
+
+Harmless invocations such as `--version` or `--help` are also treated as High without distinction (because exhaustively distinguishing harmless invocations is not safe).
 
 ### Adding a profile for a new command
 
@@ -316,52 +310,117 @@ Consistency is verified by `Validate()` (for example, if `NetworkTypeAlways`, th
 2. Set the applicable risk factors (`PrivilegeRisk` / `NetworkRisk` / `DestructionRisk` / `DataExfilRisk` / `SystemModRisk`).
 3. Specify the network type (`AlwaysNetwork()` / `ConditionalNetwork(...)`) as needed.
 4. Always write a rationale (`Reason`) for each risk factor (it is output to the audit log).
+5. When adding an interpreter or a build runner, also add it to `arbitraryCodeExecutionRunners` in `arbitrary_code.go` so that aliases are not under-evaluated.
+
+## Binary Static Analysis (`NetworkAnalyzer.Classify`)
+
+An unknown command that is not in a profile is statically analyzed using a precomputed analysis record (`RecordStore`) (`NetworkAnalyzer.Classify`, `internal/runner/base/security/network_analyzer.go`). The record contains the results of symbol analysis and syscall analysis of the ELF/Mach-O. `Classify` returns one of **four classes** (`risktypes.BinaryAnalysisResult`).
+
+| Class | Meaning | Handling in the evaluator |
+|--------|------|----------------|
+| `BinaryAnalysisClean` | No dangerous or network signal | No contribution (Low) |
+| `BinaryAnalysisNetwork` | Network signals only | Medium |
+| `BinaryAnalysisHighRisk` | Dynamic load/exec/svc/mprotect signal | High |
+| `BinaryAnalysisUncertain` | Signals cannot be obtained with certainty | **Blocking deny** (fail-closed) |
+
+Detected signals and reason codes:
+
+| Signal | Handling | Reason code |
+|----------|------|-----------|
+| Network symbol (socket/DNS) / network syscall | Network | `binary_analysis_network` |
+| Dynamic load symbol (`dlopen`/`dlsym`/`dlvsym`) | HighRisk | `binary_analysis_dynamic_load` |
+| exec syscall | HighRisk | `binary_analysis_exec` |
+| `svc #0x80` direct syscall (unresolved) | HighRisk | `binary_analysis_svc` |
+| `PROT_EXEC` in the mprotect family is confirmed or unknown | HighRisk | `binary_analysis_mprotect_exec` |
+
+**Fail-closed design**: when the certainty of the analysis cannot be guaranteed, it falls to `Uncertain` (a Blocking deny). Specifically, all of the following become `Uncertain`.
+
+- `RecordStore` is nil (no analysis capability) → `analysis_disabled` (normally denied earlier by the Rank 1 identity gate).
+- `contentHash` is empty (the binary's identity is unverified) → `uncertain_unverified_identity`.
+- The analysis record is not found → `uncertain_missing_record`.
+- Schema mismatch → `uncertain_schema_mismatch`.
+- Content hash mismatch → `uncertain_hash_mismatch`.
+
+Note that only an unclassifiable, genuine I/O failure (a record-load failure) causes `Classify` to return an **error**, which the evaluator propagates to the caller (`NormalResourceManager` emits a minimal deny audit entry and then aborts processing).
+
+> Note: `contentHash` is a precomputed hash in the "algo:hex" format obtained from hash verification, and it guarantees that the analysis record matches the binary on disk. Risk evaluation is closely linked with file integrity verification.
+
+### Detection of Network Arguments (`HasNetworkArguments`)
+
+Separately from the profile and binary analysis, if the arguments contain the following, it is regarded as a network operation (contributing Medium as a Rank 4–8 dimension for a command not registered in a profile).
+
+- A URL containing `://`.
+- An SSH-style address (`[user@]host:path`). To avoid false positives with email addresses, port numbers, and time formats, it is evaluated strictly with a regex.
+
+## Classification of the coreutils Single Binary
+
+This is special handling to support implementations, such as the Rust-based coreutils, where all subcommands share **a single binary** (`security.CoreutilsCommandRisk`, `coreutils.go`). In ordinary binary static analysis, coreutils is misclassified because the single binary contains the symbols of all subcommands. To avoid this, it is classified by dedicated logic in Rank 4, and when it applies, the binary-analysis dimension is suppressed.
+
+Decision conditions and behavior:
+
+- The target is only a command whose resolved path **has a parent directory that exactly matches the coreutils directory (`common.CoreutilsDir = /usr/lib/cargo/bin/coreutils`)**. If it does not match, it returns `handled=false` and is evaluated by the other dimensions (including binary analysis).
+- If the setuid/setgid bit is set, it is **High** (a coreutils hardlink being setuid is normally impossible, and a set bit is a sign of a packaging defect or tampering).
+- Determination of the effective subcommand:
+  - Normally the basename of the path (e.g., `/usr/lib/cargo/bin/coreutils/rm` → `rm`).
+  - For the multicall entry point (basename is `coreutils`), the first non-option element of the arguments is adopted (`coreutils rm -rf ...` → `rm`).
+- Classification by the effective subcommand:
+  - Destructive commands (`dd`, `rm`, `rmdir`, `shred`, `truncate`, `unlink`) → **High**
+  - Known safe commands (`ls`, `cat`, `mkdir`, `sha256sum`, etc., which read, retrieve information, process text, or create new files) → **Low**
+  - Everything else (under the directory but unclassified / unidentifiable) → **High** (the fail-safe default; it falls to High rather than Medium so that, when `coreutils <subcmd>` cannot be analyzed, a destructive subcommand cannot be hidden)
+- If the stat of the setuid check results in an error, the runtime path **propagates the error and is fail-closed** (a Blocking deny).
 
 ## Difference Between the Runtime Path and the Dry-Run Path
 
-There are two entry points for risk evaluation, and note that their **purposes differ**.
+There are two entry points for risk evaluation, but **both share the same `EvaluateRisk`**. The difference is only "how the result is handled" (a separate dry-run-specific logic such as the former `AnalyzeCommandSecurity` has been removed).
 
 | Aspect | Runtime path | Dry-run path |
 |------|-----------|---------------|
-| Function | `risk.StandardEvaluator.EvaluateRisk` | `security.AnalyzeCommandSecurity` |
-| Caller | `NormalResourceManager.ExecuteCommand` | `dryrun_manager.go` |
-| Purpose | Decision of whether execution is allowed (comparison with the allowed level) | **Display and explanation** of the risk |
-| Behavior on error | Fail-closed (abort execution) | Fail-safe (continue display as High) |
-| Additional checks | None | Directory-based default risk, hash verification, setuid, dangerous pattern matching, etc. |
+| Evaluation function | `risk.StandardEvaluator.EvaluateRisk` (shared) | Same (shared) |
+| Caller | `NormalResourceManager.ExecuteCommand` | `DryRunResourceManager.evaluateCommandRisk` |
+| Purpose | Decision of whether execution is allowed (comparison with the allowed level) | **Display and explanation** of the risk (does not execute) |
+| Behavior on a policy deny | Abort execution (error) | Record the deny and **continue** (continue the preview) |
+| Handling of unverified identity / analysis impossible | Blocking deny (abort) | Recorded as a Blocking deny. `verification_unavailable` (unverified identity / disabled analysis) is handled separately and reported with a dedicated exit code |
+| Internal error (record-load failure, etc.) | Emit an audit entry and abort | Emit an audit entry and abort (a hard error) |
 
-To provide more detailed information at dry-run time, `AnalyzeCommandSecurity` includes the following additional checks (a separate path from the runtime path):
-
-- **Directory-based default risk** (`getDefaultRiskByDirectory`): `/bin`, `/usr/bin`, etc. are Low; `/sbin`, `/usr/sbin`, etc. are Medium.
-- **Hash verification failure** → Critical.
-- **setuid/setgid bit** → High.
-- **Dangerous command pattern matching** (`rm -rf`, `dd if=`, `mkfs`, etc.).
-
-> Supplement: although both paths reuse common `security` package functions (privilege escalation, destructive operations, coreutils, network analysis), the assembly of the decision and the final handling are independent. When changing the logic, check the **impact on both**.
+Both paths share the point that, when the certainty of the evaluation (identity / analysis availability) cannot be guaranteed, they fall to the fail-closed side. The dry-run differs in that it adds a display for "this command is denied because it cannot be verified in this environment, but this predicts the result in a production environment where verification is possible."
 
 ## Audit Logging
 
-The result of risk evaluation is recorded in the audit log (`LogRiskProfile` in `internal/runner/base/audit/logger.go`).
+The result of risk evaluation is recorded in the audit log (`Logger.LogRiskProfile` in `internal/runner/base/audit/logger.go`). For either decision—allow or deny—and even on the path that aborts due to an internal error, exactly one entry is always output. The input is `risktypes.RiskAuditEntry` (a DTO).
+
+Main fields:
 
 - `audit_type`: `command_risk_profile`
-- `risk_level`: the computed risk level
-- `risk_factors`: an array of the `Reason` of each risk factor
-- `network_type`: the network type
+- `mode`: `normal` / `dry-run`
+- `decision`: `allow` / `deny`
+- `risk_level`: the computed effective risk level
+- `max_allowed_risk`: the configured maximum allowed risk
+- `resolved_path` / `content_hash` / `record_id`: identifying information for correlation (the absence marker when not obtained)
+- `network_type`: the network type (none/always/conditional)
+- `reason_codes`: machine-readable reason codes (an array of `ReasonCode`)
+- `risk_factors`: an array of the human-readable `Reason` of each risk factor
+- `blocking_reason`: the deny reason code (set for either a Blocking or a Critical deny)
+- `error_class`: the classification of a failure-induced deny (symlink resolution failure, coreutils file-info failure, record-load failure, path resolution failure, invalid risk_level configuration, etc.)
+- `verification_unavailable`: indicates that verification/analysis was unavailable in the dry-run
+- `command_args`: the masked command arguments
+- `chain`: each entity executed or loaded during indirect execution (path / role / disposition / content_hash)
 
-The log level corresponds to the risk level:
+The log level corresponds to the risk level, and is further raised to **at least Warn in the case of a deny** (so that even a Medium command denied under a Low ceiling can be found by a Warn/Error search).
 
 | Risk level | Log level |
 |-------------|-----------|
 | Critical | Error |
 | High | Warn |
-| Medium | Info |
-| Low / Unknown | Debug |
+| Medium | Info (Warn or higher on a deny) |
+| Low / Unknown | Debug (Warn or higher on a deny) |
 
-This makes it possible to trace afterward why a command was evaluated as a particular risk level.
+This makes it possible to trace afterward why a command was evaluated as a particular risk level and by which reason code it was denied.
 
 ## Summary
 
-- At runtime, `runner` computes the **effective risk level** of each command and compares it with the **maximum allowed risk level** in the configuration to decide whether execution is allowed.
-- The evaluation early-returns in order from the highest danger (privilege escalation → destructive operation → coreutils → network → system modification → default Low).
-- For a command with multiple factors, the **maximum** of the factors becomes the overall risk.
-- When the evaluation is not certain (symlink anomaly, missing analysis record, unverified hash, etc.), the runtime path falls to the safe side with **fail-closed** (does not execute).
-- `critical` cannot be specified in the configuration and is internally assigned to commands that "must be blocked," such as privilege escalation.
+- At runtime, `runner` computes the **verified command plan (`VerifiedCommandPlan`)** of each command and compares its effective risk level with the **maximum allowed risk level** in the configuration to decide whether execution is allowed. Indeterminate or unbindable cases are a **Blocking deny** regardless of the allowed level.
+- The evaluation first evaluates the short-circuiting deny gates (identity gate → indirect execution → privilege escalation), and then takes the **maximum** of the remaining decision dimensions (coreutils, destructive operation, system modification, profile factors, dangerous arguments, arbitrary code execution, network arguments, binary analysis). It is an order-independent maximum, not an early return.
+- **Indirect-execution forms** that execute or load an entity other than the verified binary are rejected, except for wrappers that `runner` can re-implement.
+- When the evaluation is not certain (unverified identity, disabled analysis, symlink anomaly, missing or mismatched analysis record, etc.), it falls to the safe side with **fail-closed** (a Blocking deny).
+- `critical` (and `unknown`) cannot be specified in the configuration, and `critical` is internally assigned to commands that "must be blocked," such as privilege escalation.
+- The runtime path and the dry-run path share the same `EvaluateRisk`, and only the handling of the result (whether to abort, or to display and continue) differs.

--- a/docs/dev/architecture_design/command-risk-evaluation.md
+++ b/docs/dev/architecture_design/command-risk-evaluation.md
@@ -1,0 +1,367 @@
+# Command Risk Evaluation: Technical Explanation
+
+## Overview
+
+This document explains, for developers, the mechanism of the "risk evaluation" that `runner` performs at the point when it **executes** a command.
+
+Before executing each command described in the configuration file (TOML), `runner` computes the security danger level that the command carries as a **risk level**. If the computed risk level exceeds the **maximum allowed risk level (`risk_level`)** configured on the command or group, it rejects execution of that command. This blocks, before execution, "dangerous operations that exceed the range explicitly allowed by the configuration."
+
+This evaluation works in combination with other security layers such as hash verification (file integrity verification) and binary static analysis. This document does not go into the details of those, and focuses on the **logic that determines the risk level**.
+
+### Intended Audience
+
+- Developers who change or extend the risk evaluation logic
+- Developers who add a risk profile for a new command
+- Users who want to understand the behavior of the `risk_level` setting
+
+### Related Packages
+
+| Package | Role |
+|-----------|------|
+| `internal/runner/base/risk` | Entry point for runtime risk evaluation (`Evaluator`) |
+| `internal/runner/base/security` | Individual decision logic (privilege escalation, destructive operations, network, coreutils, etc.) |
+| `internal/runner/resource` | Invocation of risk evaluation and comparison with the allowed level (decision of whether execution is allowed) |
+| `internal/runner/base/runnertypes` | The `RiskLevel` type and parsing of configuration values |
+
+## Definition of Risk Levels
+
+The risk level is an enumerated type defined by `runnertypes.RiskLevel` (`internal/runner/base/runnertypes/config.go`). **Only the four levels from `Low` upward have an ordering of danger**; note that `Unknown` (value 0) is not part of this ordering but a special value representing "risk could not be determined / not classified."
+
+```mermaid
+flowchart LR
+    classDef level fill:#fff1e6,stroke:#ff7f0e,stroke-width:1px,color:#8a3e00;
+    classDef special fill:#eeeeee,stroke:#888,stroke-width:1px,color:#333;
+
+    L["Low"] --> M["Medium"] --> H["High"] --> C["Critical"]
+    U["Unknown (value 0)<br>Indeterminate / Not classified<br>*Not 'safer than Low'*"]
+    class L,M,H,C level;
+    class U special;
+```
+
+| Level | Constant | String | Meaning |
+|--------|------|--------|------|
+| 0 | `RiskLevelUnknown` | `unknown` | Risk could not be determined / not classified (**does not mean safer than Low**) |
+| 1 | `RiskLevelLow` | `low` | Command with minimal security risk |
+| 2 | `RiskLevelMedium` | `medium` | Moderate risk (network operations, system modification, etc.) |
+| 3 | `RiskLevelHigh` | `high` | High risk (destructive operations, dynamic load, exec signal, etc.) |
+| 4 | `RiskLevelCritical` | `critical` | Command that should be blocked (privilege escalation, etc.) |
+
+**Important properties**:
+
+- `Low` through `Critical` are **comparable** as integers, and when there are multiple factors the **maximum** is adopted as a rule (`max(...)`).
+- `Unknown` (value 0) is the smallest as a number, but its meaning is "indeterminate / not classified," and it **does not mean safer than `Low`**. In the implementation, `Unknown` never passes the allowed-level comparison (`effectiveRisk > maxAllowedRisk`) as "the lowest risk." This is because the runtime path (`EvaluateRisk`) returns `Unknown` **only together with an error**, and in that case the error propagates to the caller and the result is **fail-closed** (execution is aborted). `Unknown` is mainly used as an internal signal meaning "this evaluation cannot determine it, so defer to the subsequent evaluation" (e.g., intermediate results of `getDefaultRiskByDirectory` or `AnalyzeCommandSecurity`).
+- `critical` **cannot be specified in the configuration file** (`ParseRiskLevel` returns an error). It is reserved for internal use only and is assigned to things that "must be blocked," such as privilege escalation commands.
+- When `risk_level` is omitted in the configuration, the default value is `low` (`CommandSpec.GetRiskLevel` returns `RiskLevelLow`).
+
+## Overall Runtime Flow
+
+Risk evaluation is performed within the normal execution mode (`NormalResourceManager.ExecuteCommand`). The wiring is done in `runner.go`, where `NetworkAnalyzer` → `StandardEvaluator` → `ResourceManager` are assembled in this order.
+
+```mermaid
+flowchart TD
+    classDef data fill:#e6f7ff,stroke:#1f77b4,stroke-width:1px,color:#0b3d91;
+    classDef process fill:#fff1e6,stroke:#ff7f0e,stroke-width:1px,color:#8a3e00;
+    classDef decision fill:#fde6e6,stroke:#c0392b,stroke-width:1px,color:#7b0a0a;
+
+    A[("RuntimeCommand<br>(expanded command/arguments)")] --> B["NormalResourceManager<br>ExecuteCommand"]
+    B --> C["Evaluator.EvaluateRisk<br>(compute effective risk)"]
+    C -->|"effectiveRisk"| D{"effectiveRisk ><br>maxAllowedRisk ?"}
+    E[("Configured risk_level<br>(maximum allowed risk)")] -->|"GetRiskLevel"| D
+    D -->|"Yes"| F["Reject execution<br>ErrCommandSecurityViolation"]
+    D -->|"No"| G["Execute command"]
+
+    class A,E data;
+    class B,C,G process;
+    class D decision;
+    class F decision;
+```
+
+**Legend**
+
+```mermaid
+flowchart LR
+    classDef data fill:#e6f7ff,stroke:#1f77b4,stroke-width:1px,color:#0b3d91;
+    classDef process fill:#fff1e6,stroke:#ff7f0e,stroke-width:1px,color:#8a3e00;
+    classDef decision fill:#fde6e6,stroke:#c0392b,stroke-width:1px,color:#7b0a0a;
+
+    D1[("Data")] --> P1["Process"] --> X1{"Decision"}
+    class D1 data
+    class P1 process
+    class X1 decision
+```
+
+The comparison of whether execution is allowed is performed in `internal/runner/resource/normal_manager.go`.
+
+```go
+// Step 1: Compute the effective risk
+effectiveRisk, err := n.riskEvaluator.EvaluateRisk(cmd)
+
+// Step 2: Get the maximum allowed risk from the configuration (default is low)
+maxAllowedRisk, err := cmd.GetRiskLevel()
+
+// Step 3: Compare. If it exceeds, reject execution
+if effectiveRisk > maxAllowedRisk {
+    return ..., fmt.Errorf("%w: command %s (effective risk: %s) exceeds maximum allowed risk level (%s)",
+        runnertypes.ErrCommandSecurityViolation, ...)
+}
+```
+
+Key points:
+
+- **Effective risk (effectiveRisk)**: the actual danger level computed from the content of the command.
+- **Maximum allowed risk (maxAllowedRisk)**: the upper limit the user has allowed in the configuration.
+- Because `critical` cannot be written in the configuration, anything whose effective risk becomes `critical`, such as a privilege escalation command, is **always rejected under any configuration** (of course with the default `low`, but even if you configure the maximum `high`, it becomes `critical > high`).
+
+## Risk Evaluation Algorithm (`EvaluateRisk`)
+
+The core of runtime risk is `risk.StandardEvaluator.EvaluateRisk` (`internal/runner/base/risk/evaluator.go`). The evaluation is an **early-return scheme**: it evaluates in order from the higher (more dangerous) checks and returns the level that matches first.
+
+```mermaid
+flowchart TD
+    classDef process fill:#fff1e6,stroke:#ff7f0e,stroke-width:1px,color:#8a3e00;
+    classDef decision fill:#fde6e6,stroke:#c0392b,stroke-width:1px,color:#7b0a0a;
+    classDef result fill:#e8f5e8,stroke:#2e8b57,stroke-width:2px,color:#006400;
+
+    S["EvaluateRisk(cmd)"] --> P1{"Privilege escalation command?<br>(sudo/su/doas)"}
+    P1 -->|"Yes"| RC["Critical"]
+    P1 -->|"No"| P2{"Destructive file operation?<br>(rm/dd/shred/find -delete, etc.)"}
+    P2 -->|"Yes"| RH1["High"]
+    P2 -->|"No"| P3{"Command under the coreutils<br>single binary?"}
+    P3 -->|"handled"| RCU["coreutils classification result<br>(Low/Medium/High)"]
+    P3 -->|"No"| P4{"Network operation /<br>high-risk binary signal?<br>(profile/binary analysis/arguments)"}
+    P4 -->|"high-risk signal<br>(dynamic load/exec/svc/mprotect PROT_EXEC)"| RH2["High"]
+    P4 -->|"network only"| RM1["Medium"]
+    P4 -->|"No"| P5{"System modification?<br>(systemctl/mount/apt install, etc.)"}
+    P5 -->|"Yes"| RM2["Medium"]
+    P5 -->|"No"| RL["Low (default)"]
+
+    class S process;
+    class P1,P2,P3,P4,P5 decision;
+    class RC,RH1,RH2,RM1,RM2,RCU,RL result;
+```
+
+Evaluation order (corresponding to the steps in the code):
+
+### Step 1: Privilege escalation command → Critical
+
+`security.IsPrivilegeEscalationCommand` inspects the command name. If it matches `sudo` / `su` / `doas`, it returns **Critical**.
+
+- The decision follows symlinks (`extractAllCommandNames`). Even if `/usr/bin/foo` actually points to `sudo`, it is detected.
+- If the symlink depth exceeds the limit (`MaxSymlinkDepth`), it returns an error (`ErrSymlinkDepthExceeded`) and the risk becomes `Unknown`. `EvaluateRisk` propagates the error to the caller, and the result is **fail-closed** (the command is not executed).
+
+Privilege escalation commands are defined as `PrivilegeRisk = Critical` in `commandRiskProfiles` (see the profile section below).
+
+### Step 2: Destructive file operation → High
+
+`security.IsDestructiveFileOperation` evaluates the following as **High**:
+
+- The command name is one of `rm` / `rmdir` / `unlink` / `shred` / `dd`.
+- The arguments of `find` contain `-delete`, or a destructive command immediately follows `-exec`.
+- The arguments of `rsync` contain a `--delete`-family option.
+
+### Step 3: Classification of the coreutils single binary
+
+This is special handling to support implementations, such as the Rust-based coreutils, where all subcommands share **a single binary**. `security.CoreutilsCommandRisk` makes the decision.
+
+In ordinary binary static analysis (within the network analysis of Step 4), coreutils is misclassified because the single binary contains the symbols of all subcommands. To avoid this, it is classified by dedicated logic before the analysis.
+
+Decision conditions and behavior:
+
+- The target is only a command whose resolved path **has a parent directory that exactly matches the coreutils directory (`common.CoreutilsDir`)**. If it does not match, it returns `handled=false` and proceeds to the subsequent steps.
+- If the setuid/setgid bit is set, it is **High** (a coreutils hardlink being setuid is normally impossible, and a set bit is a sign of a packaging defect or tampering).
+- Determination of the effective subcommand:
+  - Normally the basename of the path (e.g., `/opt/coreutils/rm` → `rm`).
+  - For the multicall entry point (basename is `coreutils`), the first non-option element of the arguments is adopted (`coreutils rm -rf ...` → `rm`).
+- Classification by the effective subcommand:
+  - Destructive commands (`dd`, `rm`, `rmdir`, `shred`, `truncate`, `unlink`) → **High**
+  - Known safe commands (`ls`, `cat`, `mkdir`, `sha256sum`, etc., which read, retrieve information, process text, or create new files) → **Low**
+  - Everything else (under the directory but unclassified) → **Medium** (the fail-safe default)
+- If the stat of the setuid check results in an error, the runtime path (`EvaluateRisk`) **propagates the error and is fail-closed** (does not execute).
+
+### Step 4: Network operation / high-risk binary signal → High / Medium
+
+`NetworkAnalyzer.IsNetworkOperation` makes the decision. Although the function name is "Network," its return value is `(isNetwork, isHighRisk, error)`, and it **also reports, via the `isHighRisk` side, high-risk binary signals that are not necessarily network operations**. Specifically, dynamic load symbols (`dlopen`/`dlsym`/`dlvsym`), exec syscalls, the `svc #0x80` direct syscall, and the **`PROT_EXEC` of the mprotect family** are included in this (see 4-2 for details).
+
+- `isHighRisk == true` → **High** (High regardless of whether it is network; mprotect `PROT_EXEC`, etc. fall here)
+- `isNetwork == true` (not high-risk) → **Medium**
+- Both false → proceed to the next step
+
+Detection is performed in the following priority order:
+
+```mermaid
+flowchart TD
+    classDef process fill:#fff1e6,stroke:#ff7f0e,stroke-width:1px,color:#8a3e00;
+    classDef decision fill:#fde6e6,stroke:#c0392b,stroke-width:1px,color:#7b0a0a;
+    classDef result fill:#e8f5e8,stroke:#2e8b57,stroke-width:2px,color:#006400;
+
+    A["IsNetworkOperation"] --> B{"Registered in a<br>command profile?"}
+    B -->|"NetworkTypeAlways"| R1["network=true"]
+    B -->|"NetworkTypeConditional"| C{"Subcommand/argument<br>matches network?"}
+    C -->|"Yes"| R1
+    C -->|"No"| R0["network=false"]
+    B -->|"not registered & absolute path"| D["Binary static analysis<br>(analyzeBinarySignals)"]
+    D --> E{"Network/dynamic load/<br>exec signal?"}
+    E -->|"Yes"| R2["network/highRisk"]
+    E -->|"No"| F{"URL or SSH-style<br>address in arguments?"}
+    B -->|"not registered"| F
+    F -->|"Yes"| R1
+    F -->|"No"| R0
+
+    class A,D process;
+    class B,C,E,F decision;
+    class R0,R1,R2 result;
+```
+
+#### 4-1. Decision by command profile (highest priority)
+
+It refers to the list of known commands hardcoded in `commandProfileDefinitions` (`internal/runner/base/security/command_analysis.go`). Each profile has a `NetworkType`:
+
+- `NetworkTypeAlways`: always performs network operations. If it matches, `network=true` immediately.
+  - Examples: `curl`, `wget`, `ssh`, `scp`, `nc`, `aws`, and AI-related ones (`claude`, `gemini`, etc.).
+  - **Script languages and shells are also included**: `bash`, `python`, `node`, `ruby`, `java`, `perl`, etc. are treated as `Always` (fail-safe), because even if the main binary has no network symbols, they can invoke arbitrary network tools internally.
+- `NetworkTypeConditional`: whether it becomes a network operation is determined by the arguments.
+  - `git`: when the subcommand is `clone` / `fetch` / `pull` / `push` / `remote` (decided after skipping options with `findFirstSubcommand`).
+  - `rsync`: when a remote is specified.
+  - In addition, if the arguments contain a URL or an SSH-style address, it is evaluated as network.
+
+These decisions are also made following symlinks.
+
+#### 4-2. Binary static analysis (not registered in a profile and absolute path)
+
+An unknown command that is not in a profile is statically analyzed using a precomputed analysis record (`RecordStore`) (`analyzeBinarySignals`). The record contains the results of symbol analysis and syscall analysis of the ELF/Mach-O.
+
+Detected signals and their handling:
+
+| Signal | Result |
+|----------|------|
+| Network symbol (socket/DNS) / network syscall | `isNetwork = true` (equivalent to Medium) |
+| Dynamic load symbol (`dlopen`/`dlsym`/`dlvsym`) | `isHighRisk = true` (High) |
+| exec syscall | `isHighRisk = true` (High) |
+| `svc #0x80` direct syscall (unresolved) | `isHighRisk = true` (High) |
+| `PROT_EXEC` in the mprotect family is confirmed or unknown | `isHighRisk = true` (High) |
+
+**Fail-closed design**: when the certainty of the analysis cannot be guaranteed, it falls to the safe side (high risk).
+
+- `RecordStore` is nil (no analysis capability) → `(false, false)`.
+- `contentHash` is empty (the binary's identity is unverified) → `(true, true)` = High.
+- The analysis record is not found / schema mismatch / content hash mismatch / analysis error / unknown result → all treated as High.
+
+> Note: `contentHash` is a precomputed hash in the "algo:hex" format obtained from hash verification, and it guarantees that the analysis record matches the binary on disk. Risk evaluation is closely linked with file integrity verification.
+
+#### 4-3. Argument-based detection
+
+Even when it is not determined by the profile or binary analysis, if the arguments contain the following, it is evaluated as network (`hasNetworkArguments`):
+
+- A URL containing `://`.
+- An SSH-style address (`[user@]host:path`). To avoid false positives with email addresses, port numbers, and time formats, it is evaluated strictly with a regex.
+
+### Step 5: System modification → Medium
+
+`security.IsSystemModification` evaluates the following as **Medium**:
+
+- System administration commands: `systemctl`, `service`, `mount`, `umount`, `fdisk`, `mkfs`, `crontab`, etc.
+- Package management commands (`apt`, `yum`, `npm`, `pip`, etc.), only when the arguments include `install` / `remove` / `uninstall` / `upgrade` / `update`.
+
+### Step 6: Default → Low
+
+A command that matches none of the above is treated as **Low**.
+
+## Command Risk Profile
+
+`CommandRiskProfile` (`internal/runner/base/security/command_risk_profile.go`) is a struct that holds **multiple risk factors** for a single command separately.
+
+```mermaid
+flowchart TD
+    classDef process fill:#fff1e6,stroke:#ff7f0e,stroke-width:1px,color:#8a3e00;
+    classDef result fill:#e8f5e8,stroke:#2e8b57,stroke-width:2px,color:#006400;
+
+    P["CommandRiskProfile"] --> F1["PrivilegeRisk<br>(privilege escalation)"]
+    P --> F2["NetworkRisk<br>(network)"]
+    P --> F3["DestructionRisk<br>(destructive operation)"]
+    P --> F4["DataExfilRisk<br>(data exfiltration)"]
+    P --> F5["SystemModRisk<br>(system modification)"]
+    F1 --> M["BaseRiskLevel()<br>= max(all factors)"]
+    F2 --> M
+    F3 --> M
+    F4 --> M
+    F5 --> M
+
+    class P,F1,F2,F3,F4,F5 process;
+    class M result;
+```
+
+Each factor has a `RiskFactor` (a `Level` and a human-readable `Reason`). The overall risk is computed as the **maximum** of all factors (`BaseRiskLevel`).
+
+The profile is defined with the builder pattern (`NewProfile(...).XxxRisk(...).Build()`). Example:
+
+```go
+// Privilege escalation command
+NewProfile("sudo", "su", "doas").
+    PrivilegeRisk(runnertypes.RiskLevelCritical, "...").
+    Build(),
+
+// AI service (two factors: network + data exfiltration)
+NewProfile("claude", "gemini", "chatgpt", ...).
+    NetworkRisk(runnertypes.RiskLevelHigh, "Always communicates with external AI API").
+    DataExfilRisk(runnertypes.RiskLevelHigh, "May send sensitive data to external service").
+    AlwaysNetwork().
+    Build(),
+```
+
+Consistency is verified by `Validate()` (for example, if `NetworkTypeAlways`, then `NetworkRisk >= Medium`).
+
+### Adding a profile for a new command
+
+1. Add an entry to `commandProfileDefinitions` in `command_analysis.go`.
+2. Set the applicable risk factors (`PrivilegeRisk` / `NetworkRisk` / `DestructionRisk` / `DataExfilRisk` / `SystemModRisk`).
+3. Specify the network type (`AlwaysNetwork()` / `ConditionalNetwork(...)`) as needed.
+4. Always write a rationale (`Reason`) for each risk factor (it is output to the audit log).
+
+## Difference Between the Runtime Path and the Dry-Run Path
+
+There are two entry points for risk evaluation, and note that their **purposes differ**.
+
+| Aspect | Runtime path | Dry-run path |
+|------|-----------|---------------|
+| Function | `risk.StandardEvaluator.EvaluateRisk` | `security.AnalyzeCommandSecurity` |
+| Caller | `NormalResourceManager.ExecuteCommand` | `dryrun_manager.go` |
+| Purpose | Decision of whether execution is allowed (comparison with the allowed level) | **Display and explanation** of the risk |
+| Behavior on error | Fail-closed (abort execution) | Fail-safe (continue display as High) |
+| Additional checks | None | Directory-based default risk, hash verification, setuid, dangerous pattern matching, etc. |
+
+To provide more detailed information at dry-run time, `AnalyzeCommandSecurity` includes the following additional checks (a separate path from the runtime path):
+
+- **Directory-based default risk** (`getDefaultRiskByDirectory`): `/bin`, `/usr/bin`, etc. are Low; `/sbin`, `/usr/sbin`, etc. are Medium.
+- **Hash verification failure** → Critical.
+- **setuid/setgid bit** → High.
+- **Dangerous command pattern matching** (`rm -rf`, `dd if=`, `mkfs`, etc.).
+
+> Supplement: although both paths reuse common `security` package functions (privilege escalation, destructive operations, coreutils, network analysis), the assembly of the decision and the final handling are independent. When changing the logic, check the **impact on both**.
+
+## Audit Logging
+
+The result of risk evaluation is recorded in the audit log (`LogRiskProfile` in `internal/runner/base/audit/logger.go`).
+
+- `audit_type`: `command_risk_profile`
+- `risk_level`: the computed risk level
+- `risk_factors`: an array of the `Reason` of each risk factor
+- `network_type`: the network type
+
+The log level corresponds to the risk level:
+
+| Risk level | Log level |
+|-------------|-----------|
+| Critical | Error |
+| High | Warn |
+| Medium | Info |
+| Low / Unknown | Debug |
+
+This makes it possible to trace afterward why a command was evaluated as a particular risk level.
+
+## Summary
+
+- At runtime, `runner` computes the **effective risk level** of each command and compares it with the **maximum allowed risk level** in the configuration to decide whether execution is allowed.
+- The evaluation early-returns in order from the highest danger (privilege escalation → destructive operation → coreutils → network → system modification → default Low).
+- For a command with multiple factors, the **maximum** of the factors becomes the overall risk.
+- When the evaluation is not certain (symlink anomaly, missing analysis record, unverified hash, etc.), the runtime path falls to the safe side with **fail-closed** (does not execute).
+- `critical` cannot be specified in the configuration and is internally assigned to commands that "must be blocked," such as privilege escalation.

--- a/docs/translation_glossary.md
+++ b/docs/translation_glossary.md
@@ -93,6 +93,7 @@
 |--------|---------|------|
 | データ持ち出し | data exfiltration | 機密データを外部サービスへ送出すること |
 | データフロー解析 | dataflow analysis | CFGを用いたデータの流れの解析 |
+| データ持ち出し | data exfiltration | 機密データの外部送信（セキュリティの文脈） |
 | 依存 / 依存解析 | dependency / dependency analysis | 動的ライブラリ依存解析の文脈 |
 | 判定メソッド | determination method | syscall番号の決定手段を示す文字列 |
 | デバッグ | debug / debugging | |
@@ -148,6 +149,8 @@
 | 実行 | execute / execution | |
 | 実行可能ファイル | executable | |
 | 実行時 | at runtime | |
+| 実効リスク | effective risk | 算出された実際の危険度（リスク判定の文脈） |
+| 早期リターン | early return | 最初に該当した結果を返す制御方式 |
 | 明示 | explicit | env_allowlistの継承モードの文脈 |
 | 展開 | expansion | |
 | 展開済み | expanded | 変数展開の文脈 |
@@ -165,6 +168,8 @@
 | フェイルクローズ | fail-closed | 確認できない場合は実行を拒否する設計（優雅な劣化の対義） |
 | フェイルセーフ | fail-safe | 安全側へ倒す設計 |
 | 誤検出 | false positive | 誤ってSYSCALL命令として検出すること |
+| フェイルクローズド | fail-closed | エラー時に安全側（実行中止）へ倒す設計 |
+| フェイルセーフ | fail-safe | 不明時に安全側のリスクへ倒す設計 |
 | 前向きスキャン | forward scan | 命令列を先頭から走査する解析手法 |
 | FAQ | FAQ | Frequently Asked Questions |
 | 汎用的 | generic | |
@@ -280,6 +285,8 @@
 | 習得 | mastery | |
 | マッチング | matching | パターンマッチングの文脈 |
 | 最大 | maximum | 通常 "max" ではなく "maximum" を使用 |
+| 最大許容リスクレベル | maximum allowed risk level | リスク判定の文脈 |
+| マルチコール | multicall | 単一バイナリが複数サブコマンドを兼ねる方式 |
 | 意味的 | semantic | |
 | メモ化 | memoization | 計算結果のキャッシング |
 | メモリ枯渇 | memory exhaustion | DoS攻撃の文脈 |
@@ -347,6 +354,7 @@
 | プレースホルダー構文 | placeholder syntax | |
 | 優先する | prefer | |
 | 権限 | permission / privilege | "permission"はファイル権限、"privilege"は特権 |
+| 特権昇格 | privilege escalation | セキュリティの文脈 |
 | 許可 | allow / allowed | "allowlist" の文脈では "allowed" |
 | 許可リスト | allowlist | "whitelist" は使用しない |
 | 許可する | allow | |
@@ -408,6 +416,7 @@
 | 責務分担 | responsibility split | コンポーネント間の責務の切り分け |
 | リスク | risk | |
 | リスクレベル | risk level | |
+| リスク判定 | risk evaluation | リスクレベルの算出 |
 | 堅牢性 | robustness | |
 | 役割 | role | |
 | ルート | root | |
@@ -465,6 +474,7 @@
 | 標準パス | standard path | |
 | スタート | start | |
 | 静的 | static | |
+| 静的解析 | static analysis | バイナリ静的解析の文脈 |
 | 文字列 | string | |
 | 構造体 | struct | Go言語の文脈 |
 | 置換 | substitution | 変数展開の文脈 |
@@ -673,6 +683,7 @@
 | 2026-04-30 | パッケージリファレンスドキュメント関連の用語を追加 (audit logging, bootstrap, dependency/dependency analysis, injection, integrity, interface, separation of concerns, symbol) |
 | 2026-04-30 | pclntabメンテナンスガイド関連の用語を追加 (code path, compilation unit, constant, garbage collection, header, linker, magic number, stack trace) |
 | 2026-05-01 | Mach-Oバイナリ解析ドキュメント関連の用語を追加 (breadth-first search, namespace, slice (Fat binary), trampoline) |
+| 2026-06-12 | コマンドリスク判定ドキュメント関連の用語を追加 (risk evaluation, effective risk, early return, maximum allowed risk level, multicall, fail-closed, fail-safe, data exfiltration, static analysis, privilege escalation) |
 | 2026-06-17 | 実行時リスク評価ドキュメント（Task 0136）関連の用語を追加 (arbitrary code execution, blocklist, data exfiltration, effective risk, fail-closed, fail-safe, hash pinning, hard link, threat model) |
 
 ---

--- a/docs/translation_glossary.md
+++ b/docs/translation_glossary.md
@@ -147,7 +147,6 @@
 | 例外 | exception | |
 | 実行時 | at runtime | |
 | 早期リターン | early return | 最初に該当した結果を返す制御方式 |
-| 実効リスク | effective risk | 算出された実際の危険度（リスク判定の文脈） |
 | 実行可能ファイル | executable | |
 | 実行 | execute / execution | |
 | 明示 | explicit | env_allowlistの継承モードの文脈 |

--- a/docs/translation_glossary.md
+++ b/docs/translation_glossary.md
@@ -91,9 +91,8 @@
 
 | 日本語 | English | 備考 |
 |--------|---------|------|
-| データ持ち出し | data exfiltration | 機密データを外部サービスへ送出すること |
-| データフロー解析 | dataflow analysis | CFGを用いたデータの流れの解析 |
 | データ持ち出し | data exfiltration | 機密データの外部送信（セキュリティの文脈） |
+| データフロー解析 | dataflow analysis | CFGを用いたデータの流れの解析 |
 | 依存 / 依存解析 | dependency / dependency analysis | 動的ライブラリ依存解析の文脈 |
 | 判定メソッド | determination method | syscall番号の決定手段を示す文字列 |
 | デバッグ | debug / debugging | |
@@ -146,11 +145,11 @@
 | 排他性 | exclusivity | Field exclusivity context |
 | 例 | example | |
 | 例外 | exception | |
-| 実行 | execute / execution | |
-| 実行可能ファイル | executable | |
 | 実行時 | at runtime | |
-| 実効リスク | effective risk | 算出された実際の危険度（リスク判定の文脈） |
 | 早期リターン | early return | 最初に該当した結果を返す制御方式 |
+| 実効リスク | effective risk | 算出された実際の危険度（リスク判定の文脈） |
+| 実行可能ファイル | executable | |
+| 実行 | execute / execution | |
 | 明示 | explicit | env_allowlistの継承モードの文脈 |
 | 展開 | expansion | |
 | 展開済み | expanded | 変数展開の文脈 |
@@ -165,11 +164,15 @@
 
 | 日本語 | English | 備考 |
 |--------|---------|------|
+<<<<<<< HEAD
 | フェイルクローズ | fail-closed | 確認できない場合は実行を拒否する設計（優雅な劣化の対義） |
 | フェイルセーフ | fail-safe | 安全側へ倒す設計 |
 | 誤検出 | false positive | 誤ってSYSCALL命令として検出すること |
+=======
+>>>>>>> c9a1a4b8 (docs: alphabetize new glossary entries within their sections)
 | フェイルクローズド | fail-closed | エラー時に安全側（実行中止）へ倒す設計 |
 | フェイルセーフ | fail-safe | 不明時に安全側のリスクへ倒す設計 |
+| 誤検出 | false positive | 誤ってSYSCALL命令として検出すること |
 | 前向きスキャン | forward scan | 命令列を先頭から走査する解析手法 |
 | FAQ | FAQ | Frequently Asked Questions |
 | 汎用的 | generic | |
@@ -415,8 +418,8 @@
 | 責務 | responsibility | |
 | 責務分担 | responsibility split | コンポーネント間の責務の切り分け |
 | リスク | risk | |
-| リスクレベル | risk level | |
 | リスク判定 | risk evaluation | リスクレベルの算出 |
+| リスクレベル | risk level | |
 | 堅牢性 | robustness | |
 | 役割 | role | |
 | ルート | root | |

--- a/docs/translation_glossary.md
+++ b/docs/translation_glossary.md
@@ -164,12 +164,6 @@
 
 | 日本語 | English | 備考 |
 |--------|---------|------|
-<<<<<<< HEAD
-| フェイルクローズ | fail-closed | 確認できない場合は実行を拒否する設計（優雅な劣化の対義） |
-| フェイルセーフ | fail-safe | 安全側へ倒す設計 |
-| 誤検出 | false positive | 誤ってSYSCALL命令として検出すること |
-=======
->>>>>>> c9a1a4b8 (docs: alphabetize new glossary entries within their sections)
 | フェイルクローズド | fail-closed | エラー時に安全側（実行中止）へ倒す設計 |
 | フェイルセーフ | fail-safe | 不明時に安全側のリスクへ倒す設計 |
 | 誤検出 | false positive | 誤ってSYSCALL命令として検出すること |


### PR DESCRIPTION
## 概要

`runner` が実行時に行うコマンドのリスク判定について解説するエンジニア向け技術文書を追加します（日本語版＋英語翻訳）。本文書は現行ソース（Task 0136 / 0138 で導入された `VerifiedCommandPlan`・同一性ゲート・間接実行解析のアーキテクチャ）に合わせて記述しています。

## 追加・変更内容

- **`docs/dev/architecture_design/command-risk-evaluation.ja.md`**（日本語）
  - リスクレベルの定義（`Unknown` は順序の一部ではなく「判定不能」を表す点、`critical`/`unknown` は設定不可な点を明記）
  - 実行時の全体フロー：`EvaluateRisk` は `VerifiedCommandPlan` を返し、`Blocking` 拒否と「実効リスク > 最大許容リスク」の二段で実行可否を判断
  - 判定アルゴリズム：短絡する拒否ゲート（ランク1〜3：同一性ゲート → 間接実行 → 特権昇格）＋順序非依存の最大値（ランク4〜8）。早期リターンではない点を明記
  - 間接実行（indirect execution）の解析：ラッパー・シェバン・find/xargs・動的ローダ・リモートシェル・パッケージスクリプトランナー・インラインコード等
  - バイナリ静的解析（`NetworkAnalyzer.Classify` の4クラス）、ネットワーク引数、coreutils 単一バイナリ分類、システム変更リスク、任意コード実行ランナー、コマンドリスクプロファイル
  - 実行時パスとドライランパスは同一 `EvaluateRisk` を共有する点、監査ログのフィールドと拒否時の Warn 下限
- **`docs/dev/architecture_design/command-risk-evaluation.md`**（英語翻訳）
  - 翻訳グロッサリ準拠でフル翻訳。構成・見出しは日本語版に一致
- **`docs/translation_glossary.md`**（更新）
  - リスク判定関連の用語を追加。F セクションに残っていたマージコンフリクトマーカーを解消（`フェイルクローズド` 表記に統一）

## 補足

- ドキュメントのみの変更（コード変更なし）。
- Mermaid 図はプロジェクトの凡例スタイルに準拠。
- 英訳は技術翻訳者ペルソナのレビューを実施し、Critical/Major 指摘なし・グロッサリ準拠を確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)