### PR TITLE
github: Added workflow for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ jobs:
   build:
     name: Build (${{ matrix.goos }}/${{ matrix.goarch }})
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         include:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Extract release notes from CHANGELOG.md
         id: changelog
         run: |
-          # Extract the section for this version (between ## [v...] and the next ## [)
+          # Extract the section for this version (between ## [1.0.0] and the next ## [)
           version="${{ github.ref_name }}"
           # Strip leading 'v' to match CHANGELOG headings like ## [1.0.0]
           version_bare="${version#v}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,6 @@ on:
     tags:
       - 'v*'
 
-permissions:
-  contents: write
-
 jobs:
   build:
     name: Build (${{ matrix.goos }}/${{ matrix.goarch }})
@@ -57,6 +54,8 @@ jobs:
     name: Create GitHub Release
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -76,10 +75,10 @@ jobs:
           version_bare="${version#v}"
           notes_file="$(mktemp)"
           awk -v ver="${version_bare}" \
-            '$0 ~ "^## \\[" ver "\\]" { found=1; next } found && /^## \[/ { exit } found { print }' \
+            'substr($0, 1, length("## [" ver "]")) == "## [" ver "]" { found=1; next } found && /^## \[/ { exit } found { print }' \
             CHANGELOG.md > "${notes_file}"
           if [ ! -s "${notes_file}" ]; then
-            echo "See [CHANGELOG.md](CHANGELOG.md) for details." > "${notes_file}"
+            echo "See [CHANGELOG.md](https://github.com/${{ github.repository }}/blob/${version}/CHANGELOG.md) for details." > "${notes_file}"
           fi
           echo "notes_file=${notes_file}" >> "$GITHUB_OUTPUT"
 
@@ -87,7 +86,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create ${{ github.ref_name }} \
+          gh release create "${{ github.ref_name }}" \
             --title "${{ github.ref_name }}" \
-            --notes-file ${{ steps.changelog.outputs.notes_file }} \
+            --notes-file "${{ steps.changelog.outputs.notes_file }}" \
             artifacts/*.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           mkdir -p dist
           for binary in record verify runner; do
-            go build -o dist/${binary} ./cmd/${binary}/main.go
+            go build -o dist/${binary} ./cmd/${binary}/
           done
 
       - name: Create archive
@@ -74,15 +74,14 @@ jobs:
           version="${{ github.ref_name }}"
           # Strip leading 'v' to match CHANGELOG headings like ## [1.0.0]
           version_bare="${version#v}"
-          notes=$(awk "/^## \[${version_bare}\]/{found=1; next} found && /^## \[/{exit} found{print}" CHANGELOG.md)
-          if [ -z "$notes" ]; then
-            notes="See [CHANGELOG.md](CHANGELOG.md) for details."
+          notes_file="$(mktemp)"
+          awk -v ver="${version_bare}" \
+            '$0 ~ "^## \\[" ver "\\]" { found=1; next } found && /^## \[/ { exit } found { print }' \
+            CHANGELOG.md > "${notes_file}"
+          if [ ! -s "${notes_file}" ]; then
+            echo "See [CHANGELOG.md](CHANGELOG.md) for details." > "${notes_file}"
           fi
-          {
-            echo "notes<<EOF"
-            echo "$notes"
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
+          echo "notes_file=${notes_file}" >> "$GITHUB_OUTPUT"
 
       - name: Create release
         env:
@@ -90,5 +89,5 @@ jobs:
         run: |
           gh release create ${{ github.ref_name }} \
             --title "${{ github.ref_name }}" \
-            --notes "${{ steps.changelog.outputs.notes }}" \
+            --notes-file ${{ steps.changelog.outputs.notes_file }} \
             artifacts/*.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,94 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build (${{ matrix.goos }}/${{ matrix.goarch }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+          - goos: linux
+            goarch: arm64
+          - goos: darwin
+            goarch: arm64
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build binaries
+        env:
+          CGO_ENABLED: 0
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+        run: |
+          mkdir -p dist
+          for binary in record verify runner; do
+            go build -o dist/${binary} ./cmd/${binary}/main.go
+          done
+
+      - name: Create archive
+        run: |
+          cd dist
+          tar czf ../go-safe-cmd-runner-${{ github.ref_name }}-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz record verify runner
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: go-safe-cmd-runner-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: go-safe-cmd-runner-${{ github.ref_name }}-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz
+
+  release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Extract release notes from CHANGELOG.md
+        id: changelog
+        run: |
+          # Extract the section for this version (between ## [v...] and the next ## [)
+          version="${{ github.ref_name }}"
+          # Strip leading 'v' to match CHANGELOG headings like ## [1.0.0]
+          version_bare="${version#v}"
+          notes=$(awk "/^## \[${version_bare}\]/{found=1; next} found && /^## \[/{exit} found{print}" CHANGELOG.md)
+          if [ -z "$notes" ]; then
+            notes="See [CHANGELOG.md](CHANGELOG.md) for details."
+          fi
+          {
+            echo "notes<<EOF"
+            echo "$notes"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create ${{ github.ref_name }} \
+            --title "${{ github.ref_name }}" \
+            --notes "${{ steps.changelog.outputs.notes }}" \
+            artifacts/*.tar.gz


### PR DESCRIPTION
when adding a tag like v1.0.0, Github workflow automatically generates releases for linux/amd64, linux/arm64 and darwin/arm64 platforms.