### PR TITLE
feat(0144): add single getopt parser and flag-spec types

### DIFF
--- a/docs/tasks/0144_declarative_operand_extraction/03_implementation_plan.md
+++ b/docs/tasks/0144_declarative_operand_extraction/03_implementation_plan.md
@@ -112,6 +112,12 @@
 - [ ] 差分比較の nil/空スライス対策: `reflect.DeepEqual(nil, []rawOperand{})` は `false` のため、旧/新で `operands` が一方 nil・
       他方 空スライスだと誤って不一致になる。比較前に `operands` の nil↔空を正規化する小ヘルパを挟む（または `go-cmp` の
       `cmpopts.EquateEmpty` を使う。導入可否は実装時に判断）。「空オペランドは nil に揃える」など正規化規則をテスト内に明記する。
+- [ ] 既知パリティ項目（長形再帰フラグ）の扱いを決める: 現行 `scanFlags` は `--recursive`/`--archive` を `recursiveFlags` のみに
+      登録し `boolFlags` に入れていないため、長形は「未知の `--` フラグ」として `recognized=false`（fail-closed）になる一方、
+      短形 `-r`/`-a` はクラスタ経路で `recognized=true` になる。新仕様では同フラグを 1 つの `FlagSpec.Names` にまとめるため長形も
+      `recognized=true` となり、差分テストが `recognized` 不一致を検出する。これは現行のフェイルクローズ寄りの不具合であり、差分テスト
+      の不一致は意図的な判断で解消する（仕様で長形を認識する＝挙動を是正し設計 §7 の逸脱として明記する、または現行の挙動を保つ）。
+      **凍結スナップショットを書き換えて緑にしてはならない**。同型の他フラグ（`recursiveFlags` のみに含まれる長形）も併せて点検する。
 
 **成功基準**:
 - [ ] 完全性メタテストとアリティ不変条件チェックが緑。

--- a/docs/tasks/0144_declarative_operand_extraction/03_implementation_plan.md
+++ b/docs/tasks/0144_declarative_operand_extraction/03_implementation_plan.md
@@ -70,6 +70,19 @@
 - [ ] `go test -tags test ./internal/runner/base/security/` で `getopt_test.go` が緑。
 - [ ] `make fmt && make test && make lint` が緑。
 
+### PR-1 作成ポイント: getopt parser and flag-spec types
+
+**対象ステップ**: Phase 1
+
+**推奨タイトル**: `feat(0144): add single getopt parser and flag-spec types`
+
+**レビュー観点**: `parseArgs` の形式網羅と fail-closed（未知/欠落で `Recognized=false`） / 短縮連結中の引数付きフラグ規則・引数省略可の付随形限定 / `FlagArity`・`ValueRole`・`FlagSpec`/`CommandFlagSpec` の型設計（正規キー単一源・決定性制約）
+
+- [ ] グリーンゲート（`_context.md` の "Green gate" 参照）がパスしていることを確認した
+- [ ] PR を作成した
+- [ ] PR がマージされた
+- [ ] 次のブランチへ切り替えた（次ステップは新しいブランチで作業する）
+
 ### Phase 2: 宣言的仕様表・完全性メタテスト・差分テスト基盤
 
 **変更ファイル**:
@@ -104,6 +117,19 @@
 - [ ] 完全性メタテストとアリティ不変条件チェックが緑。
 - [ ] 凍結スナップショットと差分テスト基盤がコンパイルでき、移行前は旧実装同士で恒真（基盤の健全性確認）。
 
+### PR-2 作成ポイント: declarative spec table, completeness meta-test, differential harness
+
+**対象ステップ**: Phase 2
+
+**推奨タイトル**: `feat(0144): add declarative flag spec, completeness meta-test, and differential harness`
+
+**レビュー観点**: 宣言的仕様表のアリティ不変条件（必須→省略可の誤分類防止） / 完全性メタテスト（Names 非空・`ArityNone→ValueUnset`・引数付きは `ValueRole != ValueUnset`） / 凍結スナップショットと差分テスト基盤（`reflect.DeepEqual` 構造体全体・nil↔空の正規化・移行前の恒真性）
+
+- [ ] グリーンゲート（`_context.md` の "Green gate" 参照）がパスしていることを確認した
+- [ ] PR を作成した
+- [ ] PR がマージされた
+- [ ] 次のブランチへ切り替えた（次ステップは新しいブランチで作業する）
+
 ### Phase 3: コマンド単位の移行と旧実装の撤去
 
 **変更ファイル**:
@@ -128,8 +154,24 @@
 
 **成功基準**:
 - [ ] 全コマンドで差分テストが緑。
-- [ ] `make deadcode` で旧 `extractXxx`/`scanFlags` の取り残しがない（凍結スナップショットはテスト専用のため対象外）。
+- [ ] 旧 `scanFlags`・production 側 `extractXxx`・重複フラグ集合が完全に撤去されている。一次確認は §10 の `rg` グレップ
+      （production コードでマッチ 0）と `make lint` の `unused` リンタ（未使用の非公開関数を検出）。`make deadcode` は半移行で旧関数が
+      `zoningSpecs` から到達可能なまま残ると「取り残し」を検出できない（到達可能＝未使用ではない）ため、補助的な確認に留める。
+      凍結スナップショットはテスト専用のため対象外。
 - [ ] `make fmt && make test && make lint` が緑。
+
+### PR-3 作成ポイント: migrate commands to the parser and remove legacy extractors
+
+**対象ステップ**: Phase 3
+
+**推奨タイトル**: `refactor(0144): migrate operand extraction to the declarative spec and remove legacy extractors`
+
+**レビュー観点**: 挙動保存（各コマンドで差分テスト緑をゲートするコマンド単位移行の安全性。本リファクタ最大のリスク） / tar・chattr の事前正規化と dd の非 getopt 扱い（設計 §3.5） / 旧 `scanFlags`・`extractXxx`・重複フラグ集合の完全撤去（`make deadcode` 確認） / 決定性（`Values` を `for range` せず正規キー参照）
+
+- [ ] グリーンゲート（`_context.md` の "Green gate" 参照）がパスしていることを確認した
+- [ ] PR を作成した
+- [ ] PR がマージされた
+- [ ] 次のブランチへ切り替えた（次ステップは新しいブランチで作業する）
 
 ### Phase 4: 挙動同一性・fail-closed・静的ガード
 
@@ -161,6 +203,19 @@
 - [ ] AC-09〜AC-11 が緑。`TestNoLiveIdentityInZoning` が新規 2 ファイルを含めて緑。
 - [ ] `make fmt && make test && make lint` が緑、`./internal/runner/...` がコンパイル。
 
+### PR-4 作成ポイント: behavior parity, fail-closed tests, and static guard
+
+**対象ステップ**: Phase 4
+
+**推奨タイトル**: `test(0144): add behavior-parity and fail-closed tests; extend live-identity guard`
+
+**レビュー観点**: `LocationResult` 同一性（`zoningSpecs` 全件 range）と fail-closed の網羅 / 既存 2 テストファイルが無改変（`git diff` 空）であることの確認 / 静的ガードへの新規 2 ファイル追加（既存ガード再利用・API 拡充不要）
+
+- [ ] グリーンゲート（`_context.md` の "Green gate" 参照）がパスしていることを確認した
+- [ ] PR を作成した
+- [ ] PR がマージされた
+- [ ] 次のブランチへ切り替えた（次ステップは新しいブランチで作業する）
+
 ## 3. 実装順序とマイルストーン
 
 | Phase | マイルストーン（成果物） | 反映 AC | 依存 |
@@ -169,6 +224,17 @@
 | P2 | 宣言的仕様表＋完全性メタテスト＋差分テスト基盤 | AC-01, AC-07 | P1 |
 | P3 | コマンド単位移行＋旧実装撤去＋回帰代表ケース | AC-02, AC-08 | P2 |
 | P4 | 挙動同一性・fail-closed・静的ガード | AC-09, AC-10, AC-11 | P3 |
