### PR TITLE
feat(commands): add japrose Japanese-prose pass and wire into mkarch/mkplan

### DIFF
--- a/.claude/commands/japrose.md
+++ b/.claude/commands/japrose.md
@@ -1,0 +1,118 @@
+> **Project context**: this command reviews and improves the **Japanese prose
+> quality** of a document. It refers to "the document language" and "the
+> translation glossary", whose values are defined in
+> `.claude/commands/_context.md` (Process convention). Read that file and use its
+> values. The review step follows the shared pattern in
+> `.claude/commands/_lib/review-subagent-pattern.md`. The rest of this command is
+> project-independent.
+
+## Purpose
+
+Improve the readability of a Japanese document by finding and fixing prose-quality
+problems — **not** by changing its technical content, facts, numbers, structure, or
+section order. This command targets the recurring problems that machine-assisted
+Japanese writing tends to introduce:
+
+1. **直訳調 (literal-translation tone)** — English word order, inanimate subjects,
+   overuse of passive voice, and calqued idioms that read as a literal rendering of
+   English rather than natural Japanese.
+2. **不適切・不自然な語の用法** — a word that is technically wrong or unusual for the
+   intended meaning (e.g. borrowing a kanji compound for a sense it does not carry,
+   such as 「被覆」for "coverage"), or excessive katakana-English / raw English where a
+   natural Japanese word exists.
+3. **意味のくみ取りにくい一文** — overlong sentences, ambiguous modification (係り受け),
+   missing subjects, or too many clauses packed into one sentence.
+4. **未定義語の先行使用 (undefined term used before it is introduced)** — a term,
+   abbreviation, or piece of jargon used before it is defined in reading order, so a
+   reader going through the document top-to-bottom cannot understand it.
+5. **用語の不統一** — the same concept written with more than one Japanese term or
+   notation, or a deprecated term (旧称) that the glossary says not to use.
+6. **冗長・回りくどい言い回し** — wording that can be made more direct without losing
+   meaning.
+
+## Preparation
+
+Get the target file path from the argument. If no argument is provided and a task
+document is open in the IDE, use that; otherwise ask the user which file to review.
+
+**Scope guard — apply this command only to Japanese-primary documents:**
+
+- This command operates on documents written in the document language (Japanese; see
+  `_context.md`). Typical targets: task documents under `docs/tasks/`
+  (`01_requirements.md`, `02_architecture.md`, `03_implementation_plan.md`) and
+  Japanese guide files.
+- Do **not** run it on an English `.md` that is the English half of a bilingual pair
+  (its Japanese counterpart is `*.ja.md`); translation quality of those is handled by
+  `mktrans`. If the target is such an English file, stop and say so.
+- If the file is not in Japanese, stop and report that this command is for Japanese
+  documents.
+
+## Load the Glossary
+
+Read the translation glossary (path in `_context.md`, Process convention). Use it as
+the authority for canonical terminology: the document must use the glossary's terms
+and must not use any term the glossary marks as deprecated (旧称). Do **not** invent
+new terms; if a clearer term seems warranted but is not in the glossary, flag it as a
+finding rather than silently introducing it.
+
+## Review (via Subagent)
+
+Run the critical-review subagent procedure in
+`.claude/commands/_lib/review-subagent-pattern.md` in **single-reviewer mode** with
+these inputs:
+
+- **ARTIFACT**: the target document.
+- **PERSONA**: a technical editor fluent in Japanese, whose job is to find prose that
+  is unnatural, hard to follow, literally translated, or terminologically
+  inconsistent — and to propose concrete rewrites that preserve the original meaning,
+  structure, and section order. It must look for real problems and not rubber-stamp;
+  if a category is clean it says so explicitly rather than inventing findings. It must
+  prioritize the places where a reader actually stumbles over exhaustive nitpicking.
+- **FILES**: the target document and the translation glossary (path in `_context.md`),
+  as resolved absolute-path strings.
+- **CRITERIA**: every item from the Prose-quality checklist and the Hard constraints
+  below, copied verbatim.
+
+**Prose-quality checklist (use verbatim as evaluation criteria in the subagent prompt above):**
+- [ ] 直訳調・英語語順の直訳（無生物主語の直訳、過剰な受動態、英語イディオムの逐語訳）が、意味を変えずに自然な日本語へ書き換えられている。
+- [ ] 意図した意味に対して技術的に誤った/一般的でない語（例: "coverage" を「被覆」と当てる類）が、普通の日本語の語へ置き換えられている。
+- [ ] 不要なカタカナ英語・生の英語が自然な日本語へ置き換えられている。ただし用語集に載る確立した専門用語、本文書で確立した略語、およびバッククォート内のコード識別子・コマンド名・型名は対象外（むやみに言い換えない）。
+- [ ] 長すぎる一文・曖昧な係り受け・主語の欠落・詰め込みすぎの文が、意味を保ったまま分割・整理されて読みやすくなっている。
+- [ ] 用語・略語・専門語が、読み進める順序で定義より前に使われていない（未定義の先行使用がない）。ある場合は、初出での簡潔な定義、または定義箇所への前方参照（例:「§X で定義」）で、頭から読んで理解できるようになっている。
+- [ ] 同一概念には常に同一の日本語表記が使われ、用語集に一致している。用語集が「旧称」と記す語は使われていない。
+- [ ] 冗長・回りくどい言い回しが、意味を変えずに簡潔にされている。
+- [ ] 図（Mermaid）のラベル・キャプション中の日本語にも上記が適用されている（ノード識別子・コード識別子は除く）。
+
+**Hard constraints (use verbatim; the reviewer must flag any fix that would violate one of these as out of scope):**
+- [ ] 技術的な内容・事実・数値・固有名・構造・節の順序・見出し・文書ステータスを変更しない。表現だけを直す。
+- [ ] コードブロック（```～```）の内部、Mermaid のノード/エッジ識別子、バッククォート内のコード識別子・コマンド名・関数名・型名は変更しない。地の文と図のラベルのみが対象。
+- [ ] 用語集の語を保持し、新しい用語を勝手に導入しない。より良い語が必要なら、置換せずに指摘として挙げる。
+- [ ] 既に文書内で一貫して使われている確立表現（例: fail-closed、max 合成、profile、Reject/Critical/High 等）を、「カタカナ/英語だから」という理由だけで言い換えない。
+
+## Apply Fixes
+
+From the review findings, apply the fixes to the document in place:
+
+- Fix all Critical and Major findings. Apply Minor fixes at your discretion.
+- For an **undefined-term** finding, prefer defining the term briefly at its first
+  occurrence; use a forward pointer (e.g.「§X で定義」) when an inline definition would
+  disrupt the flow; reorder only when it does not disturb the structure.
+- Never change meaning, numbers, code, or section order to satisfy a prose finding. If
+  a finding cannot be fixed without violating a Hard constraint, leave the text and
+  note why.
+- Preserve Mermaid syntax and code fences exactly; re-check that fence counts stay
+  balanced after editing diagram labels.
+
+If any Critical or Major finding required a fix, run a second review pass to verify
+the fixes (subject to the three-pass limit in the shared pattern), then stop.
+
+## Commit
+
+If this command was invoked **as a sub-step of another command** (e.g. `mkarch` /
+`mkplan`), do **not** commit — return control to the calling command, which owns the
+commit. Report the changes you made.
+
+If this command was invoked **standalone**, commit the edited document after all
+review passes are complete and all Critical and Major findings are resolved. Use a
+`docs(<task-id>): improve Japanese prose` style message that lists the kinds of fixes
+applied. (No need to wait for user confirmation before committing.)

