### PR TITLE
feat(0136): risktypes package and risk_level config foundation

### DIFF
--- a/docs/tasks/0136_runtime_risk_evaluation_enforcement/03_implementation_plan.md
+++ b/docs/tasks/0136_runtime_risk_evaluation_enforcement/03_implementation_plan.md
@@ -122,7 +122,7 @@
 
 **レビュー観点**: `risktypes` のゼロ値 fail-closed（`BinaryAnalysisClass`=Uncertain）/ 共有 DTO の最下位中立パッケージ配置（循環回避）/ `ParseRiskLevel("unknown")` のエラー化と既存値の不変 / 評価器・実行系へのシグネチャ波及が無い（本 PR は新規型・config・コメントのみで既存挙動を変えない）
 
-- [ ] グリーンゲート（`_context.md` の "Green gate" 参照）がパスしていることを確認した
+- [x] グリーンゲート（`_context.md` の "Green gate" 参照）がパスしていることを確認した
 - [ ] PR を作成した
 - [ ] PR がマージされた
 - [ ] 次のブランチへ切り替えた（次ステップは新しいブランチで作業する）

--- a/docs/tasks/0136_runtime_risk_evaluation_enforcement/03_implementation_plan.md
+++ b/docs/tasks/0136_runtime_risk_evaluation_enforcement/03_implementation_plan.md
@@ -123,7 +123,7 @@
 **レビュー観点**: `risktypes` のゼロ値 fail-closed（`BinaryAnalysisClass`=Uncertain）/ 共有 DTO の最下位中立パッケージ配置（循環回避）/ `ParseRiskLevel("unknown")` のエラー化と既存値の不変 / 評価器・実行系へのシグネチャ波及が無い（本 PR は新規型・config・コメントのみで既存挙動を変えない）
 
 - [x] グリーンゲート（`_context.md` の "Green gate" 参照）がパスしていることを確認した
-- [ ] PR を作成した
+- [x] PR を作成した（https://github.com/isseis/go-safe-cmd-runner/pull/728）
 - [ ] PR がマージされた
 - [ ] 次のブランチへ切り替えた（次ステップは新しいブランチで作業する）
 

--- a/docs/tasks/0136_runtime_risk_evaluation_enforcement/03_implementation_plan.md
+++ b/docs/tasks/0136_runtime_risk_evaluation_enforcement/03_implementation_plan.md
@@ -87,12 +87,12 @@
 
 **対象ファイル**: `internal/runner/base/risktypes/types.go`（新規）, `internal/runner/base/risktypes/reason_codes.go`（新規）
 
