### PR TITLE
feat(fixpr): add cross-thread root-cause synthesis pass

### DIFF
--- a/.claude/commands/fixpr.md
+++ b/.claude/commands/fixpr.md
@@ -47,6 +47,8 @@ gh api graphql -F owner=OWNER -F repo=REPO -F number=NUMBER -f query='
 
 Only process threads where `isResolved: false`. If there are none, stop.
 
+This query caps at 100 threads (`reviewThreads(first:100)`) and 10 comments per thread (`comments(first:10)`). If a run hits either cap — 100 threads returned, or a thread already showing 10 comments — page through with `after:` cursors (or narrow the query) until the set is complete, because the root-cause pass below assumes the full set. On a small PR these caps are not reached and no pagination is needed.
+
 ## Synthesize Across Threads (root-cause pass)
 
 Before fixing threads one by one, look at them **together**. Per-comment spot-fixes miss the case where several comments are symptoms of one root cause or a missing general principle — fixing each in isolation produces churn and leaves the cause in place. This pass runs once, up front, and feeds the per-thread pass below.
@@ -58,9 +60,9 @@ Before fixing threads one by one, look at them **together**. Per-comment spot-fi
 3. **Gate — only synthesize when the signal is real.** Act on a cluster only when one of these holds; otherwise skip straight to per-thread handling:
    - three or more related Valid threads, or
    - a cluster concentrated on one file / surface / subsystem, or
-   - the same area drawing comments across multiple review rounds.
+   - the same area recurring across review rounds you have already handled this session (from your run history), or sustained back-and-forth within a thread.
 
-   A lone comment, or unrelated comments, get per-thread handling. Do **not** invent a root cause to justify a larger change.
+   A lone comment, or unrelated comments, get per-thread handling. Do **not** invent a root cause to justify a larger change. Base every gate signal only on data you actually have — the fetched threads and their comments (paginated to completeness above), plus your session memory of prior rounds — not on metadata the query does not return (timestamps, review IDs).
 
 4. **Find the root cause / missing principle.** For each qualifying cluster, ask: would a single structural change — and/or recording a general principle (an invariant, a shared helper, a completeness rule, a data table that becomes the single source of truth) — resolve the whole cluster **and prevent recurrence**? The goal is to fix the cause, not each symptom.
 

--- a/.claude/commands/fixpr.md
+++ b/.claude/commands/fixpr.md
@@ -51,12 +51,12 @@ Only process threads where `isResolved: false`. If there are none, stop.
 
 Before fixing threads one by one, look at them **together**. Per-comment spot-fixes miss the case where several comments are symptoms of one root cause or a missing general principle — fixing each in isolation produces churn and leaves the cause in place. This pass runs once, up front, and feeds the per-thread pass below.
 
