### PR TITLE
feat(0148): add read-only Store construction to internal/fileanalysis

### DIFF
--- a/docs/tasks/0148_dry_run_hash_directory_no_create/03_implementation_plan.md
+++ b/docs/tasks/0148_dry_run_hash_directory_no_create/03_implementation_plan.md
@@ -163,23 +163,23 @@
 **対象ファイル**: `internal/fileanalysis/file_analysis_store.go`,
 `internal/fileanalysis/file_analysis_store_test.go`
 
-- [ ] **ステップ 1-1**: `NewStore`（41-68 行目）の 59-67 行目（`common.NewResolvedPath` 呼び出し以降）を
+- [x] **ステップ 1-1**: `NewStore`（41-68 行目）の 59-67 行目（`common.NewResolvedPath` 呼び出し以降）を
       `newStoreFromExistingDir(analysisDir string, pathGetter common.HashFilePathGetter) (*Store, error)`
       という非公開ヘルパーへ切り出す。`NewStore` はこのヘルパーを呼び出すように書き換える。
-- [ ] **ステップ 1-2**: `NewStoreReadOnly(analysisDir string, pathGetter common.HashFilePathGetter) (*Store, error)`
+- [x] **ステップ 1-2**: `NewStoreReadOnly(analysisDir string, pathGetter common.HashFilePathGetter) (*Store, error)`
       を追加する。`os.Lstat(analysisDir)` を行い、エラーなら
       `fmt.Errorf("failed to access analysis result directory: %w", err)` を返し（`os.MkdirAll`
       は呼ばない）、ディレクトリでなければ `fmt.Errorf("%w: %s", ErrAnalysisDirNotDirectory, analysisDir)`
       を返す。存在してディレクトリなら `newStoreFromExistingDir` を呼んで返す。
-- [ ] **ステップ 1-3**: `TestNewStoreReadOnly_MissingDirectory_ReturnsErrorWithoutCreating` を追加する。
+- [x] **ステップ 1-3**: `TestNewStoreReadOnly_MissingDirectory_ReturnsErrorWithoutCreating` を追加する。
       `TestNewStore_CreatesDirectory`（340-357 行目）と対になるよう、存在しないパスを渡して
       エラーが返ること、かつ `os.Stat` で当該パスが作成されていないことを確認する。
-- [ ] **ステップ 1-4**: `TestNewStoreReadOnly_ExistingDirectory` を追加する。`TestNewStore_ExistingDirectory`
+- [x] **ステップ 1-4**: `TestNewStoreReadOnly_ExistingDirectory` を追加する。`TestNewStore_ExistingDirectory`
       （359-366 行目）と同じ構成（既存の一時ディレクトリを渡して成功する）。
-- [ ] **ステップ 1-5**: `TestNewStoreReadOnly_NotADirectory` を追加する。`TestNewStore_NotADirectory`
+- [x] **ステップ 1-5**: `TestNewStoreReadOnly_NotADirectory` を追加する。`TestNewStore_NotADirectory`
       （368-380 行目）と同じ構成（ファイルパスを渡して `ErrAnalysisDirNotDirectory` を含むエラーが
       返る）。
-- [ ] **ステップ 1-6**: `TestNewStore_CreatesDirectory` / `TestNewStore_ExistingDirectory` / `TestNewStore_NotADirectory`
+- [x] **ステップ 1-6**: `TestNewStore_CreatesDirectory` / `TestNewStore_ExistingDirectory` / `TestNewStore_NotADirectory`
       がリファクタリング後も無変更で成立することを `go test -tags test ./internal/fileanalysis/...`
       で確認する（回帰確認）。
 

--- a/internal/fileanalysis/file_analysis_store.go
+++ b/internal/fileanalysis/file_analysis_store.go
@@ -56,6 +56,12 @@ func NewStore(analysisDir string, pathGetter common.HashFilePathGetter) (*Store,
 		return nil, fmt.Errorf("%w: %s", ErrAnalysisDirNotDirectory, analysisDir)
 	}
 
