### PR TITLE
docs(0139): implementation plan for coarse system-modification risk classification

### DIFF
--- a/docs/tasks/0139_coarse_system_modification_risk/02_architecture.md
+++ b/docs/tasks/0139_coarse_system_modification_risk/02_architecture.md
@@ -4,10 +4,10 @@
 
 | Item | Value |
 |---|---|
-| Status | `draft` |
+| Status | `approved` |
 | Created | 2026-06-18 |
-| Review date | - |
-| Reviewer | - |
+| Review date | 2026-06-18 |
+| Reviewer | isseis |
 | Comments | - |
 
 関連文書: [01_requirements.md](01_requirements.md)（承認済み要件）。本タスクの事前検討ノート

--- a/docs/tasks/0139_coarse_system_modification_risk/03_implementation_plan.md
+++ b/docs/tasks/0139_coarse_system_modification_risk/03_implementation_plan.md
@@ -27,7 +27,13 @@
 
 - アーキテクチャ §1.1 の設計原則に従う。新規パッケージ・新規エラー型は導入しない（§4）。
 - Go ソースのコメント・識別子・文字列リテラルは英語で書く。
-- 各フェーズ完了時に `make fmt` → `make test` → `make lint` を実行する（NF-002）。
+- **完全な緑ゲート（`make test`／`make lint`）は Phase 4 完了時以降に適用する**。Phase 1〜3 では
+  プロダクションコードと既存テストの整合が一時的に崩れる（例: Phase 1 で `isSystemModificationByNames`
+  を削除しても `command_analysis_test.go` は Phase 4 まで旧 API を呼ぶ。Phase 3 で `systemctl.go` を
+  削除しても `systemctl_test.go` は Phase 4 まで残る）。`make test` は `go test -tags test ./...` で
+  テストもコンパイルするため中間フェーズでは赤になる。したがって Phase 1〜3 の完了基準には**各 Phase に
+  明記したビルドゲート（`go build`、テストファイルを含まない）**を用い、`make fmt` は随時実行してよい。
+  `make test`／`make lint` の通過は Phase 4（テスト改訂完了）と Phase 6 で確認する。
 
 ### 1.3 既存コード調査結果（step 5）
 
@@ -92,10 +98,13 @@
   L75-96 付近・L175-203 付近）。
 - 開発者文書: `docs/dev/architecture_design/command-risk-evaluation.ja.md` / `.md`（「System
   Modification Risk」節、`SystemModificationRisk(names, args)`・`SystemctlSubcommandRisk`・verb-only
-  Medium の記述。EN は L291 付近）。
+  Medium の記述。EN は L291 付近）。`docs/dev/architecture_design/security-architecture.ja.md` / `.md`
+  （L445「Medium risk: … package management (apt, yum)」のコマンドリスク分類）。
 - ユーザーガイド: `docs/user/toml_config/09_practical_examples.ja.md` / `.md` ほか `toml_config/`
   配下の PM／systemctl 実践例（`risk_level=medium`・既定・**`risk_level=low`** の箇所すべて。
   systemctl は常に High になるため `low` 例も拒否される）。
+- README: `README.ja.md` / `README.md`（`systemctl status` を `risk_level = "medium"` とする実践例
+  L231-237 付近、リスク区分一覧 L444-448 のパッケージ管理=Medium 記述）。
 - sample: `sample/risk-based-control.toml`（apt update=medium L67、systemctl restart=medium L103）、
   `sample/timeout_examples.toml`（apt update/upgrade、`risk_level` 無し L72-73/79-80）。
 - sample のロード検証は `internal/runner/config/template_backward_compat_test.go`
@@ -146,7 +155,10 @@
 - [ ] [systemctl.go](../../../internal/runner/base/security/systemctl.go) を削除する。
 - [ ] [package_manager_flags.go](../../../internal/runner/base/security/package_manager_flags.go) を削除する。
 
-**完了基準**: `go build -tags test ./...` が通る。NF-001 の cross-search（§後述）で残存参照ゼロ。
+**完了基準**: `go build -tags test ./...` が通る。**ライブコードのみ**で旧シンボル残存ゼロ
+（`rg -n "SystemctlSubcommandRisk|flagStyleManagers|packageModifyingVerbs|isSystemModificationByNames|packageManagerNames|systemModificationCommandNames" internal/ cmd/` 期待: マッチ無し）。
+文書（`docs/user/`・`docs/dev/`）を含む完全な NF-001 cross-search（§6）は文書更新後の Phase 5 完了時に
+確認する（この時点では `command-risk-evaluation` 等の開発者文書に旧シンボル名が残っているため）。
 
 ### Phase 4: テスト改訂
 
@@ -186,9 +198,19 @@
   テスト名・コメントの「read-only は Medium floor」記述を「常に High」へ更新する（AC-03）。
 - [ ] risk/coreutils_consistency_test.go `TestConsistency_Systemctl`（L218）の `systemctl status`
   期待値を `RiskLevelMedium` → `RiskLevelHigh` へ変更し、コメントを更新する（AC-07）。
-- [ ] AC-09 検証テストを追加する（直接実行 sysmod deny の理由コードが `ReasonSystemModification`）。
-  既存に該当がなければ risk/evaluator_test.go に追加。`risk_level` 上限超過で deny したときの
-  `plan.Assessment.ReasonCodes` に `risktypes.ReasonSystemModification` が含まれることを表明。
+- [ ] AC-09 検証テストを 2 層で追加する。AC-09 は「deny 時の**監査ログ**に system_modification 系
+  理由コードが記録される」ことを要求するが、実際の `risk_level` 比較と deny／監査は evaluator ではなく
+  `NormalResourceManager`／`DryRunResourceManager` で行われる。したがって:
+  - (a) **dimension→理由コード**: `risk/evaluator_test.go` で、直接実行の sysmod コマンドの
+    `plan.Assessment.ReasonCodes` に `risktypes.ReasonSystemModification` が含まれることを表明
+    （名前→理由コードの結線確認）。
+  - (b) **deny+監査**: `internal/runner/resource/audit_wiring_test.go` の既存パターン
+    （`TestExecute_RejectedCommandAuditable`、`fixedPlanEvaluator` で deny plan を注入）に倣い、
+    `ReasonCodes` に `risktypes.ReasonSystemModification` を持つ deny plan で監査エントリが
+    `decision=deny` となり、その理由コード（監査ログに出力される reason コード群。logger.go が
+    `ReasonCodes` を出力）に `system_modification` が含まれることを表明する。実際のフィールド名・
+    `blocking_reason` の値は既存テスト（同ファイル）の表明形式に合わせる。これにより deny／監査の
+    主張を統一 deny 経路で実証する。
 - [ ] AC-08 回帰テストを追加する（本タスクで結論は不変だが明示固定）。security/indirect_execution_test.go に
   `analyzeIndirectCmd("env", "dpkg", "-i", "pkg.deb")` と `("env", "systemctl", "restart", "nginx")`
   が `IndirectFloor` かつ `Level == RiskLevelHigh` を、risk/evaluator_test.go に
@@ -201,11 +223,17 @@
 **ユーザー文書（AC-10/11/12/13）**
 
 - [ ] `docs/user/risk_assessment.ja.md` の systemctl/PM サブコマンド粒度記述（read-only=medium 等）を、
-  固定レベル（PM／systemctl いずれも `high`）へ更新する。表示・照会系が High へ上がる旨の移行ノート
-  （AC-10、baseline=直近リリース）と、検出限界（apk/snap/flatpak/gem・リネーム・busybox 形式、AC-12）、
-  0137/systemctl 粒度の撤回（AC-13）を記載する。
+  固定レベル（PM／systemctl いずれも `high`）へ更新する。移行ノート（AC-10、baseline=直近リリース）には
+  **以下の引き上げをすべて**記載する: (a) 表示・照会系の PM 呼び出し（従来 Low）→High、
+  (b) **パッケージ変更操作（apt install/update 等、0137 後は Medium）→High**、
+  (c) **`dpkg`/`rpm`（従来 Low／未検出）→High**、(d) systemctl read-only（従来 Medium）→High。
+  あわせて従来 `medium` で許可していた PM install/update config がブロックされ得る旨を明記する。
+  検出限界（apk/snap/flatpak/gem・リネーム・busybox 形式、AC-12）、0137/systemctl 粒度の撤回（AC-13）も記載する。
 - [ ] `docs/user/risk_assessment.md`（英語）を `/mktrans` で `.ja.md` から反映する
   （バイリンガル編集順序: ja を先に確定）。
