### PR TITLE
docs(0137): approve plan + define PR boundaries + fix architecture sudo examples

### DIFF
--- a/docs/tasks/0137_package_manager_modification_detection/02_architecture.md
+++ b/docs/tasks/0137_package_manager_modification_detection/02_architecture.md
@@ -283,7 +283,7 @@ func SystemModificationRisk(names map[string]struct{}, args []string) runnertype
 | `internal/runner/base/security/package_manager_flags_test.go` | 新規 | ツール別規則の単体テスト（dpkg/rpm/pacman の肯定・否定・境界）。 | AC-01〜AC-09 / NF-001 | （新規） |
 | `internal/runner/base/security/command_analysis_test.go` | 変更 | `TestIsSystemModification_PackageManagerVerbs`（pacman ケースは退行検証として維持）・`TestIsSystemModification` に dpkg/rpm ケースを追加。 | AC-01〜AC-11 | 同左（拡張） |
 | `internal/runner/base/risk/evaluator_test.go` | 変更 | dpkg/rpm の top-level 実効リスク（Medium。AC-12）と監査 reason code（AC-19）の検証を追加。最大値合成の不変条件は既存 `TestEvaluateRisk_MaxOfDimensionsOrderIndependent` を参照。 | AC-12 / AC-19 | 同左（拡張） |
-| `internal/runner/base/security/indirect_execution_test.go` | 変更 | ラッパー/sudo 経由の dpkg/rpm 複合（`env dpkg -i`=High、`sudo rpm -U`=Critical。いずれも ≥ Medium で Medium が支配しない）の検証を追加。 | AC-14 / AC-18 | 同左（拡張） |
+| `internal/runner/base/security/indirect_execution_test.go` | 変更 | ラッパー経由の dpkg/rpm 複合（`env dpkg -i`=High、`env sudo rpm -U`=Critical。いずれも ≥ Medium で Medium が支配しない）の検証を追加。直接 `sudo` は `AnalyzeIndirectExecution` の対象外（`IndirectNone`）のため、ここでは `env` でラップした形で検証する。 | AC-14 / AC-18 | 同左（拡張） |
 | `internal/runner/base/risk/package_manager_consistency_test.go` | 新規 | 同一 dpkg/rpm コマンド集合で実行時/dry-run が同一実効リスクを返すことを共有評価器で固定（`coreutils_consistency_test.go` と同方式）。 | AC-13 | （新規） |
 
 ドキュメント変更（F-005。`docs/tasks/` 配下のスナップショットは対象外）:
@@ -462,7 +462,7 @@ flowchart TD
 | `pacman -Syu` | フラグ短形式 `S`/`U` | Medium | AC-09 |
 | `pacman -Q` | 非該当 | Unknown | AC-09 |
 | `env dpkg -i pkg.deb` | 間接実行（ラッパー内側 RoleInner は flat High floor） | High（≥ Medium） | AC-18 |
-| `sudo rpm -U pkg.rpm` | 特権昇格次元が支配 | Critical | AC-14 / AC-18 |
+| `env sudo rpm -U pkg.rpm` | ラッパー経由で特権昇格次元が支配 | Critical | AC-14 / AC-18 |
 
 ---
 

--- a/docs/tasks/0137_package_manager_modification_detection/03_implementation_plan.md
+++ b/docs/tasks/0137_package_manager_modification_detection/03_implementation_plan.md
@@ -75,6 +75,19 @@
   **変更なしで緑**であることを確認する。`rg -n "isPacmanModifyingFlag|isPacman\b" internal --glob '*.go'`
   が 0 件であることを確認する（AC-10 / NF-005）。
 