+
+各フェーズは独立してグリーンゲートを通過でき、関心も 1 つにまとまるため、1 フェーズ＝1 PR とする（並べ替え不要）。`internal/` 内に閉じ `cmd/` 変更は無いため internal-before-cmd の制約は該当しない。
+
+### 3.2 PR 構成
+
+| PR | 対象 | 主な変更内容 |
+|---|---|---|
+| PR-1 | Phase 1 | 単一 getopt パーサ（`getopt.go`）＋型定義（`flag_spec.go` の型）＋パーサ表駆動テスト（`getopt_test.go`） |
+| PR-2 | Phase 2 | 宣言的仕様表（`flag_spec.go`）＋完全性/アリティ不変メタテスト（`flag_spec_test.go`）＋凍結スナップショット・差分テスト基盤（`extraction_legacy_test.go`/`extraction_diff_test.go`） |
+| PR-3 | Phase 3 | コマンド単位移行（`destination_zoning_spec.go`）＋旧 `scanFlags`/`extractXxx` 撤去＋回帰代表ケース（`destination_zoning_parity_test.go`）。本リファクタ最大のリスクを単独 PR に隔離（各コマンドは差分ゲートで機械的に検証）。レビュー困難なほど大きくなる場合は、非機械的な特別形（tar・chattr・dd。§3.5）を後続 PR に切り出す |
+| PR-4 | Phase 4 | 挙動同一性表・fail-closed テスト（`destination_zoning_parity_test.go`）＋静的ガード拡張（`risk/live_identity_guard_test.go`） |
 
 ## 4. テスト戦略
 
@@ -198,10 +264,10 @@
 
 ## 6. 実装チェックリスト
 
-- [ ] Phase 1 完了（パーサ・型・パーサテスト緑）
-- [ ] Phase 2 完了（仕様表・メタテスト・差分基盤）
-- [ ] Phase 3 完了（全コマンド移行・旧実装撤去・回帰ケース）
-- [ ] Phase 4 完了（同一性・fail-closed・静的ガード）
+- [ ] PR-1 マージ済み（対象: Phase 1。パーサ・型・パーサテスト緑）
+- [ ] PR-2 マージ済み（対象: Phase 2。仕様表・メタテスト・差分テスト基盤）
+- [ ] PR-3 マージ済み（対象: Phase 3。全コマンド移行・旧実装撤去・回帰ケース）
+- [ ] PR-4 マージ済み（対象: Phase 4。同一性・fail-closed・静的ガード）
 - [ ] 全 PR マージ後: `make fmt`→`make test`→`make lint` 全緑、`./internal/runner/...` コンパイル（NF-001）
 
 ## 7. 受け入れ基準の検証

--- a/docs/tasks/0144_declarative_operand_extraction/03_implementation_plan.md
+++ b/docs/tasks/0144_declarative_operand_extraction/03_implementation_plan.md
@@ -79,7 +79,7 @@
 **レビュー観点**: `parseArgs` の形式網羅と fail-closed（未知/欠落で `Recognized=false`） / 短縮連結中の引数付きフラグ規則・引数省略可の付随形限定 / `FlagArity`・`ValueRole`・`FlagSpec`/`CommandFlagSpec` の型設計（正規キー単一源・決定性制約）
 
 - [x] グリーンゲート（`_context.md` の "Green gate" 参照）がパスしていることを確認した
-- [ ] PR を作成した
+- [x] PR を作成した（#794）
 - [ ] PR がマージされた
 - [ ] 次のブランチへ切り替えた（次ステップは新しいブランチで作業する）
 

--- a/docs/tasks/0144_declarative_operand_extraction/03_implementation_plan.md
+++ b/docs/tasks/0144_declarative_operand_extraction/03_implementation_plan.md
@@ -78,7 +78,7 @@
 
 **レビュー観点**: `parseArgs` の形式網羅と fail-closed（未知/欠落で `Recognized=false`） / 短縮連結中の引数付きフラグ規則・引数省略可の付随形限定 / `FlagArity`・`ValueRole`・`FlagSpec`/`CommandFlagSpec` の型設計（正規キー単一源・決定性制約）
 
-- [ ] グリーンゲート（`_context.md` の "Green gate" 参照）がパスしていることを確認した
+- [x] グリーンゲート（`_context.md` の "Green gate" 参照）がパスしていることを確認した
 - [ ] PR を作成した
 - [ ] PR がマージされた
 - [ ] 次のブランチへ切り替えた（次ステップは新しいブランチで作業する）

--- a/docs/tasks/0144_declarative_operand_extraction/03_implementation_plan.md
+++ b/docs/tasks/0144_declarative_operand_extraction/03_implementation_plan.md
@@ -56,19 +56,19 @@
 - 新規 `internal/runner/base/security/getopt_test.go`
 
 **作業内容**:
-- [ ] `flag_spec.go` に `FlagArity`（`ArityNone`/`ArityRequired`/`ArityOptional`）・`ValueRole`（`ValueUnset`/`ValueNonPath`/
+- [x] `flag_spec.go` に `FlagArity`（`ArityNone`/`ArityRequired`/`ArityOptional`）・`ValueRole`（`ValueUnset`/`ValueNonPath`/
       `ValueWrite`/`ValueRead`）・`FlagSpec`・`CommandFlagSpec` の型を定義する（設計 §3.1）。`parseArgs` が `FlagSpec` に依存するため
       型は本フェーズで先に置く（仕様表の中身は Phase 2）。
-- [ ] `getopt.go` に `parseArgs(flags []FlagSpec, args []string) ParseResult`・`ParseResult`・`HasFlag(canonicalKey string) bool`
+- [x] `getopt.go` に `parseArgs(flags []FlagSpec, args []string) ParseResult`・`ParseResult`・`HasFlag(canonicalKey string) bool`
       を実装する（設計 §3.1）。一元処理する形式: `--flag=value`・付随短縮値・短縮連結・`--`・引数省略可・別名正規化。
       短縮連結中の引数付きフラグ規則と引数省略可の付随形限定は設計 §3.1 の規則に従う。総 argv 長に対して線形。
-- [ ] `getopt_test.go`（表駆動）を追加: 全形式の網羅（AC-03）／語を暗黙に捨てない・未知フラグ・引数必須フラグの値欠落で
+- [x] `getopt_test.go`（表駆動）を追加: 全形式の網羅（AC-03）／語を暗黙に捨てない・未知フラグ・引数必須フラグの値欠落で
       `Recognized=false`（AC-04）／別名正規化で表記違いが同一結果（AC-05）／引数省略可は付随形のみ・分離後続語を消費しない・
       クラスタ内省略可（`sed -ir` → `-i` の値 `r`）（AC-06）／大量 argv・長い短縮連結の病的入力。
 
 **成功基準**:
-- [ ] `go test -tags test ./internal/runner/base/security/` で `getopt_test.go` が緑。
-- [ ] `make fmt && make test && make lint` が緑。
+- [x] `go test -tags test ./internal/runner/base/security/` で `getopt_test.go` が緑。
+- [x] `make fmt && make test && make lint` が緑。
 
 ### PR-1 作成ポイント: getopt parser and flag-spec types
 

--- a/internal/runner/base/security/flag_spec.go
+++ b/internal/runner/base/security/flag_spec.go
@@ -12,13 +12,14 @@ const (
 )
 
 // ValueRole classifies the value captured by an argument-taking flag. ValueUnset is