+- [ ] `README.ja.md` の実践例（`systemctl status` を `risk_level = "medium"` とする箇所、L231-233 付近）を
+  `high` へ更新し、リスク区分一覧（L444-445「中: …パッケージ管理／高: システム管理(systemctl)」）から
+  パッケージ管理を Medium 区分の例から外し High 側へ移す。`README.md` を `/mktrans` で反映する。
 
 **開発者文書（F-005 §1.4）**
 
@@ -213,6 +241,9 @@
   `SystemModificationRisk(names)`（引数非依存）・名マッチ固定レベル（PM／systemctl=High）へ更新し、
   `SystemctlSubcommandRisk`・verb-only Medium の記述を削除する。
 - [ ] `docs/dev/architecture_design/command-risk-evaluation.md`（英語）を `/mktrans` で反映する。
+- [ ] `docs/dev/architecture_design/security-architecture.md`（L445「Medium risk: … package management
+  (apt, yum)」）のコマンドリスク分類記述を、パッケージマネージャ=High へ更新する。`.ja.md` も同様に更新する
+  （systemctl は同節で既に High 例として記載済み）。
 
 **ユーザーガイド（toml_config、F-005 §1.4）**
 
@@ -275,7 +306,7 @@ PR 分割は実装着手時に判断する（最小は M1-M2 を 1 PR、M3 を 1
 
 | リスク | 対策 |
 |---|---|
-| §3.5（arch）のテスト一覧が不完全で、見落としたテストが赤くなる | 本計画 §1.3 で全数を再列挙済み。`make test` を各 Phase で実行し未列挙の赤を検出。 |
+| §3.5（arch）のテスト一覧が不完全で、見落としたテストが赤くなる | 本計画 §1.3 で全数を再列挙済み。Phase 4 完了時の `make test` で未列挙の赤を検出（中間フェーズはビルドゲートのみ。§1.2）。 |
 | 旧シンボルの残存参照（コメント・文書） | NF-001 cross-search（§6）で網羅確認。 |
 | 日英文書の不整合 | `/mktrans` で `.ja.md`→`.md` を反映（直接両方編集しない）。 |
 | sample 変更による config テスト破壊 | `risk_level` は `ParseRiskLevel` で `high` が有効。ロード回帰テストで確認。 |
@@ -291,8 +322,13 @@ PR 分割は実装着手時に判断する（最小は M1-M2 を 1 PR、M3 を 1
   `rg -n "SystemctlSubcommandRisk|firstSystemctlSubcommand|systemctlChangeVerbs|systemctlReadOnlyVerbs|flagStyleManagers|flagRule|isFlagStyleModification|matchesShortFlag|packageModifyingVerbs|packageManagerNames|systemModificationCommandNames|isSystemModificationByNames" internal/ cmd/ docs/user/ docs/dev/`
   期待: マッチ無し。
 - [ ] **旧シグネチャ残存**: `rg -n "SystemModificationRisk\([^)]*,\s*\w*[Aa]rgs" -g '*.go'` 期待: マッチ無し。
-- [ ] **文書のサブコマンド粒度記述**: `rg -n "read-only|サブコマンド|status/show|verb" docs/user/risk_assessment.ja.md docs/user/risk_assessment.md docs/dev/architecture_design/command-risk-evaluation.ja.md docs/dev/architecture_design/command-risk-evaluation.md`
-  期待: systemctl/PM のリスク粒度に関する記述が残らない（coreutils 等の無関係な箇所は対象外）。
+- [ ] **stale な挙動記述の残存**: 「systemctl read-only を medium（下限）扱いする」「install/remove 系
+  verb のみ Medium とする」といった**旧挙動を現行仕様として述べる記述**が残らないこと。
+  `rg -n "read-only" docs/user/risk_assessment.ja.md docs/user/risk_assessment.md docs/dev/architecture_design/command-risk-evaluation.ja.md docs/dev/architecture_design/command-risk-evaluation.md`
+  の各ヒットを確認し、systemctl read-only=medium／floor を**現行仕様として**述べる行が無いこと。
+  **注意**: AC-13 が要求する撤回ノート（「0137 のフラグ／verb 方式と systemctl サブコマンド粒度を
+  撤回した」等、`サブコマンド`/`verb` の語を含む経緯説明）はこのチェックの**対象外（残してよい）**。
+  本チェックは「旧挙動を現行として述べる記述」だけを排除し、過去形の撤回ノートは許容する。
 - [ ] **用語集**: 該当語なし（アーキテクチャ §3.4 で確認済み）。追加作業不要。
 
 ---
@@ -309,10 +345,10 @@ PR 分割は実装着手時に判断する（最小は M1-M2 を 1 PR、M3 を 1
 | AC-06（Medium 集合維持） | test | `::TestSystemModificationRisk`（mount/.../update-rc.d=Medium）＋ `risk/evaluator_test.go::TestEvaluateRisk_NoProfileAbsolutePath`（mount/crontab=Medium） |
 | AC-07（実行時＝dry-run） | test | `internal/runner/base/risk/coreutils_consistency_test.go::TestConsistency_Systemctl`（systemctl status=High、共有評価器） |
 | AC-08（ラッパー High／特権 Critical） | test | `internal/runner/base/security/indirect_execution_test.go`（`env dpkg`/`env systemctl`→IndirectFloor High）＋ `risk/evaluator_test.go`（`sudo dpkg`/`sudo systemctl`→Critical） |
-| AC-09（直接 sysmod deny の理由コード） | test | `risk/evaluator_test.go`（deny 時 `Assessment.ReasonCodes` に `risktypes.ReasonSystemModification`） |
-| AC-10（移行ノート） | static | `rg -n "従来" docs/user/risk_assessment.ja.md` 期待: 「表示・照会系（従来 Low）・systemctl read-only（従来 Medium）が high へ上がり、従来許可していた config がブロックされ得る」旨の移行差分記述がヒット（baseline=直近リリース。単なる `high` 一致では不可、移行文を確認する） |
+| AC-09（直接 sysmod deny の監査理由） | test | `risk/evaluator_test.go`（Assessment.ReasonCodes に `ReasonSystemModification`）＋ `internal/runner/resource/audit_wiring_test.go`（`ReasonSystemModification` を持つ deny plan で監査エントリが `decision=deny` となり理由コードに `system_modification` が含まれる。deny／監査は resource manager 層で行われるため、評価器の assessment だけでは不十分） |
+| AC-10（移行ノート） | static | `rg -n "従来" docs/user/risk_assessment.ja.md` 期待: 移行差分に**4 つの引き上げがすべて**記載される — (a) 表示・照会系 PM（従来 Low）→High、(b) **PM 変更操作 install/update（0137 後 Medium）→High**、(c) **dpkg/rpm（従来 Low）→High**、(d) systemctl read-only（従来 Medium）→High。従来 `medium` の PM install config がブロックされ得る旨も明記（baseline=直近リリース。単なる `high` 一致では不可、移行文を確認する） |
 | AC-11（risk_assessment 更新） | static | `rg -n "read-only" docs/user/risk_assessment.ja.md docs/user/risk_assessment.md` 期待: systemctl read-only を medium（下限）とするサブコマンド粒度記述が残らない（coreutils 等の無関係箇所は対象外） |