+### PR-1 作成ポイント: per-tool flag mechanism refactor
+
+**対象ステップ**: 1-1 / 1-2 / 1-3 / 1-4
+
+**推奨タイトル**: `refactor(0137): generalize package-manager flag detection into a per-tool mechanism`
+
+**レビュー観点**: pacman 既存挙動の不変（有効入力で退行なし）／`isPacman`・`isPacmanModifyingFlag` の完全削除／ゲート分離（verb=`packageManagerNames`、flag=`flagStyleManagers`）の正しさ
+
+- [ ] グリーンゲート（`_context.md` の "Green gate" 参照）がパスしていることを確認した
+- [ ] PR を作成した
+- [ ] PR がマージされた
+- [ ] 次のブランチへ切り替えた（次ステップは新しいブランチで作業する）
+
 ### フェーズ 2: dpkg/rpm のデータ追加とテスト
 
 **対象ファイル**: `internal/runner/base/security/package_manager_flags.go`（変更）、
@@ -108,6 +121,20 @@
 - [ ] **2-3**: `command_analysis_test.go::TestIsSystemModification_PackageManagerVerbs` に dpkg/rpm の
   代表ケース（`dpkg -i`→true、`dpkg -l`→false、`rpm -U`→true、`rpm -qi`→false）を追加する。pacman・verb の
   既存ケースは変更しない（AC-11 退行検証）。
+
+### PR-2 作成ポイント: dpkg/rpm detection data + security-package tests
+
+**対象ステップ**: 2-1 / 2-2 / 2-3
+
+**推奨タイトル**: `feat(0137): detect dpkg/rpm flag-style system-modification operations`
+
+**レビュー観点**: dpkg/rpm 規則値の正確性（02 §3.1 規則表との一致）／肯定・否定・先頭文字境界・大小区別・rpm 除外の網羅／verb 方式の非退行
+
+- [ ] グリーンゲート（`_context.md` の "Green gate" 参照）がパスしていることを確認した
+- [ ] PR を作成した
+- [ ] PR がマージされた
+- [ ] 次のブランチへ切り替えた（次ステップは新しいブランチで作業する）
+
 - [ ] **2-4**: `internal/runner/base/risk/evaluator_test.go::TestStandardEvaluator_EvaluateRisk_SystemModifications` に
   `dpkg -i pkg.deb`→`RiskLevelMedium`、`rpm -U pkg.rpm`→`RiskLevelMedium` を追加する（`evalLevel` 利用。AC-12）。
 - [ ] **2-5**: `internal/runner/base/risk/evaluator_test.go` に `TestEvaluateRisk_PackageManagerReasonCode`（新規）を追加し、
@@ -136,6 +163,19 @@
   `coreutilsDir` グローバルを変更しないため `t.Parallel()` を使用してよい。
 - [ ] **2-8（完了ゲート）**: `make fmt` → `make test` → `make lint` が緑。`make deadcode` で未使用検出なし。
 
+### PR-3 作成ポイント: cross-package behavior and audit verification
+
+**対象ステップ**: 2-4 / 2-5 / 2-5b / 2-6 / 2-7 / 2-8
+
+**推奨タイトル**: `test(0137): verify dpkg/rpm effective risk, wrapper, audit, and runtime/dry-run consistency`
+
+**レビュー観点**: 実効 Medium と最大値合成（より高い次元が支配）／ラッパー・`env sudo` 複合の期待値（High/Critical）／deny 監査エントリ（`reason_codes`/`resolved_path`）／実行時・dry-run 整合
+
+- [ ] グリーンゲート（`_context.md` の "Green gate" 参照）がパスしていることを確認した
+- [ ] PR を作成した
+- [ ] PR がマージされた
+- [ ] 次のブランチへ切り替えた（次ステップは新しいブランチで作業する）
+
 ### フェーズ 3: ドキュメント整合（F-005）
 
 **対象ファイル**: `docs/user/risk_assessment.ja.md` / `.md`、
@@ -158,6 +198,19 @@
 - [ ] **3-6（完了ゲート）**: 日英 2 ファイルで対象操作集合・値が一致することを確認（§7 AC 検証の static
   コマンドを実行）。
 
+### PR-4 作成ポイント: user/developer documentation and glossary
+
+**対象ステップ**: 3-1 / 3-2 / 3-3 / 3-4 / 3-5 / 3-6
+
+**推奨タイトル**: `docs(0137): document dpkg/rpm system-modification detection and migration`
+
+**レビュー観点**: §3.1 表・§8 移行ノート・§7 検出限界の反映／reinstall を含む全操作種別の明示／日英整合／用語集の対訳追加
+
+- [ ] グリーンゲート（`_context.md` の "Green gate" 参照）がパスしていることを確認した
+- [ ] PR を作成した
+- [ ] PR がマージされた
+- [ ] 次のブランチへ切り替えた（次ステップは新しいブランチで作業する）
+
 ---
 
 ## 3. 実装順序とマイルストーン
