### PR TITLE
ci: CodeQL advanced setup with docs paths-ignore

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,60 @@
+# CodeQL advanced setup (replaces GitHub's default setup) so we can scope it with
+# paths-ignore: documentation-only changes (*.md / docs/ / .devcontainer/ / LICENSE)
+# do not trigger a full CodeQL analysis, matching the docs-skip classification in
+# ci.yml's check-changes job. The weekly schedule still runs a full scan regardless
+# of paths.
+name: "CodeQL Advanced"
+
+on:
+  push:
+    branches: [ "main" ]
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - ".devcontainer/**"
+      - "LICENSE"
+  pull_request:
+    branches: [ "main" ]
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - ".devcontainer/**"
+      - "LICENSE"
+  schedule:
+    - cron: '44 7 * * 6'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - language: actions
+          build-mode: none
+        - language: go
+          build-mode: autobuild
+        - language: python
+          build-mode: none
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v4
+      with:
+        languages: ${{ matrix.language }}
+        build-mode: ${{ matrix.build-mode }}
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v4
+      with:
+        category: "/language:${{matrix.language}}"


### PR DESCRIPTION
## 概要

CodeQL を **default setup → advanced setup** に切り替え、ドキュメントのみの変更で CodeQL が走らないようにする。default setup はパスフィルタ非対応で docs-only PR でも毎回走っていた（無駄）。default setup はリポジトリ Settings 側で無効化済み。

## 変更

- `.github/workflows/codeql.yml`（新規）を追加。`pull_request`/`push`（main）に `paths-ignore` を付与:
  `**/*.md` / `docs/**` / `.devcontainer/**` / `LICENSE`。これは `ci.yml` の `check-changes`（docs-skip 分類）と同じ除外集合。
- 言語マトリクス（`actions`/`go`/`python`）と構成は GitHub 推奨テンプレートに準拠（`scripts/` に Python あり、`.github/workflows/` あり、Go 本体ありを確認）。`paths-ignore` のみ追加。
- 週次 `schedule`（cron）はパスに関係なくフルスキャンを維持。

## レビュー観点・要確認

- **必須チェックの確認（重要）**: branch protection で旧 default setup の「CodeQL」がまだ**必須ステータスチェック**に残っていると、docs-only PR では本ワークフローがスキップされ当該チェックが報告されず、PR がマージ不能になります。Settings → Branches で、必須チェック名を advanced setup のジョブ名（例 `CodeQL Advanced / Analyze (go)`）へ更新するか、CodeQL を非必須にしてください（docs-only PR をスキップさせる目的と整合させる）。
- マトリクスの言語が過不足ないか（特に `actions`/`python` を含めるか）。

## 動作

- docs/設定のみの PR: CodeQL は起動しない（`ci.yml` の各ジョブも既にスキップ済み）。
- コードを含む PR: 従来どおり全言語を解析。
- main への週次フルスキャンは維持。

🤖 Generated with [Claude Code](https://claude.com/claude-code)