-| AC-12（検出限界明記） | static | 各語 `apk`／`snap`／`flatpak`／`gem`／`busybox`／リネーム を**個別に** `rg -q "<語>" docs/user/risk_assessment.ja.md` で確認し、全語がヒットすること（OR 一括ではなく全語必須。`gem` を含める） |
+| AC-12（検出限界明記） | static | 各語 `apk`／`snap`／`flatpak`／`gem`／`busybox`／リネーム を**個別に**確認し全語がヒットすること（OR 一括不可、全語必須）。`gem` は `gemini` への誤一致を避けるため**バッククォート付き／語境界**で照合する（例 `` rg -q '`gem`' docs/user/risk_assessment.ja.md `` または `rg -qP '\bgem\b(?!ini)'`）。他の語は `rg -q "<語>" docs/user/risk_assessment.ja.md` |
 | AC-13（0137/systemctl 撤回の記録） | static | `rg -n "0137" docs/user/risk_assessment.ja.md docs/dev/architecture_design/command-risk-evaluation.ja.md` 期待: 0137 フラグ方式・systemctl サブコマンド粒度の撤回／固定レベル化の記述がヒット（設計は 02_architecture.md §3.5 に記載済み） |
 | AC-14（sample config 整合） | test, static | test: `internal/runner/config/template_backward_compat_test.go`（risk-based-control.toml／timeout_examples.toml ロード成功）。static: `rg -n -A4 "^cmd = " sample/risk-based-control.toml sample/timeout_examples.toml` の出力で、**apt update／apt upgrade／systemctl restart** の各エントリに `risk_level = "high"` が付くことを確認（apt だけでなく systemctl も含む） |
 | NF-001（撤去シンボル残存ゼロ） | static | §6 の NF-001 cross-search コマンド。期待: マッチ無し |

--- a/docs/tasks/0139_coarse_system_modification_risk/03_implementation_plan.md
+++ b/docs/tasks/0139_coarse_system_modification_risk/03_implementation_plan.md
@@ -80,9 +80,9 @@
 | `TestFirstSystemctlSubcommand` | security/systemctl_test.go | verb 解析前提 | ファイル削除に伴い削除 |
 | `TestSystemctlSubcommandRisk` | security/systemctl_test.go | read-only=Medium | ファイル削除に伴い削除 |
 | `isSystemModification`（ヘルパ） | security/command_analysis_test.go L1101 | `isSystemModificationByNames` を呼ぶ | 削除（被参照テストの改訂と同時） |
-| `TestIsSystemModification_AbsolutePath` | 同 L1108 | ヘルパ経由 | `SystemModificationRisk` 直接呼びへ改訂 |
-| `TestIsSystemModification_PackageManagerVerbs` | 同 L1117 | `apt list`/`pacman -Q`=false | 照会系も High（非該当でない）へ改訂・新テストへ統合 |
-| `TestIsSystemModification` | 同 L1161 | `apt list`=false 等 | 新 `TestSystemModificationRisk` へ置換 |
+| `TestIsSystemModification_AbsolutePath` | 同 L1108 | ヘルパ経由 | 削除し、新 `TestSystemModificationRisk` の symlink/絶対パスケースで代替（Phase 4） |
+| `TestIsSystemModification_PackageManagerVerbs` | 同 L1117 | `apt list`/`pacman -Q`=false | 削除し、新 `TestSystemModificationRisk` で代替（照会系も High に変わる）（Phase 4） |
+| `TestIsSystemModification` | 同 L1161 | `apt list`=false 等 | 削除し、新 `TestSystemModificationRisk` で代替（Phase 4） |
 | `TestStandardEvaluator_EvaluateRisk_SystemModifications` | risk/evaluator_test.go L101 | `apt/yum install`=Medium | **High へ改訂**（追加特定） |
 | `TestStandardEvaluator_EvaluateRisk_SafeCommands` | 同 L121 | `apt list`=Low | `apt list` ケースを除去（apt は High）（追加特定） |
 | `TestEvaluateRisk_SystemctlSubcommandConditional` | 同 L188 | `status`/`show`=Medium | High へ改訂（status/show 行） |

--- a/docs/tasks/0139_coarse_system_modification_risk/03_implementation_plan.md
+++ b/docs/tasks/0139_coarse_system_modification_risk/03_implementation_plan.md
@@ -94,7 +94,8 @@
   Modification Risk」節、`SystemModificationRisk(names, args)`・`SystemctlSubcommandRisk`・verb-only
   Medium の記述。EN は L291 付近）。
 - ユーザーガイド: `docs/user/toml_config/09_practical_examples.ja.md` / `.md` ほか `toml_config/`
-  配下の PM／systemctl 実践例（`risk_level=medium` の箇所）。
+  配下の PM／systemctl 実践例（`risk_level=medium`・既定・**`risk_level=low`** の箇所すべて。
+  systemctl は常に High になるため `low` 例も拒否される）。
 - sample: `sample/risk-based-control.toml`（apt update=medium L67、systemctl restart=medium L103）、
   `sample/timeout_examples.toml`（apt update/upgrade、`risk_level` 無し L72-73/79-80）。
 - sample のロード検証は `internal/runner/config/template_backward_compat_test.go`
@@ -119,19 +120,22 @@
 - [ ] `isSystemModificationByNames`／`packageModifyingVerbs`／`packageManagerNames`／
   `systemModificationCommandNames` を削除する。
 - [ ] `SystemModificationRisk` の doc コメントを新仕様（引数非依存・固定レベル）へ更新する（英語）。
+- [ ] **同一 `security` パッケージ内の呼び出し元**
+  [indirect_execution.go](../../../internal/runner/base/security/indirect_execution.go) L840 を
+  `SystemModificationRisk(innerNames)` へ追従する。シグネチャ変更は同パッケージを一括コンパイルする
+  ため、この追従を Phase 1 内で行わないと `security` パッケージのビルドが必ず赤になる（呼び出し元が
+  旧シグネチャのまま残るため）。`innerArgs` がこの行で未使用化しても他で使われているため未使用変数
+  エラーは生じないことを確認する。
 
-**完了基準**: パッケージ単体ビルドが通る（`go build -tags test ./internal/runner/base/security/`）。
-旧シンボル参照が同ファイル内に残らない。
+**完了基準**: `security` パッケージのビルドが通る（`go build -tags test ./internal/runner/base/security/`。
+同パッケージ呼び出し元の追従込み）。旧シンボル参照が同ファイル内に残らない。
 
-### Phase 2: 呼び出し元のシグネチャ追従
+### Phase 2: 別パッケージ呼び出し元のシグネチャ追従
 
 **作業内容**
 
-- [ ] [evaluator.go](../../../internal/runner/base/risk/evaluator.go) L231 を
+- [ ] [evaluator.go](../../../internal/runner/base/risk/evaluator.go) L231（`risk` パッケージ）を
   `security.SystemModificationRisk(names)` へ変更する。
-- [ ] [indirect_execution.go](../../../internal/runner/base/security/indirect_execution.go) L840 を
-  `SystemModificationRisk(innerNames)` へ変更する。`innerArgs` がこの行でのみ未使用化しても他で
-  使われているため未使用変数エラーは生じないことを確認する。
 
 **完了基準**: `go build -tags test ./...` が通る。
 
@@ -155,8 +159,13 @@
   - Medium: `mount`/`umount`/`fdisk`/`parted`/`mkfs`/`fsck`/`crontab`/`at`/`batch`/`chkconfig`/
     `update-rc.d`（AC-06）。
   - Unknown: 非該当名（`echo`/`ls`）、および `names` に pm 名を含まないケース（AC-02）。
-  - args 非依存: 同一 `names` で異なる args（install 系／照会系／空）でも結果が一致（AC-05）。
   - symlink/絶対パス: `/usr/sbin/systemctl` は High、`systemctl-helper` は非該当（AC-01）。
+  - 注: `SystemModificationRisk` は引数を取らない新シグネチャのため、本関数に args を渡す形の
+    「args 非依存」テストは書けない（書くと撤去した引数を復活させてしまう）。AC-05 は「引数を
+    参照しないこと」を**シグネチャの静的確認**（§7 AC-05 の static チェック）で担保し、加えて
+    evaluator レベルで**同一コマンド・異なる引数**（例: `apt install nginx` と `apt list`）が
+    同一 High になることを `TestStandardEvaluator_EvaluateRisk_SystemModifications` に追加して
+    補強する。
 - [ ] security/command_analysis_test.go の `isSystemModification` ヘルパ（L1101）を削除する。
 - [ ] `TestIsSystemModification_AbsolutePath`（L1108）を削除する（`TestSystemModificationRisk` の
   symlink/絶対パスケースで代替）。
