### PR TITLE
feat(0148): add read-only Validator with deferred errors [Claude Sonnet5 / middle]

### DIFF
--- a/docs/tasks/0148_dry_run_hash_directory_no_create/03_implementation_plan.md
+++ b/docs/tasks/0148_dry_run_hash_directory_no_create/03_implementation_plan.md
@@ -281,7 +281,7 @@
 
 **判定理由**: `deferredErr` の早期リターンチェックを `Verify`・`VerifyWithHash`・`VerifyAndRead`・`LoadRecord` の 4 メソッドすべてに一貫して適用しないと、いずれか 1 箇所の漏れが不在ディレクトリでの `nil` store 参照パニックへ直結する、孤立した高リスクロジックである（Risk isolation 該当）。
 
-- [ ] グリーンゲート（`_context.md` の "Green gate" 参照）がパスしていることを確認した
+- [x] グリーンゲート（`_context.md` の "Green gate" 参照）がパスしていることを確認した
 - [ ] PR を作成した
 - [ ] PR がマージされた
 - [ ] 次のブランチへ切り替えた（次ステップは新しいブランチで作業する）

--- a/docs/tasks/0148_dry_run_hash_directory_no_create/03_implementation_plan.md
+++ b/docs/tasks/0148_dry_run_hash_directory_no_create/03_implementation_plan.md
@@ -282,7 +282,7 @@
 **判定理由**: `deferredErr` の早期リターンチェックを `Verify`・`VerifyWithHash`・`VerifyAndRead`・`LoadRecord` の 4 メソッドすべてに一貫して適用しないと、いずれか 1 箇所の漏れが不在ディレクトリでの `nil` store 参照パニックへ直結する、孤立した高リスクロジックである（Risk isolation 該当）。
 
 - [x] グリーンゲート（`_context.md` の "Green gate" 参照）がパスしていることを確認した
-- [ ] PR を作成した
+- [x] PR を作成した
 - [ ] PR がマージされた
 - [ ] 次のブランチへ切り替えた（次ステップは新しいブランチで作業する）
 

--- a/docs/tasks/0148_dry_run_hash_directory_no_create/03_implementation_plan.md
+++ b/docs/tasks/0148_dry_run_hash_directory_no_create/03_implementation_plan.md
@@ -205,8 +205,8 @@
 **対象ファイル**: `internal/filevalidator/validator.go`, `internal/filevalidator/validator_test.go`,
 `internal/filevalidator/validator_error_test.go`
 
-- [ ] **ステップ 2-1**: `Validator` 構造体（151-172 行目）へ `deferredErr error` フィールドを追加する。
-- [ ] **ステップ 2-2**: `NewReadOnly(algorithm HashAlgorithm, hashDir string, cfg ValidatorConfig) (*Validator, error)`
+- [x] **ステップ 2-1**: `Validator` 構造体（151-172 行目）へ `deferredErr error` フィールドを追加する。
+- [x] **ステップ 2-2**: `NewReadOnly(algorithm HashAlgorithm, hashDir string, cfg ValidatorConfig) (*Validator, error)`
       を追加する。実装は次のとおり。
       1. `algorithm == nil` なら `ErrNilAlgorithm` を返す（`New` は `newValidator` 経由でこの
          チェックを行うが、`NewReadOnly` の不在ディレクトリ分岐は `newValidator` を経由しないため、
@@ -227,7 +227,7 @@
          - それ以外（`Lstat` が権限エラー等で失敗）: `&Validator{deferredErr: err}, nil` を返す
            （構築成功）。`err` はそのまま保持するため、`errors.Is(err, os.ErrPermission)` は
            `result_collector.go` の `determineFailureReason` でそのまま機能する。
