### PR TITLE
docs(0143): reflect 0141/0142/0144/0145 completion in requirements

### DIFF
--- a/docs/tasks/0143_risk_audit_and_docs/01_requirements.md
+++ b/docs/tasks/0143_risk_audit_and_docs/01_requirements.md
@@ -204,7 +204,7 @@
   - **網羅の担保（B-3）**: 「`make test` が緑」だけでは、テストに載っていない sample config の追従漏れ（fail-silent）を
     検知できない。よって完了条件に**対象 config の網羅的な洗い出し**を含める: 引き上げ対象コマンド名（判断軸1 の
     High/Medium 化対象・判断軸2 の trust-critical 書込形）に加え、**0145 で過剰認識除去により fail-closed 化した
-    無効フラグ形**（`sponge -r`／`mkdir -a`／`unlink -r`／`mv -s` 等）を含む sample/test config を grep で列挙し、各々に
+    無効フラグ形**（`sponge -r`／`mkdir -a`／`touch -p`／`unlink -r`／`rmdir -r` 等）を含む sample/test config を grep で列挙し、各々に
     対し `risk_level` 付与済み、または新分類下で意図した結果（deny/allow）になることを確認する。
   - **検証**: 上記で列挙した config が `make test` 内でロード・評価でき、テスト用 config が新分類で**意図せず** deny
     されないこと（意図的に deny を検証する config はその旨を明示）。

--- a/docs/tasks/0143_risk_audit_and_docs/01_requirements.md
+++ b/docs/tasks/0143_risk_audit_and_docs/01_requirements.md
@@ -13,15 +13,20 @@
 > 本書は 0140 を 3 分割した第 3 タスク（横断成果物＝監査・文書）の要件である。分割方針・根本原因の訂正は
 > [0140/00_decomposition.md](../0140_risk_level_classification_review/00_decomposition.md)、原典の確定要件・根拠は
 > [0140/01_requirements.md](../0140_risk_level_classification_review/01_requirements.md)（superseded）を参照する。
-> コマンド名分類・ラッパ/特権（判断軸1）は 0141、宛先パス信頼区分（判断軸2）は 0142 が担当する。本書は両者が
-> 確定させた分類・データ構造を、監査ログ出力・理由コード・移行ノート・文書・sample config へ反映する最終タスクで
-> ある。**実装順序の最後**に位置し、0141・0142 の実装完了後に着手する（§3）。
+> 先行タスクの分担は次のとおり: コマンド名分類・ラッパ/特権（判断軸1）は 0141、宛先パス信頼区分（判断軸2）は
+> 0142。0142 のオペランド抽出層は、宣言的フラグ仕様＋単一 getopt パーサへの集中リファクタ（挙動保存）を 0144 が、
+> 各コマンドのフラグ集合の実 CLI 整合（安全側の挙動変更）を 0145 が担う。本書はこれら先行タスクが確定させた分類・
+> データ構造を、監査ログ出力・理由コード・移行ノート・文書・sample config へ反映する最終タスクであり、**実装順序の
+> 最後**に位置する（0141・0142・0144・0145 の実装完了を前提とする。§3）。
 
 ## 1. 背景と目的
 
 0141（判断軸1）・0142（判断軸2）はリスクレベル分類のロジックとデータ構造（判断軸1 の名前集合・判断軸2 の
-`LocationResult`／オペランド毎の判定 DTO・新規 `ReasonCode`）を確定させる。本タスクはそれらを **運用者が観測・理解
-できる形** に仕上げる横断成果物を所有する。具体的には:
+`LocationResult`／オペランド毎の判定 DTO・新規 `ReasonCode`）を確定させた。続く 0144 はオペランド抽出層を宣言的
+フラグ仕様（`flag_spec.go` の `CommandFlagSpec` 群）＋単一 getopt パーサへ集約し（挙動保存）、0145 はその
+フラグ集合を実 CLI に整合させて過剰認識を除去した（安全側の挙動変更＝`recognized=true→false` の fail-closed 方向）。
+本タスクはこれら先行タスクが確定させた分類・データ構造を **運用者が観測・理解できる形** に仕上げる横断成果物を所有する。
+具体的には:
 
 - **監査**: 0142 が `RiskAssessment` へ格納したオペランド毎の判定 DTO を監査ログへ実際に出力し、引き上げ/変更された
   コマンドが deny されたとき対応する理由コードが記録されることを end-to-end で担保する（0142 は DTO の定義と格納まで、