--- a/.claude/commands/japrose.md
+++ b/.claude/commands/japrose.md
@@ -90,7 +90,7 @@ these inputs:
 
 **Hard constraints (use verbatim; the reviewer must flag any fix that would violate one of these as out of scope):**
 - [ ] 技術的な内容・事実・数値・固有名・構造・節の順序・見出し・文書ステータスを変更しない。表現だけを直す。
-- [ ] コードブロック（```～```）の内部、Mermaid のノード/エッジ識別子、バッククォート内のコード識別子・コマンド名・関数名・型名は変更しない。地の文と図のラベルのみが対象。
+- [ ] コードブロック（```～```）の内部は変更しない——**ただし Mermaid 図のラベル/キャプションの表示テキストは対象とする**（Mermaid は ```mermaid のフェンス内にあるが、その表示テキストの日本語は本コマンドの対象）。Mermaid のノード/エッジ識別子、およびバッククォート内のコード識別子・コマンド名・関数名・型名は変更しない。編集対象は地の文と Mermaid 図のラベル/キャプションの表示テキストのみ。
 - [ ] 用語集の語を保持し、新しい用語を勝手に導入しない。より良い語が必要なら、置換せずに指摘として挙げる。
 - [ ] 既に文書内で一貫して使われている確立表現（例: fail-closed、max 合成、profile、Reject/Critical/High 等）を、「カタカナ/英語だから」という理由だけで言い換えない。
 
@@ -101,8 +101,9 @@ From the review findings, apply the fixes to the document in place:
 - Fix all Critical and Major findings. Apply Minor fixes at your discretion.
 - For an **undefined-term** finding, prefer defining the term briefly at its first
   occurrence; use a pointer to where it is defined later (e.g.「後述の §X で定義」) when
-  an inline definition would disrupt the flow; reorder only when it does not disturb the
-  structure.
+  an inline definition would disrupt the flow. Do **not** reorder sections or move
+  content to fix it — the structure-preservation Hard constraint forbids that; use a
+  local inline definition or a forward pointer only.
 - Never change meaning, numbers, code, or section order to satisfy a prose finding. If
   a finding cannot be fixed without violating a Hard constraint, leave the text and
   note why.

--- a/.claude/commands/japrose.md
+++ b/.claude/commands/japrose.md
@@ -68,8 +68,13 @@ these inputs:
   structure, and section order. It must look for real problems and not rubber-stamp;
   if a category is clean it says so explicitly rather than inventing findings. It must
   prioritize the places where a reader actually stumbles over exhaustive nitpicking.
-- **FILES**: the target document and the translation glossary (path in `_context.md`),
-  as resolved absolute-path strings.
+- **FILES**: the target document; the translation glossary (path in `_context.md`);
+  and, when the target is a task document under `docs/tasks/<task>/`, the sibling task
+  documents in the same directory that exist (`01_requirements.md`,
+  `02_architecture.md`, `03_implementation_plan.md`) — all as resolved absolute-path
+  strings. The sibling documents are **read-only reference** so the reviewer can check
+  terminology consistency against them (e.g. a plan vs. its architecture); only the
+  target document is edited.
 - **CRITERIA**: every item from the Prose-quality checklist and the Hard constraints
   below, copied verbatim.
 
@@ -78,7 +83,7 @@ these inputs:
 - [ ] 意図した意味に対して技術的に誤った/一般的でない語（例: "coverage" を「被覆」と当てる類）が、普通の日本語の語へ置き換えられている。
 - [ ] 不要なカタカナ英語・生の英語が自然な日本語へ置き換えられている。ただし用語集に載る確立した専門用語、本文書で確立した略語、およびバッククォート内のコード識別子・コマンド名・型名は対象外（むやみに言い換えない）。
 - [ ] 長すぎる一文・曖昧な係り受け・主語の欠落・詰め込みすぎの文が、意味を保ったまま分割・整理されて読みやすくなっている。
-- [ ] 用語・略語・専門語が、読み進める順序で定義より前に使われていない（未定義の先行使用がない）。ある場合は、初出での簡潔な定義、または定義箇所への前方参照（例:「§X で定義」）で、頭から読んで理解できるようになっている。
+- [ ] 用語・略語・専門語が、読み進める順序で定義より前に使われていない（未定義の先行使用がない）。ある場合は、初出での簡潔な定義、または後続の定義箇所への参照（例:「後述の §X で定義」）で、頭から読んで理解できるようになっている。
 - [ ] 同一概念には常に同一の日本語表記が使われ、用語集に一致している。用語集が「旧称」と記す語は使われていない。
 - [ ] 冗長・回りくどい言い回しが、意味を変えずに簡潔にされている。
 - [ ] 図（Mermaid）のラベル・キャプション中の日本語にも上記が適用されている（ノード識別子・コード識別子は除く）。
@@ -95,8 +100,9 @@ From the review findings, apply the fixes to the document in place:
 
 - Fix all Critical and Major findings. Apply Minor fixes at your discretion.
 - For an **undefined-term** finding, prefer defining the term briefly at its first
-  occurrence; use a forward pointer (e.g.「§X で定義」) when an inline definition would
-  disrupt the flow; reorder only when it does not disturb the structure.
+  occurrence; use a pointer to where it is defined later (e.g.「後述の §X で定義」) when
+  an inline definition would disrupt the flow; reorder only when it does not disturb the
+  structure.
 - Never change meaning, numbers, code, or section order to satisfy a prose finding. If
   a finding cannot be fixed without violating a Hard constraint, leave the text and
   note why.

--- a/.claude/commands/mkarch.md
+++ b/.claude/commands/mkarch.md
@@ -106,8 +106,8 @@ Work in the following order.
    as clear, natural Japanese. The two are complementary.
    - Run this **after** step 8's Critical and Major issues are resolved, so prose is
      not polished on text that step 8 then rewrites.
-   - `japrose`, when invoked as this sub-step, does not commit; this command owns the
-     commit (see the step 8 extra rule). Resolve all Critical and Major prose findings
-     before committing.
+   - `japrose`, when invoked as this sub-step, does not commit. After both step 8 and
+     step 9 are complete and all Critical and Major issues from both passes are
+     resolved, commit the created architecture document.
 
 When finished, provide a concise summary of what you created and any assumptions you had to make.

--- a/.claude/commands/mkarch.md
+++ b/.claude/commands/mkarch.md
@@ -62,7 +62,9 @@ Work in the following order.
    - **CRITERIA**: give BOTH reviewers every item from the Technical correctness checklist and the Readability and consistency checklist below, copied verbatim, as the shared floor — but each reviewer reports only items within its mandate, raising an out-of-mandate item ONLY as a one-line OUT-OF-LANE FLAG when it actually spots a potential issue there (it does not enumerate clean out-of-mandate items). Reviewer B additionally applies its operational mandate above beyond the checklists.
    - **Synthesis**: after the parallel panel returns, YOU (not a subagent) merge the two outputs per the Panel-mode "Synthesize" step in `.claude/commands/_lib/review-subagent-pattern.md` — dedup overlapping findings, reconcile conflicting severities to the higher, and reconstruct any cross-cutting issue sitting in the seam between the two mandates (a structural choice with an operational consequence). Then run the fix / re-review loop on the merged findings.
 
-   Extra rule: commit only after all review passes are complete and all Critical and Major issues are resolved.
+   Extra rule: do not commit yet. After this engineering review, a Japanese
+   prose-quality pass runs (step 9 below); commit only after BOTH passes are complete
+   and all Critical and Major issues from both are resolved.
 
 **Technical correctness checklist (use verbatim as evaluation criteria in the subagent prompt above):**
 - [ ] `01_requirements.md` is `approved`.
@@ -93,5 +95,19 @@ Work in the following order.
 - [ ] Ambiguous or overly terse expressions are rewritten in direct, plain Japanese. Readers should not need context from prior review discussions to understand the text.
 - [ ] Architectural decisions that depend on constraints not obvious from the requirements are explained inline.
 - [ ] The body describes the current system; rationale for removed or superseded designs and cross-task history is confined to a bounded appendix or blockquote, not interleaved with current-state description.
+
+9. Run the Japanese prose-quality pass by invoking the `japrose` command
+   (`.claude/commands/japrose.md`) on the created architecture document (path in
+   `_context.md`). It runs a technical-editor review focused on natural Japanese —
+   literal-translation tone, unusual/incorrect word usage, hard-to-follow sentences,
+   terms used before they are defined (so the document reads top-to-bottom), and
+   terminology consistency with the glossary — and applies the fixes. The engineering
+   review (step 8) checks design correctness; this pass checks that the document reads
+   as clear, natural Japanese. The two are complementary.
+   - Run this **after** step 8's Critical and Major issues are resolved, so prose is
+     not polished on text that step 8 then rewrites.
+   - `japrose`, when invoked as this sub-step, does not commit; this command owns the
+     commit (see the step 8 extra rule). Resolve all Critical and Major prose findings
+     before committing.
 
 When finished, provide a concise summary of what you created and any assumptions you had to make.

--- a/.claude/commands/mkplan.md
+++ b/.claude/commands/mkplan.md
@@ -77,7 +77,7 @@ Work in the following order.
    - **CRITERIA**: every item from the Technical correctness checklist, the Conditional checks section, and the Readability and consistency checklist below, copied verbatim. For Conditional checks, evaluate each item that applies to the plan; mark inapplicable items N/A (N/A is not a finding). In panel mode, give both reviewers all of them as the shared floor (option (b) in `.claude/commands/_lib/review-subagent-pattern.md`), but each reports only items within its mandate, raising an out-of-mandate item ONLY as a one-line OUT-OF-LANE FLAG when it actually spots a potential issue there (it does not enumerate clean out-of-mandate items); the Conditional checks are Reviewer B's, except the phase-names/order item which is Reviewer A's (it is an architecture-alignment concern in A's mandate).
    - **Synthesis** (panel mode only): after the parallel panel returns, YOU (not a subagent) merge the two outputs per the Panel-mode "Synthesize" step in `.claude/commands/_lib/review-subagent-pattern.md` — dedup overlapping findings, reconcile conflicting severities to the higher, reconstruct the full AC→{task,test} matrix from both reviewers' AC checks (so no AC is dropped from either the build or the verify side), and promote any confirmed OUT-OF-LANE FLAG. Then run the fix / re-review loop on the merged findings.
 
-   Extra rule: commit the implementation plan document only after all review passes are complete (in panel mode, after the Synthesis step above) and all Critical and Major issues are resolved.
+   Extra rule: do not commit yet. After this engineering review (in panel mode, after the Synthesis step above), a Japanese prose-quality pass runs (step 9 below); commit the implementation plan document only after BOTH passes are complete and all Critical and Major issues from both are resolved.
 
 **Technical correctness checklist (use verbatim as evaluation criteria in the subagent prompt above):**
 - [ ] `02_architecture.md` is `approved`.
@@ -117,5 +117,20 @@ Work in the following order.
 - [ ] Redundant or repetitive content is removed; design details already in the architecture document are referenced rather than restated.
 - [ ] Ambiguous or overly terse expressions are rewritten in direct, plain Japanese so readers do not need prior context to understand what is expected.
 - [ ] When a planning decision changes an artifact's name, extension, implementation language, or invocation, every reference to it (filename, section header, prose, completion/verification command) is updated consistently — no `.sh` filename paired with a `go run …go` description.
+
+9. Run the Japanese prose-quality pass by invoking the `japrose` command
+   (`.claude/commands/japrose.md`) on the created implementation plan document (path in
+   `_context.md`). It runs a technical-editor review focused on natural Japanese —
+   literal-translation tone, unusual/incorrect word usage, hard-to-follow sentences,
+   terms used before they are defined (so the document reads top-to-bottom), and
+   terminology consistency with the glossary and with `02_architecture.md` — and
+   applies the fixes. The engineering review (step 8) checks plan correctness and AC
+   traceability; this pass checks that the document reads as clear, natural Japanese.
+   The two are complementary.
+   - Run this **after** step 8's Critical and Major issues are resolved, so prose is
+     not polished on text that step 8 then rewrites.
+   - `japrose`, when invoked as this sub-step, does not commit; this command owns the
+     commit (see the step 8 extra rule). Resolve all Critical and Major prose findings
+     before committing.
 
 When finished, provide a concise summary of what you created and any assumptions you had to make.

--- a/.claude/commands/mkplan.md
+++ b/.claude/commands/mkplan.md
@@ -129,8 +129,8 @@ Work in the following order.
    The two are complementary.
    - Run this **after** step 8's Critical and Major issues are resolved, so prose is
      not polished on text that step 8 then rewrites.
-   - `japrose`, when invoked as this sub-step, does not commit; this command owns the
-     commit (see the step 8 extra rule). Resolve all Critical and Major prose findings
-     before committing.
+   - `japrose`, when invoked as this sub-step, does not commit. After both step 8 and
+     step 9 are complete and all Critical and Major issues from both passes are
+     resolved, commit the created implementation plan document.
 
 When finished, provide a concise summary of what you created and any assumptions you had to make.


### PR DESCRIPTION
## 概要

機械支援で日本語文書を作成する際に繰り返し生じていた品質問題——直訳調、一般的でない語の用法、意味のくみ取りにくい文、未定義の用語を定義より前に使うため頭から読むと理解できない、用語の不統一——を**修正するコマンド**を追加し、`mkarch`/`mkplan` のエンジニア観点レビューの後段に組み込む。

## 変更内容

### 1. 新コマンド `.claude/commands/japrose.md`（`mktrans` と同型の review＋fix）

日本語文書の**技術的内容・事実・数値・構造・節順を変えずに**、文章品質だけを改善する。対象とする問題:

- **直訳調**（英語語順・無生物主語の直訳・過剰な受動態・英語イディオムの逐語訳）
- **不適切／不自然な語**（例: "coverage" を「被覆」と当てる類）、過剰なカタカナ英語
- **意味のくみ取りにくい一文**（長い係り受け・主語欠落・詰め込みすぎ）
- **未定義語の先行使用**（定義より前に使われ、頭から読むと理解できない）→ 初出での定義／前方参照で修正
- **用語の不統一**・用語集の「旧称」使用
- **冗長・回りくどい言い回し**

仕組みは共有パターン `_lib/review-subagent-pattern.md` の single-reviewer モードで「日本語に精通したテクニカルエディタ」を起動し、指摘を本体が修正→再レビュー。コードブロック／Mermaid 識別子／バッククォート内のコード・型名／用語集の確立用語を保護する hard constraints 付き。単独実行時は自分でコミット、サブステップ実行時は呼び出し元がコミットする。

### 2. `mkarch.md` / `mkplan.md` にステップ9 を追加

エンジニア観点のレビュー（step 8）の Critical/Major を解消した**後**に `japrose` を呼び出し、日本語としての文書品質を向上させてからコミットする。step 8 のコミットルールも「両パス完了・両者の Critical/Major 解消後にコミット」へ更新。step 8 の「below」参照を壊さないよう、チェックリストの後ろにステップ9 を配置している。

## 設計上の判断

- エンジニアレビュー（設計/計画の正しさ）と本パス（日本語としての読みやすさ）は**相補的**な別観点として分離。
- 本パスは step 8 の修正完了後に走らせ、後で書き換わる文章を磨かないようにした。
- `japrose` はサブステップ実行時は自己コミットせず、呼び出し元が単一コミットを所有する。
- `mkplan2.md` は対象外（必要なら別途同様に組み込み可能）。

## 補足

このコマンド群は `main` から派生したブランチで、進行中のタスクブランチ（0141 等）からは独立している。

🤖 Generated with [Claude Code](https://claude.com/claude-code)