@@ -169,6 +222,18 @@
 | M3 | フェーズ 3（ドキュメント） | §7 の文書 static 検証がすべて期待どおり、日英整合 |
 
 順序は 02 §8 のフェーズ定義に一致する（M1 を先行させる NF-005）。
+
+### 3.2 PR 構成
+
+各 PR はグリーンゲート（`_context.md` の "Green gate"）を単独でパスする。`internal/` 内に閉じ、`cmd/`
+レイヤの変更はない。リファクタ（PR-1）を先行させ、その後にデータ追加（PR-2）・検証（PR-3）・文書（PR-4）を積む。
+
+| PR | 対象ステップ | 主な変更内容 |
+|---|---|---|
+| PR-1 | 1-1 / 1-2 / 1-3 / 1-4 | ツール別機構へのリファクタ（pacman 移送、`isPacmanModifyingFlag`/`isPacman` 削除）。振る舞い不変・リスク隔離 |
+| PR-2 | 2-1 / 2-2 / 2-3 | dpkg/rpm 検出データ追加と `security` パッケージの単体・回帰テスト |
+| PR-3 | 2-4 / 2-5 / 2-5b / 2-6 / 2-7 / 2-8 | `risk`/`resource` パッケージの統合・監査・整合テスト（実効リスク・ラッパー・deny 監査・実行時/dry-run） |
+| PR-4 | 3-1 / 3-2 / 3-3 / 3-4 / 3-5 / 3-6 | ユーザー/開発者文書・移行ノート・用語集の更新 |
 
 ---
 
@@ -200,9 +265,10 @@
 
 ## 6. 実装チェックリスト
 
-- [ ] フェーズ 1: 1-1 / 1-2 / 1-3 / 1-4（ゲート）
-- [ ] フェーズ 2: 2-1 / 2-2 / 2-3 / 2-4 / 2-5 / 2-6 / 2-7 / 2-8（ゲート）
-- [ ] フェーズ 3: 3-1 / 3-2 / 3-3 / 3-4 / 3-5 / 3-6（ゲート）
+- [ ] PR-1 マージ済み（対象ステップ: 1-1 / 1-2 / 1-3 / 1-4）
+- [ ] PR-2 マージ済み（対象ステップ: 2-1 / 2-2 / 2-3）
+- [ ] PR-3 マージ済み（対象ステップ: 2-4 / 2-5 / 2-5b / 2-6 / 2-7 / 2-8）
+- [ ] PR-4 マージ済み（対象ステップ: 3-1 / 3-2 / 3-3 / 3-4 / 3-5 / 3-6）
 - [ ] 全体: `make test` / `make lint` / `make deadcode` 緑
 - [ ] §8 クロス検索チェックリスト完了
 
@@ -230,7 +296,7 @@
 | AC-14 最大値合成 | test | `internal/runner/base/security/indirect_execution_test.go::TestIndirect_WrapperPackageManager`（`env dpkg -i`=High／`env sudo rpm -U`=Critical＝より高い次元が支配し、dpkg/rpm の Medium に引き下がらない）＋ 既存 `internal/runner/base/risk/evaluator_test.go::TestEvaluateRisk_MaxOfDimensionsOrderIndependent`（順序非依存の最大値不変条件。0136） |
 | AC-18 ラッパー/間接 | test | `internal/runner/base/security/indirect_execution_test.go::TestIndirect_WrapperPackageManager`（`env dpkg -i`／`timeout 60 rpm -U`=High、`env sudo rpm -U`=Critical。いずれも ≥ Medium） |
 | AC-19 監査 reason code | test | `internal/runner/base/risk/evaluator_test.go::TestEvaluateRisk_PackageManagerReasonCode`（dpkg→`ReasonSystemModification` を分類が生成）＋ `internal/runner/resource/audit_wiring_test.go::TestExecute_PackageManagerDenyAuditable`（Medium+`system_modification` の閾値 deny が `decision=deny`・`reason_codes`・`resolved_path` 付きで監査記録される） |