-- [ ] `VerifiedCommandPlan` / `VerifiedIdentity` / `RiskAssessment` / `ExecutedArtifact` / `RiskAuditEntry` を定義（`02_architecture.md` §3.1/§3.2 の型に一致。`RiskAuditEntry` は `Mode`/`Decision`/`MaxAllowedRisk`/`Chain` 等を持ち、Phase 3 の `LogRiskProfile` がこの型を受ける）。
-- [ ] **fd 所有権の型を確定（02 §3.6.2 が 03 へ委譲）**: `VerifiedFD` を「生 fd（`int`）を内包し `Close() error` と raw fd 取得（例 `Fd() int`）を持つクローズ可能ラッパー」として定義する。`VerifiedIdentity` および各 `ExecutedArtifact` は **fd を `*VerifiedFD`（nil=fd なし）で保持**する（02 が `FD *int` とスケッチしていた箇所を本タスクでは `*VerifiedFD` に確定。所有権・close を一元化）。`/proc/self/fd/<n>` の `n` はこのラッパーの `Fd()` から得る（int を直接扱うコードも矛盾なく利用できる）。生 `int` フィールドは持たせない（close 漏れ・二重所有を防ぐ）。
-- [ ] `BinaryAnalysisClass`（`Uncertain=0` がゼロ値=fail-closed）＋ `BinaryAnalysisResult` を定義（§3.1）。
-- [ ] `ReasonCode`（string 派生型）＋全定数を定義。最低限以下を含む（網羅は AC-69 でテスト）: `ReasonDestructiveFileOperation`, `ReasonSystemModification`, `ReasonPrivilegeEscalation`, `ReasonCoreutilsClassification`, `ReasonProfilePrivilege`, `ReasonProfileDestruction`, `ReasonProfileDataExfil`, `ReasonProfileNetwork`, `ReasonProfileSystemMod`, `ReasonBinaryAnalysisNetwork`, `ReasonBinaryAnalysisDynamicLoad`, `ReasonBinaryAnalysisExec`, `ReasonBinaryAnalysisSVC`, `ReasonBinaryAnalysisMprotectExec`, `ReasonUncertainMissingRecord`, `ReasonUncertainSchemaMismatch`, `ReasonUncertainHashMismatch`, `ReasonUncertainUnsupportedFormat`, `ReasonUncertainUnverifiedIdentity`, `ReasonAnalysisDisabled`, `ReasonArbitraryCodeExecution`, `ReasonDangerousArgPattern`, `ReasonSymlinkResolutionFailed`, `ReasonIdentityUnbound`, `ReasonIndirectExecutionRejected`, `ReasonForbiddenEnvVar`。各定数の文字列値は snake_case の英語（例: `"destructive_file_operation"`）。
-- [ ] `ErrorClass`（string 派生型）＋定数: `ErrorClassSymlinkResolution`, `ErrorClassCoreutilsFileInfo`, `ErrorClassRecordLoad`, `ErrorClassPathResolution`。
-- [ ] `ArtifactRole` / `ArtifactDisposition` / `Decision`（`DecisionAllow`/`DecisionDeny`）/ `ExecutionMode`（`ModeNormal`/`ModeDryRun`）を定義（§3.2）。
+- [x] `VerifiedCommandPlan` / `VerifiedIdentity` / `RiskAssessment` / `ExecutedArtifact` / `RiskAuditEntry` を定義（`02_architecture.md` §3.1/§3.2 の型に一致。`RiskAuditEntry` は `Mode`/`Decision`/`MaxAllowedRisk`/`Chain` 等を持ち、Phase 3 の `LogRiskProfile` がこの型を受ける）。
+- [x] **fd 所有権の型を確定（02 §3.6.2 が 03 へ委譲）**: `VerifiedFD` を「生 fd（`int`）を内包し `Close() error` と raw fd 取得（例 `Fd() int`）を持つクローズ可能ラッパー」として定義する。`VerifiedIdentity` および各 `ExecutedArtifact` は **fd を `*VerifiedFD`（nil=fd なし）で保持**する（02 が `FD *int` とスケッチしていた箇所を本タスクでは `*VerifiedFD` に確定。所有権・close を一元化）。`/proc/self/fd/<n>` の `n` はこのラッパーの `Fd()` から得る（int を直接扱うコードも矛盾なく利用できる）。生 `int` フィールドは持たせない（close 漏れ・二重所有を防ぐ）。
+- [x] `BinaryAnalysisClass`（`Uncertain=0` がゼロ値=fail-closed）＋ `BinaryAnalysisResult` を定義（§3.1）。
+- [x] `ReasonCode`（string 派生型）＋全定数を定義。最低限以下を含む（網羅は AC-69 でテスト）: `ReasonDestructiveFileOperation`, `ReasonSystemModification`, `ReasonPrivilegeEscalation`, `ReasonCoreutilsClassification`, `ReasonProfilePrivilege`, `ReasonProfileDestruction`, `ReasonProfileDataExfil`, `ReasonProfileNetwork`, `ReasonProfileSystemMod`, `ReasonBinaryAnalysisNetwork`, `ReasonBinaryAnalysisDynamicLoad`, `ReasonBinaryAnalysisExec`, `ReasonBinaryAnalysisSVC`, `ReasonBinaryAnalysisMprotectExec`, `ReasonUncertainMissingRecord`, `ReasonUncertainSchemaMismatch`, `ReasonUncertainHashMismatch`, `ReasonUncertainUnsupportedFormat`, `ReasonUncertainUnverifiedIdentity`, `ReasonAnalysisDisabled`, `ReasonArbitraryCodeExecution`, `ReasonDangerousArgPattern`, `ReasonSymlinkResolutionFailed`, `ReasonIdentityUnbound`, `ReasonIndirectExecutionRejected`, `ReasonForbiddenEnvVar`。各定数の文字列値は snake_case の英語（例: `"destructive_file_operation"`）。
+- [x] `ErrorClass`（string 派生型）＋定数: `ErrorClassSymlinkResolution`, `ErrorClassCoreutilsFileInfo`, `ErrorClassRecordLoad`, `ErrorClassPathResolution`。
+- [x] `ArtifactRole` / `ArtifactDisposition` / `Decision`（`DecisionAllow`/`DecisionDeny`）/ `ExecutionMode`（`ModeNormal`/`ModeDryRun`）を定義（§3.2）。
 
 **完了条件**: `go build -tags test ./internal/runner/base/risktypes/` が通る。型のゼロ値が fail-closed（`BinaryAnalysisClass` ゼロ値 = `Uncertain`）であることを単体テストで確認。
 
@@ -100,8 +100,8 @@
 
 **対象ファイル**: [config.go](../../../internal/runner/base/runnertypes/config.go), [config_test.go](../../../internal/runner/base/runnertypes/config_test.go)
 
-- [ ] `ParseRiskLevel` に `case "unknown":` を追加し `ErrInvalidRiskLevel` を返す（`"critical"` と同様。AC-24）。`"low"/"medium"/"high"/省略/空文字` は不変（AC-26）。
-- [ ] `config_test.go` に `ParseRiskLevel("unknown")` エラーケースを追加。
+- [x] `ParseRiskLevel` に `case "unknown":` を追加し `ErrInvalidRiskLevel` を返す（`"critical"` と同様。AC-24）。`"low"/"medium"/"high"/省略/空文字` は不変（AC-26）。
+- [x] `config_test.go` に `ParseRiskLevel("unknown")` エラーケースを追加。
 
 **完了条件**: `go test -tags test ./internal/runner/base/runnertypes/ -run RiskLevel` が通る。
 
@@ -109,8 +109,8 @@
 
 **対象ファイル**: [spec.go](../../../internal/runner/base/runnertypes/spec.go)
 
-- [ ] `CommandTemplate.RiskLevel`（:46 付近）コメントを `// nil: inherit from global default, otherwise must be one of: "low", "medium", "high"` から `// nil: no template-level default (a command that omits risk_level falls back here; if this is also nil, GetRiskLevel() yields "low"); otherwise must be one of: "low", "medium", "high"` へ変更（テンプレート自身が「テンプレートへフォールバック」する誤記を避け、テンプレート nil＝テンプレート既定なし、と明示。AC-16）。
-- [ ] `CommandSpec.RiskLevel`（:259 付近）の行末コメントを `// Maximum allowed risk level (nil=inherit default, otherwise: low, medium, high)` から `// Maximum allowed risk level (nil defaults to "low" after template fallback; otherwise: low, medium, high)` へ変更。
+- [x] `CommandTemplate.RiskLevel`（:46 付近）コメントを `// nil: inherit from global default, otherwise must be one of: "low", "medium", "high"` から `// nil: no template-level default (a command that omits risk_level falls back here; if this is also nil, GetRiskLevel() yields "low"); otherwise must be one of: "low", "medium", "high"` へ変更（テンプレート自身が「テンプレートへフォールバック」する誤記を避け、テンプレート nil＝テンプレート既定なし、と明示。AC-16）。
+- [x] `CommandSpec.RiskLevel`（:259 付近）の行末コメントを `// Maximum allowed risk level (nil=inherit default, otherwise: low, medium, high)` から `// Maximum allowed risk level (nil defaults to "low" after template fallback; otherwise: low, medium, high)` へ変更。
 
 **完了条件**: `rg -n "inherit from global default|nil=inherit default" internal/runner/base/runnertypes/spec.go` が 0 件。
 

