### PR TITLE
refactor(0137): generalize package-manager flag detection into a per-tool mechanism

### DIFF
--- a/docs/tasks/0137_package_manager_modification_detection/03_implementation_plan.md
+++ b/docs/tasks/0137_package_manager_modification_detection/03_implementation_plan.md
@@ -88,7 +88,7 @@
 **レビュー観点**: pacman 既存挙動の不変（有効入力で退行なし）／`isPacman`・`isPacmanModifyingFlag` の完全削除／ゲート分離（verb=`packageManagerNames`、flag=`flagStyleManagers`）の正しさ
 
 - [x] グリーンゲート（`_context.md` の "Green gate" 参照）がパスしていることを確認した
-- [ ] PR を作成した
+- [x] PR を作成した（https://github.com/isseis/go-safe-cmd-runner/pull/750）
 - [ ] PR がマージされた
 - [ ] 次のブランチへ切り替えた（次ステップは新しいブランチで作業する）
 

--- a/docs/tasks/0137_package_manager_modification_detection/03_implementation_plan.md
+++ b/docs/tasks/0137_package_manager_modification_detection/03_implementation_plan.md
@@ -59,21 +59,26 @@
 **対象ファイル**: `internal/runner/base/security/package_manager_flags.go`（新規）、
 `internal/runner/base/security/command_analysis.go`（変更）
 
-- [ ] **1-1**: `package_manager_flags.go`（`package security`、build タグなし）を作成し、`flagRule` 型と
+- [x] **1-1**: `package_manager_flags.go`（`package security`、build タグなし）を作成し、`flagRule` 型と
   `flagStyleManagers` マップリテラルを定義する。初期エントリは **pacman のみ**
   （`modifyingShortChars: "SRU"`、`modifyingLongForms: {--sync,--remove,--upgrade}`、exclude 空）。
-  型・フィールドの定義は 02 §3.1 に従う。コメント・識別子はすべて英語。
-- [ ] **1-2**: `command_analysis.go` の `isSystemModificationByNames` を、`flagStyleManagers` を引いて
+  型・フィールドの定義は 02 §3.1 に従う。コメント・識別子はすべて英語。規則適用の述語
+  （`isFlagStyleModification` / `matchesShortFlag`）も同ファイルにデータと凝集させて配置した。
+- [x] **1-2**: `command_analysis.go` の `isSystemModificationByNames` を、`flagStyleManagers` を引いて
   各フラグ方式マネージャに規則を適用する汎用ループへ置換する。判定規則（除外優先 → 長形式完全一致 →
   短形式の先頭文字一致、退化トークンは長さ検査で非該当）は 02 §3.1 に従う。verb 方式判定
   （`packageManagerNames`+`packageModifyingVerbs`）と systemctl/service 分岐は不変。フラグ方式ループは
   `flagStyleManagers` 所属で独立に発火させる（`packageManagerNames` ゲートに依存しない）。
-- [ ] **1-3**: `isPacmanModifyingFlag` 関数（コメント含む l.478〜494）と、`isSystemModificationByNames`
+- [x] **1-3**: `isPacmanModifyingFlag` 関数（コメント含む l.478〜494）と、`isSystemModificationByNames`
   内の `_, isPacman := names["pacman"]` 行および `isPacman && isPacmanModifyingFlag(arg)` 分岐を削除する。
-- [ ] **1-4（完了ゲート）**: `make fmt` → `make test` → `make lint` を実行し、既存テスト（特に
+- [x] **1-4（完了ゲート）**: `make fmt` → `make test` → `make lint` を実行し、既存テスト（特に
   `TestIsSystemModification_PackageManagerVerbs` の pacman・verb ケース、`TestIsSystemModification`）が
   **変更なしで緑**であることを確認する。`rg -n "isPacmanModifyingFlag|isPacman\b" internal --glob '*.go'`
   が 0 件であることを確認する（AC-10 / NF-005）。
+  注: `make test` 緑・既存テスト無変更緑・`rg` 0 件・`security` パッケージのスコープ付き lint 0 件を確認。
+  リポジトリ全体の `make lint` は本タスクと無関係な既存 goconst 警告（`internal/terminal/*` 等）で失敗する
+  （golangci-lint v2 の goconst パッケージ横断集計による既存事象。main でも同一に失敗）。本変更由来の新規
+  指摘はなし。
 
 ### PR-1 作成ポイント: per-tool flag mechanism refactor
 

--- a/docs/tasks/0137_package_manager_modification_detection/03_implementation_plan.md
+++ b/docs/tasks/0137_package_manager_modification_detection/03_implementation_plan.md
@@ -75,10 +75,9 @@
   `TestIsSystemModification_PackageManagerVerbs` の pacman・verb ケース、`TestIsSystemModification`）が
   **変更なしで緑**であることを確認する。`rg -n "isPacmanModifyingFlag|isPacman\b" internal --glob '*.go'`
   が 0 件であることを確認する（AC-10 / NF-005）。