@@ -31,7 +36,8 @@
 - **文書**: ユーザー/開発者文書・用語集・分類ガイドを実装の確定挙動に一致させ、破壊的変更（引き上げ・引き下げ
   双方）を移行ノートで周知し、sample/test config を新分類へ追従させる。
 
-本タスクは新しい分類ロジックを **追加しない**。0141・0142 の確定挙動を正とし、それを監査・文書へ忠実に射影する。
+本タスクは新しい分類ロジックを **追加しない**。0141・0142（分類）と 0144・0145（抽出層の構造・確定フラグ集合）の
+確定挙動を正とし、それを監査・文書へ忠実に射影する。
 後方互換不要のため段階ロールアウト/フラグは設けず、破壊的変更は移行ノートでの周知に留める
 （[00_decomposition.md](../0140_risk_level_classification_review/00_decomposition.md) §3.2）。
 
@@ -49,21 +55,31 @@
     特権、間接実行。本タスクはこれらの確定結果を文書へ反映するのみで、分類ロジックには触れない。
   - **0142 が担当する項目**: 宛先パス信頼区分の判定、オペランド抽出、`LocationResult`、オペランド毎判定 DTO の
     **定義と `RiskAssessment` への格納**（本タスクは格納済み DTO の logger 出力以降を担う）、max 合成。
+  - **0144／0145 が担当する項目**: オペランド抽出層の宣言的フラグ仕様化・単一 getopt パーサ（0144）と、フラグ集合の
+    実 CLI 整合・過剰認識除去（0145）。本タスクは抽出層の構造・フラグ知識には触れず、確定したフラグ集合・挙動変化を
+    文書（検出限界の最終整合＝AC-06）・移行ノート（0145 の安全側挙動変化＝AC-04）へ反映するのみ。
   - `RiskLevel` の段数/意味づけ変更（新レベル追加しない。0140 §6 を継承）。
   - 段階ロールアウト/フラグ/shadow（後方互換不要。新分類は 0141・0142 で直接適用済み。0140/00 §3.2）。
   - 0139 のドキュメント本体（0139 AC-06 の乖離訂正は 0141 が行い、その文書反映のみ本タスク。0139 文書は触らない）。
 
 ## 3. 横断制約（0140/00_decomposition.md §3 を継承）
 
-- **実装順序の最後・0141/0142 の実装完了後に着手する**: 本タスクの成果物（監査出力・移行ノート・ガイド・sample
-  config）はいずれも 0141・0142 の **実装された確定挙動** を正とする。コードと文書の齟齬を防ぐため、0141・0142 が
-  マージされ `make test` が緑になった後に本タスクを実施する（[00_decomposition.md](../0140_risk_level_classification_review/00_decomposition.md)
+- **実装順序の最後・0141/0142/0144/0145 の実装完了を前提とする**: 本タスクの成果物（監査出力・移行ノート・ガイド・
+  sample config）はいずれも 0141・0142（分類ロジック・DTO）と 0144・0145（抽出層の構造・確定フラグ集合）の
+  **実装された確定挙動** を正とする。コードと文書の齟齬を防ぐため、これら 4 タスクがマージされ `make test` が緑に
+  なっていることを着手の前提とする（[00_decomposition.md](../0140_risk_level_classification_review/00_decomposition.md)
   §2 実装順序・§3.4 build/完了ゲート）。
