### PR TITLE
feat(mkplan2): label PR boundaries with an implementation model tier

### DIFF
--- a/.claude/commands/_context.md
+++ b/.claude/commands/_context.md
@@ -49,8 +49,9 @@ what changes under which condition:
 PR boundary markers embedded in the implementation plan use these labels:
 
 - Section heading: `### PR-N 作成ポイント: <scope label in English>`
-- Fields: `**対象ステップ**`, `**推奨タイトル**`, `**レビュー観点**`
+- Fields: `**対象ステップ**`, `**推奨タイトル**`, `**レビュー観点**`, `**実装モデル要件**`, `**判定理由**`
 - Conventional commit scope format: `feat(<task-id>): <concise English title>`
+- Implementation model tiers (`**実装モデル要件**` values): `frontier-required`, `frontier-recommended`, `standard` — assigned by `mkplan2.md` (step 4, "Model requirement"), read by `runplan.md` when choosing the implementing model
 
 ---
 

--- a/.claude/commands/mkplan2.md
+++ b/.claude/commands/mkplan2.md
@@ -29,6 +29,12 @@ Work in the following order.
    - **Risk isolation**: Place high-risk or complex steps (e.g. recovery flows, concurrency) in their own PRs so they can be reviewed in detail without unrelated noise.
    - **Internal-before-cmd**: Changes to `internal/` packages should land before the `cmd/` layer that depends on them.
    - **Small over large**: Prefer more, smaller PRs over fewer large ones; 3–6 PRs is a reasonable target for a medium-sized feature.