-  注: `make test` 緑・既存テスト無変更緑・`rg` 0 件・`security` パッケージのスコープ付き lint 0 件を確認。
-  リポジトリ全体の `make lint` は本タスクと無関係な既存 goconst 警告（`internal/terminal/*` 等）で失敗する
-  （golangci-lint v2 の goconst パッケージ横断集計による既存事象。main でも同一に失敗）。本変更由来の新規
-  指摘はなし。
+  注: `make fmt` → `make test`（緑）→ `make lint`（ピン留め版 golangci-lint v2.11.4 で 0 issues）を確認。
+  既存テスト（`TestIsSystemModification_PackageManagerVerbs` の pacman・verb ケース、`TestIsSystemModification`）は
+  無変更で緑。`rg` 0 件。本変更由来の新規 lint 指摘なし。
 
 ### PR-1 作成ポイント: per-tool flag mechanism refactor
 
@@ -88,7 +87,7 @@
 
 **レビュー観点**: pacman 既存挙動の不変（有効入力で退行なし）／`isPacman`・`isPacmanModifyingFlag` の完全削除／ゲート分離（verb=`packageManagerNames`、flag=`flagStyleManagers`）の正しさ
 
-- [ ] グリーンゲート（`_context.md` の "Green gate" 参照）がパスしていることを確認した
+- [x] グリーンゲート（`_context.md` の "Green gate" 参照）がパスしていることを確認した
 - [ ] PR を作成した
 - [ ] PR がマージされた
 - [ ] 次のブランチへ切り替えた（次ステップは新しいブランチで作業する）

--- a/internal/runner/base/security/command_analysis.go
+++ b/internal/runner/base/security/command_analysis.go
@@ -475,24 +475,6 @@ var packageModifyingVerbs = map[string]struct{}{
 	"i": {}, "un": {}, "up": {}, // common npm shorthands
 }
 