-| AC-15 AC-34 上書き明記 | static | `rg -n "AC-34" docs/tasks/0137_package_manager_modification_detection/01_requirements.md` → §1.2 に「別途の要件変更として扱う」を上書きする記述がヒット（期待: マッチあり） |
+| AC-15（0136 AC-34 方針上書きの明記） | static | `rg -n "AC-34" docs/tasks/0137_package_manager_modification_detection/01_requirements.md` → §1.2 に「別途の要件変更として扱う」を上書きする記述がヒット（期待: マッチあり） |
 | AC-16 §3.1 表反映（日英） | static | `rg -n "dpkg|rpm" docs/user/risk_assessment.ja.md docs/user/risk_assessment.md` で §3.1 表行に dpkg/rpm の `medium` 記述がヒット（期待: 日英両ファイルでマッチ。値 `medium`・操作集合（dpkg: install/remove/purge/unpack/configure、rpm: install/upgrade/freshen/erase/**reinstall**/import/initdb/rebuilddb）が一致） |
 | AC-17 開発者文書反映（日英） | static | `rg -n "dpkg.*rpm|フラグ方式|flag style" docs/dev/architecture_design/command-risk-evaluation.ja.md docs/dev/architecture_design/command-risk-evaluation.md` で「システム変更リスク」節に flag-style 検出と rpm 除外規則がヒット（期待: 日英両方マッチ） |
 | AC-20 移行ノート（日英） | static | `rg -n "dpkg|rpm" docs/user/risk_assessment.ja.md docs/user/risk_assessment.md` の §8 に破壊的変更・`risk_level = "medium"`・`--dry-run` を含む移行項目がヒット（期待: 日英両方マッチ） |

--- a/docs/tasks/0137_package_manager_modification_detection/03_implementation_plan.md
+++ b/docs/tasks/0137_package_manager_modification_detection/03_implementation_plan.md
@@ -4,10 +4,10 @@
 
 | Item | Value |
 |---|---|
-| Status | `draft` |
+| Status | `approved` |
 | Created | 2026-06-18 |
-| Review date | - |
-| Reviewer | - |
+| Review date | 2026-06-18 |
+| Reviewer | isseis |
 | Comments | - |
 
 関連文書: [01_requirements.md](01_requirements.md) / [02_architecture.md](02_architecture.md)

--- a/docs/tasks/0137_package_manager_modification_detection/03_implementation_plan.md
+++ b/docs/tasks/0137_package_manager_modification_detection/03_implementation_plan.md
@@ -115,9 +115,11 @@
   - [ ] `TestSystemModification_RpmExcludePriority`: 除外優先（照会・検証が変更フラグより優先し非検出）。
     短形式混在 `-q -i`/`-i -q`/`-e -q`、**長形式混在** `--install --query`/`--erase --verify`、`-V` 混在
     `-i -V`（いずれも非検出。AC-07）。
-  - [ ] `TestSystemModification_DegenerateTokens`: 退化トークン（引数に単独 `-`、単独 `--`、空文字列
-    トークンを含むケース）が dpkg/rpm/pacman いずれでも非検出となり、かつパニックしないこと（先頭文字
-    参照前の長さ検査。02 §3.1 の退化トークン規則 / NF-001）。
+  - [ ] `TestSystemModification_DegenerateTokens`: 退化トークン（単独 `-`、単独 `--`、空文字列）自体が
+    フラグに該当しないこと。**唯一の候補が退化トークンの場合は非検出**（例 `dpkg -`、`dpkg --`、`dpkg ""`、
+    `rpm -`、`pacman -`）。一方、**退化トークンは有効な変更フラグを抑制しない**（例 `dpkg -i ""`／`dpkg "" -i`／
+    `rpm -U ""` は引き続き検出される。fail-safe の維持）。いずれもパニックしないこと（先頭文字参照前の
+    長さ検査。02 §3.1 の退化トークン規則 / NF-001）。
   - [ ] `TestSystemModification_PacmanFlags`: 肯定 `-S`/`-R`/`-U`/`-Syu`/`-Rns`/`--sync`/`--remove`/
     `--upgrade`、既存過検出 `-Ss`/`-Si`（先頭 `S` で検出）。否定 `-Q`/`-Qi`、許容差異 `-yS`（非検出）（AC-09）。
   - [ ] `TestSystemModification_AbsolutePathAndSymlink`: 絶対パス `/usr/bin/dpkg -i`・`/usr/bin/rpm -U` が
