### PR TITLE
feat(0142): add read-only operand path resolver and Trusted predicate

### DIFF
--- a/docs/tasks/0142_axis2_destination_zoning/02_architecture.md
+++ b/docs/tasks/0142_axis2_destination_zoning/02_architecture.md
@@ -461,8 +461,10 @@ func ResolveOperandPath(operand, base string, maxHops int) (resolved string, err
 > どの経路要素が存在するかに依存する。同一グループ内の先行コマンドが中間ディレクトリを作る（しかもそれが symlink で
 > ある）と、dry-run（先行コマンド未実行）と runtime（実行済み）で最深の存在親が変わり、同一コマンド文字列でも
 > レベルが変わりうる。よって AC-22 の「runtime==dry-run」は **「同一入力かつ同一ファイルシステム状態」** の範囲で
-> 成立すると明記する。さらに fail-closed を優先し、**未存在 leaf の最深存在親が symlink のとき**はターゲットを
-> 安全に確定できないため `ZoneUnresolved`（書込/削除=High）に倒す。これは
+> 成立すると明記する。リゾルバは経路要素を 1 つずつ追従する完全正規化方式を採り、**存在する symlink 要素は常に追従する**ため、
+> 末尾を畳み込む対象（最深の存在親）は常に解決済みの実ディレクトリになる（未解決 symlink の下に宛先を置かない）。すなわち
+> 「最深存在親が symlink」という状態は構造的に発生せず、fail-closed は mid-chain の非 ENOENT な `lstat`/`readlink` 失敗を
+> `error`（呼び出し側で `ZoneUnresolved`＝書込/削除 High）に倒すことで担保する。これは
 > [security-architecture.md の TOCTOU 既知制限](../../dev/architecture_design/security-architecture.md)（評価と実行の
 > 間の競合は脅威モデル境界外）と整合し、評価と実行の間の残存競合は同制限の範囲で受容する。
 

--- a/docs/tasks/0142_axis2_destination_zoning/03_implementation_plan.md
+++ b/docs/tasks/0142_axis2_destination_zoning/03_implementation_plan.md
@@ -600,7 +600,7 @@
 
 PR 単位で完了を追跡する（PR 構成は §3.2、各 PR の作成ポイントは Phase 末尾の「PR-N 作成ポイント」節を参照）。
 
-- [ ] PR-1 マージ済み（対象ステップ: P1）— DTO・型・reason code family（`risktypes`）／`TestReasonCodes_AllDistinct` 緑
+- [x] PR-1 マージ済み（対象ステップ: P1）— DTO・型・reason code family（`risktypes`）／`TestReasonCodes_AllDistinct` 緑
 - [ ] PR-2 マージ済み（対象ステップ: P2）— 専用リゾルバ＋Trusted 述語／symlink 偽装・fail-closed・メモ化・差分テスト緑
 - [ ] PR-3 マージ済み（対象ステップ: P3）— `ClassifyDestinationZone`（仕様表＋区分判定＋操作固有の下限＋特則）／表駆動・区分・下限テスト緑
 - [ ] PR-4 マージ済み（対象ステップ: P4）— `evaluateDimensions` 組み込み＋5 系統抑止／観測可能プロパティ・取りこぼし防止条件・既存テスト更新緑

--- a/docs/tasks/0142_axis2_destination_zoning/03_implementation_plan.md
+++ b/docs/tasks/0142_axis2_destination_zoning/03_implementation_plan.md
@@ -152,8 +152,8 @@
 
 - [x] グリーンゲート（`_context.md` の "Green gate" 参照）がパスしていることを確認した
 - [x] PR を作成した（https://github.com/isseis/go-safe-cmd-runner/pull/781）
-- [ ] PR がマージされた
-- [ ] 次のブランチへ切り替えた（次ステップは新しいブランチで作業する）
+- [x] PR がマージされた
+- [x] 次のブランチへ切り替えた（次ステップは新しいブランチで作業する）
 
 ### Phase 2: 専用リゾルバ＋Trusted 述語（AC-04, AC-23）
 

--- a/docs/tasks/0142_axis2_destination_zoning/03_implementation_plan.md
+++ b/docs/tasks/0142_axis2_destination_zoning/03_implementation_plan.md
@@ -163,43 +163,47 @@
 - 新規（必要時）`internal/runner/base/security/test_helpers_zoning.go`（`//go:build test`）
 
 **作業内容**:
-- [ ] `ResolveOperandPath(operand, base string, maxHops int) (resolved string, err error)` を実装（設計 §3.3）。
+- [x] `ResolveOperandPath(operand, base string, maxHops int) (resolved string, err error)` を実装（設計 §3.3）。
       symlink チェーンを leaf＋親で追従し、正規化済み絶対パスを返す。相対オペランドは `base`（`ln -s` 相対 target は
       リンク親、他は `EffectiveWorkDir`）基点で解決。チェーン追従中に遭遇する中間の相対 symlink は、そのリンク自身が
       存在する親ディレクトリを基点に解決する（`base`/`EffectiveWorkDir` 基点ではない。パストラバーサル・区分誤判定の防止）。
       read-only（`lstat`/`readlink` のみ）。
-- [ ] 未存在 leaf を「最深の存在親」まで解決して末尾を畳み込む。**最深存在親が symlink のときは解決を確定できないため
-      エラー**（呼び出し側で `ZoneUnresolved`＝書込/削除 High、設計 §3.3 注）。
-- [ ] cycle・深さ超過（`maxHops` 超）・mid-chain の `readlink`/`lstat` 失敗で `error` を返す（fail-closed、設計 §4）。
-- [ ] AC-23 の解決コスト計測のため、リゾルバが `lstat`/`readlink` を**注入可能な関数セット**経由で呼ぶ構造にする
+- [x] 未存在 leaf を「最深の存在親」まで解決して末尾を畳み込む。**実装は経路要素を 1 つずつ追従する完全正規化方式**を採り、
+      存在する symlink 要素は常に追従するため、末尾を畳み込む対象（最深の存在親）は常に解決済みの実ディレクトリになる。
+      よって「最深存在親が symlink」という状態は構造的に発生せず、専用のエラー分岐は不要（fail-closed は次項の
+      mid-chain 非 ENOENT 失敗のエラーで担保。設計 §3.3 注の意図＝未解決 symlink 下に宛先を置かないことを保証）。
+- [x] cycle・深さ超過（`maxHops` 超）・mid-chain の `readlink`/`lstat` 失敗（ENOENT 以外）で `error` を返す（fail-closed、設計 §4）。
+- [x] 解決コスト計測のため、リゾルバが `lstat`/`readlink` を**注入可能な関数セット**経由で呼ぶ構造にする
       （既定は実 os、テストは呼出回数を数えるスタブを注入。`StandardEvaluator.openIdentity` と同じ注入パターン）。注入集合は
       read-only の `lstat`/`readlink` のみとし、symlink を追従する `os.Stat` は含めない（設計 §3.3 の read-only 制約。`os.Stat` を
       混ぜると経路要素の所有権検査が symlink ターゲットを見てしまい区分判定を欺けるため）。
-- [ ] メモ化: 解決のメモ化を 1 回の判定呼び出し内にスコープし、鍵は**解決対象ノードの絶対パス（中間ノードを含む）**とする。
+- [x] メモ化: 解決のメモ化を 1 回の判定呼び出し内にスコープし、鍵は**解決対象ノードの絶対パス（中間ノードを含む）**とする。
       relative なオペランド／relative な symlink target は基点ディレクトリと結合・正規化した絶対パスにしてから鍵にする（relative
       文字列そのものを鍵にすると、異なる基点下の同名 relative——例 `/dir1/link` と `/dir2/link` がともに `../target` を指す——で
       誤ヒットする）。鍵は当該ノードを **symlink 追従する前**の絶対パスであり、追従後の解決済み絶対パスではない（追従後を鍵に
-      すると解決完了まで鍵が得られず循環する）。これにより共有する親チェーンの `lstat`/`readlink` 結果を 1 回に畳む（AC-23 の
-      線形計数の前提）。identity 依存の Trusted 判定そのものはキャッシュしない（設計 §3.3(e)
-      の鍵の記述を精緻化）。
-- [ ] Trusted 述語を実装（設計 §3.3(d)）: 解決後パスが `TrustedDirectories` 配下、かつ**safe-zone 起点の親以上**の経路
-      要素が run-as から書込不可（run-as 以外所有・group/other 非書込）のとき Trusted。参照 identity は注入 `RunAsIdent`
-      （live euid 不参照）。書込不可検査の対象は**起点ディレクトリの親以上**に限定（起点配下は対象外、設計 §3.3(d) の根拠）。
+      すると解決完了まで鍵が得られず循環する）。メモ化対象は存在する非 symlink ノード（実ディレクトリ/ファイル）のみとし、
+      これにより共有する親チェーンの `lstat`/`readlink` 結果を 1 回に畳む（線形計数の前提）。identity 依存の Trusted 判定
+      そのものはキャッシュしない（設計 §3.3(e) の鍵の記述を精緻化）。
+- [x] Trusted 述語を実装（設計 §3.3(d)）: 解決後パスが `TrustedDirectories` 配下、かつ**safe-zone 起点の親以上**の経路
+      要素が run-as から書込不可（run-as 所有は chmod で自己書込付与可能なため書込可とみなす・group/other 書込ビット・
+      ただし sticky ディレクトリは other 書込を除外）のとき Trusted。参照 identity は注入 `RunAsIdent`（live euid 不参照）。
+      書込不可検査の対象は**起点ディレクトリの親以上**に限定（起点配下は対象外、設計 §3.3(d) の根拠）。group 判定は
+      precomputed `RunAsIdent.Groups`（live なシステム参照なし）。
 
 **成功基準**:
-- [ ] `go test -tags test ./internal/runner/base/security/...` が通る（`//go:build test` の `test_helpers_zoning.go` を**同一タグで
-      コンパイル**し、型/シグネチャ誤りを本 Phase で検出する。`-tags test` 無しの `go build` では同ファイルが除外され検出されない）。
-- [ ] `cp evil $WORKDIR/link`（`link→/etc/passwd`）が High（ターゲット解決で trust-critical）になり Low にならない
-      （`operand_path_resolver_test.go`、設計 §7.1）。
-- [ ] `ln -s` 相対 target がリンク親基点で解決される（`EffectiveWorkDir` 基点ではない）。
-- [ ] 深い symlink チェーン（`maxHops` 超）・cycle で `error`（→ fail-closed）になる。
-- [ ] メモ化の**反証可能な呼出回数表明**（AC-23）: 共通の親チェーン（深さ D）を共有する K 個のオペランドを持つフィクスチャを
-      用意し、注入 `lstat`/`readlink` スタブの呼出回数を数える。メモ化**有り**では共有親の解決は 1 回に畳まれるため
-      呼出回数が「概ね D + K（各 leaf 1 回＋共有親 1 回分）」の定数式に等しいことを `==`（または僅差の `<=`）で表明し、メモ化を
-      外した場合の素朴な「K×(D+1)」と**有意に小さい**ことを対比する。「線形」のような非反証的表現は用いず、具体的な期待値で
-      assert する（D・K・期待値は実装で確定）。
-- [ ] Trusted 述語の差分テスト: 注入 `RunAsIdent` を実 euid/gid と異なる値にし、起点親の所有者/権限により Trusted が
-      切り替わる（AC-04(d)・AC-21 の先行検証）。
+- [x] `go test -tags test ./internal/runner/base/security/...` が通る。本 Phase は単一テストファイル
+      `operand_path_resolver_test.go`（`package security` ホワイトボックス）にヘルパを内包し、共有が生じないため
+      `test_helpers_zoning.go` は作成しない（test_organization の「共有が生じない場合は作らない」に従う。`//go:build test`
+      専用ファイルの追加は Phase 3 で共有が生じた時点で行う）。
+- [x] `cp evil $WORKDIR/link`（`link→/etc/passwd`）のターゲット解決を表明（`operand_path_resolver_test.go::TestResolveOperandPath_SymlinkTarget`
+      で leaf symlink が `/etc/passwd` に解決される＝Phase 3 の trust-critical High の前提。区分判定自体は Phase 3）。
+- [x] `ln -s` 相対 target がリンク親基点で解決される（`EffectiveWorkDir`／`base` 基点ではない）。
+- [x] 深い symlink チェーン（`maxHops` 超）・cycle で `error`（→ fail-closed）になる。
+- [x] メモ化の**反証可能な呼出回数表明**: 共通の親チェーン（深さ D）を共有する K 個のオペランドを持つフィクスチャで
+      注入 `lstat` スタブの呼出回数が `D + K` に等しいことを `==` で表明し、メモ化を外した素朴な `K×(D+1)` と対比して
+      有意に小さいことを表明（`TestMemoizationLinear`、D・K は実装で確定）。
+- [x] Trusted 述語の差分テスト: 注入 `RunAsIdent` を実 euid/gid と異なる値にし、起点親の所有者/権限により Trusted が
+      切り替わる（`TestTrustedPredicate`）。
 
 ### PR-2 作成ポイント: read-only operand path resolver and Trusted predicate
 

--- a/docs/tasks/0142_axis2_destination_zoning/03_implementation_plan.md
+++ b/docs/tasks/0142_axis2_destination_zoning/03_implementation_plan.md
@@ -233,6 +233,12 @@
 - [ ] 各オペランドに `OperandRole`（write/read）を付与する（unresolved の非対称下限のため、AC-05）。
 - [ ] `ClassifyDestinationZone(input ZoningInput, names map[string]struct{}, cmdPath string, args []string) LocationResult`
       を実装（設計 §3.2）。抽出→`ResolveOperandPath` で解決→区分判定→操作固有の下限→全オペランド max。
+      1 コマンド評価につき `operandResolver` を 1 つ生成し全オペランドで共有（メモ化で `lstat`/`readlink` を畳む）。
+- [ ] （PR-2 レビュー由来の繰り越し）`isTrustedOperand` の祖先書込可否を `operandResolver` にキャッシュし、K オペランドで
+      `origin` 祖先（深さ Do）への `lstat` が重複しないようにする。**鍵には identity を含める**（または resolver インスタンスを
+      単一 identity にスコープする）。鍵を dir のみにすると、同一 resolver を異なる `RunAsIdent` で問い合わせたとき
+      stale な書込可否を返し Trusted 判定を誤る（PR-2 で却下した dir-only 案の不具合）。本キャッシュの線形コストは下の
+      解決コスト上限テストで担保する。
 - [ ] パス信頼区分の判定（AC-01〜AC-05）: trust-critical（`SystemCriticalPaths` 一致/配下、`/` は完全一致のみ）→High、
       ordinary→Medium、safe-zone（Trusted→Low／非 Trusted→Medium フォールバック）、unresolved（write=High・read=Medium）。
       safe-zone が trust-critical と重複/配下のときは trust-critical 優先（AC-04(c)）。

--- a/docs/tasks/0142_axis2_destination_zoning/03_implementation_plan.md
+++ b/docs/tasks/0142_axis2_destination_zoning/03_implementation_plan.md
@@ -214,7 +214,7 @@
 **レビュー観点**: symlink 追従の read-only 性（`lstat`/`readlink` のみ、`os.Stat` 不参照） / メモ化キーの正しさ（相対パスのクロス基点衝突・循環の回避） / fail-closed（cycle・深さ超過・未存在 leaf が symlink） / 注入 `RunAsIdent` による Trusted 判定の決定性
 
 - [x] グリーンゲート（`_context.md` の "Green gate" 参照）がパスしていることを確認した
-- [ ] PR を作成した
+- [x] PR を作成した（https://github.com/isseis/go-safe-cmd-runner/pull/782）
 - [ ] PR がマージされた
 - [ ] 次のブランチへ切り替えた（次ステップは新しいブランチで作業する）
 

--- a/docs/tasks/0142_axis2_destination_zoning/03_implementation_plan.md
+++ b/docs/tasks/0142_axis2_destination_zoning/03_implementation_plan.md
@@ -213,7 +213,7 @@
 
 **レビュー観点**: symlink 追従の read-only 性（`lstat`/`readlink` のみ、`os.Stat` 不参照） / メモ化キーの正しさ（相対パスのクロス基点衝突・循環の回避） / fail-closed（cycle・深さ超過・未存在 leaf が symlink） / 注入 `RunAsIdent` による Trusted 判定の決定性
 
-- [ ] グリーンゲート（`_context.md` の "Green gate" 参照）がパスしていることを確認した
+- [x] グリーンゲート（`_context.md` の "Green gate" 参照）がパスしていることを確認した
 - [ ] PR を作成した
 - [ ] PR がマージされた
 - [ ] 次のブランチへ切り替えた（次ステップは新しいブランチで作業する）

--- a/internal/runner/base/security/operand_path_resolver.go
+++ b/internal/runner/base/security/operand_path_resolver.go
@@ -1,0 +1,267 @@
+package security
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"syscall"
+
+	"github.com/isseis/go-safe-cmd-runner/internal/common"
+	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/risktypes"
+)
+
+// ErrOperandResolution is returned when an operand path cannot be resolved to a
+// trustworthy absolute path. The caller folds it into ZoneUnresolved (fail-closed:
+// write/delete High, read Medium) rather than guessing a zone.
+var ErrOperandResolution = errors.New("operand path resolution failed")
+
+// lstatFunc and readlinkFunc are the read-only filesystem primitives the resolver
+// depends on. They are injected so tests can substitute counting stubs (to assert
+// the resolution cost stays linear) and so the resolver provably never follows
+// a symlink implicitly: os.Stat (which resolves the final component) is
+// deliberately NOT part of this set, because a stat that follows the leaf symlink
+// would let a symlinked path element be classified by its target's ownership and
+// defeat the zoning judgment.
+type (
+	lstatFunc    func(string) (fs.FileInfo, error)
+	readlinkFunc func(string) (string, error)
+)
+
+// operandResolver resolves operands to canonical absolute paths and answers the
+// Trusted predicate. It memoizes resolution within its own lifetime; callers
+// create one instance per classification of a single command (one RunAsIdent), so
+// the memo never mixes identities or base directories. It holds no live identity.
+type operandResolver struct {
+	lstat    lstatFunc
+	readlink readlinkFunc
+	// memo maps a confirmed-real node's pre-follow absolute path to itself. Only
+	// existing, non-symlink nodes are memoized; folding shared parent chains to a
+	// single lstat per node is what keeps resolution cost linear. Identity
+	// dependent results (the Trusted predicate) are never cached here.
+	memo map[string]string
+}
+
+// newOperandResolver builds a resolver over the given read-only primitives. The
+// production path passes os.Lstat/os.Readlink; tests pass counting or scripted
+// stubs.
+func newOperandResolver(lstat lstatFunc, readlink readlinkFunc) *operandResolver {
+	return &operandResolver{lstat: lstat, readlink: readlink, memo: make(map[string]string)}
+}
+
+// ResolveOperandPath resolves an operand to a normalized absolute path with the
+// symlink chain followed (leaf and parents). A non-existent leaf is resolved to
+// its deepest existing parent and the trailing components are folded in, so a
+// not-yet-created destination still classifies by its real parent directory. A
+// relative operand is resolved against base (the link's parent for `ln -s`
+// relative targets, EffectiveWorkDir otherwise). It fails closed: a cycle, a
+// depth-limit overflow, or a mid-chain readlink/lstat failure returns an error so
+// the caller records ZoneUnresolved. It is read-only (lstat/readlink only).
+//
+// This is the single-operand convenience over a fresh resolver; the classifier
+// reuses one operandResolver across a command's operands to share the memo.
+func ResolveOperandPath(operand, base string, maxHops int) (string, error) {
+	return newOperandResolver(os.Lstat, os.Readlink).resolve(operand, base, maxHops)
+}
+
+// resolve canonicalizes operand into an absolute, symlink-followed path.
+//
+// Invariant: the returned path's existing prefix contains no unresolved symlink
+// element: every existing path element has been followed. Trailing components
+// that do not exist are folded onto their deepest existing (real) ancestor, so a
+// not-yet-created leaf is never placed under an unresolved symlink. The judgment
+// is read-only and deterministic given a fixed filesystem state.
+func (r *operandResolver) resolve(operand, base string, maxHops int) (string, error) {
+	if operand == "" {
+		return "", fmt.Errorf("%w: empty operand", ErrOperandResolution)
+	}
+
+	path := operand
+	if !filepath.IsAbs(path) {
+		// A relative operand is anchored at base (caller supplies an absolute
+		// EffectiveWorkDir or, for an `ln -s` relative target, the link's parent).
+		path = filepath.Join(base, path)
+	}
+	path = filepath.Clean(path)
+	if !filepath.IsAbs(path) {
+		return "", fmt.Errorf("%w: %q is not absolute (base %q)", ErrOperandResolution, operand, base)
+	}
+
+	// components are the path elements below root; a cleaned absolute path has no
+	// "." or ".." elements to special-case.
+	components := splitAbs(path)
+	dest := string(filepath.Separator)
+	visited := make(map[string]struct{})
+	hops := 0
+
+	for i := 0; i < len(components); i++ {
+		name := components[i]
+		if name == "" {
+			continue
+		}
+		node := filepath.Join(dest, name)
+
+		if cached, ok := r.memo[node]; ok {
+			dest = cached
+			continue
+		}
+
+		info, err := r.lstat(node)
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				// node and every remaining component are non-existent; fold them
+				// literally onto dest, which is a resolved real directory.
+				parts := make([]string, 0, len(components)-i+1)
+				parts = append(parts, dest, name)
+				parts = append(parts, components[i+1:]...)
+				return filepath.Join(parts...), nil
+			}
+			return "", fmt.Errorf("%w: lstat %q: %w", ErrOperandResolution, node, err)
+		}
+
+		if info.Mode()&fs.ModeSymlink == 0 {
+			r.memo[node] = node
+			dest = node
+			continue
+		}
+
+		// Symlink: follow it. Count the hop and guard against cycles and runaway
+		// chains so the hot path cannot be driven into unbounded filesystem I/O.
+		hops++
+		if hops > maxHops {
+			return "", fmt.Errorf("%w: symlink depth exceeded at %q", ErrOperandResolution, node)
+		}
+		if _, seen := visited[node]; seen {
+			return "", fmt.Errorf("%w: symlink cycle at %q", ErrOperandResolution, node)
+		}
+		visited[node] = struct{}{}
+
+		target, err := r.readlink(node)
+		if err != nil {
+			return "", fmt.Errorf("%w: readlink %q: %w", ErrOperandResolution, node, err)
+		}
+
+		var newAbs string
+		if filepath.IsAbs(target) {
+			newAbs = filepath.Clean(target)
+		} else {
+			// A relative target is resolved against the link's own parent (dest),
+			// not the original base, so a chain cannot be redirected by the caller's
+			// working directory.
+			newAbs = filepath.Clean(filepath.Join(dest, target))
+		}
+
+		// Re-process from root with the target spliced in front of the not-yet-
+		// resolved suffix. The memo makes the already-resolved prefix replay
+		// without new lstat calls.
+		components = append(splitAbs(newAbs), components[i+1:]...)
+		dest = string(filepath.Separator)
+		i = -1
+	}
+
+	return dest, nil
+}
+
+// splitAbs splits a cleaned absolute path into its components below root.
+func splitAbs(path string) []string {
+	trimmed := strings.TrimPrefix(path, string(filepath.Separator))
+	if trimmed == "" {
+		return nil
+	}
+	return strings.Split(trimmed, string(filepath.Separator))
+}
+
+// isTrustedOperand reports whether resolved is a Trusted safe-zone operand: it
+// lies within one of trustedDirs, and every path element from the parent of
+// origin up to the filesystem root is non-writable by the run-as identity. The
+// reference identity is the injected RunAsIdent, never the live euid, so the
+// verdict is deterministic and identical between dry-run and runtime.
+//
+// Elements at or below origin are intentionally NOT checked: origin is the
+// safe-zone anchor (EffectiveWorkDir / dedicated temp) that the run legitimately
+// writes to, so requiring it to be non-writable would make Low unreachable. The
+// check on origin's parent and above prevents the run-as identity from repointing
+// the anchor itself.
+func (r *operandResolver) isTrustedOperand(resolved, origin string, trustedDirs []string, ident risktypes.RunAsIdent) bool {
+	if resolved == "" || origin == "" {
+		return false
+	}
+	if !withinAnyDir(resolved, trustedDirs) {
+		return false
+	}
+
+	dir := filepath.Dir(origin)
+	for {
+		info, err := r.lstat(dir)
+		if err != nil {
+			// Cannot verify this ancestor's ownership: fail closed (not Trusted).
+			return false
+		}
+		if isWritableByRunAs(info, ident) {
+			return false
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break // reached the filesystem root
+		}
+		dir = parent
+	}
+	return true
+}
+
+// withinAnyDir reports whether path equals or is contained by any of dirs.
+func withinAnyDir(path string, dirs []string) bool {
+	clean := filepath.Clean(path)
+	for _, d := range dirs {
+		if d == "" {
+			continue
+		}
+		if clean == filepath.Clean(d) || common.IsPathWithinDirectory(clean, d) {
+			return true
+		}
+	}
+	return false
+}
+
+// isWritableByRunAs reports whether the run-as identity could write to (create,
+// rename, or delete entries in) the file described by info. It follows the
+// group/other write-bit logic of checkWritePermission, including the sticky-bit
+// exemption: a world-writable directory with the sticky bit set (e.g. /tmp) does
+// not let the identity rename or delete entries it does not own, so it is not a
+// repoint risk. Ownership by the identity is itself treated as writable. Group
+// membership is read from the precomputed RunAsIdent (no live system lookup). If
+// ownership cannot be determined the result is true (writable) so the caller fails
+// closed to "not Trusted".
+func isWritableByRunAs(info fs.FileInfo, ident risktypes.RunAsIdent) bool {
+	st, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return true
+	}
+	mode := info.Mode()
+
+	// Ownership alone is a repoint risk: the owner can always chmod the entry to
+	// grant itself write, so an ancestor owned by the run-as identity is treated
+	// as writable regardless of the current write bits.
+	if st.Uid == ident.UID {
+		return true
+	}
+	if mode&0o020 != 0 && runAsInGroup(st.Gid, ident) {
+		return true
+	}
+	if mode&0o002 != 0 {
+		if mode.IsDir() && mode&fs.ModeSticky != 0 {
+			return false
+		}
+		return true
+	}
+	return false
+}
+
+// runAsInGroup reports whether gid is the run-as primary group or one of its
+// supplementary groups.
+func runAsInGroup(gid uint32, ident risktypes.RunAsIdent) bool {
+	return gid == ident.GID || slices.Contains(ident.Groups, gid)
+}

