### PR TITLE
feat(0143): follow sample and test config to the finalized risk classification

### DIFF
--- a/docs/tasks/0143_risk_audit_and_docs/03_implementation_plan.md
+++ b/docs/tasks/0143_risk_audit_and_docs/03_implementation_plan.md
@@ -236,7 +236,7 @@
 
 **対象**: [sample/](../../../sample/) 配下および全 testdata の `.toml`
 
-- [ ] 引き上げ・fail-closed 化対象コマンドを使う config を grep で網羅列挙する。対象コマンド名は次を含む（判断軸1 High/Medium
+- [x] 引き上げ・fail-closed 化対象コマンドを使う config を grep で網羅列挙する。対象コマンド名は次を含む（判断軸1 High/Medium
       化対象＝`ln`/`insmod`/`fdisk`/`mkfs`/`parted`/`fsck` 等、判断軸2 trust-critical 書込形＝`cp`/`mv`/`rsync`/`chmod`/`chown` 等、
       0145 で fail-closed 化した無効フラグ形＝`sponge`/`mkdir`/`touch`/`unlink`/`rmdir` 等）
       （[01_requirements.md](01_requirements.md) AC-07 の列挙に準拠）。
@@ -244,13 +244,13 @@
       `rg -n --glob '*.toml' -e 'cmd\s*=\s*"(/[^"]*/)?(rm|dd|shred|unlink|rmdir|mkdir|touch|mv|sponge|ln|fdisk|mkfs|insmod|parted|fsck|cp|rsync|chmod|chown)"' sample cmd internal`
       判断軸2 の `cp`/`mv`/`rsync`/`chmod`/`chown` は**宛先パス依存**で deny するため、名前ヒットしても宛先ゾーンに応じて
       意図結果を個別確認する（一律 deny にはならない）。
-- [ ] 列挙された各 config について、次のいずれかを満たすことを確認・対応する:
-  - [ ] 新分類で deny され得るものは適切な `risk_level` を付与する（例: 判断軸1 で High 化した名前を `cmd` に持つ config を新設・
+- [x] 列挙された各 config について、次のいずれかを満たすことを確認・対応する:
+  - [x] 新分類で deny され得るものは適切な `risk_level` を付与する（例: 判断軸1 で High 化した名前を `cmd` に持つ config を新設・
         変更する場合は `risk_level="high"` を付与）、または
-  - [ ] 新分類下でも意図した結果（allow/deny）になることを確認する。意図的に deny を検証する config はその旨をコメント等で明示する。
-  - [ ] 0145 の無効フラグ形（`sponge -r`/`mkdir -a`/`touch -p`/`unlink -r`/`rmdir -r`/`mv -s` 等）を使う config が**無い**こと、
+  - [x] 新分類下でも意図した結果（allow/deny）になることを確認する。意図的に deny を検証する config はその旨をコメント等で明示する。
+  - [x] 0145 の無効フラグ形（`sponge -r`/`mkdir -a`/`touch -p`/`unlink -r`/`rmdir -r`/`mv -s` 等）を使う config が**無い**こと、
         または存在する場合は fail-closed（High deny）が意図どおりであることを確認する。
-- [ ] 上記 config が `make test` 内でロード・評価でき、テスト用 config が新分類で**意図せず** deny されないことを確認する。
+- [x] 上記 config が `make test` 内でロード・評価でき、テスト用 config が新分類で**意図せず** deny されないことを確認する。
 
 **成功基準**: 列挙 grep の各ヒットに対応済み。`make test` 全件緑。
 
@@ -431,7 +431,7 @@ family テーブルを唯一の列挙源とした並行リスト廃止／AC-02 e
 - [x] Step 1.4: `operand_zones` 出力・漏えい否定テスト（logger_test.go）
 - [x] Step 1.5: deny 理由コード e2e テスト（新規 audit_reason_codes_test.go）
 - [x] Step 1.6: Phase 1 完了ゲート（fmt/test/lint）
-- [ ] Phase 2: sample/test config 追従と検証
+- [x] Phase 2: sample/test config 追従と検証
 - [ ] Step 3.1: 移行ノート（引き上げ・引き下げ独立ブロック・NF-004・0139 上書き）
 - [ ] Step 3.2: ユーザー/開発者文書の整合（除去確認・0144/0145 反映・operand_zones 追記）
 - [ ] Step 3.3: 用語集（移行ノート canonical 追加）

--- a/sample/comprehensive.toml
+++ b/sample/comprehensive.toml
@@ -87,6 +87,9 @@ name = "create_temp_file"
 description = "Create temporary file in temp directory"
 cmd = "touch"
 args = ["test_temp_file.txt"]