@@ -166,10 +175,12 @@
   の 2 関数を含む。両関数の不変条件は `TestSystemModificationRisk` の systemctl=High と
   evaluator 統合テストで代替）。
 - [ ] risk/evaluator_test.go `TestStandardEvaluator_EvaluateRisk_SystemModifications`（L111-112）の
-  `apt install`／`yum install` 期待値を `RiskLevelMedium` → `RiskLevelHigh` へ変更する。
+  `apt install`／`yum install` 期待値を `RiskLevelMedium` → `RiskLevelHigh` へ変更する。あわせて
+  `{"apt list (query)", "apt", []string{"list", "--installed"}, RiskLevelHigh}` ケースを追加する
+  （`apt install` と同一コマンド・異なる引数で同一 High ＝ AC-05 の引数非依存を evaluator レベルで補強）。
 - [ ] risk/evaluator_test.go `TestStandardEvaluator_EvaluateRisk_SafeCommands`（L131）の
   `{"apt list (query)", "apt", []string{"list", "--installed"}}` ケースを削除する（apt は High に
-  なり Low 前提が崩れるため。AC-01/10）。
+  なり Low 前提が崩れるため。上記 SystemModifications へ High として移設。AC-01/10）。
 - [ ] risk/evaluator_test.go `TestEvaluateRisk_SystemctlSubcommandConditional`（L190-191）の
   `systemctl status`／`systemctl show` 期待値を `RiskLevelMedium` → `RiskLevelHigh` へ変更し、
   テスト名・コメントの「read-only は Medium floor」記述を「常に High」へ更新する（AC-03）。
@@ -205,8 +216,11 @@
 
 **ユーザーガイド（toml_config、F-005 §1.4）**
 
-- [ ] `docs/user/toml_config/` 配下を横断検索し、PM／systemctl を `risk_level=medium`／既定で使う
-  実践例（`09_practical_examples.{ja,md}` 等）を `high` へ更新する（日英両方）。
+- [ ] `docs/user/toml_config/` 配下を横断検索し、PM／systemctl を使う実践例を `high` へ更新する
+  （日英両方）。**`risk_level=medium`／既定（無設定）だけでなく `risk_level=low` の systemctl/PM 例も
+  対象に含める**（systemctl は常に High になるため、`systemctl status` を `low` とする既存テンプレート
+  も以後拒否される）。検索は `rg -n "systemctl|/usr/bin/apt|apt-get|\"apt\"|dpkg|rpm|pacman" docs/user/toml_config/`
+  で該当行を洗い出し、各 risk_level を確認する。
 
 **sample config（AC-14）**
 
@@ -270,9 +284,12 @@ PR 分割は実装着手時に判断する（最小は M1-M2 を 1 PR、M3 を 1
 
 ## 6. クロスサーチチェックリスト（`make lint`/`make test` で検出できない項目のみ）
 
-- [ ] **NF-001 残存参照**: 次がコード・コメント・テスト・文書に残らない（`rg` でゼロ）。
-  `rg -n "SystemctlSubcommandRisk|firstSystemctlSubcommand|systemctlChangeVerbs|systemctlReadOnlyVerbs|flagStyleManagers|flagRule|isFlagStyleModification|matchesShortFlag|packageModifyingVerbs|packageManagerNames|systemModificationCommandNames|isSystemModificationByNames" -g '!docs/tasks/0139_**'`
-  期待: マッチ無し（0139 タスク文書内の経緯記述は除外）。
+- [ ] **NF-001 残存参照**: 次が**ライブコードとユーザー／開発者文書**に残らない（`rg` でゼロ）。
+  検索対象は `internal/`・`cmd/`・`docs/user/`・`docs/dev/` に限定する。`docs/tasks/` 配下は
+  0136/0137/0139 等の**歴史的タスク記録**が当該シンボル名を含む（経緯として正当に残る）ため、
+  検索対象から除外する。
+  `rg -n "SystemctlSubcommandRisk|firstSystemctlSubcommand|systemctlChangeVerbs|systemctlReadOnlyVerbs|flagStyleManagers|flagRule|isFlagStyleModification|matchesShortFlag|packageModifyingVerbs|packageManagerNames|systemModificationCommandNames|isSystemModificationByNames" internal/ cmd/ docs/user/ docs/dev/`
+  期待: マッチ無し。
 - [ ] **旧シグネチャ残存**: `rg -n "SystemModificationRisk\([^)]*,\s*\w*[Aa]rgs" -g '*.go'` 期待: マッチ無し。
 - [ ] **文書のサブコマンド粒度記述**: `rg -n "read-only|サブコマンド|status/show|verb" docs/user/risk_assessment.ja.md docs/user/risk_assessment.md docs/dev/architecture_design/command-risk-evaluation.ja.md docs/dev/architecture_design/command-risk-evaluation.md`
   期待: systemctl/PM のリスク粒度に関する記述が残らない（coreutils 等の無関係な箇所は対象外）。
@@ -288,16 +305,16 @@ PR 分割は実装着手時に判断する（最小は M1-M2 を 1 PR、M3 を 1
 | AC-02（名前が引数値のみ→非該当） | test | 同 `::TestSystemModificationRisk`（`echo` 名集合に pm 名なし→Unknown、非該当名が High/Medium を受けない） |
 | AC-03（systemctl 全 args→High） | test | `command_analysis_test.go::TestSystemModificationRisk`（systemctl=High）＋ `risk/evaluator_test.go::TestEvaluateRisk_SystemctlSubcommandConditional`（status/show=High） |
 | AC-04（service→High） | test | `risk/evaluator_test.go::TestEvaluateRisk_ServiceAllActionsHigh`、`::TestEvaluateRisk_SystemctlChangeAndServiceHigh` |
-| AC-05（args 非参照） | test, static | test: `::TestSystemModificationRisk`（同 names・異 args で同結果）。static: `rg -n "func SystemModificationRisk\(names map\[string\]struct\{\}\) " internal/runner/base/security/command_analysis.go` 期待: 1 件（args 引数なし） |
+| AC-05（args 非参照） | static, test | static: `rg -n "func SystemModificationRisk\(names map\[string\]struct\{\}\) runnertypes.RiskLevel" internal/runner/base/security/command_analysis.go` 期待: 1 件（引数に args が無く、構造的に参照不可）。test: `risk/evaluator_test.go::TestStandardEvaluator_EvaluateRisk_SystemModifications`（`apt install` と `apt list` が同一 High ＝ 引数非依存） |
 | AC-06（Medium 集合維持） | test | `::TestSystemModificationRisk`（mount/.../update-rc.d=Medium）＋ `risk/evaluator_test.go::TestEvaluateRisk_NoProfileAbsolutePath`（mount/crontab=Medium） |
 | AC-07（実行時＝dry-run） | test | `internal/runner/base/risk/coreutils_consistency_test.go::TestConsistency_Systemctl`（systemctl status=High、共有評価器） |
 | AC-08（ラッパー High／特権 Critical） | test | `internal/runner/base/security/indirect_execution_test.go`（`env dpkg`/`env systemctl`→IndirectFloor High）＋ `risk/evaluator_test.go`（`sudo dpkg`/`sudo systemctl`→Critical） |
 | AC-09（直接 sysmod deny の理由コード） | test | `risk/evaluator_test.go`（deny 時 `Assessment.ReasonCodes` に `risktypes.ReasonSystemModification`） |