-- [ ] **ステップ 2-3**: `Verify`（1075 行目）、`VerifyWithHash`（1099 行目）、`VerifyAndRead`（1199 行目）、
+- [x] **ステップ 2-3**: `Verify`（1075 行目）、`VerifyWithHash`（1099 行目）、`VerifyAndRead`（1199 行目）、
       `LoadRecord`（453 行目）の各先頭に、次の 2 行を追加する（戻り値の型に応じてゼロ値を調整）。
       ```go
       if v.deferredErr != nil {
@@ -236,25 +236,25 @@
       ```
       （`VerifyWithHash` は `return "", v.deferredErr`、`VerifyAndRead` は
       `return nil, v.deferredErr`、`LoadRecord` は `return nil, v.deferredErr`。）
-- [ ] **ステップ 2-4**: `HashDirAvailable() bool` を追加する。`return v.deferredErr == nil` のみを返す。
-- [ ] **ステップ 2-5**: `TestNewReadOnly_MissingDirectory_DoesNotCreateDirectory` を `validator_test.go` の
+- [x] **ステップ 2-4**: `HashDirAvailable() bool` を追加する。`return v.deferredErr == nil` のみを返す。
+- [x] **ステップ 2-5**: `TestNewReadOnly_MissingDirectory_DoesNotCreateDirectory` を `validator_test.go` の
       `TestNew_CreatesDirectory`（596-617 行目）の近くに追加する。存在しないパスを渡し、
       `NewReadOnly` がエラーなく `*Validator` を返すこと、かつ `os.Stat` で当該パスが作成されて
       いないことを確認する。
-- [ ] **ステップ 2-6**: `TestNewReadOnly_MissingDirectory_VerifyReturnsErrHashDirNotExist` を追加する。上記で得た
+- [x] **ステップ 2-6**: `TestNewReadOnly_MissingDirectory_VerifyReturnsErrHashDirNotExist` を追加する。上記で得た
       `*Validator` に対して `Verify`・`VerifyWithHash`・`VerifyAndRead`・`LoadRecord` をそれぞれ
       呼び、いずれも `errors.Is(err, ErrHashDirNotExist)` が真であることを確認する（テーブル駆動で
       4 メソッドをまとめてよい）。
-- [ ] **ステップ 2-7**: `TestNewReadOnly_ExistingDirectory_VerifiesSuccessfully` を追加する。`TestNew`
+- [x] **ステップ 2-7**: `TestNewReadOnly_ExistingDirectory_VerifiesSuccessfully` を追加する。`TestNew`
       （102-140 行目付近）の「valid」ケースに相当する構成で、既存ディレクトリに対して
       `NewReadOnly` → `SaveRecord`（通常の `New` で作成した別 Validator、または同一
       ディレクトリを対象に `New` で先に記録してから `NewReadOnly` で検証する）→ `Verify` が成功する
       ことを確認する。
-- [ ] **ステップ 2-8**: `TestNewReadOnly_NotADirectory` を追加する。ファイルパスを渡し、`errors.Is(err, ErrHashPathNotDir)`
+- [x] **ステップ 2-8**: `TestNewReadOnly_NotADirectory` を追加する。ファイルパスを渡し、`errors.Is(err, ErrHashPathNotDir)`
       を確認する。
-- [ ] **ステップ 2-9**: `TestNewReadOnly_NilAlgorithm` を追加する。`algorithm` に `nil` を渡し、
+- [x] **ステップ 2-9**: `TestNewReadOnly_NilAlgorithm` を追加する。`algorithm` に `nil` を渡し、
       `errors.Is(err, ErrNilAlgorithm)` を確認する。
-- [ ] **ステップ 2-10**: `validator_error_test.go`（`//go:build linux || freebsd || openbsd || netbsd`、既存の
+- [x] **ステップ 2-10**: `validator_error_test.go`（`//go:build linux || freebsd || openbsd || netbsd`、既存の
       「unreadable directory」サブテスト 126-145 行目と同じ chmod パターンを踏襲）へ
       `TestNewReadOnly_ParentUnreadable_DeferredPermissionError` を追加する。手順:
       1. `tempDir` 配下に `restricted` ディレクトリを作成する。