--- a/internal/runner/base/security/operand_path_resolver.go
+++ b/internal/runner/base/security/operand_path_resolver.go
@@ -244,6 +244,12 @@ func withinAnyDir(path string, dirs []string) bool {
 	return false
 }
 
+// Directory write-permission bits inspected by the repoint check.
+const (
+	modeGroupWrite = 0o020
+	modeOtherWrite = 0o002
+)
+
 // isWritableByRunAs reports whether the run-as identity could repoint the entry
 // described by info (rename or delete it, or chmod it to gain write) and thereby
 // redirect the safe-zone anchor. It is NOT a general "can create here" check: a
@@ -274,10 +280,15 @@ func isWritableByRunAs(info fs.FileInfo, ident risktypes.RunAsIdent) bool {
 	if st.Uid == ident.UID {
 		return true
 	}
-	if mode&0o020 != 0 && runAsInGroup(st.Gid, ident) {
-		return true
-	}
-	if mode&0o002 != 0 {
+
+	// Group-write (when run-as is in the group) or other-write grants the ability
+	// to repoint entries, EXCEPT on a sticky directory: the sticky bit restricts
+	// rename/delete to each entry's owner regardless of which write bit applies, so
+	// it is not a repoint risk. The exemption is symmetric across the group and
+	// other bits.
+	groupWrite := mode&modeGroupWrite != 0 && runAsInGroup(st.Gid, ident)
+	otherWrite := mode&modeOtherWrite != 0
+	if groupWrite || otherWrite {
 		if mode.IsDir() && mode&fs.ModeSticky != 0 {
 			return false
 		}

--- a/internal/runner/base/security/operand_path_resolver.go
+++ b/internal/runner/base/security/operand_path_resolver.go
@@ -94,7 +94,6 @@ func (r *operandResolver) resolve(operand, base string, maxHops int) (string, er
 	// "." or ".." elements to special-case.
 	components := splitAbs(path)
 	dest := string(filepath.Separator)
-	visited := make(map[string]struct{})
 	hops := 0
 
 	for i := 0; i < len(components); i++ {
@@ -128,16 +127,17 @@ func (r *operandResolver) resolve(operand, base string, maxHops int) (string, er
 			continue
 		}
 
-		// Symlink: follow it. Count the hop and guard against cycles and runaway
-		// chains so the hot path cannot be driven into unbounded filesystem I/O.
+		// Symlink: follow it. The hop counter alone bounds both runaway chains and
+		// true cycles, so the hot path cannot be driven into unbounded filesystem
+		// I/O. A visited-node set is deliberately NOT used: the same symlink node
+		// can be traversed more than once on a legitimate, terminating path (e.g.
+		// `/a/b -> /a` makes `/a/b/b/b` resolve to `/a`), so flagging a repeat node
+		// as a cycle would be a false positive. This mirrors filepath.EvalSymlinks,
+		// which likewise bounds resolution by a link-walk counter, not a visited set.
 		hops++
 		if hops > maxHops {
 			return "", fmt.Errorf("%w: symlink depth exceeded at %q", ErrOperandResolution, node)
 		}
-		if _, seen := visited[node]; seen {
-			return "", fmt.Errorf("%w: symlink cycle at %q", ErrOperandResolution, node)
-		}
-		visited[node] = struct{}{}
 
 		target, err := r.readlink(node)
 		if err != nil {

--- a/internal/runner/base/security/operand_path_resolver.go
+++ b/internal/runner/base/security/operand_path_resolver.go
@@ -193,7 +193,10 @@ func (r *operandResolver) isTrustedOperand(resolved, origin string, trustedDirs 
 		return false
 	}
 
-	dir := filepath.Dir(origin)
+	// Clean origin so a trailing separator does not make filepath.Dir return the
+	// origin directory itself (which is intentionally excluded from the check)
+	// instead of its parent.
+	dir := filepath.Dir(filepath.Clean(origin))
 	for {
 		info, err := r.lstat(dir)
 		if err != nil {

--- a/internal/runner/base/security/operand_path_resolver.go
+++ b/internal/runner/base/security/operand_path_resolver.go
@@ -189,14 +189,29 @@ func (r *operandResolver) isTrustedOperand(resolved, origin string, trustedDirs 
 	if resolved == "" || origin == "" {
 		return false
 	}
-	if !withinAnyDir(resolved, trustedDirs) {
+	// Both must be absolute: a relative origin would make the filepath.Dir ascent
+	// terminate at "." and skip the real system ancestors (/, /home, ...), and a
+	// relative resolved cannot be reasoned about. Fail closed.
+	if !filepath.IsAbs(resolved) || !filepath.IsAbs(origin) {
+		return false
+	}
+	cleanResolved := filepath.Clean(resolved)
+	cleanOrigin := filepath.Clean(origin)
+	// The operand must actually be inside (or equal to) the safe-zone anchor;
+	// otherwise the ancestor check would inspect an unrelated directory's chain and
+	// could wrongly mark it Trusted. This guards the predicate's own precondition so
+	// callers cannot misuse it.
+	if cleanResolved != cleanOrigin && !common.IsPathWithinDirectory(cleanResolved, cleanOrigin) {
+		return false
+	}
+	if !withinAnyDir(cleanResolved, trustedDirs) {
 		return false
 	}
 
 	// Clean origin so a trailing separator does not make filepath.Dir return the
 	// origin directory itself (which is intentionally excluded from the check)
 	// instead of its parent.
-	dir := filepath.Dir(filepath.Clean(origin))
+	dir := filepath.Dir(cleanOrigin)
 	for {
 		info, err := r.lstat(dir)
 		if err != nil {
@@ -229,21 +244,29 @@ func withinAnyDir(path string, dirs []string) bool {
 	return false
 }
 
-// isWritableByRunAs reports whether the run-as identity could write to (create,
-// rename, or delete entries in) the file described by info. It follows the
-// group/other write-bit logic of checkWritePermission, including the sticky-bit
-// exemption: a world-writable directory with the sticky bit set (e.g. /tmp) does
-// not let the identity rename or delete entries it does not own, so it is not a
-// repoint risk. Ownership by the identity is itself treated as writable. Group
-// membership is read from the precomputed RunAsIdent (no live system lookup). If
-// ownership cannot be determined the result is true (writable) so the caller fails
-// closed to "not Trusted".
+// isWritableByRunAs reports whether the run-as identity could repoint the entry
+// described by info (rename or delete it, or chmod it to gain write) and thereby
+// redirect the safe-zone anchor. It is NOT a general "can create here" check: a
+// sticky world-writable directory (e.g. /tmp) allows creating new entries but not
+// renaming or deleting entries owned by others, so it is not a repoint risk and is
+// reported as non-writable. Group membership is read from the precomputed
+// RunAsIdent (no live system lookup). If ownership cannot be determined the result
+// is true so the caller fails closed to "not Trusted".
 func isWritableByRunAs(info fs.FileInfo, ident risktypes.RunAsIdent) bool {
 	st, ok := info.Sys().(*syscall.Stat_t)
 	if !ok {
 		return true
 	}
 	mode := info.Mode()
+
+	// root bypasses permission bits and can repoint any entry, and a non-root owner
+	// of any ancestor could swap a symlink that root then follows. So under a root
+	// run-as every ancestor is treated as writable: the Trusted predicate is
+	// intentionally degenerate (a root command never earns the safe-zone Low; see
+	// architecture 3.6) rather than fail open.
+	if ident.UID == 0 {
+		return true
+	}
 
 	// Ownership alone is a repoint risk: the owner can always chmod the entry to
 	// grant itself write, so an ancestor owned by the run-as identity is treated

--- a/internal/runner/base/security/operand_path_resolver_test.go
+++ b/internal/runner/base/security/operand_path_resolver_test.go
@@ -5,6 +5,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/risktypes"
@@ -294,4 +295,39 @@ func TestTrustedPredicate(t *testing.T) {
 	t.Cleanup(func() { _ = os.Chmod(root, 0o700) })
 	assert.False(t, r.isTrustedOperand(resolved, origin, trustedDirs, identOther),
 		"a world-writable non-sticky ancestor should not be Trusted")
+}
+
+// TestIsWritableByRunAs_StickyExemption verifies the sticky-bit exemption is
+// symmetric across the group- and other-write bits: a sticky directory restricts
+// rename/delete to each entry's owner, so it is not a repoint risk via either bit.
+func TestIsWritableByRunAs_StickyExemption(t *testing.T) {
+	root := tempRoot(t)
+	dir := filepath.Join(root, "d")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+
+	info, err := os.Lstat(dir)
+	require.NoError(t, err)
+	gid := info.Sys().(*syscall.Stat_t).Gid
+	euid := uint32(os.Geteuid())
+	// A run-as that does not own dir but shares its group.
+	ident := risktypes.RunAsIdent{UID: euid + 1, GID: gid}
+
+	// Group-writable, no sticky: repoint risk -> writable.
+	require.NoError(t, os.Chmod(dir, 0o070))
+	info, err = os.Lstat(dir)
+	require.NoError(t, err)
+	assert.True(t, isWritableByRunAs(info, ident), "group-writable non-sticky dir is writable")
+
+	// Group-writable, sticky: not a repoint risk -> not writable.
+	require.NoError(t, os.Chmod(dir, os.ModeSticky|0o070))
+	info, err = os.Lstat(dir)
+	require.NoError(t, err)
+	assert.False(t, isWritableByRunAs(info, ident), "group-writable sticky dir is not a repoint risk")
+
+	// Other-writable, sticky: same exemption (regression for the prior behavior).
+	identOther := risktypes.RunAsIdent{UID: euid + 1, GID: gid + 1}
+	require.NoError(t, os.Chmod(dir, os.ModeSticky|0o002))
+	info, err = os.Lstat(dir)
+	require.NoError(t, err)
+	assert.False(t, isWritableByRunAs(info, identOther), "other-writable sticky dir is not a repoint risk")
 }

--- a/internal/runner/base/security/operand_path_resolver_test.go
+++ b/internal/runner/base/security/operand_path_resolver_test.go
@@ -269,6 +269,25 @@ func TestTrustedPredicate(t *testing.T) {
 	assert.False(t, r.isTrustedOperand("/etc/passwd", origin, trustedDirs, identOther),
 		"a path outside the trusted dirs should not be Trusted")
 
+	// Inside the trusted dirs but NOT inside the safe-zone origin: the predicate
+	// must not Trust it (it would otherwise inspect an unrelated ancestor chain).
+	sibling := filepath.Join(root, "sibling")
+	assert.False(t, r.isTrustedOperand(sibling, origin, trustedDirs, identOther),
+		"a path outside the safe-zone origin should not be Trusted")
+
+	// A relative origin or resolved path fails closed (the ancestor ascent would
+	// otherwise terminate at "." and skip real system ancestors).
+	assert.False(t, r.isTrustedOperand("relative/file", origin, trustedDirs, identOther),
+		"a relative resolved path should not be Trusted")
+	assert.False(t, r.isTrustedOperand(resolved, "relative/origin", trustedDirs, identOther),
+		"a relative origin should not be Trusted")
+
+	// A root run-as is intentionally degenerate: root can write anywhere, so no
+	// operand is Trusted regardless of ancestor ownership/permissions.
+	identRoot := risktypes.RunAsIdent{UID: 0, GID: 0}
+	assert.False(t, r.isTrustedOperand(resolved, origin, trustedDirs, identRoot),
+		"a root run-as should never earn the safe-zone Low")
+
 	// Making origin's parent world-writable without a sticky bit makes the foreign
 	// identity able to repoint the anchor: no longer Trusted.
 	require.NoError(t, os.Chmod(root, 0o777))

--- a/internal/runner/base/security/operand_path_resolver_test.go
+++ b/internal/runner/base/security/operand_path_resolver_test.go
@@ -1,0 +1,209 @@
+package security
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/risktypes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// tempRoot returns the test's temp dir with any symlinks resolved, so fixture
+// paths built under it contain no unexpected symlink components that would skew
+// resolver call counts.
+func tempRoot(t *testing.T) string {
+	t.Helper()
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	require.NoError(t, err)
+	return root
+}
+
+// TestResolveOperandPath_SymlinkTarget asserts the leaf symlink is followed to its
+// target, so a safe-zone-looking path that points at a trust-critical location is
+// classified by the target (cp evil $WORKDIR/link, link -> /etc/passwd).
+func TestResolveOperandPath_SymlinkTarget(t *testing.T) {
+	root := tempRoot(t)
+	link := filepath.Join(root, "link")
+	require.NoError(t, os.Symlink("/etc/passwd", link))
+
+	got, err := ResolveOperandPath(link, "", MaxSymlinkDepth)
+	require.NoError(t, err)
+	assert.Equal(t, "/etc/passwd", got)
+}
+
+// TestResolveOperandPath_RelativeSymlinkTarget asserts an `ln -s` relative target
+// resolves against the link's own parent directory, not against the supplied base.
+func TestResolveOperandPath_RelativeSymlinkTarget(t *testing.T) {
+	root := tempRoot(t)
+	linkDir := filepath.Join(root, "sub")
+	require.NoError(t, os.MkdirAll(linkDir, 0o755))
+	target := filepath.Join(linkDir, "target")
+	require.NoError(t, os.WriteFile(target, nil, 0o644))
+
+	link := filepath.Join(linkDir, "link")
+	require.NoError(t, os.Symlink("target", link)) // relative target
+
+	otherBase := filepath.Join(root, "other")
+	require.NoError(t, os.MkdirAll(otherBase, 0o755))
+
+	// The operand is absolute, so base is irrelevant for the operand itself; the
+	// relative target must still resolve against linkDir, not otherBase.
+	got, err := ResolveOperandPath(link, otherBase, MaxSymlinkDepth)
+	require.NoError(t, err)
+	assert.Equal(t, target, got)
+
+	// A relative operand, in contrast, does resolve against base.
+	got2, err := ResolveOperandPath("target", linkDir, MaxSymlinkDepth)
+	require.NoError(t, err)
+	assert.Equal(t, target, got2)
+}
+
+// TestResolveOperandPath_NonexistentLeaf asserts a not-yet-created leaf folds onto
+// its existing real parent, so a write destination classifies by that parent.
+func TestResolveOperandPath_NonexistentLeaf(t *testing.T) {
+	root := tempRoot(t)
+	got, err := ResolveOperandPath(filepath.Join(root, "newfile"), "", MaxSymlinkDepth)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(root, "newfile"), got)
+
+	// Several non-existent trailing components fold together.
+	got2, err := ResolveOperandPath(filepath.Join(root, "a", "b", "c"), "", MaxSymlinkDepth)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(root, "a", "b", "c"), got2)
+}
+
+// TestResolveOperandPath_Cycle asserts a symlink cycle fails closed with an error.
+func TestResolveOperandPath_Cycle(t *testing.T) {
+	root := tempRoot(t)
+	a := filepath.Join(root, "a")
+	b := filepath.Join(root, "b")
+	require.NoError(t, os.Symlink(b, a))
+	require.NoError(t, os.Symlink(a, b))
+
+	_, err := ResolveOperandPath(a, "", MaxSymlinkDepth)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrOperandResolution)
+}
+
+// TestResolveOperandPath_DepthExceeded asserts a chain longer than maxHops fails
+// closed, while the same chain resolves when the budget is sufficient.
+func TestResolveOperandPath_DepthExceeded(t *testing.T) {
+	root := tempRoot(t)
+	target := filepath.Join(root, "target")
+	require.NoError(t, os.WriteFile(target, nil, 0o644))
+
+	prev := target
+	const chainLen = 5
+	for i := range chainLen {
+		link := filepath.Join(root, fmt.Sprintf("l%d", i))
+		require.NoError(t, os.Symlink(prev, link))
+		prev = link
+	}
+
+	_, err := ResolveOperandPath(prev, "", 2)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrOperandResolution)
+
+	got, err := ResolveOperandPath(prev, "", MaxSymlinkDepth)
+	require.NoError(t, err)
+	assert.Equal(t, target, got)
+}
+
+// TestResolveOperandPath_MidChainLstatError asserts a non-ENOENT lstat failure
+// fails closed (read-only resolution cannot recover a permission error).
+func TestResolveOperandPath_MidChainLstatError(t *testing.T) {
+	r := newOperandResolver(
+		func(string) (fs.FileInfo, error) { return nil, os.ErrPermission },
+		os.Readlink,
+	)
+	_, err := r.resolve("/some/abs/path", "", MaxSymlinkDepth)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrOperandResolution)
+}
+
+// TestMemoizationLinear is the falsifiable resolution-cost assertion: K operands
+// sharing one parent chain of depth D resolve with D+K lstat calls when the memo
+// folds the shared chain, versus K*(D+1) without it.
+func TestMemoizationLinear(t *testing.T) {
+	root := tempRoot(t)
+	sharedDir := filepath.Join(root, "p1", "p2", "p3")
+	require.NoError(t, os.MkdirAll(sharedDir, 0o755))
+
+	const k = 5
+	leaves := make([]string, k)
+	for i := range k {
+		leaf := filepath.Join(sharedDir, fmt.Sprintf("f%d", i))
+		require.NoError(t, os.WriteFile(leaf, nil, 0o644))
+		leaves[i] = leaf
+	}
+	d := len(splitAbs(sharedDir)) // depth of the shared parent chain below root
+
+	// Memoized: one resolver shared across all operands.
+	var lstatN, readlinkN int
+	r := newOperandResolver(
+		func(p string) (fs.FileInfo, error) { lstatN++; return os.Lstat(p) },
+		func(p string) (string, error) { readlinkN++; return os.Readlink(p) },
+	)
+	for _, leaf := range leaves {
+		_, err := r.resolve(leaf, "", MaxSymlinkDepth)
+		require.NoError(t, err)
+	}
+	assert.Equal(t, d+k, lstatN, "memoized lstat calls should fold the shared parent chain to D+K")
+	assert.Equal(t, 0, readlinkN, "no symlinks in the fixture")
+
+	// Naive: a fresh resolver (empty memo) per operand re-walks the whole chain.
+	var naiveN int
+	for _, leaf := range leaves {
+		nr := newOperandResolver(
+			func(p string) (fs.FileInfo, error) { naiveN++; return os.Lstat(p) },
+			os.Readlink,
+		)
+		_, err := nr.resolve(leaf, "", MaxSymlinkDepth)
+		require.NoError(t, err)
+	}
+	assert.Equal(t, k*(d+1), naiveN, "without memo each operand re-walks D+1 nodes")
+	assert.Less(t, lstatN, naiveN, "memoization must reduce the call count")
+}
+
+// TestTrustedPredicate is the differential for the Trusted predicate: the verdict
+// depends on the injected RunAsIdent (not the live euid that owns the fixtures)
+// and on the writability of origin's ancestors.
+func TestTrustedPredicate(t *testing.T) {
+	root := tempRoot(t)
+	origin := filepath.Join(root, "work")
+	require.NoError(t, os.MkdirAll(origin, 0o700))
+	resolved := filepath.Join(origin, "file")
+	trustedDirs := []string{root}
+
+	r := newOperandResolver(os.Lstat, os.Readlink)
+	euid := uint32(os.Geteuid())
+	egid := uint32(os.Getgid())
+
+	// An identity that does NOT own the fixtures: every ancestor is non-writable
+	// (owned by the real euid, 0700; /tmp is sticky), so the operand is Trusted.
+	identOther := risktypes.RunAsIdent{UID: euid + 1, GID: egid + 1}
+	assert.True(t, r.isTrustedOperand(resolved, origin, trustedDirs, identOther),
+		"foreign run-as over non-writable ancestors should be Trusted")
+
+	// The same call with an identity that owns the ancestors is not Trusted: the
+	// owner could chmod to repoint the safe-zone anchor. The live euid is constant
+	// across both calls, so only the injected identity changed the verdict.
+	identSelf := risktypes.RunAsIdent{UID: euid, GID: egid}
+	assert.False(t, r.isTrustedOperand(resolved, origin, trustedDirs, identSelf),
+		"run-as owning the ancestors should not be Trusted")
+
+	// Outside the trusted-directory allowlist is never Trusted.
+	assert.False(t, r.isTrustedOperand("/etc/passwd", origin, trustedDirs, identOther),
+		"a path outside the trusted dirs should not be Trusted")
+
+	// Making origin's parent world-writable without a sticky bit makes the foreign
+	// identity able to repoint the anchor: no longer Trusted.
+	require.NoError(t, os.Chmod(root, 0o777))
+	t.Cleanup(func() { _ = os.Chmod(root, 0o700) })
+	assert.False(t, r.isTrustedOperand(resolved, origin, trustedDirs, identOther),
+		"a world-writable non-sticky ancestor should not be Trusted")
+}

--- a/internal/runner/base/security/operand_path_resolver_test.go
+++ b/internal/runner/base/security/operand_path_resolver_test.go
@@ -23,16 +23,22 @@ func tempRoot(t *testing.T) string {
 }
 
 // TestResolveOperandPath_SymlinkTarget asserts the leaf symlink is followed to its
-// target, so a safe-zone-looking path that points at a trust-critical location is
-// classified by the target (cp evil $WORKDIR/link, link -> /etc/passwd).
+// target, so a safe-zone-looking path that points elsewhere is classified by the
+// target (the cp evil $WORKDIR/link, link -> trust-critical case in Phase 3). The
+// target is a real file with an absolute symlink so the expected resolved path is
+// stable across platforms (a hard-coded /etc could itself be a symlink).
 func TestResolveOperandPath_SymlinkTarget(t *testing.T) {
 	root := tempRoot(t)
+	target := filepath.Join(root, "elsewhere", "secret")
+	require.NoError(t, os.MkdirAll(filepath.Dir(target), 0o755))
+	require.NoError(t, os.WriteFile(target, nil, 0o600))
+
 	link := filepath.Join(root, "link")
-	require.NoError(t, os.Symlink("/etc/passwd", link))
+	require.NoError(t, os.Symlink(target, link)) // absolute target
 
 	got, err := ResolveOperandPath(link, "", MaxSymlinkDepth)
 	require.NoError(t, err)
-	assert.Equal(t, "/etc/passwd", got)
+	assert.Equal(t, target, got)
 }
 
 // TestResolveOperandPath_RelativeSymlinkTarget asserts an `ln -s` relative target
@@ -245,6 +251,12 @@ func TestTrustedPredicate(t *testing.T) {
 	identOther := risktypes.RunAsIdent{UID: euid + 1, GID: egid + 1}
 	assert.True(t, r.isTrustedOperand(resolved, origin, trustedDirs, identOther),
 		"foreign run-as over non-writable ancestors should be Trusted")
+
+	// A trailing separator on origin must not make the ancestor check start at
+	// origin itself (filepath.Dir of an uncleaned trailing-slash path returns the
+	// dir itself); the verdict must match the no-slash case.
+	assert.True(t, r.isTrustedOperand(resolved, origin+"/", trustedDirs, identOther),
+		"a trailing separator on origin should not change the verdict")
 
 	// The same call with an identity that owns the ancestors is not Trusted: the
 	// owner could chmod to repoint the safe-zone anchor. The live euid is constant

--- a/internal/runner/base/security/operand_path_resolver_test.go
+++ b/internal/runner/base/security/operand_path_resolver_test.go
@@ -76,7 +76,9 @@ func TestResolveOperandPath_NonexistentLeaf(t *testing.T) {
 	assert.Equal(t, filepath.Join(root, "a", "b", "c"), got2)
 }
 
-// TestResolveOperandPath_Cycle asserts a symlink cycle fails closed with an error.
+// TestResolveOperandPath_Cycle asserts a true symlink cycle fails closed: the hop
+// counter bounds the loop (no visited-node set, which would false-positive on
+// legitimately repeated nodes).
 func TestResolveOperandPath_Cycle(t *testing.T) {
 	root := tempRoot(t)
 	a := filepath.Join(root, "a")
@@ -87,6 +89,22 @@ func TestResolveOperandPath_Cycle(t *testing.T) {
 	_, err := ResolveOperandPath(a, "", MaxSymlinkDepth)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrOperandResolution)
+}
+
+// TestResolveOperandPath_RepeatedSymlinkNode is the regression for the cycle
+// false-positive: a single symlink that a path legitimately traverses more than
+// once must resolve, not be rejected. With `link -> .` (a self-referential dir
+// symlink), `link/link/link/x` resolves to the real `x` under root.
+func TestResolveOperandPath_RepeatedSymlinkNode(t *testing.T) {
+	root := tempRoot(t)
+	link := filepath.Join(root, "link")
+	require.NoError(t, os.Symlink(".", link)) // link -> its own parent (root)
+	target := filepath.Join(root, "x")
+	require.NoError(t, os.WriteFile(target, nil, 0o644))
+
+	got, err := ResolveOperandPath(filepath.Join(link, "link", "link", "x"), "", MaxSymlinkDepth)
+	require.NoError(t, err)
+	assert.Equal(t, target, got)
 }
 
 // TestResolveOperandPath_DepthExceeded asserts a chain longer than maxHops fails

--- a/internal/runner/base/security/operand_path_resolver_test.go
+++ b/internal/runner/base/security/operand_path_resolver_test.go
@@ -169,6 +169,45 @@ func TestMemoizationLinear(t *testing.T) {
 	assert.Less(t, lstatN, naiveN, "memoization must reduce the call count")
 }
 
+// TestMemoizationSymlinkParentNotFolded locks in the memo's documented scope: only
+// existing non-symlink nodes are memoized, so a shared symlink parent is followed
+// once per operand (readlink == K) rather than folded. Cost stays bounded and
+// linear in K; it is not the symlink-free D+K of TestMemoizationLinear.
+func TestMemoizationSymlinkParentNotFolded(t *testing.T) {
+	root := tempRoot(t)
+	realDir := filepath.Join(root, "real")
+	require.NoError(t, os.MkdirAll(realDir, 0o755))
+	link := filepath.Join(root, "link")
+	require.NoError(t, os.Symlink(realDir, link)) // absolute target
+
+	const k = 5
+	operands := make([]string, k)
+	for i := range k {
+		require.NoError(t, os.WriteFile(filepath.Join(realDir, fmt.Sprintf("f%d", i)), nil, 0o644))
+		operands[i] = filepath.Join(link, fmt.Sprintf("f%d", i))
+	}
+
+	var lstatN, readlinkN int
+	r := newOperandResolver(
+		func(p string) (fs.FileInfo, error) { lstatN++; return os.Lstat(p) },
+		func(p string) (string, error) { readlinkN++; return os.Readlink(p) },
+	)
+	for i, op := range operands {
+		got, err := r.resolve(op, "", MaxSymlinkDepth)
+		require.NoError(t, err)
+		assert.Equal(t, filepath.Join(realDir, fmt.Sprintf("f%d", i)), got,
+			"a symlink parent must resolve to the real target")
+	}
+
+	// The symlink node is never memoized, so it is read once per operand.
+	assert.Equal(t, k, readlinkN, "shared symlink parent is followed once per operand")
+	// Exact lstat budget: op0 walks root (depth d0) + link + real + f0 = d0+3;
+	// each later operand replays root/real from the memo and only lstats link + its
+	// leaf = 2. Total d0 + 3 + 2*(K-1).
+	d0 := len(splitAbs(root))
+	assert.Equal(t, d0+3+2*(k-1), lstatN, "symlink parent is re-walked but real nodes stay memoized")
+}
+
 // TestTrustedPredicate is the differential for the Trusted predicate: the verdict
 // depends on the injected RunAsIdent (not the live euid that owns the fixtures)
 // and on the writability of origin's ancestors.


### PR DESCRIPTION
## 概要

タスク 0142（判断軸2: 宛先パス信頼区分の一貫化）の Phase 2 / PR-2。`security` パッケージに read-only な専用オペランドパスリゾルバと、オペランド毎の Trusted 述語を実装する。これらは Phase 3 の `ClassifyDestinationZone` が消費する（本 PR 時点では cmd/ から未到達＝buildability contract に基づく意図的なスキャフォールド）。

設計: `docs/tasks/0142_axis2_destination_zoning/02_architecture.md` §3.3
計画: `docs/tasks/0142_axis2_destination_zoning/03_implementation_plan.md` Phase 2

## 変更内容

- `security/operand_path_resolver.go`（新規）:
  - `ResolveOperandPath(operand, base, maxHops)` — 経路要素を 1 つずつ追従する完全正規化方式。leaf と親の両方で symlink を追従し、注入 `lstat`/`readlink` のみを使う（`os.Stat` は意図的に除外＝symlink ターゲットの所有権で区分を欺かれないため）。
  - 未存在 leaf は最深の存在「実」ディレクトリへ畳み込む。完全正規化により「最深存在親が symlink」状態は構造的に発生しない。fail-closed: cycle・深さ超過（`maxHops`）・mid-chain の非 ENOENT `lstat`/`readlink` 失敗で `error`。
  - ノード毎メモ化（存在する非 symlink ノードのみ）で共有親チェーンを畳み、K オペランドで `D+K` の `lstat` コスト。
  - `isTrustedOperand` — 解決後パスが `TrustedDirectories` 配下、かつ起点の親以上の全祖先が run-as から書込不可（所有は chmod 自己付与可能のため書込可扱い・group/other 書込ビット・sticky ディレクトリは other 書込除外）。参照 identity は注入 `RunAsIdent`（live euid 不参照）。
- `security/operand_path_resolver_test.go`（新規）: symlink ターゲット解決 / 相対 target vs 相対オペランド / 未存在畳み込み / cycle / 深さ超過 / mid-chain エラー / メモ化線形（`D+K`）/ メモ化スコープ（symlink 親は非畳み込み）/ Trusted 差分。

## レビュー観点

- symlink 追従の read-only 性（`lstat`/`readlink` のみ、`os.Stat` 不参照）
- メモ化キーの正しさ（相対パスのクロス基点衝突・循環の回避）
- fail-closed（cycle・深さ超過・mid-chain 失敗）
- 注入 `RunAsIdent` による Trusted 判定の決定性

## 文書整合

完全正規化方式の採用に伴い、設計 §3.3 注・計画 Phase 2 の記述を更新（「symlink 親 → エラー」分岐は構造的に到達不能。fail-closed は mid-chain 失敗で担保）。`test_helpers_zoning.go` は共有フィクスチャが生じる Phase 3 まで作成を延期。

## 検証

- `make fmt` / `make test` / `make lint` 全緑
- 事前チェック: ASCII のみ・planning-doc 参照なし
- deadcode の指摘は Phase 3 が消費する意図的スキャフォールド

🤖 Generated with [Claude Code](https://claude.com/claude-code)