-| AC-10（移行ノート） | static | `rg -n "high|移行|baseline|従来 (Low|Medium)" docs/user/risk_assessment.ja.md` 期待: 表示/照会系が High へ上がる移行記述が存在 |
-| AC-11（risk_assessment 更新） | static | `rg -n "medium.*floor|read-only" docs/user/risk_assessment.ja.md docs/user/risk_assessment.md` 期待: systemctl read-only=medium の記述が残らない（coreutils 無関係箇所を除く） |
-| AC-12（検出限界明記） | static | `rg -n "apk|snap|flatpak|busybox|リネーム" docs/user/risk_assessment.ja.md` 期待: 検出限界の記述が存在 |
-| AC-13（0137/systemctl 撤回の記録） | static | `rg -n "0137|撤回|置換|サブコマンド" docs/user/risk_assessment.ja.md docs/dev/architecture_design/command-risk-evaluation.ja.md` 期待: 撤回／固定レベル化の記述が存在（設計は 02_architecture.md §3.5 に記載済み） |
-| AC-14（sample config 整合） | test, static | test: `internal/runner/config/template_backward_compat_test.go`（risk-based-control.toml／timeout_examples.toml ロード成功）。static: `rg -n "cmd = \"apt\"" -A4 sample/risk-based-control.toml sample/timeout_examples.toml \| rg "risk_level = \"high\""` 期待: 該当 apt コマンドの直近に `risk_level = "high"`（`risk_level` は `args` 行の直後に置く） |
+| AC-10（移行ノート） | static | `rg -n "従来" docs/user/risk_assessment.ja.md` 期待: 「表示・照会系（従来 Low）・systemctl read-only（従来 Medium）が high へ上がり、従来許可していた config がブロックされ得る」旨の移行差分記述がヒット（baseline=直近リリース。単なる `high` 一致では不可、移行文を確認する） |
+| AC-11（risk_assessment 更新） | static | `rg -n "read-only" docs/user/risk_assessment.ja.md docs/user/risk_assessment.md` 期待: systemctl read-only を medium（下限）とするサブコマンド粒度記述が残らない（coreutils 等の無関係箇所は対象外） |
+| AC-12（検出限界明記） | static | 各語 `apk`／`snap`／`flatpak`／`gem`／`busybox`／リネーム を**個別に** `rg -q "<語>" docs/user/risk_assessment.ja.md` で確認し、全語がヒットすること（OR 一括ではなく全語必須。`gem` を含める） |
+| AC-13（0137/systemctl 撤回の記録） | static | `rg -n "0137" docs/user/risk_assessment.ja.md docs/dev/architecture_design/command-risk-evaluation.ja.md` 期待: 0137 フラグ方式・systemctl サブコマンド粒度の撤回／固定レベル化の記述がヒット（設計は 02_architecture.md §3.5 に記載済み） |
+| AC-14（sample config 整合） | test, static | test: `internal/runner/config/template_backward_compat_test.go`（risk-based-control.toml／timeout_examples.toml ロード成功）。static: `rg -n -A4 "^cmd = " sample/risk-based-control.toml sample/timeout_examples.toml` の出力で、**apt update／apt upgrade／systemctl restart** の各エントリに `risk_level = "high"` が付くことを確認（apt だけでなく systemctl も含む） |
 | NF-001（撤去シンボル残存ゼロ） | static | §6 の NF-001 cross-search コマンド。期待: マッチ無し |
 | NF-002（緑ゲート） | static | `make test && make lint` 期待: 成功 |
 