-- **着手の前提ゲート（タスク間契約。B-1）**: 0143 着手時点で、(a) 0142 が `RiskAssessment` へオペランド毎判定 DTO の
-  carrier フィールド（仮称 `OperandZones`。確定名・型は 0142/02）を定義・格納済みであること、(b) その carrier が空
-  （判断軸2 非適用）と「適用したが解決不能」を区別可能であること（AC-01）、(c) 0142 が追加した判断軸2 由来の
-  `ReasonCode` 定数が確定済みであること（AC-02/AC-03）。これらが満たされない場合は 0142 へ差し戻す（0143 では
-  carrier・分類・コードを新設しない）。
+- **前提とする確定データ（タスク間契約。B-1）**: 本タスクは次を **読み取り専用** で参照し、carrier・分類・コードを
+  新設しない（新設すると分類結果が 2 箇所で定義され齟齬を生む）:
+  - **carrier**: オペランド毎判定 DTO は `RiskAssessment.OperandZones`（型 `[]risktypes.OperandZone`。
+    [types.go](../../../internal/runner/base/risktypes/types.go) / [operand_zone.go](../../../internal/runner/base/risktypes/operand_zone.go)）に格納される。サブフィールドは
+    Index/Raw/Resolved/Zone/Role/MatchedCritical/Trusted/UnresolvedErr。
+  - **空・nil の意味**: carrier が空（`len()==0`／nil）は判断軸2 非適用を表し、判断軸2 が適用されたが解決不能な
+    オペランドは `Zone==ZoneUnresolved` の要素として残る（両者は区別可能）。
+  - **判断軸2 由来の `ReasonCode`**: [reason_codes.go](../../../internal/runner/base/risktypes/reason_codes.go) の
+    "Destination-path trust-zoning codes (axis 2)" ブロック（`ReasonTrustBoundaryWrite`/`ReasonDestinationZone`/
+    `ReasonPermissionGrant`/`ReasonDeviceIO`/`ReasonRecursiveOutsideSafeZone`/`ReasonSensitiveSourceCopy`/
+    `ReasonUnresolvedDestination`）。
 - **新分類は直接適用済み（後方互換不要。フラグ/shadow なし）**: 破壊的変更（raise/lower）の周知は本タスクの移行
   ノートに委ね、実行時の運用ガード（`RolloutMode` 等）は設けない（§3.2）。
 - **バイリンガル文書の編集順序**: ユーザー/開発者文書・ガイドは **日本語版を先に編集・コミットし、英語版へは必ず
@@ -80,16 +96,15 @@
 ### F-001: 監査ログへのオペランド毎判定フィールドの出力
 
 - **AC-01**（オペランド毎判定 DTO の logger 出力）— 0140/00 §3.4・0142 AC-19 からの引き継ぎ:
-  - **参照入力（タスク間契約）**: 本 AC は 0142 が `RiskAssessment` へ追加する carrier フィールド（0142 AC-19 の
-    オペランド毎判定 DTO スライス `[]OperandZone`。フィールド名・型・サブフィールドは 0142/02 で確定する。本書では
-    仮称 `RiskAssessment.OperandZones` と呼ぶ）を**読み取り専用の入力**とする。本タスクは carrier を**新設しない**
-    （新設すると分類結果が 2 箇所で定義され齟齬を生む）。**空・nil の意味の契約**: carrier が空（`len()==0`／nil。
-    ＝判断軸2 非適用）であることと、判断軸2 が適用されたが全オペランドが解決不能であることは、0142 側の格納で
-    区別可能であること（前者は要素ゼロ、後者は `Zone==unresolved` の要素を持つ）。この区別が成立していることを
-    0143 着手の前提とする（§3 のゲート）。
-  - **規則**: 上記 DTO（サブフィールド: Index/Raw/Resolved/Zone/MatchedCritical/Trusted/UnresolvedErr）を、
-    `LogRiskProfile`（[audit/logger.go](../../../internal/runner/base/audit/logger.go)）が `command_risk_profile` 監査
-    エントリへ構造化フィールド（`operand_zones`、各要素は上記サブフィールドを持つ JSON オブジェクト）として出力する。
+  - **参照入力**: 本 AC は carrier フィールド `RiskAssessment.OperandZones`（型 `[]risktypes.OperandZone`。
+    [types.go](../../../internal/runner/base/risktypes/types.go) / [operand_zone.go](../../../internal/runner/base/risktypes/operand_zone.go)）を**読み取り専用の入力**とする（carrier・分類は
+    §3 のとおり新設しない）。carrier が空（`len()==0`／nil）は判断軸2 非適用、判断軸2 が適用されたが解決不能な
+    オペランドは `Zone==ZoneUnresolved` の要素として残る（両者は区別可能）。
+  - **規則**: 上記 DTO（サブフィールド: Index/Raw/Resolved/Zone/**Role**/MatchedCritical/Trusted/UnresolvedErr。
+    `Role` は write/read を区別し、`ZoneUnresolved` の非対称 fail-closed〔write=High／read=Medium〕の根拠となるため
+    監査出力に含める）を、`LogRiskProfile`（[audit/logger.go](../../../internal/runner/base/audit/logger.go)）が
+    `command_risk_profile` 監査エントリへ構造化フィールド（`operand_zones`、各要素は上記サブフィールドを持つ JSON
+    オブジェクト）として出力する。
   - **存在条件**: carrier が空（`len()==0`／nil）のコマンド（判断軸2 非適用）では `operand_zones` キーを**付けない**
     （既存の `reason_codes`/`risk_factors` が `len()>0` ガードで採る扱いを範例とする。`operand_zones: []`／`null` を
     書かない＝grep/相関を壊さない）。allow/deny いずれの経路でも出力される（`LogRiskProfile` は deny の
