### PR TITLE
chore(devcontainer): install Claude Code CLI in container image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -101,3 +101,6 @@ RUN mkdir -p /home/$USERNAME/.vscode-server/extensions \
 
 WORKDIR /home/$USERNAME
 USER $USERNAME
+
+# Claude Code CLI のインストール
+RUN curl -fsSL https://claude.ai/install.sh | bash


### PR DESCRIPTION
## Summary

- `.devcontainer/Dockerfile` の末尾（`USER $USERNAME` の後）に Claude Code CLI のインストールステップを追加

## Test plan

- [ ] devcontainer をリビルドして `claude --version` が動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)