--- a/docs/tasks/0139_coarse_system_modification_risk/03_implementation_plan.md
+++ b/docs/tasks/0139_coarse_system_modification_risk/03_implementation_plan.md
@@ -1,0 +1,332 @@
+# システム変更リスク判定の粗粒度化（バイナリ名マッチへの単純化） — 実装計画書
+
+## Document Status
+
+| Item | Value |
+|---|---|
+| Status | `draft` |
+| Created | 2026-06-18 |
+| Review date | - |
+| Reviewer | - |
+| Comments | - |
+
+関連文書: [01_requirements.md](01_requirements.md)（承認済み）、[02_architecture.md](02_architecture.md)（承認済み）。
+設計の詳細は本計画では再掲せず、アーキテクチャの該当節を参照する。
+
+---
+
+## 1. 実装概要
+
+### 1.1 目的
+
+`SystemModificationRisk` から引数（サブコマンド／フラグ）解析を撤廃し、解決済みバイナリ名のみで
+固定レベルを返す構造へ単純化する（設計: [02_architecture.md](02_architecture.md) §3.1〜§3.3）。
+パッケージマネージャ・`systemctl`・`service` を High、その他名マッチ系を Medium とする。
+
+### 1.2 実装原則
+
+- アーキテクチャ §1.1 の設計原則に従う。新規パッケージ・新規エラー型は導入しない（§4）。
+- Go ソースのコメント・識別子・文字列リテラルは英語で書く。
+- 各フェーズ完了時に `make fmt` → `make test` → `make lint` を実行する（NF-002）。
+
+### 1.3 既存コード調査結果（step 5）
+
+調査で確認した現状と、本実装で必要な変更点は以下のとおり。
+
+**変更・撤去対象（`internal/runner/base/security/`）**
+
+- `SystemModificationRisk(names, args)`（[command_analysis.go](../../../internal/runner/base/security/command_analysis.go) L576）:
+  現状は `systemctl`→`SystemctlSubcommandRisk`、`service`→High、`isSystemModificationByNames`→Medium。
+  これを名マッチ固定レベルへ書き換え、引数 `args` を撤去する。
+- `isSystemModificationByNames(names, args)`（同 L540）: `systemModificationCommandNames`・
+  `packageManagerNames`＋`packageModifyingVerbs`・`flagStyleManagers`/`isFlagStyleModification` を
+  参照。撤去し、新 2 集合の名マッチへ置換。
+- 名集合: `systemModificationCommandNames`（L434、`systemctl`/`service` を含む）と
+  `packageManagerNames`（L452、`dpkg`/`rpm` を**含まない**）を、`highSystemModificationNames`
+  （PM 12 種＋`systemctl`/`service`）と `mediumSystemModificationNames`（残り）へ再編。
+  `dpkg`/`rpm` は現状どの集合にも無く本次元では未検出（実効 Low）→ High 集合へ新規追加。
+- `packageModifyingVerbs`（L469）を削除。
+- [systemctl.go](../../../internal/runner/base/security/systemctl.go) 全体（`SystemctlSubcommandRisk`／
+  `firstSystemctlSubcommand`／`systemctlChangeVerbs`／`systemctlReadOnlyVerbs`／
+  `systemctlValueOptions`／`systemctlBoolOptions`）を削除。
+- [package_manager_flags.go](../../../internal/runner/base/security/package_manager_flags.go) 全体
+  （`flagRule`／`flagStyleManagers`／`isFlagStyleModification`／`matchesShortFlag`）を削除。
+
+**維持する既存資産（再利用、変更しない）**
+
+- `anyNameInSet(names, set)`（command_analysis.go L479）: `arbitrary_code.go`・破壊的判定でも共有。
+  新 `SystemModificationRisk` でも再利用する（新ヘルパは作らない）。
+- `ResolveCommandNames`／`extractAllCommandNames`（symlink 解決）: 変更不要。
+- 危険引数パターン次元（`CheckDangerousArgPatterns`／`dangerousCommandPatterns`）: スコープ外・不変。
+  `mkfs`/`fdisk` の実効 High はこの次元が担う（§3.1 注記）。
+
+**呼び出し元（シグネチャ追従のみ、ロジック不変）**
+
+- [evaluator.go](../../../internal/runner/base/risk/evaluator.go) L231 `evaluateDimensions`。
+- [indirect_execution.go](../../../internal/runner/base/security/indirect_execution.go) L840 `evaluateInnerAs`
+  （`RoleInterpreter` 経路でのみ到達。`RoleInner` は手前の L803-810 で一律 High floor を返すため
+  AC-08 の結論に影響しない）。
+
+**影響を受ける既存テスト（全数。アーキテクチャ §3.5 の一覧に加え、本調査で追加特定したものを含む）**
+
+| テスト | 場所 | 現状の表明 | 必要な対応 |
+|---|---|---|---|
+| `TestFirstSystemctlSubcommand` | security/systemctl_test.go | verb 解析前提 | ファイル削除に伴い削除 |
+| `TestSystemctlSubcommandRisk` | security/systemctl_test.go | read-only=Medium | ファイル削除に伴い削除 |
+| `isSystemModification`（ヘルパ） | security/command_analysis_test.go L1101 | `isSystemModificationByNames` を呼ぶ | 削除（被参照テストの改訂と同時） |
+| `TestIsSystemModification_AbsolutePath` | 同 L1108 | ヘルパ経由 | `SystemModificationRisk` 直接呼びへ改訂 |
+| `TestIsSystemModification_PackageManagerVerbs` | 同 L1117 | `apt list`/`pacman -Q`=false | 照会系も High（非該当でない）へ改訂・新テストへ統合 |
+| `TestIsSystemModification` | 同 L1161 | `apt list`=false 等 | 新 `TestSystemModificationRisk` へ置換 |
+| `TestStandardEvaluator_EvaluateRisk_SystemModifications` | risk/evaluator_test.go L101 | `apt/yum install`=Medium | **High へ改訂**（追加特定） |
+| `TestStandardEvaluator_EvaluateRisk_SafeCommands` | 同 L121 | `apt list`=Low | `apt list` ケースを除去（apt は High）（追加特定） |
+| `TestEvaluateRisk_SystemctlSubcommandConditional` | 同 L188 | `status`/`show`=Medium | High へ改訂（status/show 行） |
+| `TestConsistency_Systemctl` | risk/coreutils_consistency_test.go L214 | `systemctl status`=Medium | High へ改訂（追加特定） |
+| `TestEvaluateRisk_SystemctlChangeAndServiceHigh` | risk/evaluator_test.go L180 | High | 結論不変（維持） |
+| `TestEvaluateRisk_ServiceAllActionsHigh` | 同 L197 | High | 結論不変（維持） |
+| `TestEvaluateRisk_NoProfileAbsolutePath`（mount/crontab=Medium） | 同 L203 | Medium | 結論不変（維持） |
+| `TestEvaluateRisk_DangerousArgPatternsRuntime`（mkfs.ext4=High） | 同 L212 | High | 結論不変（維持） |
+
+**影響を受ける文書・config**
+
+- ユーザー文書: `docs/user/risk_assessment.ja.md` / `.md`（systemctl/PM サブコマンド粒度の記述、
+  L75-96 付近・L175-203 付近）。
+- 開発者文書: `docs/dev/architecture_design/command-risk-evaluation.ja.md` / `.md`（「System
+  Modification Risk」節、`SystemModificationRisk(names, args)`・`SystemctlSubcommandRisk`・verb-only
+  Medium の記述。EN は L291 付近）。
+- ユーザーガイド: `docs/user/toml_config/09_practical_examples.ja.md` / `.md` ほか `toml_config/`
+  配下の PM／systemctl 実践例（`risk_level=medium` の箇所）。
+- sample: `sample/risk-based-control.toml`（apt update=medium L67、systemctl restart=medium L103）、
+  `sample/timeout_examples.toml`（apt update/upgrade、`risk_level` 無し L72-73/79-80）。
+- sample のロード検証は `internal/runner/config/template_backward_compat_test.go`
+  （L24-25 で両 sample を列挙）が担う。`risk_level` 値は load 時に `ParseRiskLevel` で検証される
+  （`high` は有効値）ため、変更後もロード成功を回帰確認できる。
+
+---
+
+## 2. 実装ステップ
+
+### Phase 1: 判定本体の名マッチ固定レベル化（[command_analysis.go](../../../internal/runner/base/security/command_analysis.go)）
+
+**作業内容**
+
+- [ ] `highSystemModificationNames`（PM 12 種：apt/apt-get/yum/dnf/zypper/pacman/brew/pip/npm/yarn/
+  **dpkg/rpm** ＋ systemctl/service）を定義する（アーキテクチャ §3.1 の定義に一致させる）。
+- [ ] `mediumSystemModificationNames`（chkconfig/update-rc.d/mount/umount/fdisk/parted/mkfs/fsck/
+  crontab/at/batch）を定義する。
+- [ ] `SystemModificationRisk` を新シグネチャ `func SystemModificationRisk(names map[string]struct{}) runnertypes.RiskLevel`
+  へ書き換える（§3.2）。判定順: high 集合一致→High、medium 集合一致→Medium、いずれも非該当→Unknown。
+  `anyNameInSet` を再利用する。
+- [ ] `isSystemModificationByNames`／`packageModifyingVerbs`／`packageManagerNames`／
+  `systemModificationCommandNames` を削除する。
+- [ ] `SystemModificationRisk` の doc コメントを新仕様（引数非依存・固定レベル）へ更新する（英語）。
+
+**完了基準**: パッケージ単体ビルドが通る（`go build -tags test ./internal/runner/base/security/`）。
+旧シンボル参照が同ファイル内に残らない。
+
+### Phase 2: 呼び出し元のシグネチャ追従
+
+**作業内容**
+
+- [ ] [evaluator.go](../../../internal/runner/base/risk/evaluator.go) L231 を
+  `security.SystemModificationRisk(names)` へ変更する。
+- [ ] [indirect_execution.go](../../../internal/runner/base/security/indirect_execution.go) L840 を
+  `SystemModificationRisk(innerNames)` へ変更する。`innerArgs` がこの行でのみ未使用化しても他で
+  使われているため未使用変数エラーは生じないことを確認する。
+
+**完了基準**: `go build -tags test ./...` が通る。
+
+### Phase 3: 旧機構ファイルの削除（NF-001）
+
+**作業内容**
+
+- [ ] [systemctl.go](../../../internal/runner/base/security/systemctl.go) を削除する。
+- [ ] [package_manager_flags.go](../../../internal/runner/base/security/package_manager_flags.go) を削除する。
+
+**完了基準**: `go build -tags test ./...` が通る。NF-001 の cross-search（§後述）で残存参照ゼロ。
+
+### Phase 4: テスト改訂
+
+**新規・改訂テスト**
+
+- [ ] security/command_analysis_test.go に `TestSystemModificationRisk` を新設する。`SystemModificationRisk`
+  を直接呼び、以下を表明する:
+  - High: `apt`/`apt-get`/`yum`/`dnf`/`zypper`/`pacman`/`brew`/`pip`/`npm`/`yarn`/`dpkg`/`rpm`、
+    `systemctl`、`service`（引数有無・install/照会の両方で High。AC-01/03/04）。
+  - Medium: `mount`/`umount`/`fdisk`/`parted`/`mkfs`/`fsck`/`crontab`/`at`/`batch`/`chkconfig`/
+    `update-rc.d`（AC-06）。
+  - Unknown: 非該当名（`echo`/`ls`）、および `names` に pm 名を含まないケース（AC-02）。
+  - args 非依存: 同一 `names` で異なる args（install 系／照会系／空）でも結果が一致（AC-05）。
+  - symlink/絶対パス: `/usr/sbin/systemctl` は High、`systemctl-helper` は非該当（AC-01）。
+- [ ] security/command_analysis_test.go の `isSystemModification` ヘルパ（L1101）を削除する。
+- [ ] `TestIsSystemModification_AbsolutePath`（L1108）を削除する（`TestSystemModificationRisk` の
+  symlink/絶対パスケースで代替）。
+- [ ] `TestIsSystemModification_PackageManagerVerbs`（L1117）を削除する（同上で代替。照会系=High に変わる）。
+- [ ] `TestIsSystemModification`（L1161）を削除する（`TestSystemModificationRisk` で代替）。
+- [ ] security/systemctl_test.go を削除する（`TestFirstSystemctlSubcommand`／`TestSystemctlSubcommandRisk`
+  の 2 関数を含む。両関数の不変条件は `TestSystemModificationRisk` の systemctl=High と
+  evaluator 統合テストで代替）。
+- [ ] risk/evaluator_test.go `TestStandardEvaluator_EvaluateRisk_SystemModifications`（L111-112）の
+  `apt install`／`yum install` 期待値を `RiskLevelMedium` → `RiskLevelHigh` へ変更する。
+- [ ] risk/evaluator_test.go `TestStandardEvaluator_EvaluateRisk_SafeCommands`（L131）の
+  `{"apt list (query)", "apt", []string{"list", "--installed"}}` ケースを削除する（apt は High に
+  なり Low 前提が崩れるため。AC-01/10）。
+- [ ] risk/evaluator_test.go `TestEvaluateRisk_SystemctlSubcommandConditional`（L190-191）の
+  `systemctl status`／`systemctl show` 期待値を `RiskLevelMedium` → `RiskLevelHigh` へ変更し、
+  テスト名・コメントの「read-only は Medium floor」記述を「常に High」へ更新する（AC-03）。
+- [ ] risk/coreutils_consistency_test.go `TestConsistency_Systemctl`（L218）の `systemctl status`
+  期待値を `RiskLevelMedium` → `RiskLevelHigh` へ変更し、コメントを更新する（AC-07）。
+- [ ] AC-09 検証テストを追加する（直接実行 sysmod deny の理由コードが `ReasonSystemModification`）。
+  既存に該当がなければ risk/evaluator_test.go に追加。`risk_level` 上限超過で deny したときの
+  `plan.Assessment.ReasonCodes` に `risktypes.ReasonSystemModification` が含まれることを表明。
+- [ ] AC-08 回帰テストを追加する（本タスクで結論は不変だが明示固定）。security/indirect_execution_test.go に
+  `analyzeIndirectCmd("env", "dpkg", "-i", "pkg.deb")` と `("env", "systemctl", "restart", "nginx")`
+  が `IndirectFloor` かつ `Level == RiskLevelHigh` を、risk/evaluator_test.go に
+  `sudo dpkg`／`sudo systemctl restart` が `RiskLevelCritical` を表明する。
+
+**完了基準**: `make test` が緑。
+
+### Phase 5: 文書・config の整合
+
+**ユーザー文書（AC-10/11/12/13）**
+
+- [ ] `docs/user/risk_assessment.ja.md` の systemctl/PM サブコマンド粒度記述（read-only=medium 等）を、
+  固定レベル（PM／systemctl いずれも `high`）へ更新する。表示・照会系が High へ上がる旨の移行ノート
+  （AC-10、baseline=直近リリース）と、検出限界（apk/snap/flatpak/gem・リネーム・busybox 形式、AC-12）、
+  0137/systemctl 粒度の撤回（AC-13）を記載する。
+- [ ] `docs/user/risk_assessment.md`（英語）を `/mktrans` で `.ja.md` から反映する
+  （バイリンガル編集順序: ja を先に確定）。
+
+**開発者文書（F-005 §1.4）**
+
+- [ ] `docs/dev/architecture_design/command-risk-evaluation.ja.md` の「System Modification Risk」節を、
+  `SystemModificationRisk(names)`（引数非依存）・名マッチ固定レベル（PM／systemctl=High）へ更新し、
+  `SystemctlSubcommandRisk`・verb-only Medium の記述を削除する。
+- [ ] `docs/dev/architecture_design/command-risk-evaluation.md`（英語）を `/mktrans` で反映する。
+
+**ユーザーガイド（toml_config、F-005 §1.4）**
+
+- [ ] `docs/user/toml_config/` 配下を横断検索し、PM／systemctl を `risk_level=medium`／既定で使う
+  実践例（`09_practical_examples.{ja,md}` 等）を `high` へ更新する（日英両方）。
+
+**sample config（AC-14）**
+
+- [ ] `sample/risk-based-control.toml` L67 の `apt update` を `risk_level = "medium"` →
+  `risk_level = "high"` に変更する。
+- [ ] `sample/risk-based-control.toml` L103 の `systemctl restart` を `risk_level = "medium"` →
+  `risk_level = "high"` に変更する。
+- [ ] `sample/timeout_examples.toml` の `system_update_index`（apt update）ブロックの
+  `args = ["update"]` 行の直後に `risk_level = "high"` 行を追加する。
+- [ ] `sample/timeout_examples.toml` の `system_upgrade`（apt upgrade -y）ブロックの
+  `args = ["upgrade", "-y"]` 行の直後に `risk_level = "high"` 行を追加する。
+- [ ] `sample/` 配下を横断検索し、上記以外に PM／systemctl を含む config が無いことを確認する
+  （見つかれば同様に `risk_level="high"` を付与）。
+
+**完了基準**: §後述の cross-search でサブコマンド粒度の残存記述ゼロ。
+`go test -tags test ./internal/runner/config/...` が緑（sample ロード回帰）。
+
+### Phase 6: 緑化（NF-002）
+
+- [ ] `make fmt` → `make test` → `make lint` をすべて成功させる。
+
+---
+
+## 3. 実装順序とマイルストーン
+
+アーキテクチャ §8 のフェーズ順に従う（Phase 1→6）。
+
+| マイルストーン | 内容 | 成果物 |
+|---|---|---|
+| M1 | Phase 1-3 | 判定本体の名マッチ化＋呼び出し元追従＋旧ファイル削除（ビルド通過） |
+| M2 | Phase 4 | テスト改訂（`make test` 緑、全 AC のテストが存在） |
+| M3 | Phase 5 | 文書・sample 整合（日英・cross-search クリア） |
+| M4 | Phase 6 | `make test && make lint` 緑（PR ゲート） |
+
+PR 分割は実装着手時に判断する（最小は M1-M2 を 1 PR、M3 を 1 PR）。
+
+---
+
+## 4. テスト戦略
+
+詳細は [02_architecture.md](02_architecture.md) §7 を参照。要点:
+
+- **単体（security）**: `TestSystemModificationRisk` で名集合・固定レベル・args 非依存・symlink を網羅。
+- **統合（risk/evaluator）**: 実行時＝dry-run 共有評価器（`TestConsistency_Systemctl`）、ラッパー／特権
+  （AC-08）、監査理由（AC-09）。
+- **回帰（config）**: `template_backward_compat_test.go` による sample ロード成功。
+- 既存で結論不変のテスト（service High、mount/crontab Medium、mkfs.ext4 High）は変更しない。
+
+---
+
+## 5. リスク管理
+
+| リスク | 対策 |
+|---|---|
+| §3.5（arch）のテスト一覧が不完全で、見落としたテストが赤くなる | 本計画 §1.3 で全数を再列挙済み。`make test` を各 Phase で実行し未列挙の赤を検出。 |
+| 旧シンボルの残存参照（コメント・文書） | NF-001 cross-search（§6）で網羅確認。 |
+| 日英文書の不整合 | `/mktrans` で `.ja.md`→`.md` を反映（直接両方編集しない）。 |
+| sample 変更による config テスト破壊 | `risk_level` は `ParseRiskLevel` で `high` が有効。ロード回帰テストで確認。 |
+
+---
+
+## 6. クロスサーチチェックリスト（`make lint`/`make test` で検出できない項目のみ）
+
+- [ ] **NF-001 残存参照**: 次がコード・コメント・テスト・文書に残らない（`rg` でゼロ）。
+  `rg -n "SystemctlSubcommandRisk|firstSystemctlSubcommand|systemctlChangeVerbs|systemctlReadOnlyVerbs|flagStyleManagers|flagRule|isFlagStyleModification|matchesShortFlag|packageModifyingVerbs|packageManagerNames|systemModificationCommandNames|isSystemModificationByNames" -g '!docs/tasks/0139_**'`
+  期待: マッチ無し（0139 タスク文書内の経緯記述は除外）。
+- [ ] **旧シグネチャ残存**: `rg -n "SystemModificationRisk\([^)]*,\s*\w*[Aa]rgs" -g '*.go'` 期待: マッチ無し。
+- [ ] **文書のサブコマンド粒度記述**: `rg -n "read-only|サブコマンド|status/show|verb" docs/user/risk_assessment.ja.md docs/user/risk_assessment.md docs/dev/architecture_design/command-risk-evaluation.ja.md docs/dev/architecture_design/command-risk-evaluation.md`
+  期待: systemctl/PM のリスク粒度に関する記述が残らない（coreutils 等の無関係な箇所は対象外）。
+- [ ] **用語集**: 該当語なし（アーキテクチャ §3.4 で確認済み）。追加作業不要。
+
+---
+
+## 7. 受け入れ基準の検証（AC トレーサビリティ）
+
+| AC | 種別 | 検証場所／コマンドと期待結果 |
+|---|---|---|
+| AC-01（PM 名→High、dpkg/rpm 含む） | test | `internal/runner/base/security/command_analysis_test.go::TestSystemModificationRisk`（apt/.../dpkg/rpm が High） |
+| AC-02（名前が引数値のみ→非該当） | test | 同 `::TestSystemModificationRisk`（`echo` 名集合に pm 名なし→Unknown、非該当名が High/Medium を受けない） |
+| AC-03（systemctl 全 args→High） | test | `command_analysis_test.go::TestSystemModificationRisk`（systemctl=High）＋ `risk/evaluator_test.go::TestEvaluateRisk_SystemctlSubcommandConditional`（status/show=High） |
+| AC-04（service→High） | test | `risk/evaluator_test.go::TestEvaluateRisk_ServiceAllActionsHigh`、`::TestEvaluateRisk_SystemctlChangeAndServiceHigh` |
+| AC-05（args 非参照） | test, static | test: `::TestSystemModificationRisk`（同 names・異 args で同結果）。static: `rg -n "func SystemModificationRisk\(names map\[string\]struct\{\}\) " internal/runner/base/security/command_analysis.go` 期待: 1 件（args 引数なし） |
+| AC-06（Medium 集合維持） | test | `::TestSystemModificationRisk`（mount/.../update-rc.d=Medium）＋ `risk/evaluator_test.go::TestEvaluateRisk_NoProfileAbsolutePath`（mount/crontab=Medium） |
+| AC-07（実行時＝dry-run） | test | `internal/runner/base/risk/coreutils_consistency_test.go::TestConsistency_Systemctl`（systemctl status=High、共有評価器） |
+| AC-08（ラッパー High／特権 Critical） | test | `internal/runner/base/security/indirect_execution_test.go`（`env dpkg`/`env systemctl`→IndirectFloor High）＋ `risk/evaluator_test.go`（`sudo dpkg`/`sudo systemctl`→Critical） |
+| AC-09（直接 sysmod deny の理由コード） | test | `risk/evaluator_test.go`（deny 時 `Assessment.ReasonCodes` に `risktypes.ReasonSystemModification`） |
+| AC-10（移行ノート） | static | `rg -n "high|移行|baseline|従来 (Low|Medium)" docs/user/risk_assessment.ja.md` 期待: 表示/照会系が High へ上がる移行記述が存在 |
+| AC-11（risk_assessment 更新） | static | `rg -n "medium.*floor|read-only" docs/user/risk_assessment.ja.md docs/user/risk_assessment.md` 期待: systemctl read-only=medium の記述が残らない（coreutils 無関係箇所を除く） |
+| AC-12（検出限界明記） | static | `rg -n "apk|snap|flatpak|busybox|リネーム" docs/user/risk_assessment.ja.md` 期待: 検出限界の記述が存在 |
+| AC-13（0137/systemctl 撤回の記録） | static | `rg -n "0137|撤回|置換|サブコマンド" docs/user/risk_assessment.ja.md docs/dev/architecture_design/command-risk-evaluation.ja.md` 期待: 撤回／固定レベル化の記述が存在（設計は 02_architecture.md §3.5 に記載済み） |
+| AC-14（sample config 整合） | test, static | test: `internal/runner/config/template_backward_compat_test.go`（risk-based-control.toml／timeout_examples.toml ロード成功）。static: `rg -n "cmd = \"apt\"" -A4 sample/risk-based-control.toml sample/timeout_examples.toml \| rg "risk_level = \"high\""` 期待: 該当 apt コマンドの直近に `risk_level = "high"`（`risk_level` は `args` 行の直後に置く） |
+| NF-001（撤去シンボル残存ゼロ） | static | §6 の NF-001 cross-search コマンド。期待: マッチ無し |
+| NF-002（緑ゲート） | static | `make test && make lint` 期待: 成功 |
+
+---
+
+## 8. 実装チェックリスト（フェーズ別）
+
+各 Phase の詳細チェックボックスは §2 にある。フェーズ完了の総括は以下で追跡する。
+
+- [ ] Phase 1: 判定本体の名マッチ固定レベル化（§2 Phase 1 の全項目）
+- [ ] Phase 2: 呼び出し元のシグネチャ追従（§2 Phase 2 の全項目）
+- [ ] Phase 3: 旧機構ファイルの削除（§2 Phase 3 の全項目）
+- [ ] Phase 4: テスト改訂（§2 Phase 4 の全項目）
+- [ ] Phase 5: 文書・config の整合（§2 Phase 5 の全項目）
+- [ ] Phase 6: 緑化 `make fmt`/`make test`/`make lint`（§2 Phase 6）
+- [ ] §6 クロスサーチチェックリストの全項目クリア
+- [ ] §7 の全 AC（AC-01〜AC-14、NF-001/002）が検証済み
+
+## 9. 成功基準
+
+- **機能完全性**: AC-01〜AC-14 がすべて §7 の対応テスト／静的検証で確認できる。
+- **品質**: `make test && make lint` が緑（NF-002）。新規 `TestSystemModificationRisk` が
+  名集合・固定レベル・args 非依存・symlink を網羅する。
+- **撤去の完全性**: §6 NF-001 cross-search で撤去シンボルの残存参照がゼロ。
+- **文書整合**: ユーザー／開発者文書・sample config が実装と一致し、サブコマンド粒度の残存記述が
+  ない。日英文書が `/mktrans` で整合している。
+
+## 10. 次のステップ
+
+- 本計画のレビュー後、Status を `approved` に更新（レビュアー）。
+- `approved` 後、Phase 1 から実装を開始（`/runplan`）。
+- 実装中は本計画のチェックボックスを随時更新する。