--- a/internal/runner/base/risktypes/reason_codes.go
+++ b/internal/runner/base/risktypes/reason_codes.go
@@ -1,0 +1,78 @@
+package risktypes
+
+// ReasonCode is the machine-readable code for an evaluation reason. It is a
+// string-derived type defined through constants; raw string literals must not be
+// used at call sites (this guards against typos, aids discoverability, and lets
+// a test verify the set of codes is exhaustive and distinct).
+//
+// Each constant's string value is snake_case English.
+type ReasonCode string
+
+const (
+	// ReasonDestructiveFileOperation marks a destructive file operation in the argv.
+	ReasonDestructiveFileOperation ReasonCode = "destructive_file_operation"
+	// ReasonSystemModification marks a system-modification command.
+	ReasonSystemModification ReasonCode = "system_modification"
+	// ReasonPrivilegeEscalation marks privilege escalation (always Critical).
+	ReasonPrivilegeEscalation ReasonCode = "privilege_escalation"
+	// ReasonCoreutilsClassification marks classification by the coreutils dimension.
+	ReasonCoreutilsClassification ReasonCode = "coreutils_classification"
+
+	// Profile-derived factors, one code per factor so audit can distinguish the
+	// profile origin from a runtime/argument origin.
+
+	// ReasonProfilePrivilege marks the profile's PrivilegeRisk factor.
+	ReasonProfilePrivilege ReasonCode = "profile_privilege"
+	// ReasonProfileDestruction marks the profile's DestructionRisk factor.
+	ReasonProfileDestruction ReasonCode = "profile_destruction"
+	// ReasonProfileDataExfil marks the profile's DataExfilRisk factor.
+	ReasonProfileDataExfil ReasonCode = "profile_data_exfil"
+	// ReasonProfileNetwork marks the profile's NetworkRisk factor.
+	ReasonProfileNetwork ReasonCode = "profile_network"
+	// ReasonProfileSystemMod marks the profile's SystemModRisk factor.
+	ReasonProfileSystemMod ReasonCode = "profile_system_mod"
+
+	// Binary-analysis signal codes.
+
+	// ReasonBinaryAnalysisNetwork marks network signals from binary analysis.
+	ReasonBinaryAnalysisNetwork ReasonCode = "binary_analysis_network"
+	// ReasonBinaryAnalysisDynamicLoad marks dynamic loading (dlopen) signals.
+	ReasonBinaryAnalysisDynamicLoad ReasonCode = "binary_analysis_dynamic_load"
+	// ReasonBinaryAnalysisExec marks exec signals.
+	ReasonBinaryAnalysisExec ReasonCode = "binary_analysis_exec"
+	// ReasonBinaryAnalysisSVC marks raw service-call (svc) signals.
+	ReasonBinaryAnalysisSVC ReasonCode = "binary_analysis_svc"
+	// ReasonBinaryAnalysisMprotectExec marks mprotect-to-executable signals.
+	ReasonBinaryAnalysisMprotectExec ReasonCode = "binary_analysis_mprotect_exec"
+
+	// Uncertain (fail-closed) codes.
+
+	// ReasonUncertainMissingRecord marks a missing analysis record for the binary.
+	ReasonUncertainMissingRecord ReasonCode = "uncertain_missing_record"
+	// ReasonUncertainSchemaMismatch marks an analysis record whose schema did not match.
+	ReasonUncertainSchemaMismatch ReasonCode = "uncertain_schema_mismatch"
+	// ReasonUncertainHashMismatch marks a content hash that did not match the record.
+	ReasonUncertainHashMismatch ReasonCode = "uncertain_hash_mismatch"
+	// ReasonUncertainUnsupportedFormat marks an unsupported binary format.
+	ReasonUncertainUnsupportedFormat ReasonCode = "uncertain_unsupported_format"
+	// ReasonUncertainUnverifiedIdentity marks an identity that could not be verified.
+	ReasonUncertainUnverifiedIdentity ReasonCode = "uncertain_unverified_identity"
+	// ReasonAnalysisDisabled marks analysis/verification being disabled in the environment.
+	ReasonAnalysisDisabled ReasonCode = "analysis_disabled"
+
+	// Runtime argument / form codes.
+
+	// ReasonArbitraryCodeExecution marks an arbitrary-code-execution runner (shell,
+	// interpreter, build/task runner).
+	ReasonArbitraryCodeExecution ReasonCode = "arbitrary_code_execution"
+	// ReasonDangerousArgPattern marks a dangerous argument pattern (rm -rf, dd if=, ...).
+	ReasonDangerousArgPattern ReasonCode = "dangerous_arg_pattern"
+	// ReasonSymlinkResolutionFailed marks a symlink resolution failure (blocking).
+	ReasonSymlinkResolutionFailed ReasonCode = "symlink_resolution_failed"
+	// ReasonIdentityUnbound marks an identity that could not be bound until exec.
+	ReasonIdentityUnbound ReasonCode = "identity_unbound"
+	// ReasonIndirectExecutionRejected marks a rejected indirect-execution form.
+	ReasonIndirectExecutionRejected ReasonCode = "indirect_execution_rejected"
+	// ReasonForbiddenEnvVar marks a forbidden environment variable being supplied.
+	ReasonForbiddenEnvVar ReasonCode = "forbidden_env_var"
+)