@@ -237,7 +239,7 @@
 |---|---|---|
 | PR-1 | 1-1 / 1-2 / 1-3 / 1-4 | ツール別機構へのリファクタ（pacman 移送、`isPacmanModifyingFlag`/`isPacman` 削除）。振る舞い不変・リスク隔離 |
 | PR-2 | 2-1 / 2-2 / 2-3 | dpkg/rpm 検出データ追加と `security` パッケージの単体・回帰テスト |
-| PR-3 | 2-4 / 2-5 / 2-5b / 2-6 / 2-7 / 2-8 | `risk`/`resource` パッケージの統合・監査・整合テスト（実効リスク・ラッパー・deny 監査・実行時/dry-run） |
+| PR-3 | 2-4 / 2-5 / 2-5b / 2-6 / 2-7 / 2-8 | `security`/`risk`/`resource` パッケージの統合・監査・整合テスト（実効リスク・ラッパー・deny 監査・実行時/dry-run） |
 | PR-4 | 3-1 / 3-2 / 3-3 / 3-4 / 3-5 / 3-6 | ユーザー/開発者文書・移行ノート・用語集の更新 |
 
 ---

--- a/docs/tasks/0137_package_manager_modification_detection/03_implementation_plan.md
+++ b/docs/tasks/0137_package_manager_modification_detection/03_implementation_plan.md
@@ -112,7 +112,12 @@
     `-e --verbose`/`-U --force`/`--install`/`--upgrade`/`--freshen`/`--erase`/`--reinstall`/`--import`/
     `--initdb`/`--rebuilddb`。否定 `-qi`/`-qa`/`-qpi`/`-ql`/`-V`/`-qa --verbose`/`--query`/`--verify`/
     `--eval`/`--querytags`/引数なし、先頭文字境界 `-E%{_libdir}`/`-D'enable_foo 1'`（AC-05/AC-06）。
-  - [ ] `TestSystemModification_RpmExcludePriority`: 除外優先 `-q -i`/`-i -q`/`-e -q`（いずれも非検出。AC-07）。
+  - [ ] `TestSystemModification_RpmExcludePriority`: 除外優先（照会・検証が変更フラグより優先し非検出）。
+    短形式混在 `-q -i`/`-i -q`/`-e -q`、**長形式混在** `--install --query`/`--erase --verify`、`-V` 混在
+    `-i -V`（いずれも非検出。AC-07）。
+  - [ ] `TestSystemModification_DegenerateTokens`: 退化トークン（引数に単独 `-`、単独 `--`、空文字列
+    トークンを含むケース）が dpkg/rpm/pacman いずれでも非検出となり、かつパニックしないこと（先頭文字
+    参照前の長さ検査。02 §3.1 の退化トークン規則 / NF-001）。
   - [ ] `TestSystemModification_PacmanFlags`: 肯定 `-S`/`-R`/`-U`/`-Syu`/`-Rns`/`--sync`/`--remove`/
     `--upgrade`、既存過検出 `-Ss`/`-Si`（先頭 `S` で検出）。否定 `-Q`/`-Qi`、許容差異 `-yS`（非検出）（AC-09）。
   - [ ] `TestSystemModification_AbsolutePathAndSymlink`: 絶対パス `/usr/bin/dpkg -i`・`/usr/bin/rpm -U` が