### PR DESCRIPTION
## 概要

タスク 0139「システム変更リスク判定の粗粒度化」の **実装計画書（`03_implementation_plan.md`）** を追加する。要件（#754）・アーキテクチャ（#755）はマージ済みで、本 PR は承認済みアーキテクチャに基づく実装計画と、アーキテクチャ文書の approve ステータス反映を含む。

## 計画の要点

- Phase 1–6 構成: 判定本体の名マッチ固定レベル化（`SystemModificationRisk` から `args` 撤去、PM＋systemctl/service=High、その他名マッチ系=Medium）→ 呼び出し元追従 → `systemctl.go`／`package_manager_flags.go` 削除 → テスト改訂 → 文書・config 整合 → 緑化。
- 全 AC（AC-01〜14・NF-001/002）に `path::TestName` または `rg` の具体的検証を割り当て。

## 調査で得た主な発見（コード照合済み）

- **アーキテクチャ §3.5 のテスト一覧が不完全**だったため、横断調査で**追加3件**を特定し計画に明記:
  `TestStandardEvaluator_EvaluateRisk_SystemModifications`（apt/yum install Medium→High）、
  `TestStandardEvaluator_EvaluateRisk_SafeCommands`（apt list を Low 期待）、
  `TestConsistency_Systemctl`（systemctl status Medium→High）。
- `dpkg`/`rpm` は現状どの集合にも無く**実効 Low → High**。
- `anyNameInSet` は共有ヘルパのため維持・再利用。

## レビュー

`/mkplan` の手順に従い critical-review を実施。**Critical/Major ゼロ**、Minor 2件（必須セクション追加・AC-14 検証 grep 堅牢化）を反映済み。

## ステータス

`03_implementation_plan.md` は **`draft`**。承認後 `/runplan` で Phase 1 から実装着手。

🤖 Generated with [Claude Code](https://claude.com/claude-code)