--- a/docs/tasks/0148_dry_run_hash_directory_no_create/03_implementation_plan.md
+++ b/docs/tasks/0148_dry_run_hash_directory_no_create/03_implementation_plan.md
@@ -222,11 +222,13 @@
            そのまま返す。
          - `err == nil && !info.IsDir()`: `fmt.Errorf("%w: %s", ErrHashPathNotDir, hashDir)` を返す
            （構築失敗）。
-         - `os.IsNotExist(err)`: `&Validator{deferredErr: fmt.Errorf("%w: %s", ErrHashDirNotExist, hashDir)}, nil`
-           を返す（構築成功、`store` は nil のまま）。
-         - それ以外（`Lstat` が権限エラー等で失敗）: `&Validator{deferredErr: err}, nil` を返す
-           （構築成功）。`err` はそのまま保持するため、`errors.Is(err, os.ErrPermission)` は
-           `result_collector.go` の `determineFailureReason` でそのまま機能する。
+         - `os.IsNotExist(err)`: `newDeferredValidator(algorithm, hashFilePathGetter, cfg,
+           fmt.Errorf("%w: %s", ErrHashDirNotExist, hashDir)), nil` を返す（構築成功、`store` は
+           ゼロ値のまま）。
+         - それ以外（`Lstat` が権限エラー等で失敗）: `newDeferredValidator(algorithm,
+           hashFilePathGetter, cfg, err), nil` を返す（構築成功）。`err` はそのまま保持するため、
+           `errors.Is(err, os.ErrPermission)` は `result_collector.go` の `determineFailureReason`
+           でそのまま機能する。
 - [x] **ステップ 2-3**: `Verify`（1075 行目）、`VerifyWithHash`（1099 行目）、`VerifyAndRead`（1199 行目）、
       `LoadRecord`（453 行目）の各先頭に、次の 2 行を追加する（戻り値の型に応じてゼロ値を調整）。
       ```go

--- a/internal/filevalidator/validator.go
+++ b/internal/filevalidator/validator.go
@@ -299,16 +299,38 @@ func NewReadOnly(algorithm HashAlgorithm, hashDir string, cfg ValidatorConfig) (
 		// Exists but is not a directory: hard error, same as New.
 		return nil, fmt.Errorf("%w: %s", ErrHashPathNotDir, hashDir)
 	case os.IsNotExist(err):
-		return &Validator{
-			deferredErr: fmt.Errorf("%w: %s", ErrHashDirNotExist, hashDir),
-		}, nil
+		return newDeferredValidator(algorithm, hashFilePathGetter, cfg,
+			fmt.Errorf("%w: %s", ErrHashDirNotExist, hashDir)), nil
 	default:
 		// Lstat failed for another reason (e.g. permission denied on a
 		// parent directory). Keep err as-is so determineFailureReason can
 		// map errors.Is(err, os.ErrPermission) to ReasonPermissionDenied.
-		return &Validator{
-			deferredErr: err,
-		}, nil
+		return newDeferredValidator(algorithm, hashFilePathGetter, cfg, err), nil
+	}
+}
+
+// newDeferredValidator builds a Validator carrying deferredErr for the
+// NewReadOnly branches where the hash directory is missing or inaccessible.
+// It initializes the same non-hash-dir fields as newValidator (fileSystem,
+// optional analyzers/caches, includeDebugInfo) so that any method guarded by
+// a deferredErr check that later gets bypassed, or that reads these fields
+// before checking deferredErr, does not panic on a nil field. hashDir, store,
+// and hashFilePathGetter-derived state are intentionally left zero-valued
+// since they require the hash directory to exist.
+func newDeferredValidator(algorithm HashAlgorithm, hashFilePathGetter common.HashFilePathGetter, cfg ValidatorConfig, deferredErr error) *Validator {
+	return &Validator{
+		algorithm:           algorithm,
+		hashFilePathGetter:  hashFilePathGetter,
+		fileSystem:          safefileio.NewFileSystem(safefileio.FileSystemConfig{}),
+		elfDynlibAnalyzer:   cfg.ELFDynLibAnalyzer,
+		machoDynlibAnalyzer: cfg.MachODynLibAnalyzer,
+		binaryAnalyzer:      cfg.BinaryAnalyzer,
+		syscallAnalyzer:     cfg.SyscallAnalyzer,
+		libcCache:           cfg.LibcCache,
+		libSystemCache:      cfg.LibSystemCache,
+		machoSyscallTable:   cfg.MachoSyscallTable,
+		includeDebugInfo:    cfg.DebugInfo,
+		deferredErr:         deferredErr,
 	}
 }
 
@@ -327,6 +349,10 @@ func (v *Validator) HashDirAvailable() bool {
 // hash file path (possible with SHA256 fallback encoding for very long paths).
 // Existing fields (e.g., SyscallAnalysis) in the record are preserved when updating.
 func (v *Validator) SaveRecord(filePath string, force bool) (string, string, error) {
+	if v.deferredErr != nil {
+		return "", "", v.deferredErr
+	}
+
 	// Validate the file path
 	targetPath, err := validatePath(filePath)
 	if err != nil {

--- a/internal/filevalidator/validator.go
+++ b/internal/filevalidator/validator.go
@@ -173,9 +173,9 @@ type Validator struct {
 	// deferredErr holds a hash-directory access error detected at read-only
 	// construction time (NewReadOnly): missing directory, or an Lstat failure
 	// such as permission denied. Verify / VerifyWithHash / VerifyAndRead /
-	// LoadRecord return this error immediately instead of touching the
-	// filesystem, so the failure is reported per file rather than at
-	// construction time. Always nil for Validators built via New.
+	// LoadRecord / SaveRecord return this error immediately instead of
+	// touching the filesystem, so the failure is reported per file rather
+	// than at construction time. Always nil for Validators built via New.
 	deferredErr error
 }
 
@@ -245,7 +245,10 @@ func newValidator(algorithm HashAlgorithm, hashDir common.ResolvedPath, hashFile
 }
 
 // NewReadOnly creates a Validator that never creates the hash directory.
-// It inspects hashDir via a single Lstat call and constructs accordingly:
+// It starts with an Lstat call to check whether hashDir exists, then
+// constructs accordingly (the existing-directory branch performs further
+// filesystem inspection via fileanalysis.NewStoreReadOnly and
+// common.NewResolvedPath):
 //   - exists and is a directory: builds a read-only Store via
 //     fileanalysis.NewStoreReadOnly and returns a fully functional Validator,
 //     identical in behavior to one built by New.

--- a/internal/filevalidator/validator.go
+++ b/internal/filevalidator/validator.go
@@ -169,6 +169,14 @@ type Validator struct {
 	// processedInterpreterAnalysis caches shebang interpreter analysis records during one Validator lifetime.
 	processedInterpreterAnalysis map[libCacheKey]*fileanalysis.Record
 	includeDebugInfo             bool
+
+	// deferredErr holds a hash-directory access error detected at read-only
+	// construction time (NewReadOnly): missing directory, or an Lstat failure
+	// such as permission denied. Verify / VerifyWithHash / VerifyAndRead /
+	// LoadRecord return this error immediately instead of touching the
+	// filesystem, so the failure is reported per file rather than at
+	// construction time. Always nil for Validators built via New.
+	deferredErr error
 }
 
 // New initializes and returns a new Validator with the specified hash algorithm and hash directory.
@@ -234,6 +242,82 @@ func newValidator(algorithm HashAlgorithm, hashDir common.ResolvedPath, hashFile
 		machoSyscallTable:   cfg.MachoSyscallTable,
 		includeDebugInfo:    cfg.DebugInfo,
 	}, nil
+}
+
+// NewReadOnly creates a Validator that never creates the hash directory.
+// It inspects hashDir via a single Lstat call and constructs accordingly:
+//   - exists and is a directory: builds a read-only Store via
+//     fileanalysis.NewStoreReadOnly and returns a fully functional Validator,
+//     identical in behavior to one built by New.
+//   - does not exist: construction still succeeds; the returned Validator
+//     carries deferredErr set to ErrHashDirNotExist. Path resolution
+//     (common.NewResolvedPath) is skipped in this case because it requires
+//     the path to exist.
+//   - exists but is not a directory: returns ErrHashPathNotDir (construction
+//     fails, same as New — this is a hard error, not a deferred one).
+//   - Lstat fails for another reason (e.g. permission denied on a parent
+//     directory): construction still succeeds; deferredErr carries the raw
+//     Lstat error so determineFailureReason can map it to
+//     ReasonPermissionDenied.
+//
+// A Validator holding a deferredErr returns it immediately from Verify,
+// VerifyWithHash, VerifyAndRead, and LoadRecord without touching the
+// filesystem. This lets dry-run report a missing or inaccessible hash
+// directory per file (e.g. hash_directory_not_found) instead of failing
+// Validator construction outright, which would otherwise collapse to the
+// less specific skipped_no_validator reason.
+//
+// NewReadOnly never calls SaveRecord; callers needing to write hash records
+// must use New instead.
+func NewReadOnly(algorithm HashAlgorithm, hashDir string, cfg ValidatorConfig) (*Validator, error) {
+	if algorithm == nil {
+		return nil, ErrNilAlgorithm
+	}
+
+	hashFilePathGetter := NewHybridHashFilePathGetter()
+
+	info, err := os.Lstat(hashDir)
+	switch {
+	case err == nil && info.IsDir():
+		store, err := fileanalysis.NewStoreReadOnly(hashDir, hashFilePathGetter)
+		if err != nil {
+			return nil, fmt.Errorf("failed to open analysis store: %w", err)
+		}
+
+		resolvedHashDir, err := common.NewResolvedPath(hashDir)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve hash directory path %q: %w", hashDir, err)
+		}
+
+		v, err := newValidator(algorithm, resolvedHashDir, hashFilePathGetter, cfg)
+		if err != nil {
+			return nil, err
+		}
+		v.store = store
+		return v, nil
+	case err == nil:
+		// Exists but is not a directory: hard error, same as New.
+		return nil, fmt.Errorf("%w: %s", ErrHashPathNotDir, hashDir)
+	case os.IsNotExist(err):
+		return &Validator{
+			deferredErr: fmt.Errorf("%w: %s", ErrHashDirNotExist, hashDir),
+		}, nil
+	default:
+		// Lstat failed for another reason (e.g. permission denied on a
+		// parent directory). Keep err as-is so determineFailureReason can
+		// map errors.Is(err, os.ErrPermission) to ReasonPermissionDenied.
+		return &Validator{
+			deferredErr: err,
+		}, nil
+	}
+}
+
+// HashDirAvailable reports whether the hash directory was usable at
+// construction time. It returns false when NewReadOnly deferred an error
+// (missing or inaccessible directory), and true otherwise (including for
+// Validators built via New, which always succeed with a usable directory).
+func (v *Validator) HashDirAvailable() bool {
+	return v.deferredErr == nil
 }
 
 // SaveRecord calculates the hash of the file at filePath and saves it to the hash directory.
@@ -451,6 +535,10 @@ func (v *Validator) prefixedHashForPath(filePath string) (string, error) {
 
 // LoadRecord returns the full analysis record for the given file path.
 func (v *Validator) LoadRecord(filePath string) (*fileanalysis.Record, error) {
+	if v.deferredErr != nil {
+		return nil, v.deferredErr
+	}
+
 	targetPath, err := validatePath(filePath)
 	if err != nil {
 		return nil, err
@@ -1073,6 +1161,10 @@ func isKnownVDSO(soname string) bool {
 // Verify checks if the file at filePath matches its recorded hash.
 // Returns ErrMismatch if the hashes don't match, or ErrHashFileNotFound if no hash is recorded.
 func (v *Validator) Verify(filePath string) error {
+	if v.deferredErr != nil {
+		return v.deferredErr
+	}
+
 	// Validate the file path
 	targetPath, err := validatePath(filePath)
 	if err != nil {
@@ -1097,6 +1189,10 @@ func (v *Validator) Verify(filePath string) error {
 // callers can forward it to downstream consumers (e.g. ELF analysis) without
 // a redundant read of the file.
 func (v *Validator) VerifyWithHash(filePath string) (string, error) {
+	if v.deferredErr != nil {
+		return "", v.deferredErr
+	}
+
 	targetPath, err := validatePath(filePath)
 	if err != nil {
 		return "", err
@@ -1197,6 +1293,10 @@ func (v *Validator) verifyAndReadContent(targetPath common.ResolvedPath, readCon
 
 // VerifyAndRead atomically verifies file integrity and returns its content to prevent TOCTOU attacks
 func (v *Validator) VerifyAndRead(filePath string) ([]byte, error) {
+	if v.deferredErr != nil {
+		return nil, v.deferredErr
+	}
+
 	// Validate the file path
 	targetPath, err := validatePath(filePath)
 	if err != nil {

--- a/internal/filevalidator/validator_error_test.go
+++ b/internal/filevalidator/validator_error_test.go
@@ -168,6 +168,37 @@ func TestFilesystemEdgeCases(t *testing.T) {
 	})
 }
 
+// TestNewReadOnly_ParentUnreadable_DeferredPermissionError tests that when
+// hashDir does not exist and its parent directory cannot be traversed
+// (Lstat returns a permission error rather than IsNotExist), NewReadOnly
+// still succeeds construction and defers the permission error to Verify,
+// per 02_architecture.md Q-03 (the successor to the removed dry-run
+// os.ErrPermission fallback).
+//
+// Like the "unreadable directory" subtest above, this test is meaningless
+// when run as root, since chmod 0o000 does not deny access to root. This is
+// an existing constraint of this file's permission tests, not one newly
+// introduced here.
+func TestNewReadOnly_ParentUnreadable_DeferredPermissionError(t *testing.T) {
+	tempDir := safeTempDir(t)
+	restrictedDir := filepath.Join(tempDir, "restricted")
+	require.NoError(t, os.Mkdir(restrictedDir, 0o755))
+
+	// hashDir is a path under restrictedDir that is never created.
+	hashDir := filepath.Join(restrictedDir, "hashes")
+
+	require.NoError(t, os.Chmod(restrictedDir, 0o000))
+	t.Cleanup(func() { _ = os.Chmod(restrictedDir, 0o755) })
+
+	validator, err := NewReadOnly(&SHA256{}, hashDir, ValidatorConfig{})
+	require.NoError(t, err, "NewReadOnly should succeed even when Lstat fails with a permission error")
+	require.NotNil(t, validator)
+	assert.False(t, validator.HashDirAvailable())
+
+	verifyErr := validator.Verify(filepath.Join(tempDir, "any_file.txt"))
+	assert.ErrorIs(t, verifyErr, os.ErrPermission)
+}
+
 // TestErrorMessages verifies that error messages are clear and helpful
 func TestErrorMessages(t *testing.T) {
 	tempDir := safeTempDir(t)

--- a/internal/filevalidator/validator_error_test.go
+++ b/internal/filevalidator/validator_error_test.go
@@ -180,6 +180,9 @@ func TestFilesystemEdgeCases(t *testing.T) {
 // an existing constraint of this file's permission tests, not one newly
 // introduced here.
 func TestNewReadOnly_ParentUnreadable_DeferredPermissionError(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("Skipping privilege test when running as root")
+	}
 	tempDir := safeTempDir(t)
 	restrictedDir := filepath.Join(tempDir, "restricted")
 	require.NoError(t, os.Mkdir(restrictedDir, 0o755))

--- a/internal/filevalidator/validator_test.go
+++ b/internal/filevalidator/validator_test.go
@@ -616,6 +616,104 @@ func TestNew_CreatesDirectory(t *testing.T) {
 	require.NotNil(t, store, "Store should return non-nil store")
 }
 
+// TestNewReadOnly_MissingDirectory_DoesNotCreateDirectory tests that
+// NewReadOnly succeeds without creating hashDir when it does not exist,
+// unlike New (see TestNew_CreatesDirectory).
+func TestNewReadOnly_MissingDirectory_DoesNotCreateDirectory(t *testing.T) {
+	tempDir := safeTempDir(t)
+	hashDir := filepath.Join(tempDir, "nonexistent_subdir")
+
+	_, err := os.Stat(hashDir)
+	require.True(t, os.IsNotExist(err), "hashDir should not exist before calling NewReadOnly")
+
+	validator, err := NewReadOnly(&SHA256{}, hashDir, ValidatorConfig{})
+	require.NoError(t, err, "NewReadOnly should succeed even though hashDir doesn't exist")
+	require.NotNil(t, validator)
+
+	_, statErr := os.Stat(hashDir)
+	assert.True(t, os.IsNotExist(statErr), "hashDir must not be created by NewReadOnly")
+}
+
+// TestNewReadOnly_MissingDirectory_VerifyReturnsErrHashDirNotExist tests that
+// all read methods on a Validator built for a missing directory surface
+// ErrHashDirNotExist immediately, without touching the filesystem.
+func TestNewReadOnly_MissingDirectory_VerifyReturnsErrHashDirNotExist(t *testing.T) {
+	tempDir := safeTempDir(t)
+	hashDir := filepath.Join(tempDir, "nonexistent_subdir")
+
+	validator, err := NewReadOnly(&SHA256{}, hashDir, ValidatorConfig{})
+	require.NoError(t, err)
+	require.NotNil(t, validator)
+	require.False(t, validator.HashDirAvailable(), "HashDirAvailable should be false for a missing hash directory")
+
+	testFilePath := filepath.Join(tempDir, "some_file.txt")
+	require.NoError(t, os.WriteFile(testFilePath, []byte("content"), 0o644))
+
+	t.Run("Verify", func(t *testing.T) {
+		err := validator.Verify(testFilePath)
+		assert.ErrorIs(t, err, ErrHashDirNotExist)
+	})
+	t.Run("VerifyWithHash", func(t *testing.T) {
+		_, err := validator.VerifyWithHash(testFilePath)
+		assert.ErrorIs(t, err, ErrHashDirNotExist)
+	})
+	t.Run("VerifyAndRead", func(t *testing.T) {
+		_, err := validator.VerifyAndRead(testFilePath)
+		assert.ErrorIs(t, err, ErrHashDirNotExist)
+	})
+	t.Run("LoadRecord", func(t *testing.T) {
+		_, err := validator.LoadRecord(testFilePath)
+		assert.ErrorIs(t, err, ErrHashDirNotExist)
+	})
+}
+
+// TestNewReadOnly_ExistingDirectory_VerifiesSuccessfully tests that
+// NewReadOnly builds a fully functional Validator when hashDir already
+// exists, matching the New + SaveRecord + Verify round trip.
+func TestNewReadOnly_ExistingDirectory_VerifiesSuccessfully(t *testing.T) {
+	tempDir := safeTempDir(t)
+	hashDir := filepath.Join(tempDir, "hashes")
+	require.NoError(t, os.MkdirAll(hashDir, 0o750))
+
+	// Record the file using the normal (writable) constructor.
+	writer, err := New(&SHA256{}, hashDir, ValidatorConfig{})
+	require.NoError(t, err)
+
+	testFilePath := filepath.Join(tempDir, "test.txt")
+	require.NoError(t, os.WriteFile(testFilePath, []byte("test content"), 0o644))
+	_, _, err = writer.SaveRecord(testFilePath, false)
+	require.NoError(t, err)
+
+	// Verify it using a read-only Validator.
+	reader, err := NewReadOnly(&SHA256{}, hashDir, ValidatorConfig{})
+	require.NoError(t, err)
+	require.NotNil(t, reader)
+	assert.True(t, reader.HashDirAvailable(), "HashDirAvailable should be true for an existing hash directory")
+
+	assert.NoError(t, reader.Verify(testFilePath))
+}
+
+// TestNewReadOnly_NotADirectory tests that NewReadOnly fails construction
+// (hard error, not a deferred one) when hashDir exists but is a regular file,
+// matching New's behavior for the same input (Q-02 in 02_architecture.md).
+func TestNewReadOnly_NotADirectory(t *testing.T) {
+	tempDir := safeTempDir(t)
+	notADir := filepath.Join(tempDir, "not_a_dir")
+	require.NoError(t, os.WriteFile(notADir, []byte("content"), 0o644))
+
+	validator, err := NewReadOnly(&SHA256{}, notADir, ValidatorConfig{})
+	assert.ErrorIs(t, err, ErrHashPathNotDir)
+	assert.Nil(t, validator)
+}
+
+// TestNewReadOnly_NilAlgorithm tests that NewReadOnly rejects a nil algorithm
+// before inspecting hashDir at all.
+func TestNewReadOnly_NilAlgorithm(t *testing.T) {
+	validator, err := NewReadOnly(nil, safeTempDir(t), ValidatorConfig{})
+	assert.ErrorIs(t, err, ErrNilAlgorithm)
+	assert.Nil(t, validator)
+}
+
 // collidingHashFilePathGetter always maps every file path to the same
 // record file, simulating a hash file path collision.
 type collidingHashFilePathGetter struct {


### PR DESCRIPTION
## Summary

Adds `filevalidator.NewReadOnly`, a `Validator` construction path that never calls `os.MkdirAll`. This is PR-2 of task 0148 ("dry-run should not create the hash directory"), building on PR-1's `fileanalysis.NewStoreReadOnly`.

- `Validator` gains a `deferredErr` field.
- `NewReadOnly` inspects `hashDir` via a single `Lstat` and branches:
  - exists + directory → builds a fully functional `Validator` via the existing `newValidator` (reused, not duplicated).
  - exists + not a directory → hard error `ErrHashPathNotDir` (construction fails, same as `New`).
  - does not exist → construction succeeds; `deferredErr` = wrapped `ErrHashDirNotExist`.
  - other `Lstat` error (e.g. permission denied) → construction succeeds; `deferredErr` = the raw error, unwrapped, so `errors.Is(err, os.ErrPermission)` keeps working downstream.
- `Verify`, `VerifyWithHash`, `VerifyAndRead`, `LoadRecord` all check `deferredErr` first and return it immediately without touching the filesystem.
- `HashDirAvailable()` reports whether the hash directory was usable at construction time.

`NewReadOnly` is not yet called from any production path — `internal/verification`'s dry-run wiring lands in PR-3.

## レビュー観点

- `deferredErr` を保持したまま構築成功させる 4 分岐（存在/不在/非ディレクトリ/権限エラー）が `02_architecture.md` §3.1・§5.3 の Q-01〜Q-03 と一致しているか
- `Verify`・`VerifyWithHash`・`VerifyAndRead`・`LoadRecord` の 4 メソッド全てで `deferredErr` チェック漏れがないか
- chmod を使う権限テストが CI の root 実行下で偽陽性になる既知の制約を正しく踏襲しているか

## Test plan

- [x] `make fmt`
- [x] `make test`
- [x] `make lint`
- [x] `make deadcode` (confirms `NewReadOnly`/`NewStoreReadOnly` are expected-unreachable scaffolding until PR-3)
- [x] New unit tests: `TestNewReadOnly_MissingDirectory_DoesNotCreateDirectory`, `TestNewReadOnly_MissingDirectory_VerifyReturnsErrHashDirNotExist` (table-driven over all 4 methods), `TestNewReadOnly_ExistingDirectory_VerifiesSuccessfully`, `TestNewReadOnly_NotADirectory`, `TestNewReadOnly_NilAlgorithm`, `TestNewReadOnly_ParentUnreadable_DeferredPermissionError`
- [x] Independent critical-review subagent pass — no Critical/Major findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