+	return newStoreFromExistingDir(analysisDir, pathGetter)
+}
+
+// newStoreFromExistingDir builds a Store from an existing analysisDir.
+// It resolves the path and returns a Store with the resolved directory.
+func newStoreFromExistingDir(analysisDir string, pathGetter common.HashFilePathGetter) (*Store, error) {
 	resolvedDir, err := common.NewResolvedPath(analysisDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve analysis directory: %w", err)
@@ -65,6 +71,20 @@ func NewStore(analysisDir string, pathGetter common.HashFilePathGetter) (*Store,
 		analysisDir: resolvedDir,
 		pathGetter:  pathGetter,
 	}, nil
+}
+
+// NewStoreReadOnly creates a new Store without creating analysisDir.
+// It returns an error if analysisDir does not exist or is not a directory.
+func NewStoreReadOnly(analysisDir string, pathGetter common.HashFilePathGetter) (*Store, error) {
+	info, err := os.Lstat(analysisDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to access analysis result directory: %w", err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("%w: %s", ErrAnalysisDirNotDirectory, analysisDir)
+	}
+
+	return newStoreFromExistingDir(analysisDir, pathGetter)
 }
 
 // Load loads the analysis record for the given file path.

--- a/internal/fileanalysis/file_analysis_store_test.go
+++ b/internal/fileanalysis/file_analysis_store_test.go
@@ -379,6 +379,41 @@ func TestNewStore_NotADirectory(t *testing.T) {
 	assert.Contains(t, err.Error(), "not a directory")
 }
 
+func TestNewStoreReadOnly_MissingDirectory_ReturnsErrorWithoutCreating(t *testing.T) {
+	tmpDir := tu.SafeTempDir(t)
+	analysisDir := filepath.Join(tmpDir, "new", "nested", "dir")
+
+	_, err := os.Stat(analysisDir)
+	assert.True(t, os.IsNotExist(err))
+
+	store, err := NewStoreReadOnly(analysisDir, &mockPathGetter{})
+	require.Error(t, err)
+	assert.Nil(t, store)
+
+	_, statErr := os.Stat(analysisDir)
+	assert.True(t, os.IsNotExist(statErr), "directory must not be created by NewStoreReadOnly")
+}
+
+func TestNewStoreReadOnly_ExistingDirectory(t *testing.T) {
+	tmpDir := tu.SafeTempDir(t)
+
+	store, err := NewStoreReadOnly(tmpDir, &mockPathGetter{})
+	require.NoError(t, err)
+	assert.NotNil(t, store)
+}
+
+func TestNewStoreReadOnly_NotADirectory(t *testing.T) {
+	tmpDir := tu.SafeTempDir(t)
+	notADir := filepath.Join(tmpDir, "file.txt")
+
+	err := os.WriteFile(notADir, []byte("not a directory"), 0o644)
+	require.NoError(t, err)
+
+	_, err = NewStoreReadOnly(notADir, &mockPathGetter{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not a directory")
+}
+
 func TestStore_SaveAndLoad_DynLibDeps(t *testing.T) {
 	tmpDir := tu.SafeTempDir(t)
 	analysisDir := filepath.Join(tmpDir, "analysis")

--- a/internal/fileanalysis/file_analysis_store_test.go
+++ b/internal/fileanalysis/file_analysis_store_test.go
@@ -410,8 +410,7 @@ func TestNewStoreReadOnly_NotADirectory(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = NewStoreReadOnly(notADir, &mockPathGetter{})
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "not a directory")
+	assert.ErrorIs(t, err, ErrAnalysisDirNotDirectory)
 }
 
 func TestStore_SaveAndLoad_DynLibDeps(t *testing.T) {


### PR DESCRIPTION
## Summary

Add a read-only construction path for `fileanalysis.Store` so dry-run can
access an existing hash directory without creating it as a side effect.

## Changes

- Extract `newStoreFromExistingDir` from `NewStore` to share
  resolution-and-assembly logic between the creation path and the new
  read-only path.
- Add `NewStoreReadOnly`, which performs `os.Lstat` only and never calls
  `os.MkdirAll`.
- Add unit tests for missing-directory, existing-directory, and
  not-a-directory cases.

## Review points

- `newStoreFromExistingDir` extraction does not change `NewStore` behavior.
- `NewStoreReadOnly` never creates a directory.
- Existing `NewStore` tests still pass unchanged.

## Verification

- `make fmt && make test && make lint && make deadcode`
- `go test -tags test ./internal/fileanalysis/...`

Refs: task 0148