--- a/internal/runner/base/risktypes/reason_codes_test.go
+++ b/internal/runner/base/risktypes/reason_codes_test.go
@@ -1,0 +1,49 @@
+package risktypes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestReasonCodes_AllDistinct verifies that every defined reason code has a
+// distinct, non-empty string value. A duplicate value would make two different
+// reasons indistinguishable in the audit log.
+func TestReasonCodes_AllDistinct(t *testing.T) {
+	all := []ReasonCode{
+		ReasonDestructiveFileOperation,
+		ReasonSystemModification,
+		ReasonPrivilegeEscalation,
+		ReasonCoreutilsClassification,
+		ReasonProfilePrivilege,
+		ReasonProfileDestruction,
+		ReasonProfileDataExfil,
+		ReasonProfileNetwork,
+		ReasonProfileSystemMod,
+		ReasonBinaryAnalysisNetwork,
+		ReasonBinaryAnalysisDynamicLoad,
+		ReasonBinaryAnalysisExec,
+		ReasonBinaryAnalysisSVC,
+		ReasonBinaryAnalysisMprotectExec,
+		ReasonUncertainMissingRecord,
+		ReasonUncertainSchemaMismatch,
+		ReasonUncertainHashMismatch,
+		ReasonUncertainUnsupportedFormat,
+		ReasonUncertainUnverifiedIdentity,
+		ReasonAnalysisDisabled,
+		ReasonArbitraryCodeExecution,
+		ReasonDangerousArgPattern,
+		ReasonSymlinkResolutionFailed,
+		ReasonIdentityUnbound,
+		ReasonIndirectExecutionRejected,
+		ReasonForbiddenEnvVar,
+	}
+
+	seen := make(map[ReasonCode]struct{}, len(all))
+	for _, rc := range all {
+		assert.NotEmpty(t, string(rc), "reason code must have a non-empty string value")
+		_, dup := seen[rc]
+		assert.Falsef(t, dup, "duplicate reason code value: %q", rc)
+		seen[rc] = struct{}{}
+	}
+}