@@ -286,10 +291,10 @@
 | AC-04 dpkg 絶対パス・symlink | test | `…::TestSystemModification_AbsolutePathAndSymlink`（`/usr/bin/dpkg -i` と symlink エイリアスが true） |
 | AC-05 rpm 検出（修飾子併用含む） | test | `…::TestSystemModification_RpmFlags`（肯定群が true。`-e --verbose`/`--reinstall`/`--import` 等を含む） |
 | AC-06 rpm 照会非検出 | test | `…::TestSystemModification_RpmFlags`（否定群・先頭文字境界が false） |
-| AC-07 rpm 除外優先 | test | `…::TestSystemModification_RpmExcludePriority`（`-q -i`/`-i -q`/`-e -q` が false） |
+| AC-07 rpm 除外優先 | test | `…::TestSystemModification_RpmExcludePriority`（短形式 `-q -i`/`-i -q`/`-e -q`、長形式混在 `--install --query`/`--erase --verify`、`-V` 混在 `-i -V` がすべて false） |
 | AC-08 rpm 絶対パス・symlink | test | `…::TestSystemModification_AbsolutePathAndSymlink`（`/usr/bin/rpm -U` と symlink が true） |
 | AC-09 pacman 回帰・許容差異 | test | `…::TestSystemModification_PacmanFlags`（`-S`/`-Syu`/`-Rns`/`-Ss`/`-Si`=true、`-Q`/`-Qi`/`-yS`=false）＋ `command_analysis_test.go::TestIsSystemModification_PackageManagerVerbs`（既存 pacman ケース無変更緑） |
-| AC-10 マネージャ名分岐の排除 | static | `rg -n "isPacmanModifyingFlag|isPacman\b" internal --glob '*.go'` → 0 件（期待: マッチなし） |
+| AC-10 マネージャ名分岐の排除 | static | ① `rg -n "isPacmanModifyingFlag|isPacman\b|isDpkg|isRpm" internal/runner/base/security --glob '*.go'` → 0 件（マネージャ専用関数・分岐がないこと）。② `rg -n '"dpkg"|"rpm"' internal/runner/base/security/command_analysis.go` → 0 件（dpkg/rpm は `flagStyleManagers` データ（`package_manager_flags.go`）のみに現れ、判定本体に直接の名前ゲートを持たないこと。`packageManagerNames` の `"pacman"` は verb 集合として残るため本チェック対象外） |
 | AC-11 verb 方式の非退行 | test | `command_analysis_test.go::TestIsSystemModification_PackageManagerVerbs`（apt/yum/dnf/yarn/npm/brew ケース無変更緑） |
 | AC-12 実効 Medium | test | `internal/runner/base/risk/evaluator_test.go::TestStandardEvaluator_EvaluateRisk_SystemModifications`（`dpkg -i`/`rpm -U`=`RiskLevelMedium`） |
 | AC-13 実行時/dry-run 一致 | test | `internal/runner/base/risk/package_manager_consistency_test.go::TestPackageManagerRiskConsistency_RuntimeVsDryRun` |
@@ -299,8 +304,8 @@
 | AC-15（0136 AC-34 方針上書きの明記） | static | `rg -n "AC-34" docs/tasks/0137_package_manager_modification_detection/01_requirements.md` → §1.2 に「別途の要件変更として扱う」を上書きする記述がヒット（期待: マッチあり） |
 | AC-16 §3.1 表反映（日英） | static | `rg -n "dpkg|rpm" docs/user/risk_assessment.ja.md docs/user/risk_assessment.md` で §3.1 表行に dpkg/rpm の `medium` 記述がヒット（期待: 日英両ファイルでマッチ。値 `medium`・操作集合（dpkg: install/remove/purge/unpack/configure、rpm: install/upgrade/freshen/erase/**reinstall**/import/initdb/rebuilddb）が一致） |
 | AC-17 開発者文書反映（日英） | static | `rg -n "dpkg.*rpm|フラグ方式|flag style" docs/dev/architecture_design/command-risk-evaluation.ja.md docs/dev/architecture_design/command-risk-evaluation.md` で「システム変更リスク」節に flag-style 検出と rpm 除外規則がヒット（期待: 日英両方マッチ） |