-// the zero value and marks an unclassified value flag; the completeness meta-test
-// rejects it, so every argument-taking flag must declare a concrete role.
+// the zero value and marks a flag that takes no value; it is valid only for ArityNone.
+// Every argument-taking flag (ArityRequired or ArityOptional) must declare a concrete
+// role.
 type ValueRole int
 
 // Value roles for argument-taking flags.
 const (
-	ValueUnset   ValueRole = iota // unclassified (zero-value sentinel; fails the completeness meta-test)
+	ValueUnset   ValueRole = iota // no value captured; valid only for ArityNone flags
 	ValueNonPath                  // a non-path value that may be ignored (explicitly classified)
 	ValueWrite                    // the value is a write-destination operand
 	ValueRead                     // the value is a read-source operand

--- a/internal/runner/base/security/flag_spec.go
+++ b/internal/runner/base/security/flag_spec.go
@@ -1,0 +1,45 @@
+package security
+
+// FlagArity describes whether a flag takes an argument and, if it does, whether the
+// argument is required or optional.
+type FlagArity int
+
+// Flag arities recognized by the parser.
+const (
+	ArityNone     FlagArity = iota // boolean flag: takes no argument
+	ArityRequired                  // takes a required argument (attached form or the next token)
+	ArityOptional                  // optional argument: attached form only (--flag=v / -ov), never the next token
+)
+
+// ValueRole classifies the value captured by an argument-taking flag. ValueUnset is
+// the zero value and marks an unclassified value flag; the completeness meta-test
+// rejects it, so every argument-taking flag must declare a concrete role.
+type ValueRole int
+
+// Value roles for argument-taking flags.
+const (
+	ValueUnset   ValueRole = iota // unclassified (zero-value sentinel; fails the completeness meta-test)
+	ValueNonPath                  // a non-path value that may be ignored (explicitly classified)
+	ValueWrite                    // the value is a write-destination operand
+	ValueRead                     // the value is a read-source operand
+)
+
+// FlagSpec is the declarative specification of one logical flag. Every spelling
+// (short and long) is collected in Names; Names[0] is the canonical key under which
+// the parser records the flag. Names must hold at least one element.
+type FlagSpec struct {
+	Names     []string
+	Arity     FlagArity
+	Recursive bool      // a recursion flag (e.g. -r / -R / -a)
+	Value     ValueRole // role of the captured value when Arity is Required/Optional; ValueUnset when ArityNone
+}
+
+// CommandFlagSpec is one command's declarative flag set plus the thin function that
+// maps a parsed result into an extraction. The raw argv is passed to ToExtraction
+// only for the non-getopt value grammars (dd's if=/of= key=value, chattr's attribute
+// tokens); getopt-conformant commands read flag values from the ParseResult alone.
+type CommandFlagSpec struct {
+	Kind         LocationKind
+	Flags        []FlagSpec
+	ToExtraction func(ParseResult, []string) extraction
+}

--- a/internal/runner/base/security/getopt.go
+++ b/internal/runner/base/security/getopt.go
@@ -22,14 +22,16 @@ func (r ParseResult) HasFlag(canonicalKey string) bool {
 	return ok
 }
 
-// argParser holds the mutable state threaded through one parseArgs call: the flag
-// lookup table, the argv being scanned, the cursor into it, and the result being
-// built. Keeping this state on a struct (rather than passing a closure plus indices
-// between free functions) is the idiomatic Go way to share it across the helpers.
+// argParser holds the state shared across one parseArgs call: the flag lookup table
+// and the argv being scanned (both read-only after setup), plus the result being
+// accumulated. The cursor into argv is NOT stored here; it is a local owned by the
+// parseArgs loop, which is its single writer. Helpers read the cursor and report back
+// (via consumedNext) whether they took the following token, instead of mutating it.
+// Using a struct with methods (rather than passing a closure and indices between free
+// functions) is the idiomatic Go way to share this.
 type argParser struct {
 	byName map[string]*FlagSpec
 	args   []string
-	i      int
 	res    ParseResult
 }
 
@@ -49,24 +51,32 @@ func parseArgs(flags []FlagSpec, args []string) ParseResult {
 		args:   args,
 		res:    ParseResult{Values: make(map[string][]string), Recognized: true},
 	}
-	for i := range flags {
-		f := &flags[i]
+	for _, f := range flags {
 		for _, n := range f.Names {
-			p.byName[n] = f
+			p.byName[n] = &f
 		}
 	}
 
+	// i is the cursor and the loop is its only writer. Each token is the "--"
+	// terminator, a non-flag argument, or a flag token. A flag that takes a separate
+	// value also consumes the next token; parseFlagToken reports that via consumedNext
+	// so the loop skips it. A non-recognized token records fail-closed but does not
+	// stop the scan.
 	endOpts := false
-	for p.i = 0; p.i < len(p.args); p.i++ {
-		a := p.args[p.i]
+	for i := 0; i < len(p.args); i++ {
+		a := p.args[i]
 		switch {
 		case !endOpts && a == "--":
 			endOpts = true
 		case endOpts || len(a) < 2 || a[0] != '-':
 			p.res.NonFlagArgs = append(p.res.NonFlagArgs, a)
 		default:
-			if !p.parseFlagToken(a) {
+			consumedNext, ok := p.parseFlagToken(i)
+			if !ok {
 				p.res.Recognized = false
+			}
+			if consumedNext {
+				i++
 			}
 		}
 	}
@@ -86,35 +96,37 @@ func (p *argParser) mark(f *FlagSpec, vals ...string) {
 	}
 }
 
-// parseFlagToken classifies one option token (a, already known to start with '-' and
-// not be "--"). It advances the cursor when a value flag consumes the next token, and
-// returns false when the token cannot be fully recognized (unknown flag or missing
-// required value), so the caller can set Recognized=false.
-func (p *argParser) parseFlagToken(a string) bool {
+// parseFlagToken classifies the option token at args[i] (known to start with '-' and
+// not be "--"). consumedNext is true when the flag took args[i+1] as its value, so the
+// caller skips it. ok is false when the token cannot be fully recognized (unknown flag
+// or missing required value), so the caller can set Recognized=false.
+func (p *argParser) parseFlagToken(i int) (consumedNext, ok bool) {
+	a := p.args[i]
 	name, val, hasEq := strings.Cut(a, "=")
-	if f, ok := p.byName[name]; ok {
-		return p.markNamedFlag(f, val, hasEq)
+	if f, found := p.byName[name]; found {
+		return p.markNamedFlag(f, i, val, hasEq)
 	}
 	// An unknown long flag (--foo) may take a value, so fail closed.
 	if strings.HasPrefix(a, "--") {
-		return false
+		return false, false
 	}
-	return p.parseShortCluster(a)
+	return p.parseShortCluster(i)
 }
 
-// markNamedFlag records an exactly-spelled flag and consumes its value per arity. It
-// returns false only when a required value is missing.
-func (p *argParser) markNamedFlag(f *FlagSpec, val string, hasEq bool) bool {
+// markNamedFlag records an exactly-spelled flag and consumes its value per arity.
+// consumedNext is true when a required value was taken from args[i+1]; ok is false only
+// when a required value is missing.
+func (p *argParser) markNamedFlag(f *FlagSpec, i int, val string, hasEq bool) (consumedNext, ok bool) {
 	switch f.Arity {
 	case ArityRequired:
 		switch {
 		case hasEq:
 			p.mark(f, val)
-		case p.i+1 < len(p.args):
-			p.mark(f, p.args[p.i+1])
-			p.i++
+		case i+1 < len(p.args):
+			p.mark(f, p.args[i+1])
+			return true, true
 		default:
-			return false // required value missing at end of argv
+			return false, false // required value missing at end of argv
 		}
 	case ArityOptional:
 		if hasEq {
@@ -125,19 +137,20 @@ func (p *argParser) markNamedFlag(f *FlagSpec, val string, hasEq bool) bool {
 	default: // ArityNone
 		p.mark(f) // boolean/recursion flag; any attached =value is ignored (legacy parity)
 	}
-	return true
+	return false, true
 }
 
-// parseShortCluster parses a short-flag cluster (e.g. -rf, or a value flag with an
-// attached value like -C/usr). A value flag inside the cluster captures the rest of
-// the token as its value (or, when required and nothing is attached, the next token);
-// dropping that value would default a destination to the cwd (fail-open). It returns
-// false on an unknown cluster char or a required value with nothing to consume.
-func (p *argParser) parseShortCluster(a string) bool {
+// parseShortCluster parses a short-flag cluster at args[i] (e.g. -rf, or a value flag
+// with an attached value like -C/usr). A value flag inside the cluster captures the
+// rest of the token as its value, or args[i+1] when nothing is attached (consumedNext);
+// dropping that value would default a destination to the cwd (fail-open). ok is false
+// on an unknown cluster char or a required value with nothing to consume.
+func (p *argParser) parseShortCluster(i int) (consumedNext, ok bool) {
+	a := p.args[i]
 	for k, c := range a[1:] {
-		f, ok := p.byName["-"+string(c)]
-		if !ok {
-			return false
+		f, found := p.byName["-"+string(c)]
+		if !found {
+			return false, false
 		}
 		if f.Arity == ArityNone {
 			p.mark(f)
@@ -150,15 +163,15 @@ func (p *argParser) parseShortCluster(a string) bool {
 		switch {
 		case rest != "":
 			p.mark(f, rest)
-		case f.Arity == ArityRequired && p.i+1 < len(p.args):
-			p.mark(f, p.args[p.i+1])
-			p.i++
+		case f.Arity == ArityRequired && i+1 < len(p.args):
+			p.mark(f, p.args[i+1])
+			return true, true
 		case f.Arity == ArityOptional:
 			p.mark(f) // optional, no attached value; do not consume the next token
 		default:
-			return false // required value flag with nothing to consume
+			return false, false // required value flag with nothing to consume
 		}
-		return true // a value flag consumes the remainder of the cluster
+		return false, true // a value flag consumes the remainder of the cluster
 	}
-	return true
+	return false, true
 }

--- a/internal/runner/base/security/getopt.go
+++ b/internal/runner/base/security/getopt.go
@@ -22,6 +22,17 @@ func (r ParseResult) HasFlag(canonicalKey string) bool {
 	return ok
 }
 
+// argParser holds the mutable state threaded through one parseArgs call: the flag
+// lookup table, the argv being scanned, the cursor into it, and the result being
+// built. Keeping this state on a struct (rather than passing a closure plus indices
+// between free functions) is the idiomatic Go way to share it across the helpers.
+type argParser struct {
+	byName map[string]*FlagSpec
+	args   []string
+	i      int
+	res    ParseResult
+}
+
 // parseArgs is the single getopt parser shared by every command. It consumes a flag
 // set (only the flags; it never inspects Kind or ToExtraction) and classifies argv.
 //
@@ -33,83 +44,86 @@ func (r ParseResult) HasFlag(canonicalKey string) bool {
 // recorded under the canonical name). It is pure: linear in total argv length, with
 // no filesystem, environment, or process-identity access.
 func parseArgs(flags []FlagSpec, args []string) ParseResult {
-	byName := make(map[string]*FlagSpec)
+	p := &argParser{
+		byName: make(map[string]*FlagSpec),
+		args:   args,
+		res:    ParseResult{Values: make(map[string][]string), Recognized: true},
+	}
 	for i := range flags {
 		f := &flags[i]
 		for _, n := range f.Names {
-			byName[n] = f
-		}
-	}
-
-	res := ParseResult{Values: make(map[string][]string), Recognized: true}
-	// mark records a flag's presence under its canonical key and appends any captured
-	// values (none for a bare boolean or value-less optional flag).
-	mark := func(f *FlagSpec, vals ...string) {
-		key := f.Names[0]
-		if _, ok := res.Values[key]; !ok {
-			res.Values[key] = []string{}
-		}
-		res.Values[key] = append(res.Values[key], vals...)
-		if f.Recursive {
-			res.Recursive = true
+			p.byName[n] = f
 		}
 	}
 
 	endOpts := false
-	for i := 0; i < len(args); i++ {
-		a := args[i]
+	for p.i = 0; p.i < len(p.args); p.i++ {
+		a := p.args[p.i]
 		switch {
 		case !endOpts && a == "--":
 			endOpts = true
 		case endOpts || len(a) < 2 || a[0] != '-':
-			res.NonFlagArgs = append(res.NonFlagArgs, a)
+			p.res.NonFlagArgs = append(p.res.NonFlagArgs, a)
 		default:
-			if !parseFlagToken(a, args, &i, byName, mark) {
-				res.Recognized = false
+			if !p.parseFlagToken(a) {
+				p.res.Recognized = false
 			}
 		}
 	}
-	return res
+	return p.res
+}
+
+// mark records a flag's presence under its canonical key and appends any captured
+// values (none for a bare boolean or value-less optional flag).
+func (p *argParser) mark(f *FlagSpec, vals ...string) {
+	key := f.Names[0]
+	if _, ok := p.res.Values[key]; !ok {
+		p.res.Values[key] = []string{}
+	}
+	p.res.Values[key] = append(p.res.Values[key], vals...)
+	if f.Recursive {
+		p.res.Recursive = true
+	}
 }
 
 // parseFlagToken classifies one option token (a, already known to start with '-' and
-// not be "--"). It advances i when a value flag consumes the next token, and returns
-// false when the token cannot be fully recognized (unknown flag or missing required
-// value), so the caller can set Recognized=false.
-func parseFlagToken(a string, args []string, i *int, byName map[string]*FlagSpec, mark func(*FlagSpec, ...string)) bool {
+// not be "--"). It advances the cursor when a value flag consumes the next token, and
+// returns false when the token cannot be fully recognized (unknown flag or missing
+// required value), so the caller can set Recognized=false.
+func (p *argParser) parseFlagToken(a string) bool {
 	name, val, hasEq := strings.Cut(a, "=")
-	if f, ok := byName[name]; ok {
-		return markNamedFlag(f, val, hasEq, args, i, mark)
+	if f, ok := p.byName[name]; ok {
+		return p.markNamedFlag(f, val, hasEq)
 	}
 	// An unknown long flag (--foo) may take a value, so fail closed.
 	if strings.HasPrefix(a, "--") {
 		return false
 	}
-	return parseShortCluster(a, args, i, byName, mark)
+	return p.parseShortCluster(a)
 }
 
 // markNamedFlag records an exactly-spelled flag and consumes its value per arity. It
 // returns false only when a required value is missing.
-func markNamedFlag(f *FlagSpec, val string, hasEq bool, args []string, i *int, mark func(*FlagSpec, ...string)) bool {
+func (p *argParser) markNamedFlag(f *FlagSpec, val string, hasEq bool) bool {
 	switch f.Arity {
 	case ArityRequired:
 		switch {
 		case hasEq:
-			mark(f, val)
-		case *i+1 < len(args):
-			mark(f, args[*i+1])
-			*i++
+			p.mark(f, val)
+		case p.i+1 < len(p.args):
+			p.mark(f, p.args[p.i+1])
+			p.i++
 		default:
 			return false // required value missing at end of argv
 		}
 	case ArityOptional:
 		if hasEq {
-			mark(f, val)
+			p.mark(f, val)
 		} else {
-			mark(f) // present without a value; never consume the next token
+			p.mark(f) // present without a value; never consume the next token
 		}
 	default: // ArityNone
-		mark(f) // boolean/recursion flag; any attached =value is ignored (legacy parity)
+		p.mark(f) // boolean/recursion flag; any attached =value is ignored (legacy parity)
 	}
 	return true
 }
@@ -119,14 +133,14 @@ func markNamedFlag(f *FlagSpec, val string, hasEq bool, args []string, i *int, m
 // the token as its value (or, when required and nothing is attached, the next token);
 // dropping that value would default a destination to the cwd (fail-open). It returns
 // false on an unknown cluster char or a required value with nothing to consume.
-func parseShortCluster(a string, args []string, i *int, byName map[string]*FlagSpec, mark func(*FlagSpec, ...string)) bool {
+func (p *argParser) parseShortCluster(a string) bool {
 	for k, c := range a[1:] {
-		f, ok := byName["-"+string(c)]
+		f, ok := p.byName["-"+string(c)]
 		if !ok {
 			return false
 		}
 		if f.Arity == ArityNone {
-			mark(f)
+			p.mark(f)
 			continue
 		}
 		// c begins at byte 1+k within a (1 for the leading dash); the attached value is
@@ -135,12 +149,12 @@ func parseShortCluster(a string, args []string, i *int, byName map[string]*FlagS
 		rest := a[1+k+len(string(c)):]
 		switch {
 		case rest != "":
-			mark(f, rest)
-		case f.Arity == ArityRequired && *i+1 < len(args):
-			mark(f, args[*i+1])
-			*i++
+			p.mark(f, rest)
+		case f.Arity == ArityRequired && p.i+1 < len(p.args):
+			p.mark(f, p.args[p.i+1])
+			p.i++
 		case f.Arity == ArityOptional:
-			mark(f) // optional, no attached value; do not consume the next token
+			p.mark(f) // optional, no attached value; do not consume the next token
 		default:
 			return false // required value flag with nothing to consume
 		}

--- a/internal/runner/base/security/getopt.go
+++ b/internal/runner/base/security/getopt.go
@@ -32,7 +32,7 @@ func (r ParseResult) HasFlag(canonicalKey string) bool {
 // Using a struct with methods (rather than passing a closure and indices between free
 // functions) is the idiomatic Go way to share this.
 type argParser struct {
-	byName map[string]*FlagSpec
+	byName map[string]FlagSpec
 	args   []string
 	res    ParseResult
 }
@@ -51,13 +51,13 @@ type argParser struct {
 // filesystem, environment, or process-identity access.
 func parseArgs(flags []FlagSpec, args []string) ParseResult {
 	p := &argParser{
-		byName: make(map[string]*FlagSpec),
+		byName: make(map[string]FlagSpec),
 		args:   args,
 		res:    ParseResult{Values: make(map[string][]string), Recognized: true},
 	}
 	for _, f := range flags {
 		for _, n := range f.Names {
-			p.byName[n] = &f
+			p.byName[n] = f
 		}
 	}
 
@@ -89,7 +89,7 @@ func parseArgs(flags []FlagSpec, args []string) ParseResult {
 
 // mark records a flag's presence under its canonical key and appends any captured
 // values (none for a bare boolean or value-less optional flag).
-func (p *argParser) mark(f *FlagSpec, vals ...string) {
+func (p *argParser) mark(f FlagSpec, vals ...string) {
 	key := f.Names[0]
 	if _, ok := p.res.Values[key]; !ok {
 		p.res.Values[key] = []string{}
@@ -120,7 +120,7 @@ func (p *argParser) parseFlagToken(i int) (consumedNext, ok bool) {
 // markNamedFlag records an exactly-spelled flag and consumes its value per arity.
 // consumedNext is true when a required value was taken from args[i+1]; ok is false only
 // when a required value is missing.
-func (p *argParser) markNamedFlag(f *FlagSpec, i int, val string, hasEq bool) (consumedNext, ok bool) {
+func (p *argParser) markNamedFlag(f FlagSpec, i int, val string, hasEq bool) (consumedNext, ok bool) {
 	switch f.Arity {
 	case ArityRequired:
 		switch {

--- a/internal/runner/base/security/getopt.go
+++ b/internal/runner/base/security/getopt.go
@@ -2,12 +2,6 @@ package security
 
 import "strings"
 
-// clusterCharValueOffset is the index, within a short-flag token, of the first
-// character after the current cluster char: 1 for the leading dash plus 1 for the
-// char itself. For token a and cluster position k (index into a[1:]), the attached
-// value is a[clusterCharValueOffset+k:].
-const clusterCharValueOffset = 2
-
 // ParseResult is the output of the single getopt parser. Flag values are keyed by the
 // flag's canonical name (FlagSpec.Names[0]), so a spelling variant ("-t" vs
 // "--target-directory") yields the same key. A no-argument flag is recorded with an
@@ -135,7 +129,10 @@ func parseShortCluster(a string, args []string, i *int, byName map[string]*FlagS
 			mark(f)
 			continue
 		}
-		rest := a[clusterCharValueOffset+k:] // characters after c within this token
+		// c begins at byte 1+k within a (1 for the leading dash); the attached value is
+		// everything after c. Use len(string(c)) rather than a fixed offset so a
+		// multi-byte rune is not sliced in half.
+		rest := a[1+k+len(string(c)):]
 		switch {
 		case rest != "":
 			mark(f, rest)

--- a/internal/runner/base/security/getopt.go
+++ b/internal/runner/base/security/getopt.go
@@ -164,11 +164,14 @@ func (p *argParser) parseShortCluster(i int) (consumedNext, ok bool) {
 			continue
 		}
 		// c begins at byte 1+k within a (1 for the leading dash); the attached value is
-		// everything after c. utf8.RuneLen(c) is the allocation-free byte length of c, so
+		// everything after c. Re-decode at that position for c's true byte width:
+		// DecodeRuneInString reports width 1 for a malformed byte (whereas
+		// utf8.RuneLen(utf8.RuneError) over-reports 3), so the index stays in bounds and
 		// a multi-byte rune is never sliced in half. Note: for a short option the '=' is
 		// PART of the value (-C=v means -C with value "=v"), matching getopt and the
 		// legacy scanFlags; it must not be stripped here.
-		rest := a[1+k+utf8.RuneLen(c):]
+		_, cWidth := utf8.DecodeRuneInString(a[1+k:])
+		rest := a[1+k+cWidth:]
 		switch {
 		case rest != "":
 			p.mark(f, rest)

--- a/internal/runner/base/security/getopt.go
+++ b/internal/runner/base/security/getopt.go
@@ -1,6 +1,9 @@
 package security
 
-import "strings"
+import (
+	"strings"
+	"unicode/utf8"
+)
 
 // ParseResult is the output of the single getopt parser. Flag values are keyed by the
 // flag's canonical name (FlagSpec.Names[0]), so a spelling variant ("-t" vs
@@ -161,9 +164,11 @@ func (p *argParser) parseShortCluster(i int) (consumedNext, ok bool) {
 			continue
 		}
 		// c begins at byte 1+k within a (1 for the leading dash); the attached value is
-		// everything after c. Use len(string(c)) rather than a fixed offset so a
-		// multi-byte rune is not sliced in half.
-		rest := a[1+k+len(string(c)):]
+		// everything after c. utf8.RuneLen(c) is the allocation-free byte length of c, so
+		// a multi-byte rune is never sliced in half. Note: for a short option the '=' is
+		// PART of the value (-C=v means -C with value "=v"), matching getopt and the
+		// legacy scanFlags; it must not be stripped here.
+		rest := a[1+k+utf8.RuneLen(c):]
 		switch {
 		case rest != "":
 			p.mark(f, rest)

--- a/internal/runner/base/security/getopt.go
+++ b/internal/runner/base/security/getopt.go
@@ -4,19 +4,21 @@ import "strings"
 
 // ParseResult is the output of the single getopt parser. Flag values are keyed by the
 // flag's canonical name (FlagSpec.Names[0]), so a spelling variant ("-t" vs
-// "--target-directory") yields the same key. A no-argument flag is recorded with an
-// empty (non-nil) slice, so its presence is the existence of the key, not a non-empty
-// length: use HasFlag for presence.
+// "--target-directory") yields the same key. A flag that captured no value is recorded
+// with an empty (non-nil) slice -- this covers both a no-argument flag and an
+// optional-argument flag given without a value. Presence is therefore the existence of
+// the key, not a non-empty length: use HasFlag for presence, and never infer arity or
+// value-presence from len(values).
 type ParseResult struct {
-	Values      map[string][]string // canonical flag name -> captured values (empty slice for no-arg flags)
+	Values      map[string][]string // canonical flag name -> captured values (empty slice when the flag captured no value)
 	Recursive   bool                // a recursion flag appeared at least once
 	NonFlagArgs []string            // arguments that are neither a flag nor a flag's value
-	Recognized  bool                // every token was classified (false is fail-closed)
+	Recognized  bool                // false if any option-like token was unrecognized (fail-closed)
 }
 
 // HasFlag reports whether the flag with the given canonical key (FlagSpec.Names[0])
-// appeared. It must be used for presence checks: len(Values[k]) > 0 misdetects a
-// no-argument flag, which is stored as an empty slice.
+// appeared. It must be used for presence checks: len(Values[k]) > 0 misdetects a flag
+// that captured no value, which is stored as an empty slice.
 func (r ParseResult) HasFlag(canonicalKey string) bool {
 	_, ok := r.Values[canonicalKey]
 	return ok
@@ -35,16 +37,18 @@ type argParser struct {
 	res    ParseResult
 }
 
-// parseArgs is the single getopt parser shared by every command. It consumes a flag
-// set (only the flags; it never inspects Kind or ToExtraction) and classifies argv.
+// parseArgs is the single getopt parser shared by every command. It takes only the
+// flag specs -- not the command's Kind or ToExtraction, which the caller applies -- and
+// classifies argv.
 //
-// Contract: it never silently drops a token. Each argument becomes a recognized flag,
-// a captured flag value, or a NonFlagArg. An unknown flag or a missing required value
-// sets Recognized=false (fail-closed) rather than guessing. It handles --flag=value,
-// an attached short value (-C/usr), a short cluster (-rf), the -- option terminator,
-// optional arguments (attached form only), and spelling-alias normalization (values
-// recorded under the canonical name). It is pure: linear in total argv length, with
-// no filesystem, environment, or process-identity access.
+// Contract: it never silently misclassifies an option-like token as a positional. Each
+// argument becomes a recognized flag, a captured flag value, or a NonFlagArg; an
+// unknown flag or a flag missing its required value instead sets Recognized=false
+// (fail-closed) and is not added to NonFlagArgs. It handles --flag=value, an attached
+// short value (-C/usr), a short cluster (-rf), the -- option terminator, optional
+// arguments (attached form only), and spelling-alias normalization (values recorded
+// under the canonical name). It is pure: linear in total argv length, with no
+// filesystem, environment, or process-identity access.
 func parseArgs(flags []FlagSpec, args []string) ParseResult {
 	p := &argParser{
 		byName: make(map[string]*FlagSpec),

--- a/internal/runner/base/security/getopt.go
+++ b/internal/runner/base/security/getopt.go
@@ -1,0 +1,153 @@
+package security
+
+import "strings"
+
+// clusterCharValueOffset is the index, within a short-flag token, of the first
+// character after the current cluster char: 1 for the leading dash plus 1 for the
+// char itself. For token a and cluster position k (index into a[1:]), the attached
+// value is a[clusterCharValueOffset+k:].
+const clusterCharValueOffset = 2
+
+// ParseResult is the output of the single getopt parser. Flag values are keyed by the
+// flag's canonical name (FlagSpec.Names[0]), so a spelling variant ("-t" vs
+// "--target-directory") yields the same key. A no-argument flag is recorded with an
+// empty (non-nil) slice, so its presence is the existence of the key, not a non-empty
+// length: use HasFlag for presence.
+type ParseResult struct {
+	Values      map[string][]string // canonical flag name -> captured values (empty slice for no-arg flags)
+	Recursive   bool                // a recursion flag appeared at least once
+	NonFlagArgs []string            // arguments that are neither a flag nor a flag's value
+	Recognized  bool                // every token was classified (false is fail-closed)
+}
+
+// HasFlag reports whether the flag with the given canonical key (FlagSpec.Names[0])
+// appeared. It must be used for presence checks: len(Values[k]) > 0 misdetects a
+// no-argument flag, which is stored as an empty slice.
+func (r ParseResult) HasFlag(canonicalKey string) bool {
+	_, ok := r.Values[canonicalKey]
+	return ok
+}
+
+// parseArgs is the single getopt parser shared by every command. It consumes a flag
+// set (only the flags; it never inspects Kind or ToExtraction) and classifies argv.
+//
+// Contract: it never silently drops a token. Each argument becomes a recognized flag,
+// a captured flag value, or a NonFlagArg. An unknown flag or a missing required value
+// sets Recognized=false (fail-closed) rather than guessing. It handles --flag=value,
+// an attached short value (-C/usr), a short cluster (-rf), the -- option terminator,
+// optional arguments (attached form only), and spelling-alias normalization (values
+// recorded under the canonical name). It is pure: linear in total argv length, with
+// no filesystem, environment, or process-identity access.
+func parseArgs(flags []FlagSpec, args []string) ParseResult {
+	byName := make(map[string]*FlagSpec)
+	for i := range flags {
+		f := &flags[i]
+		for _, n := range f.Names {
+			byName[n] = f
+		}
+	}
+
+	res := ParseResult{Values: make(map[string][]string), Recognized: true}
+	// mark records a flag's presence under its canonical key and appends any captured
+	// values (none for a bare boolean or value-less optional flag).
+	mark := func(f *FlagSpec, vals ...string) {
+		key := f.Names[0]
+		if _, ok := res.Values[key]; !ok {
+			res.Values[key] = []string{}
+		}
+		res.Values[key] = append(res.Values[key], vals...)
+		if f.Recursive {
+			res.Recursive = true
+		}
+	}
+
+	endOpts := false
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		switch {
+		case !endOpts && a == "--":
+			endOpts = true
+		case endOpts || len(a) < 2 || a[0] != '-':
+			res.NonFlagArgs = append(res.NonFlagArgs, a)
+		default:
+			if !parseFlagToken(a, args, &i, byName, mark) {
+				res.Recognized = false
+			}
+		}
+	}
+	return res
+}
+
+// parseFlagToken classifies one option token (a, already known to start with '-' and
+// not be "--"). It advances i when a value flag consumes the next token, and returns
+// false when the token cannot be fully recognized (unknown flag or missing required
+// value), so the caller can set Recognized=false.
+func parseFlagToken(a string, args []string, i *int, byName map[string]*FlagSpec, mark func(*FlagSpec, ...string)) bool {
+	name, val, hasEq := strings.Cut(a, "=")
+	if f, ok := byName[name]; ok {
+		return markNamedFlag(f, val, hasEq, args, i, mark)
+	}
+	// An unknown long flag (--foo) may take a value, so fail closed.
+	if strings.HasPrefix(a, "--") {
+		return false
+	}
+	return parseShortCluster(a, args, i, byName, mark)
+}
+
+// markNamedFlag records an exactly-spelled flag and consumes its value per arity. It
+// returns false only when a required value is missing.
+func markNamedFlag(f *FlagSpec, val string, hasEq bool, args []string, i *int, mark func(*FlagSpec, ...string)) bool {
+	switch f.Arity {
+	case ArityRequired:
+		switch {
+		case hasEq:
+			mark(f, val)
+		case *i+1 < len(args):
+			mark(f, args[*i+1])
+			*i++
+		default:
+			return false // required value missing at end of argv
+		}
+	case ArityOptional:
+		if hasEq {
+			mark(f, val)
+		} else {
+			mark(f) // present without a value; never consume the next token
+		}
+	default: // ArityNone
+		mark(f) // boolean/recursion flag; any attached =value is ignored (legacy parity)
+	}
+	return true
+}
+
+// parseShortCluster parses a short-flag cluster (e.g. -rf, or a value flag with an
+// attached value like -C/usr). A value flag inside the cluster captures the rest of
+// the token as its value (or, when required and nothing is attached, the next token);
+// dropping that value would default a destination to the cwd (fail-open). It returns
+// false on an unknown cluster char or a required value with nothing to consume.
+func parseShortCluster(a string, args []string, i *int, byName map[string]*FlagSpec, mark func(*FlagSpec, ...string)) bool {
+	for k, c := range a[1:] {
+		f, ok := byName["-"+string(c)]
+		if !ok {
+			return false
+		}
+		if f.Arity == ArityNone {
+			mark(f)
+			continue
+		}
+		rest := a[clusterCharValueOffset+k:] // characters after c within this token
+		switch {
+		case rest != "":
+			mark(f, rest)
+		case f.Arity == ArityRequired && *i+1 < len(args):
+			mark(f, args[*i+1])
+			*i++
+		case f.Arity == ArityOptional:
+			mark(f) // optional, no attached value; do not consume the next token
+		default:
+			return false // required value flag with nothing to consume
+		}
+		return true // a value flag consumes the remainder of the cluster
+	}
+	return true
+}

--- a/internal/runner/base/security/getopt_test.go
+++ b/internal/runner/base/security/getopt_test.go
@@ -119,7 +119,7 @@ func TestParseArgs_FailClosed(t *testing.T) {
 }
 
 // TestParseArgs_AliasNormalization verifies spelling variants of one flag normalize
-// to the same canonical key (AC-05).
+// to the same canonical key.
 func TestParseArgs_AliasNormalization(t *testing.T) {
 	short := parseArgs(optFlags(), []string{"-t", "/dst"})
 	long := parseArgs(optFlags(), []string{"--target-directory", "/dst"})
@@ -136,7 +136,7 @@ func TestParseArgs_AliasNormalization(t *testing.T) {
 }
 
 // TestParseArgs_OptionalArg verifies optional-argument flags take a value only in the
-// attached form and never consume a separate following token (AC-06).
+// attached form and never consume a separate following token.
 func TestParseArgs_OptionalArg(t *testing.T) {
 	// Bare long optional flag: present, no value; the following token is a non-flag arg.
 	bare := parseArgs(optFlags(), []string{"--one-top-level", "a.tar"})

--- a/internal/runner/base/security/getopt_test.go
+++ b/internal/runner/base/security/getopt_test.go
@@ -200,6 +200,21 @@ func TestParseArgs_ShortClusterAttachedEquals(t *testing.T) {
 	assert.Equal(t, []string{"src"}, got.NonFlagArgs, "the next token must not be consumed")
 }
 
+// TestParseArgs_MalformedUTF8 pins that argv tokens containing invalid UTF-8 bytes
+// (possible on Unix) are handled without panicking. A standalone malformed byte is an
+// unknown short flag and fails closed; malformed bytes trailing a value flag are
+// captured as that flag's opaque value without a slice-bounds panic.
+func TestParseArgs_MalformedUTF8(t *testing.T) {
+	// A lone malformed byte is not a known flag -> fail closed, no panic.
+	bad := parseArgs(optFlags(), []string{string([]byte{'-', 0xff})})
+	assert.False(t, bad.Recognized, "a malformed-byte short flag must fail closed")
+
+	// Malformed bytes attached to a value flag are captured as the value, no panic.
+	val := parseArgs(optFlags(), []string{string([]byte{'-', 't', 0xff})})
+	assert.True(t, val.Recognized)
+	assert.Equal(t, []string{string([]byte{0xff})}, val.Values["-t"])
+}
+
 // TestParseArgs_HasFlag verifies presence detection for a no-argument flag, where the
 // value slice is empty (the len>0 trap).
 func TestParseArgs_HasFlag(t *testing.T) {

--- a/internal/runner/base/security/getopt_test.go
+++ b/internal/runner/base/security/getopt_test.go
@@ -79,6 +79,18 @@ func TestParseArgs_Forms(t *testing.T) {
 			wantNonFlag: nil,
 			wantRec:     true,
 		},
+		{
+			name:        "duplicate value flag accumulates values in order",
+			args:        []string{"-t", "/a", "-t", "/b"},
+			wantValues:  map[string][]string{"-t": {"/a", "/b"}},
+			wantNonFlag: nil,
+		},
+		{
+			name:        "empty token is a non-flag argument",
+			args:        []string{"", "x"},
+			wantValues:  map[string][]string{},
+			wantNonFlag: []string{"", "x"},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -160,6 +172,18 @@ func TestParseArgs_OptionalArg(t *testing.T) {
 	assert.True(t, bareShort.HasFlag("-i"))
 	assert.Empty(t, bareShort.Values["-i"])
 	assert.Equal(t, []string{"x"}, bareShort.NonFlagArgs)
+}
+
+// TestParseArgs_NoArgFlagIgnoresAttachedValue pins that a no-argument flag given an
+// attached =value (e.g. --force=x) stays recognized and present but carries no value;
+// the attached value is dropped. This matches legacy scanFlags: tightening it to
+// fail-closed would break behavioral parity.
+func TestParseArgs_NoArgFlagIgnoresAttachedValue(t *testing.T) {
+	got := parseArgs(optFlags(), []string{"--force=x", "a"})
+	assert.True(t, got.Recognized)
+	assert.True(t, got.HasFlag("-f"))
+	assert.Empty(t, got.Values["-f"], "attached value on a no-arg flag is dropped")
+	assert.Equal(t, []string{"a"}, got.NonFlagArgs)
 }
 
 // TestParseArgs_HasFlag verifies presence detection for a no-argument flag, where the

--- a/internal/runner/base/security/getopt_test.go
+++ b/internal/runner/base/security/getopt_test.go
@@ -1,0 +1,189 @@
+package security
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// optFlags is a representative flag set exercising each arity, recursion, and
+// spelling aliases, used by the parser tests below.
+func optFlags() []FlagSpec {
+	return []FlagSpec{
+		{Names: []string{"-t", "--target-directory"}, Arity: ArityRequired, Value: ValueWrite},
+		{Names: []string{"-C", "--directory"}, Arity: ArityRequired, Value: ValueNonPath},
+		{Names: []string{"-r", "-R", "--recursive"}, Arity: ArityNone, Recursive: true},
+		{Names: []string{"-f", "--force"}, Arity: ArityNone},
+		{Names: []string{"--one-top-level"}, Arity: ArityOptional, Value: ValueWrite},
+		{Names: []string{"-i", "--in-place"}, Arity: ArityOptional, Value: ValueNonPath},
+	}
+}
+
+// TestParseArgs_Forms covers the flag forms the single parser unifies.
+func TestParseArgs_Forms(t *testing.T) {
+	cases := []struct {
+		name        string
+		args        []string
+		wantValues  map[string][]string
+		wantNonFlag []string
+		wantRec     bool
+	}{
+		{
+			name:        "long flag with attached value",
+			args:        []string{"--target-directory=/dst", "a", "b"},
+			wantValues:  map[string][]string{"-t": {"/dst"}},
+			wantNonFlag: []string{"a", "b"},
+		},
+		{
+			name:        "long flag with separate value",
+			args:        []string{"--target-directory", "/dst", "a"},
+			wantValues:  map[string][]string{"-t": {"/dst"}},
+			wantNonFlag: []string{"a"},
+		},
+		{
+			name:        "short flag with attached value",
+			args:        []string{"-C/usr", "x"},
+			wantValues:  map[string][]string{"-C": {"/usr"}},
+			wantNonFlag: []string{"x"},
+		},
+		{
+			name:        "short flag with separate value",
+			args:        []string{"-t", "/dst"},
+			wantValues:  map[string][]string{"-t": {"/dst"}},
+			wantNonFlag: nil,
+		},
+		{
+			name:        "short cluster of boolean and recursion flags",
+			args:        []string{"-rf", "x"},
+			wantValues:  map[string][]string{"-r": {}, "-f": {}},
+			wantNonFlag: []string{"x"},
+			wantRec:     true,
+		},
+		{
+			name:        "double dash terminates option parsing",
+			args:        []string{"--", "-t", "x"},
+			wantValues:  map[string][]string{},
+			wantNonFlag: []string{"-t", "x"},
+		},
+		{
+			name:        "single dash is a non-flag argument",
+			args:        []string{"-", "x"},
+			wantValues:  map[string][]string{},
+			wantNonFlag: []string{"-", "x"},
+		},
+		{
+			name:        "value flag at cluster tail captures next token",
+			args:        []string{"-rt", "/dst"},
+			wantValues:  map[string][]string{"-r": {}, "-t": {"/dst"}},
+			wantNonFlag: nil,
+			wantRec:     true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseArgs(optFlags(), tc.args)
+			assert.True(t, got.Recognized, "valid input must be recognized")
+			assert.Equal(t, tc.wantRec, got.Recursive)
+			assert.Equal(t, tc.wantNonFlag, got.NonFlagArgs)
+			assert.Equal(t, tc.wantValues, got.Values)
+		})
+	}
+}
+
+// TestParseArgs_FailClosed verifies that no token is silently dropped: an unknown
+// flag or a missing required value sets Recognized=false.
+func TestParseArgs_FailClosed(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"unknown long flag", []string{"--unknown", "x"}},
+		{"unknown long flag with value form", []string{"--unknown=v", "x"}},
+		{"required value missing at end", []string{"-t"}},
+		{"required long value missing at end", []string{"--target-directory"}},
+		{"unknown short flag", []string{"-z"}},
+		{"unknown char in cluster", []string{"-rz"}},
+		{"required value flag at cluster tail with nothing to consume", []string{"-rt"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseArgs(optFlags(), tc.args)
+			assert.False(t, got.Recognized, "%v must fail closed", tc.args)
+		})
+	}
+
+	// A fully-known input is recognized (happy path).
+	ok := parseArgs(optFlags(), []string{"-rf", "-t", "/dst", "src"})
+	assert.True(t, ok.Recognized)
+}
+
+// TestParseArgs_AliasNormalization verifies spelling variants of one flag normalize
+// to the same canonical key (AC-05).
+func TestParseArgs_AliasNormalization(t *testing.T) {
+	short := parseArgs(optFlags(), []string{"-t", "/dst"})
+	long := parseArgs(optFlags(), []string{"--target-directory", "/dst"})
+	assert.Equal(t, short.Values, long.Values, "spelling variants must produce the same Values")
+	assert.Equal(t, []string{"/dst"}, short.Values["-t"])
+
+	// A recursion alias normalizes to the canonical recursion key and sets Recursive.
+	rLong := parseArgs(optFlags(), []string{"--recursive"})
+	rShort := parseArgs(optFlags(), []string{"-R"})
+	assert.True(t, rLong.Recursive)
+	assert.True(t, rShort.Recursive)
+	assert.True(t, rLong.HasFlag("-r"))
+	assert.True(t, rShort.HasFlag("-r"))
+}
+
+// TestParseArgs_OptionalArg verifies optional-argument flags take a value only in the
+// attached form and never consume a separate following token (AC-06).
+func TestParseArgs_OptionalArg(t *testing.T) {
+	// Bare long optional flag: present, no value; the following token is a non-flag arg.
+	bare := parseArgs(optFlags(), []string{"--one-top-level", "a.tar"})
+	assert.True(t, bare.Recognized)
+	assert.True(t, bare.HasFlag("--one-top-level"))
+	assert.Empty(t, bare.Values["--one-top-level"], "bare optional flag has no value")
+	assert.Equal(t, []string{"a.tar"}, bare.NonFlagArgs, "the next token must not be consumed")
+
+	// Attached long form captures the value.
+	attached := parseArgs(optFlags(), []string{"--one-top-level=/top", "a.tar"})
+	assert.Equal(t, []string{"/top"}, attached.Values["--one-top-level"])
+	assert.Equal(t, []string{"a.tar"}, attached.NonFlagArgs)
+
+	// Optional short flag inside a cluster takes the remainder as its value (sed -ir).
+	cluster := parseArgs(optFlags(), []string{"-ir"})
+	assert.True(t, cluster.Recognized)
+	assert.Equal(t, []string{"r"}, cluster.Values["-i"], "-ir means -i with attached value r, not -i -r")
+
+	// Bare optional short flag: present, no value; the next token is not consumed.
+	bareShort := parseArgs(optFlags(), []string{"-i", "x"})
+	assert.True(t, bareShort.HasFlag("-i"))
+	assert.Empty(t, bareShort.Values["-i"])
+	assert.Equal(t, []string{"x"}, bareShort.NonFlagArgs)
+}
+
+// TestParseArgs_HasFlag verifies presence detection for a no-argument flag, where the
+// value slice is empty (the len>0 trap).
+func TestParseArgs_HasFlag(t *testing.T) {
+	got := parseArgs(optFlags(), []string{"-f"})
+	assert.True(t, got.HasFlag("-f"), "a no-arg flag that appeared is present")
+	assert.Empty(t, got.Values["-f"], "a no-arg flag is stored as an empty slice")
+	assert.False(t, got.HasFlag("-t"), "a flag that did not appear is absent")
+}
+
+// TestParseArgs_Pathological confirms large and deeply clustered inputs are handled
+// linearly without panicking.
+func TestParseArgs_Pathological(t *testing.T) {
+	many := make([]string, 10000)
+	for i := range many {
+		many[i] = "p"
+	}
+	got := parseArgs(optFlags(), many)
+	assert.True(t, got.Recognized)
+	assert.Len(t, got.NonFlagArgs, 10000)
+
+	longCluster := "-" + strings.Repeat("rf", 5000) // all known boolean/recursion chars
+	gotCluster := parseArgs(optFlags(), []string{longCluster})
+	assert.True(t, gotCluster.Recognized)
+	assert.True(t, gotCluster.Recursive)
+}

--- a/internal/runner/base/security/getopt_test.go
+++ b/internal/runner/base/security/getopt_test.go
@@ -186,6 +186,20 @@ func TestParseArgs_NoArgFlagIgnoresAttachedValue(t *testing.T) {
 	assert.Equal(t, []string{"a"}, got.NonFlagArgs)
 }
 
+// TestParseArgs_ShortClusterAttachedEquals locks getopt short-option semantics: inside
+// a short cluster the '=' is part of the attached value (-rt=/dst means -t with value
+// "=/dst"), not a key/value separator. This matches GNU getopt for short options and
+// the legacy scanFlags behavior, so it must not be "fixed" by stripping the '=': doing
+// so would break behavioral parity and could turn a captured value into an empty one
+// that falls through to consume the next token.
+func TestParseArgs_ShortClusterAttachedEquals(t *testing.T) {
+	got := parseArgs(optFlags(), []string{"-rt=/dst", "src"})
+	assert.True(t, got.Recognized)
+	assert.True(t, got.Recursive)
+	assert.Equal(t, []string{"=/dst"}, got.Values["-t"], "short-option '=' is part of the value, not a separator")
+	assert.Equal(t, []string{"src"}, got.NonFlagArgs, "the next token must not be consumed")
+}
+
 // TestParseArgs_HasFlag verifies presence detection for a no-argument flag, where the
 // value slice is empty (the len>0 trap).
 func TestParseArgs_HasFlag(t *testing.T) {


### PR DESCRIPTION
## 概要

タスク 0144「オペランド抽出の宣言的フラグ仕様化（単一 getopt パーサ）」の Phase 1（PR-1）。
コマンドごとの個別抽出処理を後続フェーズで置き換えるための土台として、単一 getopt パーサと宣言的フラグ仕様の型を追加する。本 PR ではパーサ・型・単体テストのみを追加し、production への結線（既存 `scanFlags`/`extractXxx` の置換）は Phase 3 で行う。

## 変更内容

- `flag_spec.go`: `FlagArity`（None/Required/Optional）、`ValueRole`（Unset 番兵/NonPath/Write/Read）、`FlagSpec`、`CommandFlagSpec` の型定義（仕様表は Phase 2）。
- `getopt.go`: `parseArgs([]FlagSpec, args) -> ParseResult` と `HasFlag`。`--flag=value`・付随短縮値・短縮連結・`--`・引数省略可（付随形のみ）・別名正規化（値は正規キーに集約）を一元処理する。トークンを黙って捨てない（未知フラグ・引数欠落で `Recognized=false`）。純粋・線形。
- `getopt_test.go`: 形式網羅・fail-closed・別名正規化・引数省略可・境界（重複フラグ/空語/引数なしフラグへの付随値ドロップ）・病的入力の表駆動テスト。

## レビュー観点

- `parseArgs` の形式網羅と fail-closed（未知/欠落で `Recognized=false`）
- 短縮連結中の引数付きフラグ規則・引数省略可の付随形限定
- `FlagArity`・`ValueRole`・`FlagSpec`/`CommandFlagSpec` の型設計（正規キー単一源・決定性制約）

## 既知の引き継ぎ事項

現行 `scanFlags` は `--recursive`/`--archive` を `recursiveFlags` のみに登録するため、長形は fail-closed（`recognized=false`）だが短形は認識される。新仕様は両形を認識するため、Phase 2 の差分テストが `recognized` 不一致を検出する。これは意図的な判断で解消する旨を実装計画 Phase 2 に記録済み（凍結スナップショットの書き換えは禁止）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)