+   - **Model requirement**: Decide which capability tier the implementing model needs for each PR, so a frontier model is spent where it pays off and the rest is left to a cheaper model backed by the `weakreview` pass. Label each PR:
+     - `frontier-required` — the PR contains a step that requires an unprecedented design decision (e.g. a Phase 0-style PoC or feasibility probe), or a step matching `mkplan.md` step 8's panel-mode triggers (a heavy integration-test / CI / external-resource surface, or a security-gate / migration step such as a staged rollout or simultaneous behavior raises and lowers).
+     - `frontier-recommended` — the PR contains a step whose approach is not yet settled (the plan's `既存コード調査結果` section lists two or more competing implementation approaches for it), or a step matching two or more of `mkplan.md`'s Conditional checks.
+     - `standard` — everything else.
+
+     Derive these labels in the same analysis pass as **Risk isolation** — they read the same signals (step risk, complexity, external surface). Do not re-analyse the steps a second time for labelling.
 
    Decide whether any steps need to be reordered within their phase to align with the PR groupings. Only reorder steps when necessary — do not change step order unless it is required to make a PR group coherent.
 
@@ -48,6 +54,10 @@ Work in the following order.
 
    **レビュー観点**: <key1> / <key2> / <key3>
 
+   **実装モデル要件**: frontier-required | frontier-recommended | standard
+
+   **判定理由**: <one line>
+
    - [ ] グリーンゲート（`_context.md` の "Green gate" 参照）がパスしていることを確認した
    - [ ] PR を作成した
    - [ ] PR がマージされた
@@ -60,16 +70,18 @@ Work in the following order.
    - `**対象ステップ**` lists the step IDs covered by this PR, separated by ` / `.
    - `**推奨タイトル**` is a conventional commit title in English.
    - `**レビュー観点**` lists 2–4 key review points in Japanese.
+   - `**実装モデル要件**` is exactly one of `frontier-required`, `frontier-recommended`, or `standard`, chosen by applying the **Model requirement** principle in step 4 to the steps this PR covers. A PR takes the highest tier any of its steps requires.
+   - `**判定理由**` is a one-line Japanese justification naming the specific trigger that decided the tier (e.g. the step ID and its unprecedented design decision, the panel-mode trigger it matches, the competing approaches in `既存コード調査結果`, or the Conditional checks it matches). For `standard`, state that no trigger matched.
 
 7. Add or update a `### 3.2 PR 構成` subsection under §3 (or whichever section covers the implementation overview/test strategy) with a summary table:
 
    ```markdown
    ### 3.2 PR 構成
 
-   | PR | 対象ステップ | 主な変更内容 |
-   |---|---|---|
-   | PR-1 | 1-1 / 1-2 / 1-3 | … |
-   | PR-2 | 1-4 / 1-5 / 1-6 | … |
+   | PR | 対象ステップ | 主な変更内容 | 実装モデル要件 |
+   |---|---|---|---|
+   | PR-1 | 1-1 / 1-2 / 1-3 | … | frontier-required |
+   | PR-2 | 1-4 / 1-5 / 1-6 | … | standard |
    …
    ```
 
@@ -83,7 +95,7 @@ Work in the following order.
 
 9. Run the critical-review subagent procedure in `.claude/commands/_lib/review-subagent-pattern.md` with these inputs:
     - **ARTIFACT**: the PR boundary design.
-    - **PERSONA**: an experienced senior engineer and senior SRE. Direct it to surface PRs that are too large to review, PRs that cannot be built independently, missing risk isolation, and cross-references that were not updated after renumbering.
+    - **PERSONA**: an experienced senior engineer and senior SRE. Direct it to surface PRs that are too large to review, PRs that cannot be built independently, missing risk isolation, and cross-references that were not updated after renumbering. Also direct it to assess whether each PR's `実装モデル要件` label is justified by the steps that PR covers — both an over-labelled PR (frontier tier with no matching trigger) and an under-labelled one (a high-risk or unsettled step labelled `standard`).
     - **FILES**: the implementation plan document, the architecture document, and the requirements document (paths in `_context.md`), as resolved absolute-path strings.
     - **CRITERIA**: every item from the PR boundary review checklist below, copied verbatim.
 
@@ -95,6 +107,8 @@ Work in the following order.
 - [ ] No step that modifies an `internal/` interface lands in a later PR than the `cmd/` step that depends on it.
 - [ ] Each PR group can pass the green gate (defined in `_context.md`) on its own without stubs from future steps.
 - [ ] High-risk or complex steps (recovery, concurrency, state machines) are isolated in their own PR or placed last in a PR so they do not block review of simpler changes.
+- [ ] Every PR marker's `実装モデル要件` label is consistent with its risk-isolation status — a PR containing an isolated high-risk step is not labeled `standard`.
+- [ ] Every PR marker has a `判定理由` line that names the specific trigger behind its `実装モデル要件` label (or states that none matched, for `standard`).
 - [ ] The `**対象ステップ**` field in each PR marker lists exactly the steps in that group and no others.
 - [ ] The `### 3.2 PR 構成` table is present and consistent with the PR marker sections.
 - [ ] §6 checklist entries reference PRs (not phases) and are consistent with the PR markers.

--- a/.claude/commands/mkplan2.md
+++ b/.claude/commands/mkplan2.md
@@ -31,7 +31,7 @@ Work in the following order.
    - **Small over large**: Prefer more, smaller PRs over fewer large ones; 3–6 PRs is a reasonable target for a medium-sized feature.
    - **Model requirement**: Decide which capability tier the implementing model needs for each PR, so a frontier model is spent where it pays off and the rest is left to a cheaper model backed by the `weakreview` pass. Label each PR:
      - `frontier-required` — the PR contains a step that requires an unprecedented design decision (e.g. a Phase 0-style PoC or feasibility probe), or a step matching `mkplan.md` step 8's panel-mode triggers (a heavy integration-test / CI / external-resource surface, or a security-gate / migration step such as a staged rollout or simultaneous behavior raises and lowers).
-     - `frontier-recommended` — the PR contains a step whose approach is not yet settled (the plan's `既存コード調査結果` section lists two or more competing implementation approaches for it), or a step matching two or more of `mkplan.md`'s Conditional checks.
+     - `frontier-recommended` — the PR contains a step whose approach is not yet settled (the plan's `既存コード調査結果` section lists two or more competing implementation approaches for it), a step matching two or more of `mkplan.md`'s Conditional checks, or an isolated high-risk/complex step (e.g. recovery flows, concurrency, state machines).
      - `standard` — everything else.
 
      Derive these labels in the same analysis pass as **Risk isolation** — they read the same signals (step risk, complexity, external surface). Do not re-analyse the steps a second time for labelling.

--- a/.claude/commands/mkplan2.md
+++ b/.claude/commands/mkplan2.md
@@ -29,7 +29,7 @@ Work in the following order.
    - **Risk isolation**: Place high-risk or complex steps (e.g. recovery flows, concurrency) in their own PRs so they can be reviewed in detail without unrelated noise.
    - **Internal-before-cmd**: Changes to `internal/` packages should land before the `cmd/` layer that depends on them.
    - **Small over large**: Prefer more, smaller PRs over fewer large ones; 3–6 PRs is a reasonable target for a medium-sized feature.
-   - **Model requirement**: Decide which capability tier the implementing model needs for each PR, so a frontier model is spent where it pays off and the rest is left to a cheaper model backed by the `weakreview` pass. Label each PR:
+   - **Model requirement**: Decide which capability tier the implementing model needs for each PR, so a frontier model is spent where it pays off and the rest is left to a cheaper model backed by the `weakreview.md` pass. Label each PR:
      - `frontier-required` — the PR contains a step that requires an unprecedented design decision (e.g. a Phase 0-style PoC or feasibility probe), or a step matching `mkplan.md` step 8's panel-mode triggers (a heavy integration-test / CI / external-resource surface, or a security-gate / migration step such as a staged rollout or simultaneous behavior raises and lowers).
      - `frontier-recommended` — the PR contains a step whose approach is not yet settled (the plan's `既存コード調査結果` section lists two or more competing implementation approaches for it), a step matching two or more of `mkplan.md`'s Conditional checks, or an isolated high-risk/complex step (e.g. recovery flows, concurrency, state machines).
      - `standard` — everything else.

--- a/.claude/commands/runplan.md
+++ b/.claude/commands/runplan.md
@@ -11,6 +11,12 @@
 > for domain-specific examples (step 5) and for Go-specific rules (`testutil/`,
 > `test_helpers.go`, `//go:build test`) when changing tech stacks. The review step
 > uses the shared procedure in `.claude/commands/_lib/review-subagent-pattern.md`.
+> Before starting an implementation session, check the `**実装モデル要件**` field of
+> the `### PR-N 作成ポイント` marker covering the work you are about to pick up (see
+> `_context.md`, "PR marker conventions"): `frontier-required` means run this session
+> on a frontier model; `frontier-recommended` prefers one; `standard` may run on a
+> cheaper model, with `weakreview.md` as the follow-up check. This does not change
+> any step below.
 
 Your goal is to implement one task under `docs/tasks/` by following its `03_implementation_plan.md`.
 


### PR DESCRIPTION
## 背景

`mkplan2.md` は PR 境界を設計するが、各 PR を「どの水準のモデルに実装させるべきか」は記録していない。一方で実装フェーズ (`runplan.md`) はフロンティア級〜低コストモデルへの分担運用を想定しており、その判断材料 (ステップのリスク・複雑さ・外部依存面) は step 4 の Risk isolation が既に読んでいる情報とほぼ同じ。そこで PR 境界設計と同時に判定・記録させる。

これはコマンド定義ファイル (テンプレート) 自体への変更で、特定タスクの `03_implementation_plan.md` は書き換えていない。

## 変更内容

**`.claude/commands/mkplan2.md`**
- **ステップ4**: 既存5原則と並列に6つ目の原則 **Model requirement** を追加。3水準を定義:
  - `frontier-required` — 先例のない設計判断を要するステップ (Phase 0 的 PoC 等)、または `mkplan.md` ステップ8の panel mode 発動条件に該当するステップを含む
  - `frontier-recommended` — `既存コード調査結果` に複数の実装方針が併記されている、または `mkplan.md` の Conditional checks に2つ以上該当するステップを含む
  - `standard` — それ以外
  - ラベル付けは Risk isolation と同じ分析パスで行い、二重に作業しない旨を明記
- **ステップ6**: PR マーカーのテンプレートに `**実装モデル要件**` と `**判定理由**` を追加 (`**レビュー観点**` の下、既存の書式に準拠)。記入ルールも "Where:" リストに追記 (PR は含まれるステップの最高水準を取る)
- **ステップ7**: `### 3.2 PR 構成` サマリテーブルに「実装モデル要件」列を追加
- **ステップ9**: PERSONA にラベルの妥当性確認 (過大・過小の両方向) を指示
- **PR boundary review checklist**: risk-isolation 項目と並べて整合性チェックを追加

**`.claude/commands/_context.md`**
- 「PR marker conventions」節に新フィールド2件と3水準の語彙を正準定義として追加

**`.claude/commands/runplan.md`**
- "Project context (read first)" 節に、セッション開始時にラベルを参照してモデルを選ぶ旨を最小限追記。手続きロジックは変更なし

**`.claude/commands/weakreview.md`** — 変更なし。水準に関わらず diff と計画文書から動作するため、参照を追加すると同期対象が増えるだけと判断。

## 補足

`判定理由` のテンプレート内プレースホルダは既存の `<key1>` / `<concise English title>` に合わせ `<one line>` (英語) とし、「記入する本文は日本語」という点は "Where:" のルール側で規定した (`レビュー観点` と同じ扱い)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)