-| AC-20 移行ノート（日英） | static | `rg -n "dpkg|rpm" docs/user/risk_assessment.ja.md docs/user/risk_assessment.md` の §8 に破壊的変更・`risk_level = "medium"`・`--dry-run` を含む移行項目がヒット（期待: 日英両方マッチ） |
-| AC-21 検出限界（日英） | static | `rg -n "apk|snap|busybox|allowlist" docs/user/risk_assessment.ja.md docs/user/risk_assessment.md` で検出対象外・backstop 記述がヒット（期待: 日英両方マッチ） |
+| AC-20 移行ノート（日英） | static + manual | static: `rg -n "dpkg|rpm" docs/user/risk_assessment.ja.md docs/user/risk_assessment.md` → dpkg/rpm がヒット（現状 0 件のため新規追加を検出）。manual: その追記が **§8 移行ノート内**に dpkg/rpm の破壊的変更項目（旧 `low`/未指定→`medium` でブロック、回避策 `risk_level = "medium"`、`--dry-run` 事前確認）として存在することを目視確認（§3.1 表への追加（AC-16）とは別の §8 への追記であること）。日英両方 |
+| AC-21 検出限界（日英） | static | `rg -n "apk|snap|flatpak|busybox" docs/user/risk_assessment.ja.md docs/user/risk_assessment.md` → 検出対象外マネージャ・multi-call の限界記述がヒット（これらの語は現状 0 件のため新規記述を確実に検出。`allowlist` は既存記述にも現れるため判定語に用いない）。日英両方マッチ |
 | AC-22 用語集 | static | `rg -n "フラグ方式|flag style|ツール別|per-tool" docs/translation_glossary.md` → 追加用語がヒット（期待: マッチあり） |
 
 > AC-16/AC-20/AC-21 の rg は dpkg/rpm 等の語のヒットに加え、対象節（§3.1 表 / §8 / §7）での記述であることと


### PR DESCRIPTION
## 概要

タスク 0137（dpkg/rpm フラグ方式のシステム変更検出）の実装計画の確定。実装計画書の承認反映、PR 境界設計（mkplan2）、および**マージ済み PR #746 のレビューコメント**（アーキテクチャ設計書の sudo 例）への追従修正を含む。要件 (#742)・アーキテクチャ (#744)・実装計画 draft (#746) はマージ済み。

## 含まれるコミット

1. **`docs(task 0137): Approved the implementation plan`** — `03_implementation_plan.md` を `approved` に更新。
2. **`docs(0137): define PR boundaries in the implementation plan`** — mkplan2。`### PR-N 作成ポイント` マーカー×4、`### 3.2 PR 構成` 表、PR ベースの §6 チェックリストを埋め込み。
3. **`docs(0137): use wrapped env sudo in architecture sudo examples (PR #746 review)`** — マージ済み PR #746 に付いたアーキテクチャ設計書へのレビューコメントに対応。

## PR 境界（実装は本計画承認後の後続）

| PR | 対象ステップ | 概要 |
|---|---|---|
| 実装-PR-1 `refactor` | 1-1〜1-4 | ツール別機構へのリファクタ（pacman 移送、`isPacmanModifyingFlag` 削除） |
| 実装-PR-2 `feat` | 2-1〜2-3 | dpkg/rpm 検出データ＋security 単体・回帰テスト |
| 実装-PR-3 `test` | 2-4〜2-8 | risk/resource 統合・監査・整合テスト |
| 実装-PR-4 `docs` | 3-1〜3-6 | ユーザー/開発者文書・移行ノート・用語集 |

（注: 上表は「実装フェーズの」PR 計画であり、本 PR 自体はドキュメント確定 PR）

## アーキテクチャ sudo 例の修正（コミット3）

直接 `sudo rpm -U` は `EvaluateRisk` のランク3特権ゲートで処理され、`AnalyzeIndirectExecution` では `IndirectNone` になり indirect テストの対象外。§3.3 のテスト責務表と §6.2 例表を `env sudo rpm -U`（ラップ形）に修正。実装計画書(03)は前ラウンドで既に `env sudo` を使用済みのため変更不要。

## 影響範囲

`docs/` 配下のみ（コード変更なし）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)