@@ -99,7 +114,8 @@
     ため operand DTO には自動適用されない。`Chain` の Path が未マスクである既存傾向と同根なので、明示配線が必要）。
   - **テスト**:
     - 代表コマンド（`cp evil /usr/bin/ls`・symlink 経由・複数オペランド）で `command_risk_profile` エントリを捕捉し、
-      `operand_zones` 配列の各要素の Index/Raw/Resolved/Zone/Trusted が 0142 が格納した値どおりに出力されることを表明。
+      `operand_zones` 配列の各要素の Index/Raw/Resolved/Zone/Role/Trusted が carrier に格納された値どおりに出力される
+      ことを表明。
     - carrier が空のコマンドでは `operand_zones` キーが**無い**こと、deny 経路でも出力されることを表明。
     - **漏えい否定テスト（S-1）**: Raw/Resolved/`UnresolvedErr` に秘匿パターン（資格情報を含むパス等）を持つオペランドを
       与え、出力で当該秘匿値が**マスクされている**ことを表明（存在テストでなく漏えいの否定）。
@@ -114,10 +130,12 @@
     `reason_codes`（および Critical/Blocking deny では `blocking_reason`）に、その deny を生んだ判定経路に対応する
     理由コードが記録される。
   - **テスト**: 代表ケースで deny エントリを捕捉し理由コードを表明する — 判断軸1 由来（例 `insmod`＝
-    `system_modification`）、判断軸2 由来（例 trust-critical 書込）、危険引数パターン由来（`dd if=`＝
-    `dangerous_arg_pattern`）。判断軸2 由来コードは、**0142 が確定させた定数名を正確に引く**（本タスクは実装順序の
-    最後で着手時点に 0142 のコードが確定済みのため、仮称でなく確定名で書く。0142 NF-001 が追加する「信頼境界書込・
-    権限付与・パス信頼区分由来」コードを参照。S-3）。理由コードは family が区別できる（AC-03 で機械的に担保）。
+    `system_modification`）、判断軸2 由来（例 trust-critical 書込＝`ReasonTrustBoundaryWrite`／`trust_boundary_write`）、
+    危険引数パターン由来（`dd if=`＝`dangerous_arg_pattern`）。判断軸2 由来コードは
+    [reason_codes.go](../../../internal/runner/base/risktypes/reason_codes.go) の "axis 2" ブロックの定数名
+    （`ReasonTrustBoundaryWrite`/`ReasonPermissionGrant`/`ReasonDeviceIO`/`ReasonRecursiveOutsideSafeZone`/
+    `ReasonSensitiveSourceCopy`/`ReasonUnresolvedDestination`/`ReasonDestinationZone`）を正確に引く（S-3）。理由コードは
+    family が区別できる（AC-03 で機械的に担保）。
 - **AC-03**（理由コード family 区別の最終化）— [00_decomposition.md](../0140_risk_level_classification_review/00_decomposition.md)
   §4 NF-001 の「監査ストリームの family 区別の最終化」:
   - **規則**: 0141・0142 が各々追加した `ReasonCode`（[reason_codes.go](../../../internal/runner/base/risktypes/reason_codes.go)）を