-1. **Read the full set first.** Load every unresolved thread (above) and do a quick validity triage of each (Valid / Invalid / Unclear, per Step 1's criteria) so you know which are real before acting.
+1. **Read the full set first.** Load every unresolved thread (above) and do a quick validity triage of each (Valid / Invalid / Unclear, per the criteria in Step 1 under "Address Each Unresolved Thread") so you know which are real before acting.
 
 2. **Cluster.** Group the Valid (and Unclear) threads by shared root cause — same file or surface, same kind of defect, or the same invariant being violated.
 
 3. **Gate — only synthesize when the signal is real.** Act on a cluster only when one of these holds; otherwise skip straight to per-thread handling:
-   - roughly three or more related Valid threads, or
+   - three or more related Valid threads, or
    - a cluster concentrated on one file / surface / subsystem, or
    - the same area drawing comments across multiple review rounds.
 
@@ -65,7 +65,7 @@ Before fixing threads one by one, look at them **together**. Per-comment spot-fi
 4. **Find the root cause / missing principle.** For each qualifying cluster, ask: would a single structural change — and/or recording a general principle (an invariant, a shared helper, a completeness rule, a data table that becomes the single source of truth) — resolve the whole cluster **and prevent recurrence**? The goal is to fix the cause, not each symptom.
 
 5. **Apply once, if in scope.** If yes and the change is within the PR's scope:
-   - Make the structural change a single, self-contained change. Run the build checks (defined in `.claude/commands/_context.md`, Tech-stack convention), then commit it **once** — not one commit per symptom.
+   - Make the structural change a single, self-contained change. Run the build checks (defined in `.claude/commands/_context.md`, Tech-stack convention) to confirm no errors, then commit it **once** — not one commit per symptom.
    - Optionally record the principle/invariant in the artifact itself (a code comment, a design or plan document), **including how future same-class comments should be handled**, so the cause does not recur and the next review can be triaged against it.
 
 6. **Guardrails (all required).**

--- a/.claude/commands/fixpr.md
+++ b/.claude/commands/fixpr.md
@@ -47,6 +47,35 @@ gh api graphql -F owner=OWNER -F repo=REPO -F number=NUMBER -f query='
 
 Only process threads where `isResolved: false`. If there are none, stop.
 
+## Synthesize Across Threads (root-cause pass)
+
+Before fixing threads one by one, look at them **together**. Per-comment spot-fixes miss the case where several comments are symptoms of one root cause or a missing general principle — fixing each in isolation produces churn and leaves the cause in place. This pass runs once, up front, and feeds the per-thread pass below.
+
+1. **Read the full set first.** Load every unresolved thread (above) and do a quick validity triage of each (Valid / Invalid / Unclear, per Step 1's criteria) so you know which are real before acting.
+
+2. **Cluster.** Group the Valid (and Unclear) threads by shared root cause — same file or surface, same kind of defect, or the same invariant being violated.
+
+3. **Gate — only synthesize when the signal is real.** Act on a cluster only when one of these holds; otherwise skip straight to per-thread handling:
+   - roughly three or more related Valid threads, or
+   - a cluster concentrated on one file / surface / subsystem, or
+   - the same area drawing comments across multiple review rounds.
+
+   A lone comment, or unrelated comments, get per-thread handling. Do **not** invent a root cause to justify a larger change.
+
+4. **Find the root cause / missing principle.** For each qualifying cluster, ask: would a single structural change — and/or recording a general principle (an invariant, a shared helper, a completeness rule, a data table that becomes the single source of truth) — resolve the whole cluster **and prevent recurrence**? The goal is to fix the cause, not each symptom.
+
+5. **Apply once, if in scope.** If yes and the change is within the PR's scope:
+   - Make the structural change a single, self-contained change. Run the build checks (defined in `.claude/commands/_context.md`, Tech-stack convention), then commit it **once** — not one commit per symptom.
+   - Optionally record the principle/invariant in the artifact itself (a code comment, a design or plan document), **including how future same-class comments should be handled**, so the cause does not recur and the next review can be triaged against it.
+
+6. **Guardrails (all required).**
+   - **Subsumption check:** confirm each clustered comment is concretely addressed by the structural change. Drop nothing — a comment the structural change does not actually cover still gets per-thread handling.
+   - **No manufactured causes:** the existence of several comments is not itself a root cause. Adopt a structural fix only when it genuinely subsumes the members; otherwise fix them individually.
+   - **Do not dismiss real defects:** when you record a principle to handle a class of comments uniformly (e.g. "deferred to implementation"), it applies only to items the principle truly covers. A comment that reveals a *new* structural gap (a wrong invariant, a missing branch, a fail-open) is a defect, not noise — fix it, do not wave it through.
+   - **Scope/size gate:** if the structural change is large, architecturally significant, or otherwise beyond a routine review fix, do **not** apply it unilaterally — present it to the user (problem, options with pros/cons, recommendation) and let them decide before applying.
+
+7. **Hand off to the per-thread pass.** A thread resolved by a structural change is closed below by replying with a link to that change/commit and resolving it — not by a duplicate spot-fix. Every remaining thread is handled individually.
+
 ## Address Each Unresolved Thread
 
 Process each thread in order as follows.
@@ -65,6 +94,8 @@ Based on this assessment, classify the thread as one of:
 - **Unclear**: You are uncertain whether the fix is appropriate → follow [When the fix is unclear].
 
 ### When the comment is valid and the fix is clear
+
+If the root-cause pass already addressed this thread with a structural change, reply pointing to that change (the commit or the recorded principle/section) and resolve the thread — skip the per-comment fix below to avoid duplicating it. Otherwise:
 
 1. Fix the code as indicated by the comment.
 2. Run the build checks (defined in `.claude/commands/_context.md`, Tech-stack convention) to confirm no errors.
@@ -137,3 +168,14 @@ For each skipped thread, present the following:
 - **Problem summary**: Briefly describe the issue raised by the comment.
 - **Proposed approaches**: List multiple possible options with pros and cons for each.
 - **Recommendation**: If possible, recommend one option and explain why.
+
+## Summarize Root Causes
+
+If the root-cause pass produced any structural change, recorded principle, or cluster, report it to the user so the systemic fix is visible (not buried among per-thread replies):
+
+- **Clusters found**: the groups of comments and the shared root cause / missing principle behind each.
+- **Structural changes applied**: what was changed once instead of N spot-fixes, and which threads each subsumes.
+- **Principles recorded**: any invariant / rule written into the artifact, and how future same-class comments will be triaged against it.
+- **Surfaced for decision**: any structural change held back by the scope/size gate and awaiting the user's call.
+
+If the root-cause pass found nothing (all comments were independent), state that briefly and skip this section.


### PR DESCRIPTION
## 背景

`fixpr` はこれまで **per-thread・逐次・反応的** な処理だけで構成されていた——各レビューコメントを独立に validity 判定し、1件ずつ修正する。だが実際には複数コメントが**1つの根本原因**や**欠落した一般原則**の症状であることが多く、個別に直すと churn が出て原因が残る。コメント群を**横断して見る視点**がコマンドに欠けていた。

（この PR は #769 のレビュー対応セッションで得た知見の一般化。あの PR では12件のコメントを分類して2〜3個の根本原因に集約し、12個の spot-fix でなく構造（文法表・テスト網・完全性規律・一般則）を1回入れて束ねるのが有効だった。）

## 変更

`## Fetch` と `## Address` の間に **`## Synthesize Across Threads (root-cause pass)`** を新設。1回だけ前段で走り、per-thread パスに受け渡す:

- 全スレッドを先に読み、validity を素早く仕分け
- 関連する Valid/Unclear をクラスタリング
- **発火条件で gate**（関連3件以上／1サーフェスに集中／同一領域で複数ラウンド）——単発・無関係なコメントは従来どおり個別対応
- 共有原因があれば**単一の構造的修正（1コミット）**＋（任意で）**再発防止の原則を成果物に記録**（将来の同種コメントの triage 方法も含む）
- **ガードレール**（全必須）: 包含検証（コメントを取りこぼさない）／根本原因の捏造禁止／一律処理しても genuine な欠陥は見逃さない／規模が大きい変更はユーザに提示（scope gate）

あわせて:
- per-thread の valid 経路は、構造修正で解けたスレッドを**リンク返信＋resolve**にして重複修正を防ぐ
- 末尾に **`## Summarize Root Causes`** を追加し、クラスタ・構造的修正・記録した原則をユーザに要約報告

## レビュー観点

- 過剰一般化／スコープクリープへの歯止めが効いているか（gate・捏造禁止・scope gate）
- 単発コメントや無関係コメントで synthesis が空振りして余計なオーバーヘッドにならないか
- 既存の per-thread フロー・build checks・commit 粒度・Revisit と整合しているか

🤖 Generated with [Claude Code](https://claude.com/claude-code)