### PR TITLE
docs(0142): axis-2 destination zoning — implementation plan

### DIFF
--- a/docs/tasks/0142_axis2_destination_zoning/01_requirements.md
+++ b/docs/tasks/0142_axis2_destination_zoning/01_requirements.md
@@ -141,7 +141,7 @@
   ln・mkdir・touch・install・tee・sponge・truncate・`sed -i`・tar・unzip・dd・mount・umount・chmod・chown・chgrp・
   setfacl・chattr・mknod・find（破壊/書込アクション）・データ送信の書込形（F-004）。個別フラグ/形は要件本文で
   列挙せず、コマンド→Kind→オペランド抽出規則を単一の仕様（実装内テーブル）で表し、既知コマンド×代表フラグの
-  表駆動（プロパティ/網羅）テストで被覆を担保する。未知/曖昧形は fail-closed（AC-05）。
+  表駆動（プロパティ/網羅）テストで網羅性を担保する。未知/曖昧形は fail-closed（AC-05）。
   AC-06 の必須テスト行（仕様表のエントリとして持つ。下表の難所は最低限）:
 
   | 難所 | 抽出/パス信頼区分の判定規則 |

--- a/docs/tasks/0142_axis2_destination_zoning/02_architecture.md
+++ b/docs/tasks/0142_axis2_destination_zoning/02_architecture.md
@@ -395,7 +395,7 @@ func ClassifyDestinationZone(input ZoningInput, names map[string]struct{}, cmdPa
 
 **オペランド抽出仕様表（AC-06／根本原因1）**: コマンド→`LocationKind`→オペランド抽出規則の対応を、コード内の
 **単一テーブル**として持つ。要件本文・本設計は個別フラグを網羅列挙せず、既知コマンド×代表フラグの表駆動
-（網羅）テストで網羅性を担保する（§7.1）。仕様表が持つべき難所のエントリ（in-place 編集・`ln -s` 相対 target・
+テストで網羅性を担保する（§7.1）。仕様表が持つべき難所のエントリ（in-place 編集・`ln -s` 相対 target・
 アーカイブ抽出 vs 一覧・末尾 `/` 削除・`dd` デバイス・権限/所有権付与・データ送信書込先）は
 [01_requirements.md](01_requirements.md) §F-002 の表を正とする。未知/曖昧形は `ZoneUnresolved`（fail-closed）。
 

--- a/docs/tasks/0142_axis2_destination_zoning/02_architecture.md
+++ b/docs/tasks/0142_axis2_destination_zoning/02_architecture.md
@@ -395,7 +395,7 @@ func ClassifyDestinationZone(input ZoningInput, names map[string]struct{}, cmdPa
 
 **オペランド抽出仕様表（AC-06／根本原因1）**: コマンド→`LocationKind`→オペランド抽出規則の対応を、コード内の
 **単一テーブル**として持つ。要件本文・本設計は個別フラグを網羅列挙せず、既知コマンド×代表フラグの表駆動
-（網羅）テストで被覆を担保する（§7.1）。仕様表が持つべき難所のエントリ（in-place 編集・`ln -s` 相対 target・
+（網羅）テストで網羅性を担保する（§7.1）。仕様表が持つべき難所のエントリ（in-place 編集・`ln -s` 相対 target・
 アーカイブ抽出 vs 一覧・末尾 `/` 削除・`dd` デバイス・権限/所有権付与・データ送信書込先）は
 [01_requirements.md](01_requirements.md) §F-002 の表を正とする。未知/曖昧形は `ZoneUnresolved`（fail-closed）。
 
@@ -501,7 +501,7 @@ High に分類している既存 5 系統の破壊系 High 寄与を評価対象
 1 profile に破壊＋他因子が同居しても取りこぼし（他因子を落とす）／過剰（破壊 High を残す）を起こさないよう、
 無効化は破壊コンポーネント粒度で定義する。
 
-**置き換えの被覆不変条件（①〜⑤ ⊆ §3.2 の下限・区分）**: 「5 系統をまとめて外す」が High の取りこぼし（fail-open）に
+**置き換えの取りこぼし防止条件（①〜⑤ ⊆ §3.2 の下限・区分）**: 「5 系統をまとめて外す」が High の取りこぼし（fail-open）に
 ならないことを保証するため、外す各系統が捕捉していた水準を判断軸2 のどの規則が同等以上に再確立するかを表で固定する。
 
 | 外す系統 | 旧来の捕捉 | 判断軸2 での再確立 |
@@ -512,7 +512,7 @@ High に分類している既存 5 系統の破壊系 High 寄与を評価対象
 | ④ `dangerousCommandPatterns` rank6 | `{rm,-rf}` High・`{dd,if=}` High・`{chmod,777}` High・`{chown,root}` Medium | `rm -rf`＝再帰下限（AC-11）／区分、`dd if=`＝デバイス IO 下限（AC-10）、`chmod 777`＝world-writable 権限付与下限（AC-08, High）、`chown root`＝所有権変更（trust-critical 宛先は権限付与下限で High、ordinary 宛先は区分 Medium）で同等以上 |
 | ⑤ coreutils setuid lstat 下限 | setuid/setgid バイナリ High | 既存 lstat シグナル（`hasSetuidOrSetgidBit` 相当）を権限付与下限が**そのまま流用**（再パースしない） |
 
-> この被覆不変条件をテストで固定する（§7.2）。とくに ④ の `chmod 777`／`chown root` が §3.2 の権限付与下限／区分で
+> この取りこぼし防止条件をテストで固定する（§7.2）。とくに ④ の `chmod 777`／`chown root` が §3.2 の権限付与下限／区分で
 > 同等以上のレベルになることを表明し、「外したが再確立されない隙間」を塞ぐ。
 
 > **既存方針への意図的な例外（インライン明示・command 仕様の要請）**

--- a/docs/tasks/0142_axis2_destination_zoning/02_architecture.md
+++ b/docs/tasks/0142_axis2_destination_zoning/02_architecture.md
@@ -452,7 +452,8 @@ func ResolveOperandPath(operand, base string, maxHops int) (resolved string, err
   - safe-zone の Low 降格は Trusted のときに限り、非 Trusted なら降格しない（fail-closed → Medium）。参照 identity は
     注入 `RunAsIdent`（live euid ではない）。leaf が既存 symlink なら最終ターゲットで区分判定する。
 - (e) **メモ化の鍵とスコープ（AC-23）**: 解決のメモ化は 1 回の `ClassifyDestinationZone` 呼び出し（＝単一コマンド・
-  単一 `RunAsIdent`）の内側にスコープし、鍵は**解決対象の入力パス（中間パスを含む）**とする。キャッシュするのは read-only な解決結果
+  単一 `RunAsIdent`）の内側にスコープし、鍵は**解決対象ノードの絶対パス（中間ノードを含む。relative なパスは基点ディレクトリと
+  結合・正規化した、symlink 追従前の絶対パス）**とする。キャッシュするのは read-only な解決結果
   （`lstat`/`readlink`）のみで、identity 依存の Trusted 判定そのものはキャッシュしない（あるいは鍵へ identity を
   含める）。これにより同一 base/identity の前提が崩れず、クロス identity のキャッシュ誤用を避ける。
 
@@ -577,11 +578,15 @@ High に分類している既存 5 系統の破壊系 High 寄与を評価対象
     `user@host:path`・`rsync://…` に加え `host::module` をリモート宛先として認識する。リモート宛先のときは zone 判定の
     対象となるローカルパスが無いため、実効レベルは egress（名前ベース Medium）が支配する（ローカル宛先のときのみ
     書込先のパス信頼区分と max 合成する）。
-  - **(2) `hasNetworkArguments` に `host::module` 検出を追加する**: 二重コロンの左側がホスト名様トークン
-    （`[A-Za-z0-9.-]+`）で右側がモジュール名様トークンの形（`host::module`）を検出条件に加える。これにより
-    `rsync src host::module` が egress Medium に分類される。**過剰分類を避けるための限定**: 左側をホスト名文字に限定し、
-    `s/::/.../` のような `/` を含むトークンや C++ スコープ様の式を巻き込まない。なお誤検出が起きても引き上げは Medium
-    までで安全側（fail-safe）。`rsync` 全体を無条件 Medium へ格上げはしない（過剰分類を起こさず隙間だけ塞ぐ）。
+  - **(2) `host::module` の egress 検出は `rsync` に限定する**: 二重コロンの左がホスト名様トークン（`[A-Za-z0-9.-]+`）で
+    右がモジュール名様トークンの形（`host::module`）を検出条件に加え、`rsync src host::module` を egress Medium に分類する。
+    ただし `hasNetworkArguments` は profile 無しの全コマンドへ広く適用される（`evaluator.go` の
+    `!profileFound && HasNetworkArguments(args)`）ため、検出を**無条件に足すと過剰分類する**——`std::string`・`HTTP::Tiny`・
+    `Namespace::Class` のような `::` を含む無関係な引数まで誤検出する（左側をホスト名様トークンに限定しても `std`／`HTTP` 等が
+    合致するため防げない）。よって `host::module` 検出は**コマンド名が `rsync` のときだけ有効化**する——rsync 専用の引数解析
+    （`KindDataTransferWrite` 抽出）に閉じ込めるか、`hasNetworkArguments` をコマンド名で gate する。`/` を含むトークンや純ローカル
+    パスは巻き込まない。なお誤検出が起きても引き上げは Medium までで安全側（fail-safe）だが、無関係コマンドの過剰分類は避ける。
+    `rsync` 全体を無条件 Medium へ格上げはしない（過剰分類を起こさず隙間だけ塞ぐ）。
   - **必須テスト**: `rsync src host::module` が Medium（egress 由来。理由コードで出所を表明）、純ローカル `rsync /a /b` が
     Low（過剰分類しない）、`rsync /local /usr/bin/x`（ローカル trust-critical 宛先）が High（書込先区分が支配）。
 
@@ -656,7 +661,7 @@ type SecuritySpec struct {
 | `internal/runner/base/risktypes/reason_codes.go` | 変更 | 判断軸2 の `ReasonCode` family を追加（§4）。網羅性/一意性テストを緑に保つ | NF-001 | `reason_codes_test.go::TestReasonCodes_AllDistinct`（新コードを登録） |
 | `internal/runner/base/security/destination_zoning.go` | 新規 | `LocationKind`/`ZoningInput`/`LocationResult`・オペランド抽出仕様表・区分判定・操作固有の下限・`ClassifyDestinationZone` | AC-01〜AC-16 | — |
 | `internal/runner/base/security/operand_path_resolver.go` | 新規 | symlink 追従の専用リゾルバ（leaf＋親・深さ制限・メモ化）・Trusted 述語 | AC-04, AC-23 | — |
-| `internal/runner/base/security/network_analyzer.go`（`hasNetworkArguments`）／`command_analysis.go`（`containsSSHStyleAddress`） | 変更 | rsync デーモンの `host::module` 形をリモート終端として検出（§3.5）。ホスト名様左側に限定し過剰分類を避ける | AC-16 | `network_analyzer_test.go`／`command_analysis_test.go`（`host::module`=リモート、純ローカルは非ネットワークの回帰追加） |
+| `internal/runner/base/security/network_analyzer.go`（`hasNetworkArguments`）／`command_analysis.go`（`containsSSHStyleAddress`） | 変更 | rsync デーモンの `host::module` 形をリモート終端として検出（§3.5）。検出は `rsync` コマンドに限定し、`std::string` 等の `::` 引数の過剰分類を避ける | AC-16 | `network_analyzer_test.go`／`command_analysis_test.go`（`rsync` の `host::module`=リモート、非 rsync の `std::string` 等は非ネットワーク、純ローカルは非ネットワークの回帰追加） |
 | `internal/runner/base/security/types.go` | 変更 | `Config` に `TrustedDirectories []string` を追加 | AC-20 | — |
 | `internal/runner/base/risk/evaluator.go` | 変更 | `evaluateDimensions` に判断軸2 を組み込み、完全認識時に既存 5 系統を抑止し `LocationResult` を唯一の寄与に。`NewStandardEvaluator` に `*security.Config` 引数追加。`RunAsIdent` 注入フィールド | AC-17, AC-18, AC-20, AC-21 | `coreutils_consistency_test.go::{TestConsistency_RmAllForms,TestConsistency_DestructiveAbsolutePath,TestCoreutilsRiskConsistency_Setuid}`、`evaluator_test.go`（破壊系ケース） |
 | `internal/runner/runner.go` | 変更 | `security.Config` に `TrustedDirectories` を転送し、呼び出し鎖（`createResourceManager`・両 `create*ResourceManager`・`resolveRiskEvaluator`）へ securityConfig を通して `NewStandardEvaluator` へ渡す（§3.6）。normal/dry-run の両経路に同一に渡す | AC-20, AC-22 | — |

--- a/docs/tasks/0142_axis2_destination_zoning/02_architecture.md
+++ b/docs/tasks/0142_axis2_destination_zoning/02_architecture.md
@@ -452,7 +452,7 @@ func ResolveOperandPath(operand, base string, maxHops int) (resolved string, err
   - safe-zone の Low 降格は Trusted のときに限り、非 Trusted なら降格しない（fail-closed → Medium）。参照 identity は
     注入 `RunAsIdent`（live euid ではない）。leaf が既存 symlink なら最終ターゲットで区分判定する。
 - (e) **メモ化の鍵とスコープ（AC-23）**: 解決のメモ化は 1 回の `ClassifyDestinationZone` 呼び出し（＝単一コマンド・
-  単一 `RunAsIdent`）の内側にスコープし、鍵は**解決後の絶対パス**とする。キャッシュするのは read-only な解決結果
+  単一 `RunAsIdent`）の内側にスコープし、鍵は**解決対象の入力パス（中間パスを含む）**とする。キャッシュするのは read-only な解決結果
   （`lstat`/`readlink`）のみで、identity 依存の Trusted 判定そのものはキャッシュしない（あるいは鍵へ identity を
   含める）。これにより同一 base/identity の前提が崩れず、クロス identity のキャッシュ誤用を避ける。
 

--- a/docs/tasks/0142_axis2_destination_zoning/02_architecture.md
+++ b/docs/tasks/0142_axis2_destination_zoning/02_architecture.md
@@ -4,10 +4,10 @@
 
 | Item | Value |
 |---|---|
-| Status | `draft` |
+| Status | `approved` |
 | Created | 2026-06-23 |
-| Review date | - |
-| Reviewer | - |
+| Review date | 2026-06-23 |
+| Reviewer | isseis |
 | Comments | - |
 
 > 本書は 0140 を 3 分割した第 2 タスク（判断軸2＝宛先パス信頼区分）の設計である。要件は

--- a/docs/tasks/0142_axis2_destination_zoning/03_implementation_plan.md
+++ b/docs/tasks/0142_axis2_destination_zoning/03_implementation_plan.md
@@ -505,7 +505,7 @@
 | AC-23 解決コスト上限 | test | `security/operand_path_resolver_test.go::TestResolutionCeiling`＋`::TestMemoizationLinear` | 上限超過=High、呼出線形 |
 | NF-001 reason code 網羅/一意 | test | `risktypes/reason_codes_test.go::TestReasonCodes_AllDistinct` | 新 7 定数含め緑 |
 | NF-002 ビルド/テスト緑 | static | `make test && make lint`（または `go build -tags test ./internal/runner/...`） | 終了コード 0 |
-| NF-003 決定的・read-only | test+static | test: `::TestDeterminismRuntimeEqualsDryRun`／static: `rg -n '(os|syscall|unix)\.(Create|CreateTemp|Remove|RemoveAll|WriteFile|Mkdir|MkdirAll|MkdirTemp|OpenFile|Symlink|Link|Rename|Chmod|Chown|Lchown|Chtimes|Truncate|NewFile|Write|Unlink|Rmdir|Fchmod|Fchown)' internal/runner/base/security/destination_zoning.go internal/runner/base/security/operand_path_resolver.go`（期待: **マッチ 0 件**） | 書込系 API 不在（read-only） |
+| NF-003 決定的・read-only | test+static | test: `::TestDeterminismRuntimeEqualsDryRun`／static: `rg -n 'os\.(Create|CreateTemp|Remove|RemoveAll|WriteFile|Mkdir|MkdirAll|MkdirTemp|OpenFile|Symlink|Link|Rename|Chmod|Chown|Lchown|Chtimes|Truncate|NewFile)|(syscall|unix)\.(Write|Pwrite|Unlink|Unlinkat|Rmdir|Mkdir|Mkdirat|Open|Openat|Symlink|Link|Rename|Chmod|Fchmod|Chown|Fchown|Lchown|Truncate|Ftruncate)' internal/runner/base/security/destination_zoning.go internal/runner/base/security/operand_path_resolver.go`（期待: **マッチ 0 件**） | 書込系 API 不在（read-only） |
 
 > **grep ガードの正規表現に関する注意（ripgrep のメタ文字）**: ripgrep 既定（Rust regex）では `|` が選択（alternation）で、`\|` は
 > **リテラルのパイプ文字**になる。`\|` を選択のつもりで使うとパターンが空振りし、危険 API が存在してもガードが「0 件＝合格」と

--- a/docs/tasks/0142_axis2_destination_zoning/03_implementation_plan.md
+++ b/docs/tasks/0142_axis2_destination_zoning/03_implementation_plan.md
@@ -162,9 +162,12 @@
       （既定は実 os、テストは呼出回数を数えるスタブを注入。`StandardEvaluator.openIdentity` と同じ注入パターン）。注入集合は
       read-only の `lstat`/`readlink` のみとし、symlink を追従する `os.Stat` は含めない（設計 §3.3 の read-only 制約。`os.Stat` を
       混ぜると経路要素の所有権検査が symlink ターゲットを見てしまい区分判定を欺けるため）。
-- [ ] メモ化: 解決のメモ化を 1 回の判定呼び出し内にスコープし、鍵は**解決対象の入力パス（中間パスを含む）**とする。これにより
-      共有する親チェーンの `lstat`/`readlink` 結果を 1 回に畳む（解決後の絶対パスを鍵にすると、解決を終えるまで鍵が得られず
-      再解決を防げない＝AC-23 の線形計数が成り立たない）。identity 依存の Trusted 判定そのものはキャッシュしない（設計 §3.3(e)
+- [ ] メモ化: 解決のメモ化を 1 回の判定呼び出し内にスコープし、鍵は**解決対象ノードの絶対パス（中間ノードを含む）**とする。
+      relative なオペランド／relative な symlink target は基点ディレクトリと結合・正規化した絶対パスにしてから鍵にする（relative
+      文字列そのものを鍵にすると、異なる基点下の同名 relative——例 `/dir1/link` と `/dir2/link` がともに `../target` を指す——で
+      誤ヒットする）。鍵は当該ノードを **symlink 追従する前**の絶対パスであり、追従後の解決済み絶対パスではない（追従後を鍵に
+      すると解決完了まで鍵が得られず循環する）。これにより共有する親チェーンの `lstat`/`readlink` 結果を 1 回に畳む（AC-23 の
+      線形計数の前提）。identity 依存の Trusted 判定そのものはキャッシュしない（設計 §3.3(e)
       の鍵の記述を精緻化）。
 - [ ] Trusted 述語を実装（設計 §3.3(d)）: 解決後パスが `TrustedDirectories` 配下、かつ**safe-zone 起点の親以上**の経路
       要素が run-as から書込不可（run-as 以外所有・group/other 非書込）のとき Trusted。参照 identity は注入 `RunAsIdent`
@@ -284,7 +287,7 @@
 
 **変更ファイル**:
 - 変更 `internal/runner/base/security/destination_zoning.go`（`KindDataTransferWrite` のリモート終端判定）
-- 変更 `internal/runner/base/security/network_analyzer.go`（`hasNetworkArguments` に `host::module` 追加）
+- 変更 `internal/runner/base/security/network_analyzer.go`（`host::module` 検出を `rsync` 限定で追加。グローバルな `hasNetworkArguments` を全コマンドへは広げない）
 - 変更 `internal/runner/base/security/command_analysis.go`（`containsSSHStyleAddress` 周辺、必要時）
 - 変更 `internal/runner/base/risk/destination_zoning_integration_test.go`
 - 変更 `internal/runner/base/security/network_analyzer_test.go`
@@ -296,8 +299,12 @@
 - [ ] 最終リスク = `max(データ送信の名前 Medium〔0141〕, 書込先のパス信頼区分)` を合成する（max 合成の所有者は本タスク、AC-16）。
 - [ ] rsync のリモート終端判定に `host::module`（二重コロン bare module、末尾パス無し）を追加（設計 §3.5(1)）。リモート宛先の
       ときは zone 対象のローカルパスが無く egress（名前ベース Medium）が支配、ローカル宛先のときのみ書込先区分と max。
-- [ ] `hasNetworkArguments` に `host::module` 検出を追加（設計 §3.5(2)）: 左側をホスト名様トークン（`[A-Za-z0-9.-]+`）に限定し、
-      `/` を含むトークンや C++ スコープ様式を巻き込まない（過剰分類回避）。`rsync` 全体の無条件 Medium 格上げはしない。
+- [ ] `host::module`（二重コロン bare module）の egress 検出は **`rsync` コマンドに限定**して有効化する（設計 §3.5(2)）。
+      `hasNetworkArguments` は profile 無しの全コマンドへ広く適用される（`evaluator.go` の `!profileFound && HasNetworkArguments(args)`）
+      ため、ここへ無条件に `host::module` を足すと `std::string`／`HTTP::Tiny`／`Namespace::Class` のような `::` を含む無関係な引数まで
+      誤検出して過剰分類する（左側をホスト名様トークン `[A-Za-z0-9.-]+` に限定しても `std`／`HTTP` 等が合致し防げない）。よって検出は
+      コマンド名が `rsync` のときだけ有効化する（rsync 専用の引数解析＝`KindDataTransferWrite` 抽出に閉じ込めるか、`hasNetworkArguments`
+      をコマンド名で gate する）。`/` を含むトークンや純ローカルパスは巻き込まない。`rsync` 全体の無条件 Medium 格上げはしない。
 
 **成功基準**:
 - [ ] (i) `curl <url> -o $WORKDIR/safe`=Medium。**Medium の出所**を表明する（単なるレベル==Medium では既存 network profile の
@@ -310,6 +317,9 @@
 - [ ] `rsync src host::module`=Medium（egress 由来、理由コードで出所表明）。
 - [ ] 純ローカル `rsync /a /b`=Low（過剰分類しない）。
 - [ ] `rsync /local /usr/bin/x`（ローカル trust-critical 宛先）=High（書込先区分が支配）。
+- [ ] **非 rsync の `::` 引数は過剰分類しない**（`host::module` 検出の rsync 限定の回帰）: profile 無しのコマンドに `std::string`／
+      `HTTP::Tiny`／`Namespace::Class` 等の `::` を含む引数を与えても network 引数（`ReasonNetworkArgument` Medium）に誤分類されない
+      （`network_analyzer_test.go`／`command_analysis_test.go`）。
 
 ### Phase 6: config 組み込み＋identity 注入（AC-20, AC-21）
 
@@ -485,7 +495,7 @@
 | AC-13 mount/umount | test | `security/destination_zoning_test.go::TestOperandSpecific_Mount` | trust-critical=High、`umount -a`=High |
 | AC-14 tee/sponge | test | `security/destination_zoning_test.go::TestOperandSpecific_Tee` | 全 FILE の max、内側未実行 |
 | AC-15 find 破壊 | test | `security/destination_zoning_test.go::TestOperandSpecific_Find` | `-delete`/`-fprint*` の宛先判定、読取専用非昇格 |
-| AC-16 データ送信書込先＋max | test | `risk/destination_zoning_integration_test.go::TestDataTransferWriteComposition` | (i)=Medium(出所=名前)、(ii)=High、rsync 3 ケース |
+| AC-16 データ送信書込先＋max | test | `risk/destination_zoning_integration_test.go::TestDataTransferWriteComposition`＋`security/network_analyzer_test.go`（非 rsync `::` 非過剰分類） | (i)=Medium(出所=名前)、(ii)=High、rsync 3 ケース、非 rsync `std::string` 非ネットワーク |
 | AC-17 既存 High 置き換え | test | `risk/destination_zoning_integration_test.go::TestAxis2ReplacesLegacyHigh` | safe-zone=Low／ordinary=Medium／unresolved=High |
 | AC-18 max 合成 | test | `risk/destination_zoning_integration_test.go::TestAxis1Axis2MaxComposition` | `cp -a … /usr/bin`=High、順序非依存 |
 | AC-19 監査 DTO 格納 | test | `risk/destination_zoning_integration_test.go::TestOperandZonesStored` | 各要素の値検証、非適用=空・解決不能=`Zone==ZoneUnresolved` |

--- a/docs/tasks/0142_axis2_destination_zoning/03_implementation_plan.md
+++ b/docs/tasks/0142_axis2_destination_zoning/03_implementation_plan.md
@@ -152,7 +152,9 @@
 **作業内容**:
 - [ ] `ResolveOperandPath(operand, base string, maxHops int) (resolved string, err error)` を実装（設計 §3.3）。
       symlink チェーンを leaf＋親で追従し、正規化済み絶対パスを返す。相対オペランドは `base`（`ln -s` 相対 target は
-      リンク親、他は `EffectiveWorkDir`）基点で解決。read-only（`lstat`/`readlink` のみ）。
+      リンク親、他は `EffectiveWorkDir`）基点で解決。チェーン追従中に遭遇する中間の相対 symlink は、そのリンク自身が
+      存在する親ディレクトリを基点に解決する（`base`/`EffectiveWorkDir` 基点ではない。パストラバーサル・区分誤判定の防止）。
+      read-only（`lstat`/`readlink` のみ）。
 - [ ] 未存在 leaf を「最深の存在親」まで解決して末尾を畳み込む。**最深存在親が symlink のときは解決を確定できないため
       エラー**（呼び出し側で `ZoneUnresolved`＝書込/削除 High、設計 §3.3 注）。
 - [ ] cycle・深さ超過（`maxHops` 超）・mid-chain の `readlink`/`lstat` 失敗で `error` を返す（fail-closed、設計 §4）。
@@ -160,8 +162,10 @@
       （既定は実 os、テストは呼出回数を数えるスタブを注入。`StandardEvaluator.openIdentity` と同じ注入パターン）。注入集合は
       read-only の `lstat`/`readlink` のみとし、symlink を追従する `os.Stat` は含めない（設計 §3.3 の read-only 制約。`os.Stat` を
       混ぜると経路要素の所有権検査が symlink ターゲットを見てしまい区分判定を欺けるため）。
-- [ ] メモ化: 解決のメモ化を 1 回の判定呼び出し内にスコープし、鍵は**解決後の絶対パス**とする。identity 依存の Trusted
-      判定そのものはキャッシュしない（設計 §3.3(e)）。
+- [ ] メモ化: 解決のメモ化を 1 回の判定呼び出し内にスコープし、鍵は**解決対象の入力パス（中間パスを含む）**とする。これにより
+      共有する親チェーンの `lstat`/`readlink` 結果を 1 回に畳む（解決後の絶対パスを鍵にすると、解決を終えるまで鍵が得られず
+      再解決を防げない＝AC-23 の線形計数が成り立たない）。identity 依存の Trusted 判定そのものはキャッシュしない（設計 §3.3(e)
+      の鍵の記述を精緻化）。
 - [ ] Trusted 述語を実装（設計 §3.3(d)）: 解決後パスが `TrustedDirectories` 配下、かつ**safe-zone 起点の親以上**の経路
       要素が run-as から書込不可（run-as 以外所有・group/other 非書込）のとき Trusted。参照 identity は注入 `RunAsIdent`
       （live euid 不参照）。書込不可検査の対象は**起点ディレクトリの親以上**に限定（起点配下は対象外、設計 §3.3(d) の根拠）。
@@ -491,13 +495,20 @@
 | AC-23 解決コスト上限 | test | `security/operand_path_resolver_test.go::TestResolutionCeiling`＋`::TestMemoizationLinear` | 上限超過=High、呼出線形 |
 | NF-001 reason code 網羅/一意 | test | `risktypes/reason_codes_test.go::TestReasonCodes_AllDistinct` | 新 7 定数含め緑 |
 | NF-002 ビルド/テスト緑 | static | `make test && make lint`（または `go build -tags test ./internal/runner/...`） | 終了コード 0 |
-| NF-003 決定的・read-only | test+static | test: `::TestDeterminismRuntimeEqualsDryRun`／static: `rg -n 'os\.(Create|CreateTemp|Remove|RemoveAll|WriteFile|Mkdir|MkdirAll|MkdirTemp|OpenFile|Symlink|Link|Rename|Chmod|Chown|Lchown|Chtimes|Truncate|NewFile)' internal/runner/base/security/destination_zoning.go internal/runner/base/security/operand_path_resolver.go`（期待: **マッチ 0 件**） | 書込系 API 不在（read-only） |
+| NF-003 決定的・read-only | test+static | test: `::TestDeterminismRuntimeEqualsDryRun`／static: `rg -n '(os|syscall|unix)\.(Create|CreateTemp|Remove|RemoveAll|WriteFile|Mkdir|MkdirAll|MkdirTemp|OpenFile|Symlink|Link|Rename|Chmod|Chown|Lchown|Chtimes|Truncate|NewFile|Write|Unlink|Rmdir|Fchmod|Fchown)' internal/runner/base/security/destination_zoning.go internal/runner/base/security/operand_path_resolver.go`（期待: **マッチ 0 件**） | 書込系 API 不在（read-only） |
 
 > **grep ガードの正規表現に関する注意（ripgrep のメタ文字）**: ripgrep 既定（Rust regex）では `|` が選択（alternation）で、`\|` は
 > **リテラルのパイプ文字**になる。`\|` を選択のつもりで使うとパターンが空振りし、危険 API が存在してもガードが「0 件＝合格」と
 > 誤判定する（fail-open）。よって選択は素の `|` で書く（上記 NF-003 行・下記 AC-21 ガードとも修正済み）。
 >
-> grep ガード（AC-21 static）の具体コマンド: `rg -n 'os\.Get(euid|uid|gid|egid|groups)|user\.Current|syscall\.Get(euid|uid|gid|egid|groups)|unix\.Get(euid|uid|gid|egid|groups)' internal/runner/base/security/destination_zoning.go internal/runner/base/security/operand_path_resolver.go` の期待結果は **マッチ 0 件**（uid/euid/gid/egid/groups を `os`/`syscall`/`unix` の各パッケージで網羅）。`live_identity_guard_test.go` がこの検査をテストとして実行する。
+> grep ガード（AC-21 static）の具体コマンド: `rg -n 'os\.Get(euid|uid|gid|egid|groups)|user\.(Current|Lookup)|syscall\.Get(euid|uid|gid|egid|groups)|unix\.Get(euid|uid|gid|egid|groups)' internal/runner/base/security/destination_zoning.go internal/runner/base/security/operand_path_resolver.go` の期待結果は **マッチ 0 件**（uid/euid/gid/egid/groups を `os`/`syscall`/`unix` の各パッケージで網羅し、`user.Current`／`user.Lookup*` の OS ユーザーDB 参照も塞ぐ）。`live_identity_guard_test.go` がこの検査をテストとして実行する。
+>
+> **静的 grep ガードの位置づけ（再発防止の原則）**: NF-003／AC-21 の grep は禁止 API の**非網羅な denylist** であり、完全性の
+> 保証ではない。read-only／live-identity 不参照の**権威ある保証は挙動テスト**——`TestDeterminismRuntimeEqualsDryRun`
+> （runtime==dry-run）と `TestRunAsIdentDifferential`（注入 identity と実 euid を変えて判定が変わることを表明）——が担う。grep は
+> defense-in-depth の二次チェックとして、代表的な書込／identity API を低コストに塞ぐ。将来「API X が漏れている」との指摘は、
+> X が安価なら正規表現へ追加し、そうでなくても上記挙動テストが本質的に捕捉することを確認すれば足りる（正規表現の網羅性
+> 自体を完全性条件にはしない）。
 > **自己検証（正のコントロール）を必須にする**: ガードテストは、検査用の正規表現がコンパイルでき、かつ既知の悪例文字列
 > （例 `"os.Geteuid()"`・`"os.Create(p)"`）に**必ずマッチする**ことを表明する正のコントロールを含める。これにより将来の
 > タイプミスでパターンが空振りに戻っても、ガードが沈黙で壊れることを防ぐ。

--- a/docs/tasks/0142_axis2_destination_zoning/03_implementation_plan.md
+++ b/docs/tasks/0142_axis2_destination_zoning/03_implementation_plan.md
@@ -1,0 +1,530 @@
+# 判断軸2: 宛先パス信頼区分の一貫化 — 実装計画書
+
+## Document Status
+
+| Item | Value |
+|---|---|
+| Status | `draft` |
+| Created | 2026-06-23 |
+| Review date | - |
+| Reviewer | - |
+| Comments | - |
+
+> 本書は 0140 を 3 分割した第 2 タスク（判断軸2＝宛先パス信頼区分）の実装計画である。要件は
+> [01_requirements.md](01_requirements.md)、設計は [02_architecture.md](02_architecture.md) を正とする。
+> 本書は設計図を再掲せず、各タスクから設計の該当節（§3.x 等）を参照する。本タスクは 0141 が再編した共有コード
+> （`evaluateDimensions`・名前集合）の**完了後**にその上へ構築する。
+
+---
+
+## 1. 実装概要
+
+### 1.1 目的
+
+ファイル操作コマンド（`cp`/`rm`/`dd`/`tar`/`mount`/`chmod` 等）の作用先パスを解決後パスへ正規化し、パス信頼区分
+（trust-critical/ordinary/safe-zone/unresolved）へ分類してリスクを判定する判断軸2 を、既存のリスク評価パイプライン
+（`StandardEvaluator.evaluateDimensions`）へ組み込む。完全認識時には、これらコマンドを現在 High に分類している既存
+5 系統の判定を判断軸2 の結果で置き換える（設計 §3.4）。
+
+### 1.2 実装方針
+
+- **設計に従う**: 型・関数・判定規則・脅威モデルはすべて [02_architecture.md](02_architecture.md) を正とし、本書は
+  作業の分解・順序・検証方法のみを定義する。
+- **fail-closed 既定**: 解決/抽出が不確実なオペランドは `ZoneUnresolved`（書込/削除=High・読み取り元=Medium）に倒す
+  （設計 §3.1・§5.1）。実装で迷う形は安全側へ。
+- **純関数・決定的**: パス解決は `lstat`/`readlink` のみの read-only。判定は注入 `RunAsIdent`・注入パス集合と評価時点の
+  ファイルシステム状態のみに依存し、live identity（`os.Geteuid` 等）・`$HOME` env を読まない（設計 §3.6・§5.3）。
+- **English ソース**: 追加する Go の識別子・コメント・文字列リテラルはすべて英語（テストソースを含む）。本計画書の
+  地の文は日本語。
+- **段階ロールアウトなし**: 後方互換不要のため新分類を直接適用する。フラグ/shadow は設けない（設計 付録）。
+- **完了基準**: 各 Phase 完了時に `make fmt`→`make test`→`make lint` を緑にする。中核 2 パッケージ（`security`/`risk`）に
+  加え、本タスクが変更する統合パッケージ（`internal/runner`・`internal/runner/config`）まで、コンパイルとテストが通ることを
+  完了基準とする。具体的には `./internal/runner/...` または `make test` 全体が緑であること（NF-002）。
+
+### 1.3 既存コード調査結果
+
+実装着手前に、設計が参照する全シンボルの存在・シグネチャを確認した（`internal/runner/` 配下）。要点:
+
+**risktypes（`internal/runner/base/risktypes/`）**
+- `RiskAssessment`（`types.go:112-134`）: 既存フィールドは `Level`/`Blocking`/`BlockingReason`/`ErrorClass`/
+  `ReasonCodes`/`Reasons`/`NetworkType`。本タスクは `OperandZones []OperandZone` を**追加**する（既存は不変）。
+- `ReasonCode`（`reason_codes.go:9`、`type ReasonCode string`）: 既存 29 定数。本タスクは新 family 7 種を追加する。
+- `TestReasonCodes_AllDistinct`（`reason_codes_test.go:12-52`）: **ハードコードされた全定数スライス**（`reason_codes_test.go:13`）を
+  走査し、空値なし・重複なしを検証する。新コード追加時はこのスライスへの登録も必要（登録漏れでテストが緑のまま穴になる）。
+- import は `runnertypes`＋stdlib のみ。`security → risktypes → runnertypes` の一方向依存が成立（DTO を `risktypes` に
+  置く設計 §3.1 の前提を確認済み）。
+
+**security（`internal/runner/base/security/`）**
+- `Config`（`types.go:109-151`）: `SystemCriticalPaths`（`:137`）・`OutputCriticalPathPatterns`（`:141`）・
+  `TrustedGIDs`（`:148`）を保持。本タスクは `TrustedDirectories []string` を**追加**する。
+- `(*Config).GetSystemCriticalPaths()`（`types.go:309-312`）・`DefaultConfig()`（`types.go:160-258`、既定の
+  `SystemCriticalPaths`＝`:226-229`、`OutputCriticalPathPatterns`＝`:230-246`）存在。
+- 置き換え対象 5 系統の所在:
+  - ① `IsDestructiveFileOperation`（`command_analysis.go:531-562`）→ `evaluateDimensions` の `evaluator.go:229`。
+  - ② `CoreutilsCommandRisk`（`coreutils.go:116-171`、破壊系で `RiskLevelHigh,true,nil`＝`:162-164`）→ `evaluator.go:218-224`。
+    `coreutilsHandled` は binary 解析抑止（`evaluator.go:263`）にも使うため、破壊系 High の抑止と binary 解析抑止を分離して扱う。
+  - ③ profile `DestructionRisk`（`command_risk_profile.go:37`、`rm`/`dd` のみが保持＝`command_analysis.go:41-46`）→
+    `applyProfileFactors`（`evaluator.go:287`）/`ProfileFactorRisk`（`command_risk_profile.go:180`）。
+  - ④ `dangerousCommandPatterns` rank6（`command_analysis.go:216-234`）: `{rm,-rf}` High・`{dd,if=}` High・
+    `{chmod,777}` High・`{chown,root}` **Medium**（`:227`、設計 §3.4 表と一致）・`{sudo,rm}` High。`CheckDangerousArgPatterns` 経由で
+    `evaluator.go:243`。ネットワーク系（`wget`/`curl`/`nc`）は同テーブルにあるが置き換え対象外。
+  - ⑤ setuid/setgid lstat 下限: シグナルは `hasSetuidOrSetgidBit`（`command_analysis.go:802-828`、`os.Stat`＋
+    `os.ModeSetuid|os.ModeSetgid`）。`CoreutilsCommandRisk` の setuid 経路（`coreutils_test.go:110` が表明）と連動。設計 §3.2 注のとおり
+    **再パースせず既存シグナルを流用**する。
+- リゾルバ流用元: `walkSymlinkChain`（`command_analysis.go:635`）・`ResolveCommandNames`（`command_analysis.go:727`）、
+  `MaxSymlinkDepth=40`（`types.go:84`）。専用リゾルバはこの追従型を手本に新規実装する（`safefileio` は symlink 拒否設計のため流用不可、設計 §3.3）。
+- ネットワーク終端検出: `hasNetworkArguments`/`HasNetworkArguments`（`network_analyzer.go:202`/`:212`）・
+  `containsSSHStyleAddress`（`command_analysis.go:390-411`、`user@host:path`・`host:path` を `/`・`~` 含有で検出、二重コロン
+  `host::module` は未検出）。P5 でこの隙間を塞ぐ（設計 §3.5）。
+- `RuntimeCommand.EffectiveWorkDir`（`runnertypes/runtime.go:260-261`）存在。
+
+**risk（`internal/runner/base/risk/`）**
+- `StandardEvaluator`（`evaluator.go:30-34`）: `networkAnalyzer`・注入可能 `openIdentity`。
+- `NewStandardEvaluator(networkAnalyzer *security.NetworkAnalyzer) Evaluator`（`evaluator.go:36-42`）: 本タスクで
+  `*security.Config` 引数を**1 つ追加**する。
+- `evaluateDimensions(cmd, names, profile, profileFound) (risktypes.RiskAssessment, error)`（`evaluator.go:204-274`）:
+  順位 4-8 の max 合成。本タスクで判断軸2 ディスパッチを追加する。
+- `resolveRiskEvaluator(opts, verificationManager) risk.Evaluator`（`runner.go:238-250`）: 現状 `securityConfig` を
+  受け取らない。
+
+**runner（`internal/runner/`）**
+- `NewRunner`（`runner.go:285-381`）が `security.DefaultConfig()`（`:306`）を構築し `TrustedGIDs` を転送（`:308-309`）するが、
+  `securityConfig` ローカルは `security.NewValidator` に渡るのみで、`createResourceManager`（`:196`）→
+  `createDryRunResourceManager`（`:208`）/`createNormalResourceManager`（`:253`）→`resolveRiskEvaluator` の鎖には**未到達**。
+  本タスクはこの鎖へ `securityConfig`（または信頼区分判定用 config）を通す（設計 §3.6）。
+- `opts.riskEvaluator`（`runner.go:93`）・`WithRiskEvaluator`（`:139-147`）でテスト注入可能。
+
+**runnertypes / config / privilege**
+- `SecuritySpec`（`runnertypes/spec.go:111-117`、`TrustedGIDs []uint32 toml:"trusted_gids"`＝`:116`）に
+  `TrustedDirectories []string toml:"trusted_directories"` を追加する。
+- `config/loader.go` は go-toml/v2 で `toml.Unmarshal`（`:261`）する自動マッピング。新フィールドは構造体タグで自動デコード
+  されるため、ローダ変更は最小（追加フィールドの転送経路のみ確認）。
+- `privilege/unix.go` は `user.Lookup`/`user.LookupGroup` を使用。run-as 解決はこれと同質の純解決を注入層に置く（設計 §3.6）。
+
+**更新が必要な既存テスト**
+- `risk/coreutils_consistency_test.go`: `TestConsistency_RmAllForms`（`:186-213`）・`TestConsistency_DestructiveAbsolutePath`
+  （`:170-180`）・`TestCoreutilsRiskConsistency_Setuid`（`:138-163`）。
+- `risk/evaluator_test.go`: `TestEvaluateRisk_AbsoluteRmRfHigh`（`:192`）等、`rm`/`dd` を一律 High と表明する破壊系ケース。
+- `security/coreutils_test.go`: `CoreutilsCommandRisk` の挙動テスト（`:52` 破壊系・`:110` setuid）は**関数自体を変えないため不変**
+  （置き換えは評価層のディスパッチに閉じる、設計 §3.4）。
+- `security/network_analyzer_test.go`・`security/command_analysis_test.go`（`TestContainsSSHStyleAddress`＝`:21`、
+  rsync ssh-style ＝`:234`）: P5 で `host::module` の回帰を追加。
+
+---
+
+## 2. 実装ステップ
+
+各 Phase の完了時に `make fmt`→`make test`→`make lint` を緑にする。Phase 順序は設計 §8 の優先順位表に一致させる。
+
+### Phase 1: DTO・型定義・reason code family（AC-05, AC-19, NF-001）
+
+**変更ファイル**:
+- 新規 `internal/runner/base/risktypes/operand_zone.go`
+- 変更 `internal/runner/base/risktypes/types.go`
+- 変更 `internal/runner/base/risktypes/reason_codes.go`
+- 変更 `internal/runner/base/risktypes/reason_codes_test.go`
+- 新規 `internal/runner/base/risktypes/operand_zone_test.go`
+
+**作業内容**:
+- [ ] `operand_zone.go` に `PathTrustZone`（`ZoneTrustCritical`/`ZoneOrdinary`/`ZoneSafeZone`/`ZoneUnresolved`）を定義（設計 §3.1）。
+- [ ] `operand_zone.go` に `OperandRole`（`OperandRoleWrite`/`OperandRoleRead`）を定義（設計 §3.1）。
+- [ ] `operand_zone.go` に `OperandZone` 構造体（`Index`/`Raw`/`Resolved`/`Zone`/`Role`/`MatchedCritical`/`Trusted`/`UnresolvedErr`）を定義（設計 §3.1）。
+- [ ] `operand_zone.go` に `RunAsIdent` 構造体（`UID`/`GID`/`Groups`）を定義（設計 §3.1）。
+- [ ] `types.go` の `RiskAssessment` に `OperandZones []OperandZone` フィールドを追加（既存フィールドは不変、設計 §3.1）。
+- [ ] `reason_codes.go` に新 family 7 定数を追加（設計 §4）: `ReasonTrustBoundaryWrite`=`"trust_boundary_write"`・
+      `ReasonDestinationZone`=`"destination_zone"`・`ReasonPermissionGrant`=`"permission_grant"`・`ReasonDeviceIO`=`"device_io"`・
+      `ReasonRecursiveOutsideSafeZone`=`"recursive_outside_safe_zone"`・`ReasonSensitiveSourceCopy`=`"sensitive_source_copy"`・
+      `ReasonUnresolvedDestination`=`"unresolved_destination"`。
+- [ ] `reason_codes_test.go` の全定数スライス（`:13`）へ上記 7 定数を登録する（登録漏れ防止）。
+
+**成功基準**:
+- [ ] `go build -tags test ./internal/runner/base/risktypes/` が通る。
+- [ ] `TestReasonCodes_AllDistinct` が新 7 定数を含めて緑（空値なし・重複なし、NF-001）。
+- [ ] `operand_zone_test.go` が `OperandZone` のゼロ値・各 enum 値の文字列表現を表明（型定義の健全性）。
+
+### Phase 2: 専用リゾルバ＋Trusted 述語（AC-04, AC-23）
+
+**変更ファイル**:
+- 新規 `internal/runner/base/security/operand_path_resolver.go`
+- 新規 `internal/runner/base/security/operand_path_resolver_test.go`
+- 新規（必要時）`internal/runner/base/security/test_helpers_zoning.go`（`//go:build test`）
+
+**作業内容**:
+- [ ] `ResolveOperandPath(operand, base string, maxHops int) (resolved string, err error)` を実装（設計 §3.3）。
+      symlink チェーンを leaf＋親で追従し、正規化済み絶対パスを返す。相対オペランドは `base`（`ln -s` 相対 target は
+      リンク親、他は `EffectiveWorkDir`）基点で解決。read-only（`lstat`/`readlink` のみ）。
+- [ ] 未存在 leaf を「最深の存在親」まで解決して末尾を畳み込む。**最深存在親が symlink のときは解決を確定できないため
+      エラー**（呼び出し側で `ZoneUnresolved`＝書込/削除 High、設計 §3.3 注）。
+- [ ] cycle・深さ超過（`maxHops` 超）・mid-chain の `readlink`/`lstat` 失敗で `error` を返す（fail-closed、設計 §4）。
+- [ ] AC-23 の解決コスト計測のため、リゾルバが `lstat`/`readlink`/`stat` を**注入可能な関数セット**経由で呼ぶ構造にする
+      （既定は実 os、テストは呼出回数を数えるスタブを注入。`StandardEvaluator.openIdentity` と同じ注入パターン）。
+- [ ] メモ化: 解決のメモ化を 1 回の判定呼び出し内にスコープし、鍵は**解決後の絶対パス**とする。identity 依存の Trusted
+      判定そのものはキャッシュしない（設計 §3.3(e)）。
+- [ ] Trusted 述語を実装（設計 §3.3(d)）: 解決後パスが `TrustedDirectories` 配下、かつ**safe-zone 起点の親以上**の経路
+      要素が run-as から書込不可（run-as 以外所有・group/other 非書込）のとき Trusted。参照 identity は注入 `RunAsIdent`
+      （live euid 不参照）。書込不可検査の対象は**起点ディレクトリの親以上**に限定（起点配下は対象外、設計 §3.3(d) の根拠）。
+
+**成功基準**:
+- [ ] `go test -tags test ./internal/runner/base/security/...` が通る（`//go:build test` の `test_helpers_zoning.go` を**同一タグで
+      コンパイル**し、型/シグネチャ誤りを本 Phase で検出する。`-tags test` 無しの `go build` では同ファイルが除外され検出されない）。
+- [ ] `cp evil $WORKDIR/link`（`link→/etc/passwd`）が High（ターゲット解決で trust-critical）になり Low にならない
+      （`operand_path_resolver_test.go`、設計 §7.1）。
+- [ ] `ln -s` 相対 target がリンク親基点で解決される（`EffectiveWorkDir` 基点ではない）。
+- [ ] 深い symlink チェーン（`maxHops` 超）・cycle で `error`（→ fail-closed）になる。
+- [ ] メモ化の**反証可能な呼出回数表明**（AC-23）: 共通の親チェーン（深さ D）を共有する K 個のオペランドを持つフィクスチャを
+      用意し、注入 `lstat`/`readlink` スタブの呼出回数を数える。メモ化**有り**では共有親の解決は 1 回に畳まれるため
+      呼出回数が「概ね D + K（各 leaf 1 回＋共有親 1 回分）」の定数式に等しいことを `==`（または僅差の `<=`）で表明し、メモ化を
+      外した場合の素朴な「K×(D+1)」と**有意に小さい**ことを対比する。「線形」のような非反証的表現は用いず、具体的な期待値で
+      assert する（D・K・期待値は実装で確定）。
+- [ ] Trusted 述語の差分テスト: 注入 `RunAsIdent` を実 euid/gid と異なる値にし、起点親の所有者/権限により Trusted が
+      切り替わる（AC-04(d)・AC-21 の先行検証）。
+
+### Phase 3: オペランド抽出仕様表＋区分判定＋操作固有の下限（AC-01〜AC-15）
+
+**変更ファイル**:
+- 新規 `internal/runner/base/security/destination_zoning.go`
+- 新規 `internal/runner/base/security/destination_zoning_test.go`
+- 変更（必要時）`internal/runner/base/security/test_helpers_zoning.go`
+
+**作業内容**:
+- [ ] `LocationKind`（`KindNone`〜`KindDataTransferWrite`）・`ZoningInput`・`LocationResult` を定義（設計 §3.2）。
+- [ ] コマンド→`LocationKind`→オペランド抽出規則を**単一の仕様テーブル**として実装（AC-06／根本原因1、設計 §3.2）。
+      対象コマンドは要件 §F-002（cp/mv/rm/rmdir/unlink/shred/ln/mkdir/touch/install/tee/sponge/truncate/`sed -i`/tar/
+      unzip/dd/mount/umount/chmod/chown/chgrp/setfacl/chattr/find＋データ送信書込形）。難所のエントリは要件 §F-002 の表を正とする。
+- [ ] 各オペランドに `OperandRole`（write/read）を付与する（unresolved の非対称下限のため、AC-05）。
+- [ ] `ClassifyDestinationZone(input ZoningInput, names map[string]struct{}, cmdPath string, args []string) LocationResult`
+      を実装（設計 §3.2）。抽出→`ResolveOperandPath` で解決→区分判定→操作固有の下限→全オペランド max。
+- [ ] パス信頼区分の判定（AC-01〜AC-05）: trust-critical（`SystemCriticalPaths` 一致/配下、`/` は完全一致のみ）→High、
+      ordinary→Medium、safe-zone（Trusted→Low／非 Trusted→Medium フォールバック）、unresolved（write=High・read=Medium）。
+      safe-zone が trust-critical と重複/配下のときは trust-critical 優先（AC-04(c)）。
+- [ ] 操作固有の下限を区分判定後に上乗せ（safe-zone でも Low に降格しない、AC-08〜AC-12、設計 §3.2 表）:
+  - [ ] 権限/所有権/属性付与（setuid/setgid・world-writable・trust-critical 所有権変更・`chattr -i`）→ High（AC-08, AC-09）。
+        setuid/setgid シグナルは `hasSetuidOrSetgidBit` を**流用**（再パースしない、設計 §3.2 注）。
+  - [ ] `dd` デバイス IO（`if=`/`of=` がブロック/危険キャラクタデバイス。`/dev/null`・`/dev/zero` 除外）→ High。機密/
+        trust-critical な `if=` は Medium 下限。パス文字列でなくデバイス種別で判定（AC-10）。
+  - [ ] safe-zone 外への再帰（`rm -r`/`cp -R`/`-a` 等が外へ及ぶ）→ High（AC-11）。
+  - [ ] 機密ファイル複製（コピー元が機密/trust-critical）→ Medium 下限（読み取り元、AC-12）。判定集合は既存
+        `Config.OutputCriticalPathPatterns` を流用（設計 §3.2 注、DRY）。
+- [ ] コマンド別オペランド特則を実装（AC-12〜AC-15、設計 §3.2／要件 §F-003(b)）: mv/ln の移動元/リンク元、`cp -p`/`-a` の
+      特権メタデータ複製 High、mount/umount（mountpoint＋マウント元、`umount -a` 無条件 High）、tee/sponge（全 FILE max）、
+      find（`-delete`/`-fprint*` の宛先判定、`-exec` 系の内側実行は本タスク対象外＝0141/既存）。
+- [ ] `LocationResult.Recognized` を計算（完全認識: 全オペランドが非 `ZoneUnresolved` かつ全 argv を解析しきった、設計 §3.4）。
+      未解析トークン/未知の値取りフラグが残れば `Recognized=false`＋`ZoneUnresolved` 下限。
+- [ ] 各オペランドの判定を `[]OperandZone`（Index/Raw/Resolved/Zone/Role/MatchedCritical/Trusted/UnresolvedErr）として記録し
+      `LocationResult.Operands` に格納。判定由来の `ReasonCode` を `LocationResult.ReasonCodes` に積む。「空（非適用）」と「適用済み
+      解決不能（`Zone==ZoneUnresolved` 要素）」を区別可能にする（0143 AC-01 の消費契約、設計 §3.1）。この区別は AC-19 検証で**2 つの
+      独立したケース**として表明する（非ファイル操作コマンド→`len(OperandZones)==0`、適用済み解決不能→`Zone==ZoneUnresolved` 要素を持つ）。
+
+**成功基準**:
+- [ ] 既知コマンド×代表フラグの表駆動テストで、要件 §F-002 の難所（in-place 編集・`ln -s` 相対 target・アーカイブ抽出 vs 一覧・
+      末尾 `/` 削除・`dd` デバイス・権限/所有権付与・データ送信書込先）が各々テスト行を持つ（AC-06, AC-06a）。
+- [ ] AC-08〜AC-15 で名指しされた全書込/削除/付与形が仕様表のテスト行を持つ（AC 本文と仕様表のドリフト防止、AC-06a）。
+- [ ] 区分判定テスト: trust-critical（`/usr/local/bin`=High・`/` 完全一致のみ）・ordinary（`/srv`/`/opt`=Medium）・
+      safe-zone（Trusted=Low／非 Trusted=Medium）・unresolved（write=High・read=Medium）。`/var`・`/var/log` は trust-critical の
+      ため ordinary フィクスチャに使わない（設計 §7.1）。
+- [ ] 操作固有の下限が safe-zone でも降格しないこと（`chmod u+s`・`chmod 0777`・`chown root /usr/bin/x`・`chattr -i`・
+      `dd of=/dev/sda`・`rm -r` 外部・`cp /etc/shadow $WORKDIR/x`、AC-08〜AC-12）。
+- [ ] 複数オペランドの max（AC-07、設計 §6.2 の `cp /etc/shadow $WORKDIR/x`=Medium 例を含む）。
+
+### Phase 4: `evaluateDimensions` 組み込み＋既存 5 系統の完全認識時抑止（AC-17, AC-18）
+
+**変更ファイル**:
+- 変更 `internal/runner/base/risk/evaluator.go`
+- 変更 `internal/runner/base/security/command_risk_profile.go`（`ProfileFactorRisk` に DestructionRisk-only 抑止フラグ）
+- 変更 `internal/runner/base/risk/evaluator_test.go`
+- 変更 `internal/runner/base/risk/coreutils_consistency_test.go`
+- 新規 `internal/runner/base/risk/destination_zoning_integration_test.go`
+
+**作業内容**:
+- [ ] `evaluateDimensions` に判断軸2 ディスパッチを追加（設計 §3.4・§6.1）: `ClassifyDestinationZone` を呼び、
+      `Applies==true && Recognized==true` のときだけ既存 5 系統の破壊系 High 寄与を抑止し `LocationResult.Level` を唯一の
+      寄与にする。不完全認識/非ファイル操作のときは既存 5 系統をそのまま残す（fail-open 回避）。
+- [ ] ① `IsDestructiveFileOperation`（`evaluator.go:229`）の寄与を完全認識時に飛ばす。
+- [ ] ② `CoreutilsCommandRisk` の破壊系 High 寄与（`evaluator.go:218-224`）を完全認識時に飛ばす。**binary 解析抑止に使う
+      `coreutilsHandled`（`:263`）は維持**し、破壊系 High の加算のみ抑止する（両者を分離）。
+- [ ] ③ profile `DestructionRisk` を**破壊コンポーネント粒度**で抑止（設計 §3.4）: `ProfileFactorRisk`/`applyProfileFactors`
+      に `DestructionRisk` のみ無効化するフラグを渡す。他因子（`NetworkRisk`/`DataExfilRisk` 等）と `NetworkType`/`Reasons` は
+      引き続き適用する。
+- [ ] ④ `CheckDangerousArgPatterns`（`evaluator.go:243`）の寄与を完全認識のファイル操作コマンドで抑止する。
+  - [ ] **抑止はディスパッチ粒度**で行う（`Applies && Recognized` のときに④の寄与加算をまとめて飛ばす）。
+        `CheckDangerousArgPatterns` は複数エントリのマッチを単一レベル（`ReasonDangerousArgPattern`）へ畳み込んで返すため、
+        ③のように関数内で破壊コンポーネントだけを抜く方式は適用できない。当該コマンドで④を呼ばない（または④の戻り値を
+        加算しない）形にする。
+  - [ ] 取りこぼし防止: 完全認識のファイル操作コマンドでは④の一致エントリは破壊系（`{rm,-rf}`/`{dd,if=}`/`{chmod,777}`/
+        `{chown,root}`）であり、これらは判断軸2 の区分/操作固有の下限で再確立される（設計 §3.4 表）。`wget`/`curl`/`nc` 等の
+        ネットワーク系エントリは**データ送信書込形にのみ一致**し、その egress Medium は④ではなく 0141 の名前下限と AC-16 の
+        合成（§3.5）で再確立されるため、④抑止で取りこぼさない。
+  - [ ] `nc`/`netcat`（ファイル操作でも 0142 のデータ送信書込形でもないコマンド）は `Applies==false` で従来どおり④が効く。
+- [ ] ⑤ setuid/setgid lstat 下限は**再パースせず**、`hasSetuidOrSetgidBit` 相当の既存シグナルを操作固有の下限（Phase 3）が
+      流用する（設計 §3.2 注・§3.4 例外）。
+- [ ] `RiskAssessment.Level` を判断軸1 と max 合成（AC-18）。`LocationResult.ReasonCodes` を `RiskAssessment.ReasonCodes` に追記。
+- [ ] 既存テストを宛先依存へ更新（設計 §3.4 のインライン記載に従う）:
+  - [ ] `coreutils_consistency_test.go::TestConsistency_RmAllForms` を更新（信頼 safe-zone=Low／trust-critical=High／unresolved=High）。
+  - [ ] `coreutils_consistency_test.go::TestConsistency_DestructiveAbsolutePath` を更新（trust-critical 絶対パス=High は維持、safe-zone 絶対パス=Low）。
+  - [ ] `coreutils_consistency_test.go::TestCoreutilsRiskConsistency_Setuid` を更新（setuid は権限付与下限で High を維持）。
+  - [ ] `evaluator_test.go::TestEvaluateRisk_AbsoluteRmRfHigh` 等の破壊系ケースを宛先依存へ更新。
+
+**成功基準**:
+- [ ] 信頼 safe-zone `rm -rf $WORKDIR/build`=Low（④rank6・②coreutils の固定 High で打ち消されない、AC-17）。
+- [ ] ordinary `rm /srv/app/cache.dat`=Medium（AC-17）。
+- [ ] 未知フラグで宛先不確実な `rm`=High（①〜⑤を残す、AC-17）。
+- [ ] `cp -a … /usr/bin`=High（判断軸1×判断軸2 の max、順序非依存、AC-18）。
+- [ ] 置き換えの取りこぼし防止条件（外した 5 系統が捕捉していた危険判定を、判断軸2 が同等以上のレベルで取りこぼさず再確立する
+      ことの確認。設計 §3.4 表）: ④の `chmod 777`=High・`chown root`（trust-critical 宛先=High／ordinary=Medium）が
+      §3.2 の権限付与下限/区分で同等以上になることを表明（「外したが再確立されない隙間」を塞ぐ）。
+- [ ] 非ファイル操作コマンド（同名でも `find -exec` の内側実行等）では④等を無効化しないこと。
+
+### Phase 5: データ送信書込先合成＋rsync `host::module` 検出（AC-16）
+
+**変更ファイル**:
+- 変更 `internal/runner/base/security/destination_zoning.go`（`KindDataTransferWrite` のリモート終端判定）
+- 変更 `internal/runner/base/security/network_analyzer.go`（`hasNetworkArguments` に `host::module` 追加）
+- 変更 `internal/runner/base/security/command_analysis.go`（`containsSSHStyleAddress` 周辺、必要時）
+- 変更 `internal/runner/base/risk/destination_zoning_integration_test.go`
+- 変更 `internal/runner/base/security/network_analyzer_test.go`
+- 変更 `internal/runner/base/security/command_analysis_test.go`
+
+**作業内容**:
+- [ ] `KindDataTransferWrite` の書込先抽出（`curl -o`/`-O`・`wget` 既定/`-O`/`-P <dir>`・`scp host:/x DEST`・`sftp` バッチ書込・
+      `rsync … DEST`/`--delete`）を仕様表に実装（設計 §3.5）。
+- [ ] 最終リスク = `max(データ送信の名前 Medium〔0141〕, 書込先のパス信頼区分)` を合成する（max 合成の所有者は本タスク、AC-16）。
+- [ ] rsync のリモート終端判定に `host::module`（二重コロン bare module、末尾パス無し）を追加（設計 §3.5(1)）。リモート宛先の
+      ときは zone 対象のローカルパスが無く egress（名前ベース Medium）が支配、ローカル宛先のときのみ書込先区分と max。
+- [ ] `hasNetworkArguments` に `host::module` 検出を追加（設計 §3.5(2)）: 左側をホスト名様トークン（`[A-Za-z0-9.-]+`）に限定し、
+      `/` を含むトークンや C++ スコープ様式を巻き込まない（過剰分類回避）。`rsync` 全体の無条件 Medium 格上げはしない。
+
+**成功基準**:
+- [ ] (i) `curl <url> -o $WORKDIR/safe`=Medium。**Medium の出所**を表明する（単なるレベル==Medium では既存 network profile の
+      Medium と区別できない、canary の落とし穴。設計 §3.5）。出所表明は次のいずれか:
+  - 既存 Medium profile を持たないデータ送信書込形を選び「Medium への唯一の経路が名前下限」状況を作る（**自己完結で推奨**。
+    0141 の理由コード識別子の確定に依存しない）、または
+  - `RiskAssessment.ReasonCodes` に 0141 名前下限由来の理由コードを含むことを表明（この場合、当該理由コード定数が 0141 で確定済み
+    かを §10 のクロス検索で事前確認する）。
+- [ ] (ii) `curl -o /usr/bin/x`=High（書込先が名前下限を上回る、AC-16）。
+- [ ] `rsync src host::module`=Medium（egress 由来、理由コードで出所表明）。
+- [ ] 純ローカル `rsync /a /b`=Low（過剰分類しない）。
+- [ ] `rsync /local /usr/bin/x`（ローカル trust-critical 宛先）=High（書込先区分が支配）。
+
+### Phase 6: config 組み込み＋identity 注入（AC-20, AC-21）
+
+**変更ファイル**:
+- 変更 `internal/runner/base/security/types.go`（`Config.TrustedDirectories`）
+- 変更 `internal/runner/base/runnertypes/spec.go`（`SecuritySpec.TrustedDirectories`）
+- 変更 `internal/runner/base/runnertypes/spec_test.go`
+- 変更（必要時）`internal/runner/config/loader.go`
+- 変更 `internal/runner/base/risk/evaluator.go`（`NewStandardEvaluator` 引数追加・`RunAsIdent` 注入フィールド）
+- 変更 `internal/runner/runner.go`（呼び出し鎖への securityConfig 転送）
+- 変更 `internal/runner/base/risk/destination_zoning_integration_test.go`
+
+**作業内容**:
+- [ ] `security.Config` に `TrustedDirectories []string` を追加（設計 §3.6）。
+- [ ] `SecuritySpec` に `TrustedDirectories []string toml:"trusted_directories"` を追加（既存 `TrustedGIDs` と並置、設計 §3.6）。
+- [ ] `NewStandardEvaluator` に `*security.Config` 引数を 1 つ追加（既存引数・戻り型は不変、設計 §3.6）。
+- [ ] `StandardEvaluator` に `*security.Config` フィールドと run-as 解決ロジック（注入可能フィールド、既定は os/user ベース）を
+      追加（既存 `openIdentity` と同じ注入パターン、設計 §3.6）。
+- [ ] run-as 名→`RunAsIdent` の解決を評価層（組み込み層）で行い、precomputed 値を `ZoningInput` へ注入（設計 §3.6・AC-21）。
+      `ClassifyDestinationZone` 以下は live identity API を読まない。
+- [ ] run-as 未設定時は **runner が起動時に確定した original 実行 identity** を注入時に一度だけ解決して用いる。`RunAsIdent` の
+      zero 値（`UID:0`）を「未設定」既定にしない（設計 §3.6）。
+- [ ] run-as 名が解決できない場合は当該コマンドの全オペランドを `ZoneUnresolved`（write=High・read=Medium）に倒す（fail-closed、設計 §3.6）。
+- [ ] `runner.go` の呼び出し鎖（`createResourceManager`・両 `create*ResourceManager`・`resolveRiskEvaluator`）へ `securityConfig`
+      を通し、`NewStandardEvaluator` へ渡す。normal/dry-run の両経路に**同一に**渡す（AC-22 の一貫性、設計 §3.6）。
+- [ ] `config/loader.go` で `[security] trusted_directories` が `SecuritySpec` へデコードされ runner へ転送されることを確認
+      （自動マッピングなら最小変更）。
+
+**成功基準**:
+- [ ] `spec_test.go` で `[security] trusted_directories` が `SecuritySpec.TrustedDirectories` にパースされる（AC-20）。
+- [ ] config 経由（テスト注入でなく本番経路）で `SystemCriticalPaths`/`TrustedDirectories` が判定に届き、AC-01/AC-04 が成立する
+      （AC-20）。
+- [ ] identity 注入の差分テスト: 注入 `RunAsIdent` をテストプロセスの実 euid/gid と**異なる**値にし、Trusted/Low 判定が注入
+      identity に従って変わる（AC-21、決定性テストでは証明できない live 不参照を表明）。
+- [ ] run-as 名解決失敗で `ZoneUnresolved`（High）に倒れる（AC-21 fail-closed）。
+
+### Phase 7: 決定性・上限の統合テスト・grep ガード（AC-22, AC-23）
+
+**変更ファイル**:
+- 変更 `internal/runner/base/risk/destination_zoning_integration_test.go`
+- 新規 `internal/runner/base/risk/live_identity_guard_test.go`（grep ガード）
+
+**作業内容**:
+- [ ] 決定性テスト（AC-22）: 同一入力・同一 FS 状態で runtime 経路と dry-run 経路が同一レベルを返すことを表明。
+- [ ] 解決コスト上限テスト（AC-23）: 多数オペランド（>N）・深い symlink チェーン（>M）で fail-closed（High）になり、メモ化により
+      注入 `lstat`/`stat` 呼出回数が線形に収まることを表明。
+- [ ] grep ガード（AC-21 補助）: 判断軸2 の組み込みコード（`destination_zoning.go`・`operand_path_resolver.go`）が live-identity
+      API（`os.Geteuid`/`os.Getuid`/`syscall`/`unix` の uid/gid/groups・`user.Current`）を呼ばないことを `rg`（§7 footnote の選択
+      `|` を用いた正規表現）で検査するテスト。**正のコントロール**（既知の悪例文字列が必ずマッチすること）を併せて表明し、
+      パターンの空振り（fail-open）を防ぐ。
+
+**成功基準**:
+- [ ] 決定性テストが緑（runtime==dry-run、AC-22）。
+- [ ] 上限超過で High・呼出回数が線形（AC-23）。
+- [ ] grep ガードが緑（live-identity API の不在、AC-21）。
+
+---
+
+## 3. 実装順序とマイルストーン
+
+| Phase | マイルストーン（成果物） | 反映 AC | 依存 |
+|---|---|---|---|
+| P1 | DTO・型・reason code family（`risktypes`） | AC-05, AC-19, NF-001 | なし |
+| P2 | 専用リゾルバ＋Trusted 述語（`security`） | AC-04, AC-23 | P1 |
+| P3 | `ClassifyDestinationZone`（抽出仕様表＋区分判定＋操作固有の下限） | AC-01〜AC-15 | P2 |
+| P4 | `evaluateDimensions` 組み込み＋既存 5 系統抑止 | AC-17, AC-18 | P3 |
+| P5 | データ送信書込先合成＋rsync `host::module` | AC-16 | P3 |
+| P6 | config 組み込み＋identity 注入（本番経路） | AC-20, AC-21 | P4 |
+| P7 | 決定性・上限・grep ガードの統合検証 | AC-22, AC-23, NF-003 | P4-P6 |
+
+各マイルストーン完了時に `make fmt`→`make test`→`make lint` を緑にする。最終マイルストーンの完了基準は、中核 2 パッケージに
+加え統合パッケージ（`./internal/runner/...` または `make test` 全体）がコンパイル・緑であること（NF-002）。
+
+---
+
+## 4. テスト戦略
+
+設計 §7 を正とし、本節は配置とカバレッジ目標を定める。
+
+### 4.1 単体テスト
+- **`security/operand_path_resolver_test.go`**: symlink 追従（ターゲット解決で safe-zone 偽装を破れない）・`ln -s` 相対 target・
+  深さ/cycle の fail-closed・メモ化の線形呼出・Trusted 述語の差分（AC-04, AC-23）。
+- **`security/destination_zoning_test.go`**: オペランド抽出仕様表の表駆動（難所網羅、AC-06/AC-06a）・区分判定（AC-01〜AC-05）・
+  操作固有の下限（AC-08〜AC-12）・コマンド別特則（AC-12〜AC-15）・複数オペランド max（AC-07）。
+- **`security/network_analyzer_test.go`・`security/command_analysis_test.go`**: `host::module` をリモート終端として検出、
+  純ローカルは非ネットワークの回帰（AC-16）。
+- **`risktypes/operand_zone_test.go`・`reason_codes_test.go`**: DTO 型健全性・reason code 網羅性/一意性（AC-19, NF-001）。
+- **`runnertypes/spec_test.go`**: `[security] trusted_directories` パース（AC-20）。
+
+### 4.2 統合テスト
+- **`risk/destination_zoning_integration_test.go`**: `evaluateDimensions` 経由の置き換え観測可能プロパティ（AC-17）・
+  max 合成（AC-18）・データ送信書込先（AC-16）・DTO 格納の値検証（AC-19）・identity 注入の差分（AC-21）・決定性（AC-22）・
+  解決コスト上限（AC-23）。
+- **更新する既存テスト**: `risk/coreutils_consistency_test.go`・`risk/evaluator_test.go`（破壊系を宛先依存へ）。
+
+### 4.3 後方互換テスト
+- 後方互換は不要（新分類を直接適用、設計 付録）。代わりに**置き換えの取りこぼし防止条件**（設計 §3.4 表）をテストで固定し、
+  外した 5 系統が捕捉していた水準を判断軸2 が同等以上に再確立することを表明する（fail-open の隙間を塞ぐ）。
+
+### 4.4 テストヘルパ方針（`test_organization.md`）
+- FS フィクスチャ（特定の所有者/権限/setuid/symlink を持つディレクトリ・ファイル）を 2 つの新規テストファイルで共有する場合は、
+  `security` パッケージ内部の `test_helpers_zoning.go`（`//go:build test`、production と同一パッケージ名）に置く（private API・
+  内部型を使うため Classification B。既存 `security/test_helpers.go` と同じ `//go:build test`＋`package security` 規約）。共有が
+  生じない場合はヘルパファイルを作らずテスト内に閉じる。
+- **FS フィクスチャのクリーンアップ規律**: symlink チェーン・所有者/権限制御ディレクトリ・setuid/world-writable ファイルは実
+  ファイルシステム上に作る（注入スタブは AC-23 の呼出計数専用で、実 `lstat`/`readlink` の symlink 追従は実 FS で検証する）。全
+  フィクスチャは `t.TempDir`（自動クリーンアップ）配下に作り、temp 配下に閉じない作成があれば取得箇所で `t.Cleanup` を登録する
+  （後続 assert が失敗してもリークしない）。
+- **他 UID 所有の親ディレクトリ（Trusted 述語の非降格ケース）**: AC-04(d) の「起点親が run-as 以外所有」を実 FS で再現するには
+  別 UID 所有のディレクトリ作成（`chown`）が必要で、通常は root 権限を要する。検出は純関数
+  `missingForeignOwnerCapability(getuid func() int) []string`（root でない・`chown` 不可なら理由を返す）＋薄い `t.Skip` ラッパとして
+  実装し、required 条件欠如・正常系を単体テストする（環境スキップの純粋性）。root 不要で表現できる非 Trusted ケース（group/other
+  書込可な親など、`os.Chmod` で再現可能）を優先し、root 必須ケースのみスキップ対象にする。
+- **gosec `//nolint` の確定手順**: world-writable/setuid フィクスチャ（`os.Chmod(path, 0o777)`／`os.ModeSetuid` 付与）は gosec が
+  flag しうる。**まず**捨てフィクスチャに対し `make lint` を実行して(1)実際に発火する規則（G302 poor file perms／G306 等）と(2)この
+  リポジトリで `_test.go` が lint 対象かを確認する。**その後**、発火した各該当箇所（`//go:build test` の `test_helpers_zoning.go` を
+  含む。同ファイルは lint 対象にコンパイルされる）に**最小ブロック限定の `//nolint:<発火規則>` を理由コメント付き**で付与し、
+  同一パターンの全インスタンスへミラーする。コメントは「test-only fixture」である旨を明記し、production 能力と読めないようにする。
+
+---
+
+## 5. リスク管理
+
+| リスク | 影響 | 緩和策 |
+|---|---|---|
+| 既存 5 系統の抑止漏れ（fail-open） | 危険形が Low で素通り | 設計 §3.4 の取りこぼし防止条件をテストで固定。完全認識時のみ抑止し、不完全認識は 5 系統 High を残す（P4 成功基準） |
+| ②coreutils の `coreutilsHandled` 二重用途 | 破壊系 High 抑止と binary 解析抑止の取り違え | 破壊系 High 加算の抑止と binary 解析抑止（`:263`）を分離して実装（P4 作業内容） |
+| ③profile 抑止の粒度誤り | 他因子（network 等）の取りこぼし／破壊 High の残存 | DestructionRisk コンポーネント粒度で無効化（P4 作業内容、設計 §3.4） |
+| canary の偽陽性（AC-16(i)） | 名前下限の欠落を既存 profile Medium が隠す | レベルでなく Medium の出所（理由コード）を表明（P5 成功基準、設計 §3.5） |
+| live identity 混入（AC-21 退行） | dry-run と runtime の乖離 | 注入 `RunAsIdent` のみ参照＋grep ガード＋差分テスト（P6/P7） |
+| ホットパスの無制限 FS I/O（DoS） | ExecuteCommand 遅延 | メモ化＋オペランド/ホップ上限で fail-closed（P2/P7、AC-23） |
+| 未存在 leaf の FS 状態依存 | dry-run と runtime でレベル差 | 最深存在親が symlink なら `ZoneUnresolved`（High）に倒す（P2、設計 §3.3 注） |
+
+スケジュールリスク: P4（評価層の置き換え）が最大の難所。P1-P3 を先に固め、P4 はテスト先行（既存テストの宛先依存化）で着手する。
+
+---
+
+## 6. 実装チェックリスト
+
+- [ ] **P1**: DTO・型・reason code family（`risktypes`）／`TestReasonCodes_AllDistinct` 緑
+- [ ] **P2**: 専用リゾルバ＋Trusted 述語／symlink 偽装・fail-closed・メモ化・差分テスト緑
+- [ ] **P3**: `ClassifyDestinationZone`（仕様表＋区分判定＋操作固有の下限＋特則）／表駆動・区分・下限テスト緑
+- [ ] **P4**: `evaluateDimensions` 組み込み＋5 系統抑止／観測可能プロパティ・取りこぼし防止条件・既存テスト更新緑
+- [ ] **P5**: データ送信書込先合成＋rsync `host::module`／(i)(ii)・rsync 3 ケース緑
+- [ ] **P6**: config 組み込み＋identity 注入（本番経路）／spec パース・差分テスト・fail-closed 緑
+- [ ] **P7**: 決定性・上限・grep ガード／runtime==dry-run・線形呼出・live 不参照 緑
+- [ ] 全 Phase 完了後: `make fmt`→`make test`→`make lint` 全緑、`./internal/runner/...` コンパイル（NF-002）
+
+---
+
+## 7. 受け入れ基準の検証
+
+各 AC を検証するタスク/テストを対応づける。種別は `test`（実行可能・誤挙動で落ちる）/`static`（rg/grep/compile）/`manual`。
+
+| AC | 種別 | テスト場所 / 検証コマンド | 期待結果 |
+|---|---|---|---|
+| AC-01 trust-critical High | test | `security/destination_zoning_test.go::TestClassifyDestinationZone_TrustCritical` | `/usr/local/bin`=High、`/` は完全一致のみ |
+| AC-02 ordinary Medium | test | `security/destination_zoning_test.go::TestClassifyDestinationZone_Ordinary` | `/srv`/`/opt`=Medium |
+| AC-03 safe-zone Low/Medium | test | `security/destination_zoning_test.go::TestClassifyDestinationZone_SafeZone` | Trusted=Low／非 Trusted=Medium |
+| AC-04(a) 解決後パス判定 | test | `security/operand_path_resolver_test.go::TestResolveOperandPath_SymlinkTarget` | `cp evil $WORKDIR/link`(`link→/etc/passwd`)=High |
+| AC-04(b) safe-zone 起点限定 | test | `security/operand_path_resolver_test.go::TestSafeZoneOrigin` | `$HOME`/共有 `/tmp` は起点に含めない |
+| AC-04(c) 重複は trust-critical 優先 | test | `security/destination_zoning_test.go::TestSafeZoneOverlapsCritical` | 重複/配下は High |
+| AC-04(d) Trusted 述語 | test | `security/operand_path_resolver_test.go::TestTrustedPredicate` | 起点親が書込可なら非 Trusted→Medium |
+| AC-05 unresolved 非対称 | test | `security/destination_zoning_test.go::TestUnresolvedAsymmetry` | write=High・read=Medium |
+| AC-06 抽出網羅 | test | `security/destination_zoning_test.go::TestOperandExtraction_SpecTable`（表駆動） | 難所各行が抽出される |
+| AC-06a 仕様表↔AC 連動 | test | `security/destination_zoning_test.go::TestOperandExtraction_SpecTable` | AC-08〜AC-15 名指し形が各々テスト行を持つ |
+| AC-07 複数オペランド max | test | `security/destination_zoning_test.go::TestMultipleOperandsMax` | 各区分の max |
+| AC-08 権限/所有権/属性付与 | test | `security/destination_zoning_test.go::TestFloor_PermissionGrant` | setuid/0777/trust-critical 所有権/chattr -i=High、safe-zone でも降格せず |
+| AC-09 install 権限フラグ | test | `security/destination_zoning_test.go::TestFloor_InstallPermission` | `-m` setuid/`-o`/`-g`=High |
+| AC-10 dd デバイス IO | test | `security/destination_zoning_test.go::TestFloor_DeviceIO` | 危険デバイス=High、`/dev/null` 除外 |
+| AC-11 safe-zone 外再帰 | test | `security/destination_zoning_test.go::TestFloor_RecursiveOutside` | 外部再帰=High、内部閉鎖=Low |
+| AC-12 cp/mv/rm/ln 特則 | test | `security/destination_zoning_test.go::TestOperandSpecific_CopyMoveLink` | 機密コピー元=Medium 下限、`cp -a` 特権メタ=High |
+| AC-13 mount/umount | test | `security/destination_zoning_test.go::TestOperandSpecific_Mount` | trust-critical=High、`umount -a`=High |
+| AC-14 tee/sponge | test | `security/destination_zoning_test.go::TestOperandSpecific_Tee` | 全 FILE の max、内側未実行 |
+| AC-15 find 破壊 | test | `security/destination_zoning_test.go::TestOperandSpecific_Find` | `-delete`/`-fprint*` の宛先判定、読取専用非昇格 |
+| AC-16 データ送信書込先＋max | test | `risk/destination_zoning_integration_test.go::TestDataTransferWriteComposition` | (i)=Medium(出所=名前)、(ii)=High、rsync 3 ケース |
+| AC-17 既存 High 置き換え | test | `risk/destination_zoning_integration_test.go::TestAxis2ReplacesLegacyHigh` | safe-zone=Low／ordinary=Medium／unresolved=High |
+| AC-18 max 合成 | test | `risk/destination_zoning_integration_test.go::TestAxis1Axis2MaxComposition` | `cp -a … /usr/bin`=High、順序非依存 |
+| AC-19 監査 DTO 格納 | test | `risk/destination_zoning_integration_test.go::TestOperandZonesStored` | 各要素の値検証、非適用=空・解決不能=`Zone==ZoneUnresolved` |
+| AC-20 config 組み込み | test | `runnertypes/spec_test.go::TestSecuritySpec_TrustedDirectories`＋`risk/destination_zoning_integration_test.go::TestConfigWiredEndToEnd` | 本番経路で判定に届く |
+| AC-21 identity 注入純粋性 | test+static | test: `risk/destination_zoning_integration_test.go::TestRunAsIdentDifferential`／static: `risk/live_identity_guard_test.go::TestNoLiveIdentityInZoning` | 注入 identity で判定変化／live API 不参照 |
+| AC-22 runtime==dry-run | test | `risk/destination_zoning_integration_test.go::TestDeterminismRuntimeEqualsDryRun` | 同一入力・同一 FS で同一レベル |
+| AC-23 解決コスト上限 | test | `security/operand_path_resolver_test.go::TestResolutionCeiling`＋`::TestMemoizationLinear` | 上限超過=High、呼出線形 |
+| NF-001 reason code 網羅/一意 | test | `risktypes/reason_codes_test.go::TestReasonCodes_AllDistinct` | 新 7 定数含め緑 |
+| NF-002 ビルド/テスト緑 | static | `make test && make lint`（または `go build -tags test ./internal/runner/...`） | 終了コード 0 |
+| NF-003 決定的・read-only | test+static | test: `::TestDeterminismRuntimeEqualsDryRun`／static: `rg -n 'os\.(Create|Remove|RemoveAll|WriteFile|Mkdir|MkdirAll|OpenFile|Symlink|Link|Rename|Chmod|Chown|Truncate|NewFile)' internal/runner/base/security/destination_zoning.go internal/runner/base/security/operand_path_resolver.go`（期待: **マッチ 0 件**） | 書込系 API 不在（read-only） |
+
+> **grep ガードの正規表現に関する注意（ripgrep のメタ文字）**: ripgrep 既定（Rust regex）では `|` が選択（alternation）で、`\|` は
+> **リテラルのパイプ文字**になる。`\|` を選択のつもりで使うとパターンが空振りし、危険 API が存在してもガードが「0 件＝合格」と
+> 誤判定する（fail-open）。よって選択は素の `|` で書く（上記 NF-003 行・下記 AC-21 ガードとも修正済み）。
+>
+> grep ガード（AC-21 static）の具体コマンド: `rg -n 'os\.Geteuid|os\.Getuid|user\.Current|syscall\.Get(euid|uid|gid|egid)|unix\.Get(euid|uid|gid|egid)|unix\.Getgroups' internal/runner/base/security/destination_zoning.go internal/runner/base/security/operand_path_resolver.go` の期待結果は **マッチ 0 件**。`live_identity_guard_test.go` がこの検査をテストとして実行する。
+> **自己検証（正のコントロール）を必須にする**: ガードテストは、検査用の正規表現がコンパイルでき、かつ既知の悪例文字列
+> （例 `"os.Geteuid()"`・`"os.Create(p)"`）に**必ずマッチする**ことを表明する正のコントロールを含める。これにより将来の
+> タイプミスでパターンが空振りに戻っても、ガードが沈黙で壊れることを防ぐ。
+
+---
+
+## 8. 成功基準
+
+- **機能完全性**: AC-01〜AC-23・NF-001〜NF-003 が §7 の test/static 検証で緑。
+- **品質**: `make test`・`make lint`・`make fmt` 緑。中核 2 パッケージ＋統合パッケージ（`./internal/runner/...`）コンパイル（NF-002）。
+- **セキュリティ検証**: 設計 §5.2 脅威モデルの各脅威（symlink 偽装・宛先隠蔽・safe-zone 内の危険操作・部分認識 fail-open・
+  live identity 乖離）が対応テストで緑。置き換えの取りこぼし防止条件（設計 §3.4 表）が固定されている。
+- **文書整合**: 本タスクは DTO 定義と `RiskAssessment` への格納まで。logger への JSON 出力・移行ノート・sample config 追従・
+  ガイドは 0143 が担う（要件 §2 Out）。
+
+---
+
+## 9. 次のステップ
+
+- 本計画書を `approved` にした後、Phase 順（P1→P7）に実装を進める。各 Phase 完了時にチェックボックスを更新する。
+- 実装完了後、0143（監査フィールドの logger 出力・移行ノート・文書整合・sample config 追従）へ引き継ぐ。本タスクが格納する
+  `RiskAssessment.OperandZones` の「空 vs 適用済み解決不能」の区別が 0143 AC-01 の消費契約となる（設計 §3.1）。
+
+---
+
+## 10. クロス検索チェックリスト（`make lint`/`make test` で検出できない項目のみ）
+
+- [ ] `NewStandardEvaluator` の呼び出し箇所を全列挙し、新 `*security.Config` 引数を全て更新: `rg -n "NewStandardEvaluator\(" -g '*.go' internal`（本番＋テストの全呼び出しに引数追加。引数追加はコンパイルで検出されるが、テスト注入箇所の見落とし防止に列挙する）。
+- [ ] reason code 新 7 定数の二重定義・タイポ確認: `rg -n "trust_boundary_write|destination_zone|permission_grant|device_io|recursive_outside_safe_zone|sensitive_source_copy|unresolved_destination" -g '*.go' internal`（定義は `reason_codes.go` の 1 箇所のみ）。
+- [ ] `TrustedDirectories` の用語一貫性（設計・要件・spec・loader・config sample で同一表記。sample config 追従自体は 0143）: `rg -n "trusted_directories|TrustedDirectories" -g '*.go' internal`。
+- [ ] 設計 §3.4 で「不変」とした `security/coreutils_test.go` の `CoreutilsCommandRisk` テストが誤って変更されていないこと（関数挙動は不変、置き換えは評価層のみ）。
+- [ ] AC-16(i) の出所表明で 0141 名前下限由来の理由コードを参照する場合は、その定数が 0141 で確定済みかを事前確認: `rg -n "ReasonCode = \"" internal/runner/base/risktypes/reason_codes.go`（データ送信の名前下限に対応する定数名を特定。未確定なら自己完結の canary 形を採る）。

--- a/docs/tasks/0142_axis2_destination_zoning/03_implementation_plan.md
+++ b/docs/tasks/0142_axis2_destination_zoning/03_implementation_plan.md
@@ -156,8 +156,10 @@
 - [ ] 未存在 leaf を「最深の存在親」まで解決して末尾を畳み込む。**最深存在親が symlink のときは解決を確定できないため
       エラー**（呼び出し側で `ZoneUnresolved`＝書込/削除 High、設計 §3.3 注）。
 - [ ] cycle・深さ超過（`maxHops` 超）・mid-chain の `readlink`/`lstat` 失敗で `error` を返す（fail-closed、設計 §4）。
-- [ ] AC-23 の解決コスト計測のため、リゾルバが `lstat`/`readlink`/`stat` を**注入可能な関数セット**経由で呼ぶ構造にする
-      （既定は実 os、テストは呼出回数を数えるスタブを注入。`StandardEvaluator.openIdentity` と同じ注入パターン）。
+- [ ] AC-23 の解決コスト計測のため、リゾルバが `lstat`/`readlink` を**注入可能な関数セット**経由で呼ぶ構造にする
+      （既定は実 os、テストは呼出回数を数えるスタブを注入。`StandardEvaluator.openIdentity` と同じ注入パターン）。注入集合は
+      read-only の `lstat`/`readlink` のみとし、symlink を追従する `os.Stat` は含めない（設計 §3.3 の read-only 制約。`os.Stat` を
+      混ぜると経路要素の所有権検査が symlink ターゲットを見てしまい区分判定を欺けるため）。
 - [ ] メモ化: 解決のメモ化を 1 回の判定呼び出し内にスコープし、鍵は**解決後の絶対パス**とする。identity 依存の Trusted
       判定そのものはキャッシュしない（設計 §3.3(e)）。
 - [ ] Trusted 述語を実装（設計 §3.3(d)）: 解決後パスが `TrustedDirectories` 配下、かつ**safe-zone 起点の親以上**の経路
@@ -349,7 +351,7 @@
 **作業内容**:
 - [ ] 決定性テスト（AC-22）: 同一入力・同一 FS 状態で runtime 経路と dry-run 経路が同一レベルを返すことを表明。
 - [ ] 解決コスト上限テスト（AC-23）: 多数オペランド（>N）・深い symlink チェーン（>M）で fail-closed（High）になり、メモ化により
-      注入 `lstat`/`stat` 呼出回数が線形に収まることを表明。
+      注入 `lstat`/`readlink` 呼出回数が線形に収まることを表明。
 - [ ] grep ガード（AC-21 補助）: 判断軸2 の組み込みコード（`destination_zoning.go`・`operand_path_resolver.go`）が live-identity
       API（`os.Geteuid`/`os.Getuid`/`syscall`/`unix` の uid/gid/groups・`user.Current`）を呼ばないことを `rg`（§7 footnote の選択
       `|` を用いた正規表現）で検査するテスト。**正のコントロール**（既知の悪例文字列が必ずマッチすること）を併せて表明し、
@@ -489,13 +491,13 @@
 | AC-23 解決コスト上限 | test | `security/operand_path_resolver_test.go::TestResolutionCeiling`＋`::TestMemoizationLinear` | 上限超過=High、呼出線形 |
 | NF-001 reason code 網羅/一意 | test | `risktypes/reason_codes_test.go::TestReasonCodes_AllDistinct` | 新 7 定数含め緑 |
 | NF-002 ビルド/テスト緑 | static | `make test && make lint`（または `go build -tags test ./internal/runner/...`） | 終了コード 0 |
-| NF-003 決定的・read-only | test+static | test: `::TestDeterminismRuntimeEqualsDryRun`／static: `rg -n 'os\.(Create|Remove|RemoveAll|WriteFile|Mkdir|MkdirAll|OpenFile|Symlink|Link|Rename|Chmod|Chown|Truncate|NewFile)' internal/runner/base/security/destination_zoning.go internal/runner/base/security/operand_path_resolver.go`（期待: **マッチ 0 件**） | 書込系 API 不在（read-only） |
+| NF-003 決定的・read-only | test+static | test: `::TestDeterminismRuntimeEqualsDryRun`／static: `rg -n 'os\.(Create|CreateTemp|Remove|RemoveAll|WriteFile|Mkdir|MkdirAll|MkdirTemp|OpenFile|Symlink|Link|Rename|Chmod|Chown|Lchown|Chtimes|Truncate|NewFile)' internal/runner/base/security/destination_zoning.go internal/runner/base/security/operand_path_resolver.go`（期待: **マッチ 0 件**） | 書込系 API 不在（read-only） |
 
 > **grep ガードの正規表現に関する注意（ripgrep のメタ文字）**: ripgrep 既定（Rust regex）では `|` が選択（alternation）で、`\|` は
 > **リテラルのパイプ文字**になる。`\|` を選択のつもりで使うとパターンが空振りし、危険 API が存在してもガードが「0 件＝合格」と
 > 誤判定する（fail-open）。よって選択は素の `|` で書く（上記 NF-003 行・下記 AC-21 ガードとも修正済み）。
 >
-> grep ガード（AC-21 static）の具体コマンド: `rg -n 'os\.Geteuid|os\.Getuid|user\.Current|syscall\.Get(euid|uid|gid|egid)|unix\.Get(euid|uid|gid|egid)|unix\.Getgroups' internal/runner/base/security/destination_zoning.go internal/runner/base/security/operand_path_resolver.go` の期待結果は **マッチ 0 件**。`live_identity_guard_test.go` がこの検査をテストとして実行する。
+> grep ガード（AC-21 static）の具体コマンド: `rg -n 'os\.Get(euid|uid|gid|egid|groups)|user\.Current|syscall\.Get(euid|uid|gid|egid|groups)|unix\.Get(euid|uid|gid|egid|groups)' internal/runner/base/security/destination_zoning.go internal/runner/base/security/operand_path_resolver.go` の期待結果は **マッチ 0 件**（uid/euid/gid/egid/groups を `os`/`syscall`/`unix` の各パッケージで網羅）。`live_identity_guard_test.go` がこの検査をテストとして実行する。
 > **自己検証（正のコントロール）を必須にする**: ガードテストは、検査用の正規表現がコンパイルでき、かつ既知の悪例文字列
 > （例 `"os.Geteuid()"`・`"os.Create(p)"`）に**必ずマッチする**ことを表明する正のコントロールを含める。これにより将来の
 > タイプミスでパターンが空振りに戻っても、ガードが沈黙で壊れることを防ぐ。


### PR DESCRIPTION
## 概要

判断軸2（宛先パス信頼区分）タスク 0142 の **実装計画書**（`03_implementation_plan.md`）を追加し、あわせてアーキテクチャ設計書を `approved` に確定、`被覆` の不自然な表現を平易な日本語へ修正する docs PR。

## 含まれる変更

- **`03_implementation_plan.md`（新規・`draft`）**: Phase P1〜P7（DTO/型 → 専用リゾルバ＋Trusted 述語 → `ClassifyDestinationZone`（抽出仕様表＋区分判定＋操作固有の下限）→ `evaluateDimensions` 組み込みと既存 5 系統の抑止 → データ送信書込先合成（rsync `host::module` 含む）→ `security.Config`/`RunAsIdent` 組み込み → 決定性・解決コスト上限・grep ガード）。AC-01〜AC-23・NF-001〜003 を網羅する受け入れ基準検証表つき。
- **`02_architecture.md`**: ステータスを `approved` に確定（Reviewer: isseis）。`被覆` 表現を修正。
- **`01_requirements.md`**: `被覆を担保` → `網羅性を担保`。

## 品質確認

- 実装計画は **2 名のパネルレビュー（SWE＋SDET）** で点検し、Critical 1・Major 4 ほかを修正:
  - ripgrep ガードの正規表現が `\|`（リテラルのパイプ）で空振りし、live-identity 不参照（AC-21）・read-only（NF-003）ガードが偽合格する不具合を修正（経験的に検証済み）。
  - AC-23 メモ化テストに反証可能な呼出回数の budget を付与。
  - FS フィクスチャのクリーンアップ／他 UID 所有のスキップ／gosec `//nolint` のスコープを明確化。
  - `CheckDangerousArgPatterns`（④）の抑止をディスパッチ粒度に整理。
- **日本語プロース品質パス（japrose）** を実施。

## 補足

- 設計が参照する全シンボル（`evaluateDimensions` の抑止点・`NewStandardEvaluator` シグネチャ・`resolveRiskEvaluator` 鎖・`dangerousCommandPatterns` 等）を `internal/runner/` の実コードと照合済み。
- 実装コードは含まない（計画書承認後に着手）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)