@@ -136,6 +154,12 @@
 - **AC-04**（移行周知・引き上げ）— 0140 AC-32: 本一連の変更で **Low/Medium → High** に引き上がるコマンド群
   （0141 F-001〜F-002、0142 の trust-critical ケース）により、従来許可していた config がブロックされ得ることを移行
   ノートとして文書化する。安全運用は allowlist + ハッシュ固定 + 明示的な `risk_level` 設定が前提であることを併記する。
+  - **0145 由来の fail-closed 化（過剰認識除去）の周知**: 0145 は実 CLI に存在しないフラグの受理（過剰認識）を除去し、
+    当該フラグを与えた入力を `recognized=true→false`（＝High fail-closed）へ倒した（例 `sponge -r`／`mkdir -a`／
+    `touch -p`／`unlink -r`／`rmdir -r`／`mv -s` 等。0145 §1.1・AC-02）。これは分類の raise ではなく精度是正だが、
+    従来これらの形を **recognized のまま** 通していた config は新たに High で deny され得る（fail-loud）。移行ノートに
+    「対象コマンド×無効フラグ形が fail-closed に変わる」旨を引き上げ側の周知として明記する（緩和方向ではないため
+    AC-05 の独立警告ブロックには含めない）。
 - **AC-05**（移行周知・引き下げ）— 0140 AC-33: 本一連の変更で **High → Medium/Low** に引き下がるコマンド
   （`rm`/`rmdir`/`shred`/`unlink`/`dd` の safe-zone/ordinary ケース＝0142 の D7 引き下げ）を **セキュリティ緩和方向の
   変更（security relaxation）** として移行ノートに明示する（baseline は直近リリースの挙動）。
@@ -157,7 +181,12 @@
   - 用語集: [docs/translation_glossary.md](../../../docs/translation_glossary.md) に本一連で用いた用語（パス信頼区分／
     trust-critical／safe-zone／オペランド毎判定 等）を追加し、訳語を統一する。**changelog の和語は「移行ノート」を
     canonical とし（0141/0142/0143 で統一済み。N-4）、用語集に登録する**。
-  - 0141 が開発者文書へ暫定追記した検出限界（0141 AC-20）の最終整合・日英反映を本タスクが所有する。
+  - 0141 が開発者文書へ暫定追記した検出限界（0141 AC-20）の最終整合・日英反映を本タスクが所有する。**0144/0145 を
+    反映した記述更新**: 検出限界の記述は「コマンドごとに独自実装した引数パーサ」を前提としていたが、0144 が宣言的
+    フラグ仕様（`flag_spec.go`）＋単一 getopt パーサへ集約し、0145 がフラグ集合を実 CLI に整合させた。よって開発者文書の
+    フラグ解析・検出限界の節は、(i) 現行アーキテクチャ（宣言的仕様＋単一パーサ＋完全性メタテスト）を反映し、(ii) 0145 で
+    解消した過剰認識（実 CLI に無いフラグの受理）を旧制約として残さないよう更新する。fail-closed `Recognized` contract が
+    安全保証を担う点（0142 §3.2）は不変として明記する。
   - **完了条件（observable 化, B-3）**: レビュアの主観でなく、次のチェックリストの充足をもって完了とする
     （0140 で起きた「文書↔実装の乖離」の再生産を防ぐ）:
     - (a) **追加の網羅**: 実装で High/Medium/Low に確定した全コマンド分類が、各文書の分類表に漏れなく反映されている。