--- a/internal/runner/base/risktypes/types.go
+++ b/internal/runner/base/risktypes/types.go
@@ -1,0 +1,249 @@
+// Package risktypes holds the shared data-transfer objects exchanged between the
+// risk evaluator, the audit logger, the security analyzers, and the resource
+// managers. It is the lowest neutral package in this area: it depends only on
+// runnertypes (for RiskLevel) and the standard library, so the risk and audit
+// packages can both reference these types without forming a risk -> audit -> risk
+// import cycle.
+package risktypes
+
+import (
+	"syscall"
+
+	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/runnertypes"
+)
+
+// VerifiedFD is a closable wrapper around a verified file descriptor.
+//
+// Contract:
+//   - It owns the underlying descriptor and is the single place that closes it,
+//     so callers must not hold or close the raw int separately (this prevents
+//     double-close and divided ownership).
+//   - Close is idempotent and safe on a nil receiver: the first call closes the
+//     descriptor, later calls (and a nil receiver) return nil.
+//   - Fd returns the raw descriptor for callers that build /proc/self/fd/<n>
+//     paths or pass the descriptor to a child process.
+//
+// The descriptor itself is opened and consumed in Phase 2 (fd-bound execution);
+// this type only declares the ownership contract.
+type VerifiedFD struct {
+	fd     int
+	closed bool
+}
+
+// NewVerifiedFD wraps an already-opened, verified file descriptor.
+func NewVerifiedFD(fd int) *VerifiedFD {
+	return &VerifiedFD{fd: fd}
+}
+
+// Fd returns the raw file descriptor. The descriptor remains owned by the
+// VerifiedFD; callers must not close it directly.
+func (f *VerifiedFD) Fd() int {
+	return f.fd
+}
+
+// Close closes the underlying descriptor. It is idempotent and safe to call on
+// a nil receiver.
+func (f *VerifiedFD) Close() error {
+	if f == nil || f.closed {
+		return nil
+	}
+	f.closed = true
+	return syscall.Close(f.fd)
+}
+
+// VerifiedIdentity binds a verified executable to the moment of exec.
+//
+// A VerifiedIdentity exists only when verification succeeded, so ResolvedPath and
+// ContentHash always hold real values here; "absent" is represented by a nil
+// *VerifiedIdentity on the owning plan, never by a sentinel empty string.
+type VerifiedIdentity struct {
+	// FD is the verified file descriptor used for fd-bound execution where the
+	// environment supports it. nil means no descriptor is held.
+	FD *VerifiedFD
+	// ResolvedPath is the verified absolute path of the executable.
+	ResolvedPath string
+	// ContentHash is the finalized content hash of the verified executable.
+	ContentHash string
+}
+
+// VerifiedCommandPlan is the confirmed, ready-to-exec description of a command.
+// The executor runs only this plan and must never exec the original argv/env
+// directly. The execution fields (ResolvedPath/ResolvedArgv/ResolvedEnv) are set
+// only for allowed (executable) plans; for plans denied before verification
+// completes they are empty, and the audit resolved_path is derived from Identity
+// rather than from these fields.
+type VerifiedCommandPlan struct {
+	ResolvedPath string            // absolute path to exec (allowed plans only)
+	ResolvedArgv []string          // final argv after indirect-execution expansion (allowed plans only)
+	ResolvedEnv  map[string]string // validated env with forbidden variables removed (allowed plans only)
+	Identity     *VerifiedIdentity // identity bound until exec; nil = denied plan with no verified identity
+	Artifacts    []ExecutedArtifact
+	Assessment   RiskAssessment
+}
+
+// RiskAssessment is the effective risk and the reasoning behind it.
+type RiskAssessment struct {
+	// Level is the effective risk, the maximum across all evaluated dimensions.
+	Level runnertypes.RiskLevel
+	// Blocking, when true, denies execution regardless of the configured
+	// risk_level (uncertain analysis or an identity that cannot be bound).
+	Blocking bool
+	// BlockingReason is the machine-readable deny reason. It is set for every
+	// deny, whether Blocking is true or Level is Critical; it is empty when the
+	// command is allowed.
+	BlockingReason ReasonCode
+	// ErrorClass classifies a failure-induced deny (symlink resolution failure,
+	// coreutils file-info failure, etc.). Empty for non-failure denies and for
+	// allowed commands. It is copied verbatim into the audit entry.
+	ErrorClass ErrorClass
+	// ReasonCodes carries the machine-readable evaluation reasons.
+	ReasonCodes []ReasonCode
+	// Reasons carries human-readable reasons (e.g. profile-derived reasons).
+	// Emitted as risk_factors in the audit log.
+	Reasons []string
+	// NetworkType is recorded for audit (none/always/conditional).
+	NetworkType string
+}
+
+// BinaryAnalysisClass is the classification produced by binary signal analysis.
+// The zero value is the safest one, Uncertain (fail-closed): a value left
+// uninitialized never falls through to "safe" (Low).
+type BinaryAnalysisClass int
+
+const (
+	// BinaryAnalysisUncertain (zero value) means the analysis could not reach a
+	// confident verdict (missing record, schema mismatch, unsupported format,
+	// unexpected state) and the command must be blocked.
+	BinaryAnalysisUncertain BinaryAnalysisClass = iota
+	// BinaryAnalysisClean means no dangerous signal was found -> Low.
+	BinaryAnalysisClean
+	// BinaryAnalysisNetwork means only network signals were found -> Medium.
+	BinaryAnalysisNetwork
+	// BinaryAnalysisHighRisk means dangerous signals (dlopen/exec/svc/mprotect)
+	// were found -> High.
+	BinaryAnalysisHighRisk
+)
+
+// BinaryAnalysisResult carries the classification together with the
+// machine-readable reason codes that justified it, so the originating signals
+// are preserved (collapsing to Class alone would lose the reasoning).
+type BinaryAnalysisResult struct {
+	Class       BinaryAnalysisClass
+	ReasonCodes []ReasonCode
+}
+
+// Decision is the final audit verdict. Per the audit contract it is the two
+// values allow/deny only; an error-induced abort is recorded as deny with the
+// failure kind carried separately in ErrorClass.
+type Decision string
+
+const (
+	// DecisionAllow indicates the command was allowed.
+	DecisionAllow Decision = "allow"
+	// DecisionDeny indicates the command was denied.
+	DecisionDeny Decision = "deny"
+)
+
+// ExecutionMode is the audit execution mode. It is a local string type to avoid
+// a resource -> audit -> resource import cycle.
+type ExecutionMode string
+
+const (
+	// ModeNormal is normal (executing) mode.
+	ModeNormal ExecutionMode = "normal"
+	// ModeDryRun is dry-run (preview) mode.
+	ModeDryRun ExecutionMode = "dry-run"
+)
+
+// ErrorClass classifies a failure-induced deny.
+type ErrorClass string
+
+const (
+	// ErrorClassSymlinkResolution is a symlink resolution failure.
+	ErrorClassSymlinkResolution ErrorClass = "symlink_resolution"
+	// ErrorClassCoreutilsFileInfo is a coreutils file-info lookup failure.
+	ErrorClassCoreutilsFileInfo ErrorClass = "coreutils_file_info"
+	// ErrorClassRecordLoad is an analysis record load failure.
+	ErrorClassRecordLoad ErrorClass = "record_load"
+	// ErrorClassPathResolution is a command path resolution failure.
+	ErrorClassPathResolution ErrorClass = "path_resolution"
+)
+
+// ArtifactRole is the role of an artifact within an indirect-execution chain.
+type ArtifactRole string
+
+const (
+	// RoleWrapper is a wrapper command (env/timeout/nice/...).
+	RoleWrapper ArtifactRole = "wrapper"
+	// RoleInner is the inner command extracted from a wrapper.
+	RoleInner ArtifactRole = "inner"
+	// RoleInterpreter is a shell or interpreter resolved from a shebang.
+	RoleInterpreter ArtifactRole = "interpreter"
+	// RolePreload is a loader preload/library artifact.
+	RolePreload ArtifactRole = "preload"
+	// RoleExecTarget is the final executed target.
+	RoleExecTarget ArtifactRole = "exec-target"
+)
+
+// ArtifactDisposition is how an artifact was handled by the gate.
+type ArtifactDisposition string
+
+const (
+	// DispVerified means the artifact was verified and identity-bound.
+	DispVerified ArtifactDisposition = "verified"
+	// DispRejected means the artifact could not be bound and was rejected.
+	DispRejected ArtifactDisposition = "rejected"
+	// DispAllowlistFailed means the artifact failed the allowlist/hash gate.
+	DispAllowlistFailed ArtifactDisposition = "allowlist-failed"
+)
+
+// ExecutedArtifact is the audit information for a single artifact actually
+// executed or loaded during indirect execution. Each artifact in a chain
+// (shebang interpreter, loader preload/library, wrapper helper) carries its own
+// VerifiedIdentity, since it must be identity-bound until its own exec/load.
+// An artifact that cannot be bound is marked DispRejected and its form is
+// refused.
+type ExecutedArtifact struct {
+	// Path is the resolved absolute path.
+	Path string
+	// ContentHash is nil when unverified (not used for matching; Identity is the
+	// source of truth when present).
+	ContentHash *string
+	// Identity is the verified identity of this artifact (nil = cannot bind ->
+	// rejected).
+	Identity *VerifiedIdentity
+	// Role is the artifact's role in the chain.
+	Role ArtifactRole
+	// Disposition is how the artifact was handled.
+	Disposition ArtifactDisposition
+}
+
+// RiskAuditEntry is the parameter object passed to audit.LogRiskProfile. It is
+// defined here (rather than in the audit package) so audit can receive it
+// without importing the risk package, avoiding an import cycle.
+//
+// Values that cannot be obtained are represented by nil pointers (absence),
+// never by sentinel strings inside value fields; rendering absence as a fixed
+// marker happens only at the log-output boundary.
+type RiskAuditEntry struct {
+	CommandName string
+	Mode        ExecutionMode
+	// ResolvedPath is nil when the path was not resolved (e.g. deny on resolution failure).
+	ResolvedPath *string
+	// ContentHash is nil when unverified (not used for matching).
+	ContentHash *string
+	// RecordID is nil when no analysis record was used.
+	RecordID       *string
+	Assessment     RiskAssessment
+	MaxAllowedRisk runnertypes.RiskLevel
+	Decision       Decision
+	// VerificationUnavailable marks a dry-run deny caused by analysis/verification
+	// being unavailable in the environment (deny, but environment-induced).
+	VerificationUnavailable bool
+	// ErrorClass classifies a failure-induced deny. For Blocking denies it mirrors
+	// Assessment.ErrorClass; on the error-return path where no plan is available
+	// the manager sets it directly. Empty when the deny is not failure-induced.
+	ErrorClass ErrorClass
+	// Chain is every artifact in an indirect-execution chain.
+	Chain []ExecutedArtifact
+}