-// isPacmanModifyingFlag reports whether a pacman option flag performs an
-// install/remove/upgrade. pacman selects its operation via -S (sync/install),
-// -R (remove), or -U (upgrade), possibly combined (-Syu, -Rns), or via the long
-// forms --sync/--remove/--upgrade.
-func isPacmanModifyingFlag(arg string) bool {
-	switch arg {
-	case "--sync", "--remove", "--upgrade":
-		return true
-	}
-	if strings.HasPrefix(arg, "--") {
-		return false
-	}
-	if strings.HasPrefix(arg, "-") && len(arg) > 1 {
-		return strings.ContainsAny(arg[1:], "SRU")
-	}
-	return false
-}
-
 // anyNameInSet reports whether any of the resolved command names is in set.
 func anyNameInSet(names, set map[string]struct{}) bool {
 	for n := range names {
@@ -563,14 +545,19 @@ func isSystemModificationByNames(names map[string]struct{}, args []string) bool 
 	if anyNameInSet(names, packageManagerNames) {
 		// Only consider install/remove/upgrade-style operations as system
 		// modification (a bare query such as "apt list" is not).
-		_, isPacman := names["pacman"]
 		for _, arg := range args {
 			if _, ok := packageModifyingVerbs[arg]; ok {
 				return true
 			}
-			if isPacman && isPacmanModifyingFlag(arg) {
-				return true
-			}
+		}
+	}
+
+	// Flag-style managers (pacman/dpkg/rpm) select their operation from option
+	// flags rather than a verb. This gate is independent of packageManagerNames so
+	// managers absent from the verb set still reach their flag rule.
+	for n := range names {
+		if rule, ok := flagStyleManagers[n]; ok && isFlagStyleModification(rule, args) {
+			return true
 		}
 	}
 

--- a/internal/runner/base/security/package_manager_flags.go
+++ b/internal/runner/base/security/package_manager_flags.go
@@ -1,0 +1,86 @@
+package security
+
+import "strings"
+
+// flagRule describes how one flag-style package manager selects a modifying
+// operation from its option flags. All character matching is case-sensitive.
+type flagRule struct {
+	// modifyingShortChars: for a short-option token (-X, not --X), if its FIRST
+	// character (immediately after the single dash) is one of these, the token
+	// marks a modifying operation (pacman "SRU", dpkg "irP", rpm "iUFe"). The mode
+	// selector is always the first short-option character in these tools, so
+	// first-character matching avoids false positives from concatenated argument
+	// values (e.g. rpm -E%{_libdir}) or single-dash long forms (e.g. dpkg -list).
+	modifyingShortChars string
+
+	// modifyingLongForms: exact-match long options that are modifying
+	// (e.g. "--install", "--purge", "--reinstall"). Matched whole-token.
+	modifyingLongForms map[string]struct{}
+
+	// excludeShortChars / excludeLongForms: if ANY token in args carries one of
+	// these query/verify markers, the command is treated as non-modifying
+	// regardless of modifying flags (rpm: short "qV", long "--query"/"--verify";
+	// empty for pacman/dpkg). This encodes the least-privilege query exception.
+	excludeShortChars string
+	excludeLongForms  map[string]struct{}
+}
+
+// flagStyleManagers maps a manager basename to its flag-style detection rule.
+// Adding a new flag-style package manager means adding one entry here; the
+// detection logic in isSystemModificationByNames stays unchanged.
+var flagStyleManagers = map[string]flagRule{
+	"pacman": {
+		// pacman selects its operation via -S (sync/install), -R (remove), or
+		// -U (upgrade), possibly combined (-Syu, -Rns), or via the long forms
+		// --sync/--remove/--upgrade. No query/verify exclusion.
+		modifyingShortChars: "SRU",
+		modifyingLongForms: map[string]struct{}{
+			"--sync":    {},
+			"--remove":  {},
+			"--upgrade": {},
+		},
+	},
+}
+
+// isFlagStyleModification reports whether args invoke a modifying operation under
+// the given flag-style rule. A query/verify exclusion token (if the rule defines
+// any) takes precedence over modifying flags, returning false. Degenerate tokens
+// (a lone "-", a lone "--", or an empty string) match neither modifying nor
+// exclude flags; the length checks below guard against out-of-range indexing.
+func isFlagStyleModification(rule flagRule, args []string) bool {
+	if rule.excludeShortChars != "" || len(rule.excludeLongForms) > 0 {
+		for _, arg := range args {
+			if matchesShortFlag(arg, rule.excludeShortChars) {
+				return false
+			}
+			if _, ok := rule.excludeLongForms[arg]; ok {
+				return false
+			}
+		}
+	}
+
+	for _, arg := range args {
+		if _, ok := rule.modifyingLongForms[arg]; ok {
+			return true
+		}
+		if matchesShortFlag(arg, rule.modifyingShortChars) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// matchesShortFlag reports whether arg is a short-option token (a single leading
+// dash, not "--") whose first character is in chars. It returns false for long
+// options ("--..."), degenerate tokens (lone "-", empty string), and when chars
+// is empty, so callers need not pre-validate the token shape.
+func matchesShortFlag(arg, chars string) bool {
+	if chars == "" {
+		return false
+	}
+	if len(arg) <= 1 || arg[0] != '-' || arg[1] == '-' {
+		return false
+	}
+	return strings.IndexByte(chars, arg[1]) >= 0
+}


### PR DESCRIPTION
## 概要 (PR-1 / task 0137 フェーズ 1)

`internal/runner/base/security` のシステム変更検出を、pacman 固有のフラグ判定から
データ駆動の**ツール別機構**へ一般化する**振る舞い不変リファクタ**です。dpkg/rpm の追加は
後続 PR-2 で行います（本 PR では pacman のみ移送）。

## 変更内容

- 新規 `package_manager_flags.go`: `flagRule` 型と `flagStyleManagers` テーブル（pacman のみ）、
  および規則適用述語（`isFlagStyleModification` / `matchesShortFlag`）をデータと凝集させて配置。
- `command_analysis.go`: `isSystemModificationByNames` を `flagStyleManagers` を引く汎用ループへ置換。
  pacman 専用関数 `isPacmanModifyingFlag` と `isPacman` 分岐を削除。
- フラグ方式ゲートは `packageManagerNames`（verb 方式）とは独立に発火（02 §3.2）。

## レビュー観点

- **pacman 既存挙動の不変**: 有効な pacman 使用（`-S`/`-R`/`-U`/`-Syu`/`-Rns`/`-Ss`/`-Si`/
  `--sync`/`--remove`/`--upgrade` → 検出、`-Q`/`-Qi` → 非検出）で退行なし。短形式判定を
  any-char（`ContainsAny`）から先頭文字一致へ統一したことによる差異は、非慣用・無効な並び
  （例 `-yS`）に限られる（承認済み・AC-09 の許容範囲）。
- **`isPacman`・`isPacmanModifyingFlag` の完全削除**: `rg "isPacmanModifyingFlag|isPacman\b"` → 0 件（AC-10 / NF-005）。
- **ゲート分離の正しさ**: verb 方式=`packageManagerNames`、flag 方式=`flagStyleManagers`。

## 検証

- `make test` 緑、既存 `TestIsSystemModification_PackageManagerVerbs` / `TestIsSystemModification` は無変更で緑。
- `make lint`（pinned golangci-lint v2.11.4）0 issues。
- `make deadcode` で本変更由来の未使用なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)