@@ -174,8 +203,9 @@
   付与されている）よう更新・検証する（0139 AC-14 と同型）。
   - **網羅の担保（B-3）**: 「`make test` が緑」だけでは、テストに載っていない sample config の追従漏れ（fail-silent）を
     検知できない。よって完了条件に**対象 config の網羅的な洗い出し**を含める: 引き上げ対象コマンド名（判断軸1 の
-    High/Medium 化対象・判断軸2 の trust-critical 書込形）を含む sample/test config を grep で列挙し、各々に対し
-    `risk_level` 付与済み、または新分類下で意図した結果（deny/allow）になることを確認する。
+    High/Medium 化対象・判断軸2 の trust-critical 書込形）に加え、**0145 で過剰認識除去により fail-closed 化した
+    無効フラグ形**（`sponge -r`／`mkdir -a`／`unlink -r`／`mv -s` 等）を含む sample/test config を grep で列挙し、各々に
+    対し `risk_level` 付与済み、または新分類下で意図した結果（deny/allow）になることを確認する。
   - **検証**: 上記で列挙した config が `make test` 内でロード・評価でき、テスト用 config が新分類で**意図せず** deny
     されないこと（意図的に deny を検証する config はその旨を明示）。
 
@@ -184,7 +214,7 @@
 - **AC-08**（分類ガイドの最終化）— 0140 AC-36: アーキテクト/SRE 向け概念ガイド
   [risk-level-classification-guide.ja.md](../../../docs/dev/architecture_design/risk-level-classification-guide.ja.md)
   を最終化する。**作業順序は厳守**する:
-  1. **0141・0142 のコード実装完了が先**（§3 の前提）。
+  1. **0141・0142・0144・0145 のコード実装完了が先**（§3 の前提）。
   2. 実装完了後、現在 draft の日本語版を実装の確定挙動（判断軸1/判断軸2・max 合成・Critical 限定・safe-zone の
      安全要件等）に合わせて改訂・確定する（実装と齟齬しないこと）。
   3. 日本語版の確定後に **最後に英語版 `risk-level-classification-guide.md` を `/mktrans` で作成** する（CLAUDE.md の


### PR DESCRIPTION
## 概要

タスク 0143（監査・文書整合）の要件定義書を、先行タスク **0141 / 0142 / 0144 / 0145 のマージ完了**に合わせて更新する。本書は当初 0141/0142 のみを前提に書かれ、オペランド carrier や axis-2 `ReasonCode` を「仮称・確定予定」として参照していた。実装が確定した現在の状態に合わせ、さらに後続 2 タスク（0144/0145）の影響を反映する。

## 変更内容

- **carrier の確定名化**: `RiskAssessment.OperandZones`（`[]risktypes.OperandZone`）として §3 ゲート・AC-01 から仮称表現を除去。
- **axis-2 ReasonCode の確定名**: AC-02・ゲートで `ReasonTrustBoundaryWrite` 等を [reason_codes.go](internal/runner/base/risktypes/reason_codes.go) の "axis 2" ブロックの定数名で参照。
- **0144 の `Role` サブフィールド**: `operand_zones` の監査出力仕様とテスト（AC-01）に追加。
- **AC-06**: 検出限界の開発者文書を、単一 getopt パーサ（0144）＋実 CLI 整合（0145）の現行アーキテクチャに合わせ、解消済みの「コマンドごとの独自パーサ」制約を残さないよう更新する旨を追記。
- **AC-04 / AC-07**: 0145 の過剰認識除去（`recognized=true→false`／fail-loud）を移行ノートの引き上げ側周知として明記し、fail-closed 化した無効フラグ形を sample/test config の grep 対象に追加。

## 補足

- 文書のみの変更（コード・テストへの影響なし）。
- レビュー指摘を受け、更新履歴・「マージ後に確定」等のメタ記述は除去し、**初読者が現在の状態をそのまま理解できる形**に再編集済み。
- 新規 `ReasonCode` は追加されないため NF-001・family 区別の節は不変。

🤖 Generated with [Claude Code](https://claude.com/claude-code)