--- a/internal/runner/base/risktypes/types.go
+++ b/internal/runner/base/risktypes/types.go
@@ -23,6 +23,10 @@ import (
 //   - Fd returns the raw descriptor for callers that build /proc/self/fd/<n>
 //     paths or pass the descriptor to a child process.
 //
+// VerifiedFD is not safe for concurrent use: its Close uses a non-atomic
+// check-then-set, so the single owner must serialize Close (e.g. the owning
+// plan closes it once during teardown).
+//
 // The descriptor itself is opened and consumed in Phase 2 (fd-bound execution);
 // this type only declares the ownership contract.
 type VerifiedFD struct {

--- a/internal/runner/base/risktypes/types.go
+++ b/internal/runner/base/risktypes/types.go
@@ -7,6 +7,7 @@
 package risktypes
 
 import (
+	"sync/atomic"
 	"syscall"
 
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/runnertypes"
@@ -18,20 +19,17 @@ import (
 //   - It owns the underlying descriptor and is the single place that closes it,
 //     so callers must not hold or close the raw int separately (this prevents
 //     double-close and divided ownership).
-//   - Close is idempotent and safe on a nil receiver: the first call closes the
-//     descriptor, later calls (and a nil receiver) return nil.
+//   - Close is idempotent and safe for concurrent use: it guarantees the
+//     underlying descriptor is closed exactly once even if several callers race,
+//     and a nil receiver returns nil.
 //   - Fd returns the raw descriptor for callers that build /proc/self/fd/<n>
 //     paths or pass the descriptor to a child process.
-//
-// VerifiedFD is not safe for concurrent use: its Close uses a non-atomic
-// check-then-set, so the single owner must serialize Close (e.g. the owning
-// plan closes it once during teardown).
 //
 // The descriptor itself is opened and consumed in Phase 2 (fd-bound execution);
 // this type only declares the ownership contract.
 type VerifiedFD struct {
 	fd     int
-	closed bool
+	closed atomic.Bool
 }
 
 // NewVerifiedFD wraps an already-opened, verified file descriptor.
@@ -45,13 +43,16 @@ func (f *VerifiedFD) Fd() int {
 	return f.fd
 }
 
-// Close closes the underlying descriptor. It is idempotent and safe to call on
-// a nil receiver.
+// Close closes the underlying descriptor. It is idempotent, safe for concurrent
+// use, and safe to call on a nil receiver. The atomic swap ensures syscall.Close
+// runs for exactly one caller, avoiding a double-close race (CWE-1341).
 func (f *VerifiedFD) Close() error {
-	if f == nil || f.closed {
+	if f == nil {
 		return nil
 	}
-	f.closed = true
+	if f.closed.Swap(true) {
+		return nil
+	}
 	return syscall.Close(f.fd)
 }
 

--- a/internal/runner/base/risktypes/types_test.go
+++ b/internal/runner/base/risktypes/types_test.go
@@ -2,6 +2,7 @@ package risktypes
 
 import (
 	"os"
+	"sync"
 	"syscall"
 	"testing"
 
@@ -39,4 +40,31 @@ func TestVerifiedFD_FdAndIdempotentClose(t *testing.T) {
 func TestVerifiedFD_NilReceiverClose(t *testing.T) {
 	var vfd *VerifiedFD
 	assert.NoError(t, vfd.Close(), "Close on a nil receiver must return nil")
+}
+
+// TestVerifiedFD_ConcurrentClose exercises the thread-safe close contract: with
+// many callers racing on Close, the descriptor must be closed exactly once (no
+// double-close), and every call must return nil. Run under -race to catch data
+// races on the closed flag.
+func TestVerifiedFD_ConcurrentClose(t *testing.T) {
+	fd, err := syscall.Open(os.DevNull, syscall.O_RDONLY, 0)
+	require.NoError(t, err)
+
+	vfd := NewVerifiedFD(fd)
+
+	const goroutines = 16
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	errs := make([]error, goroutines)
+	for i := range goroutines {
+		go func() {
+			defer wg.Done()
+			errs[i] = vfd.Close()
+		}()
+	}
+	wg.Wait()
+
+	for i, e := range errs {
+		assert.NoErrorf(t, e, "concurrent Close call %d must return nil", i)
+	}
 }

--- a/internal/runner/base/risktypes/types_test.go
+++ b/internal/runner/base/risktypes/types_test.go
@@ -1,0 +1,42 @@
+package risktypes
+
+import (
+	"os"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBinaryAnalysisClass_ZeroValueIsUncertain confirms the fail-closed contract:
+// an uninitialized BinaryAnalysisClass must be Uncertain (the blocking verdict),
+// never Clean.
+func TestBinaryAnalysisClass_ZeroValueIsUncertain(t *testing.T) {
+	var zero BinaryAnalysisClass
+	assert.Equal(t, BinaryAnalysisUncertain, zero, "zero value must be Uncertain (fail-closed)")
+	assert.NotEqual(t, BinaryAnalysisClean, zero, "zero value must not be Clean")
+}
+
+// TestBinaryAnalysisResult_ZeroValueIsUncertain confirms that a zero-valued
+// result carries the Uncertain class.
+func TestBinaryAnalysisResult_ZeroValueIsUncertain(t *testing.T) {
+	var r BinaryAnalysisResult
+	assert.Equal(t, BinaryAnalysisUncertain, r.Class)
+}
+
+func TestVerifiedFD_FdAndIdempotentClose(t *testing.T) {
+	fd, err := syscall.Open(os.DevNull, syscall.O_RDONLY, 0)
+	require.NoError(t, err)
+
+	vfd := NewVerifiedFD(fd)
+	assert.Equal(t, fd, vfd.Fd())
+
+	assert.NoError(t, vfd.Close(), "first close should succeed")
+	assert.NoError(t, vfd.Close(), "second close should be a no-op (idempotent)")
+}
+
+func TestVerifiedFD_NilReceiverClose(t *testing.T) {
+	var vfd *VerifiedFD
+	assert.NoError(t, vfd.Close(), "Close on a nil receiver must return nil")
+}

--- a/internal/runner/base/runnertypes/config.go
+++ b/internal/runner/base/runnertypes/config.go
@@ -93,7 +93,7 @@ func (r RiskLevel) String() string {
 func ParseRiskLevel(s string) (RiskLevel, error) {
 	switch s {
 	case UnknownRiskLevelString:
-		return RiskLevelUnknown, nil
+		return RiskLevelUnknown, fmt.Errorf("%w: unknown risk level cannot be set in configuration (reserved for internal use only)", ErrInvalidRiskLevel)
 	case LowRiskLevelString:
 		return RiskLevelLow, nil
 	case MediumRiskLevelString:

--- a/internal/runner/base/runnertypes/config_test.go
+++ b/internal/runner/base/runnertypes/config_test.go
@@ -15,10 +15,10 @@ func TestParseRiskLevel(t *testing.T) {
 		hasError bool
 	}{
 		{
-			name:     "valid unknown risk",
+			name:     "unknown is rejected in configuration",
 			input:    "unknown",
 			expected: RiskLevelUnknown,
-			hasError: false,
+			hasError: true,
 		},
 		{
 			name:     "valid low risk",
@@ -73,6 +73,44 @@ func TestParseRiskLevel(t *testing.T) {
 	}
 }
 
+// TestParseRiskLevel_UnknownError verifies that "unknown" is rejected as a
+// configuration value with ErrInvalidRiskLevel.
+func TestParseRiskLevel_UnknownError(t *testing.T) {
+	level, err := ParseRiskLevel("unknown")
+	assert.ErrorIs(t, err, ErrInvalidRiskLevel)
+	assert.Equal(t, RiskLevelUnknown, level)
+}
+
+// TestParseRiskLevel_UnknownConfigRejected verifies that a command configured
+// with risk_level="unknown" surfaces the error through GetRiskLevel.
+func TestParseRiskLevel_UnknownConfigRejected(t *testing.T) {
+	cmd := &CommandSpec{RiskLevel: StringPtr("unknown")}
+	level, err := cmd.GetRiskLevel()
+	assert.ErrorIs(t, err, ErrInvalidRiskLevel)
+	assert.Equal(t, RiskLevelUnknown, level)
+}
+
+// TestParseRiskLevel_ValidValues verifies that the previously accepted values
+// (low/medium/high and omitted/empty) keep parsing unchanged.
+func TestParseRiskLevel_ValidValues(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected RiskLevel
+	}{
+		{"low", RiskLevelLow},
+		{"medium", RiskLevelMedium},
+		{"high", RiskLevelHigh},
+		{"", RiskLevelLow}, // empty/omitted defaults to low
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			level, err := ParseRiskLevel(tt.input)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, level)
+		})
+	}
+}
+
 func TestRiskLevelString(t *testing.T) {
 	tests := []struct {
 		level    RiskLevel
@@ -101,10 +139,10 @@ func TestCommandGetRiskLevel(t *testing.T) {
 		expectError bool
 	}{
 		{
-			name:        "valid unknown risk",
+			name:        "unknown is rejected in configuration",
 			riskStr:     "unknown",
 			expected:    RiskLevelUnknown,
-			expectError: false,
+			expectError: true,
 		},
 		{
 			name:        "valid low risk",

--- a/internal/runner/base/runnertypes/spec.go
+++ b/internal/runner/base/runnertypes/spec.go
@@ -43,7 +43,7 @@ type CommandTemplate struct {
 	OutputSizeLimit *int64 `toml:"output_size_limit"`
 
 	// RiskLevel specifies the maximum allowed risk level (optional)
-	// nil: inherit from global default, otherwise must be one of: "low", "medium", "high"
+	// nil: no template-level default (a command that omits risk_level falls back here; if this is also nil, GetRiskLevel() yields "low"); otherwise must be one of: "low", "medium", "high"
 	RiskLevel *string `toml:"risk_level"`
 
 	// OutputFile specifies the output file path for redirection (optional)
@@ -256,7 +256,7 @@ type CommandSpec struct {
 	OutputSizeLimit *int64  `toml:"output_size_limit"` // Command-specific output size limit in bytes (nil=inherit from global, 0=unlimited) - raw value for TOML unmarshaling
 	RunAsUser       string  `toml:"run_as_user"`       // User to execute command as (using seteuid)
 	RunAsGroup      string  `toml:"run_as_group"`      // Group to execute command as (using setegid)
-	RiskLevel       *string `toml:"risk_level"`        // Maximum allowed risk level (nil=inherit default, otherwise: low, medium, high)
+	RiskLevel       *string `toml:"risk_level"`        // Maximum allowed risk level (nil defaults to "low" after template fallback; otherwise: low, medium, high)
 	// OutputFile specifies the output file path for redirection
 	// nil: not specified (can be inherited), non-nil: output file path
 	OutputFile *string `toml:"output_file"`

--- a/internal/runner/base/runnertypes/spec_test.go
+++ b/internal/runner/base/runnertypes/spec_test.go
@@ -545,10 +545,10 @@ func TestCommandSpec_GetRiskLevel(t *testing.T) {
 			wantErr:   false,
 		},
 		{
-			name:      "unknown risk level",
+			name:      "unknown risk level is rejected",
 			riskLevel: "unknown",
 			want:      RiskLevelUnknown,
-			wantErr:   false,
+			wantErr:   true,
 		},
 		{
 			name:      "invalid risk level",


### PR DESCRIPTION
## 概要

タスク 0136「実行時リスク判定の強化」の最初の実装 PR（PR-1）。実装計画 §2 の Step 1-1 / 1-2 / 1-3 を対象とする基盤 PR。新規型・config・コメントのみで、`unknown` 拒否を除き既存挙動を変えない。

- **Step 1-1**: 共有 DTO パッケージ `internal/runner/base/risktypes` を新設。評価器（`risk`）・監査（`audit`）・`security`・`resource` の全てが参照する型を、最下位の中立パッケージ（依存は `runnertypes` と標準ライブラリのみ）に配置し `risk -> audit -> risk` 循環を回避。
  - `types.go`: `VerifiedCommandPlan` / `VerifiedIdentity` / `VerifiedFD`（クローズ可能 fd ラッパー・idempotent かつ並行安全な Close〔`atomic.Bool` swap で正確に 1 回 close〕）/ `RiskAssessment` / `BinaryAnalysisClass`（ゼロ値=Uncertain=fail-closed）/ `BinaryAnalysisResult` / `ExecutedArtifact` / `RiskAuditEntry`、および string 派生 enum（`Decision`/`ExecutionMode`/`ErrorClass`/`ArtifactRole`/`ArtifactDisposition`）。02 §3.1 の `FD *int` スケッチは計画 Step 1-1 の確定どおり `*VerifiedFD` で実装。
  - `reason_codes.go`: `ReasonCode` string 派生型と全定数。
- **Step 1-2**: `ParseRiskLevel("unknown")` を `ErrInvalidRiskLevel` でエラー化（`"critical"` と同様）。low/medium/high/省略/空は不変。
- **Step 1-3**: `spec.go` の `risk_level` コメントを実態（テンプレートフォールバック → nil なら "low"）へ修正。存在しない「global default 継承」記述を是正。

## レビュー観点

- `risktypes` のゼロ値 fail-closed（`BinaryAnalysisClass`=Uncertain）。
- 共有 DTO の最下位中立パッケージ配置（循環回避）。
- `ParseRiskLevel("unknown")` のエラー化と既存値（low/medium/high/空）の不変。
- 評価器・実行系へのシグネチャ波及が無い（本 PR は新規型・config・コメントのみで既存挙動を変えない）。

## テスト / 品質

- `make test`: 全パス。
- `make lint`（CI ピン版 golangci-lint v2.11.4）: 0 issues。
- 新規テスト: fail-closed ゼロ値、`VerifiedFD` idempotent/nil-receiver/並行 Close（`-race`）、reason-code 網羅・distinctness、`ParseRiskLevel` unknown 拒否・config 経路拒否・有効値不変。
- critical-review サブエージェント 1 パス済み。PR #728 自動レビュー（gemini 3 件）反映: `VerifiedFD.Close` を `atomic.Bool` で並行安全化（double-close 競合 CWE-1341 を回避）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)