+# A write whose destination is not a trusted safe-zone is classified Medium by the
+# destination trust zone, so the command must allow at least Medium to run.
+risk_level = "medium"
 
 [[groups.commands]]
 name = "list_temp_contents"
@@ -111,6 +114,9 @@ name = "create_file_with_workdir_path"
 description = "Create file with workdir path in filename"
 cmd = "touch"
 args = ["%{__runner_workdir}/workdir_reference.txt"]
+# A workdir write is Medium under the destination trust zone (the run-as identity
+# is not the safe-zone's trusted owner), so allow at least Medium.
+risk_level = "medium"
 
 # Group 4: Working directory tests
 [[groups]]
@@ -129,6 +135,9 @@ name = "create_workdir_file"
 description = "Create file in custom working directory"
 cmd = "touch"
 args = ["workdir_test_file.txt"]
+# A write into the custom working directory is Medium under the destination trust
+# zone, so allow at least Medium.
+risk_level = "medium"
 
 # Group 5: Environment variable and internal variable tests
 [[groups]]

--- a/sample/variable_expansion_advanced.toml
+++ b/sample/variable_expansion_advanced.toml
@@ -70,6 +70,9 @@ name = "backup_with_timestamp"
 description = "Create backup path with date and user"
 cmd = "/bin/mkdir"
 args = ["-p", "%{backup_root}/%{date}/%{user}/data"]
+# Writing under the trust-critical /var tree is classified High by the destination
+# trust zone, so the command must allow High to run.
+risk_level = "high"
 [groups.commands.vars]
 backup_root = "/var/backups"
 date = "2025-10-01"

--- a/sample/variable_expansion_basic.toml
+++ b/sample/variable_expansion_basic.toml
@@ -33,6 +33,9 @@ name = "copy_file"
 description = "Copy file using variables in args"
 cmd = "/bin/cp"
 args = ["%{home}/source.txt", "%{backup_dir}/backup.txt"]
+# A copy into an ordinary destination (/opt/backups) is classified Medium by the
+# destination trust zone, so the command must allow at least Medium to run.
+risk_level = "medium"
 env_import = ["home=HOME"]
 [groups.commands.vars]
 backup_dir = "/opt/backups"


### PR DESCRIPTION
## 概要 (Phase 2 of task 0143 — AC-07)

判断軸1（名前分類）・判断軸2（宛先パス信頼区分）の確定分類により**分類が引き上がったコマンド**を使う既存 config を網羅列挙し、新分類下でも runnable であるよう必要な `risk_level` を付与した。`risk_level` はコマンドの**最大許容リスク**（未設定時は既定 `low`）であり、新分類で Medium/High になるコマンドは明示が無いと実行時に deny される。

### 列挙と対応（全件）

全 `.toml`（36 件）を sweep し、引き上げ対象コマンドを `cmd` に持つヒットは全て sample/ 内のファイル操作のみ。各コマンドを実 zoning 評価器で実測し、分類どおりの `risk_level` を付与:

| config | コマンド | 実測分類 | 対応 |
|---|---|---|---|
| variable_expansion_basic.toml | `cp` → /opt/backups | Medium (`destination_zone`) | `risk_level="medium"` 付与 |
| variable_expansion_advanced.toml | `mkdir -p` → /var/backups | **High** (`trust_boundary_write`、/var は trust-critical) | `risk_level="high"` 付与 |
| comprehensive.toml | `touch` ×3（workdir 書込） | Medium | `risk_level="medium"` 付与 |
| risk-based-control.toml | `rm -rf /tmp/...` | Medium | 既存 `risk_level="high"` のまま（意図どおり、変更なし） |

### レビュー観点

- **grep 網羅性**: 判断軸1 High 名（`ln`/`insmod`/`fdisk`/`mkfs`/`parted`/`fsck`）・判断軸2 書込形（`cp`/`mv`/`rsync`/`chmod`/`chown`/`touch`/`mkdir`）・0145 無効フラグ形（`sponge -r`/`mkdir -a`/`touch -p`/`unlink -r`/`rmdir -r`/`mv -s`）を全 toml に対して確認。該当ヒットは上表が全件で、無効フラグ形・他の axis-1 High 名を `cmd` に持つ config は**存在しない**。
- **意図せぬ deny が無いこと**: 付与した各 `risk_level` は実測分類**以上**（cp=medium、mkdir=high、touch=medium）。各 config は config backward-compat テストでロード・検証され、`make test` 緑。

### 検証

- 各コマンドの分類は実 `newConfigEvaluator(security.DefaultConfig())` で実測（throwaway probe で確認・削除済み）。
- `make test` / `make lint` 緑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)