### PR TITLE
feat(0153): Add default clause to applyBinaryAnalysis for unknown classes (Phase 1)

### DIFF
--- a/docs/tasks/0153_failopen_error_handling_crosscut/03_implementation_plan.md
+++ b/docs/tasks/0153_failopen_error_handling_crosscut/03_implementation_plan.md
@@ -4,10 +4,10 @@
 
 | Item | Value |
 |---|---|
-| Status | `draft` |
-| Created | 2026-07-19 |
-| Review date | - |
-| Reviewer | - |
+| Status | `approved` |
+| Created | 2026-07-20 |
+| Review date | 2026-07-20 |
+| Reviewer | isseis |
 | Comments | - |
 
 ## 関連ドキュメント

--- a/docs/tasks/0153_failopen_error_handling_crosscut/03_implementation_plan.md
+++ b/docs/tasks/0153_failopen_error_handling_crosscut/03_implementation_plan.md
@@ -426,8 +426,8 @@ Phase 4 と Phase 6 を別ブランチで並行実装する場合、`standard_an
 ## 6. 実装チェックリスト
 
 ### Phase 1: A5 Low-3
-- [ ] Step 1-1: `default` 節を追加
-- [ ] Step 1-2: 未知クラスのテストを追加
+- [x] Step 1-1: `default` 節を追加
+- [x] Step 1-2: 未知クラスのテストを追加
 
 ### Phase 2: B3 L1
 - [ ] Step 2-1: `hasDynamicLibraryDeps` の DynString エラー分離

--- a/internal/runner/base/risk/evaluator.go
+++ b/internal/runner/base/risk/evaluator.go
@@ -458,6 +458,14 @@ func (e *StandardEvaluator) applyBinaryAnalysis(a *risktypes.RiskAssessment, cmd
 	if err != nil {
 		return nil, err
 	}
+	return applyClassResult(a, result), nil
+}
+
+// applyClassResult maps a BinaryAnalysisResult to a RiskAssessment update. An
+// unknown class is treated as fail-closed (Blocking), mirroring the Uncertain
+// case. Known classes: Uncertain → Blocking, HighRisk/Network → elevate level,
+// Clean → no contribution.
+func applyClassResult(a *risktypes.RiskAssessment, result risktypes.BinaryAnalysisResult) *risktypes.RiskAssessment {
 	switch result.Class {
 	case risktypes.BinaryAnalysisUncertain:
 		blocked := blockingAssessment("", "")
@@ -465,7 +473,7 @@ func (e *StandardEvaluator) applyBinaryAnalysis(a *risktypes.RiskAssessment, cmd
 		if len(result.ReasonCodes) > 0 {
 			blocked.BlockingReason = result.ReasonCodes[0]
 		}
-		return &blocked, nil
+		return &blocked
 	case risktypes.BinaryAnalysisHighRisk:
 		a.Level = max(a.Level, runnertypes.RiskLevelHigh)
 		a.ReasonCodes = append(a.ReasonCodes, result.ReasonCodes...)
@@ -474,8 +482,15 @@ func (e *StandardEvaluator) applyBinaryAnalysis(a *risktypes.RiskAssessment, cmd
 		a.ReasonCodes = append(a.ReasonCodes, result.ReasonCodes...)
 	case risktypes.BinaryAnalysisClean:
 		// No contribution.
+	default:
+		blocked := blockingAssessment("", "")
+		blocked.ReasonCodes = result.ReasonCodes
+		if len(result.ReasonCodes) > 0 {
+			blocked.BlockingReason = result.ReasonCodes[0]
+		}
+		return &blocked
 	}
-	return nil, nil
+	return nil
 }
 
 // networkTypeString renders a NetworkOperationType for the audit NetworkType field.

--- a/internal/runner/base/risk/evaluator_test.go
+++ b/internal/runner/base/risk/evaluator_test.go
@@ -625,6 +625,82 @@ func TestEvaluateRisk_AllowedPlanCarriesVerifiedFd(t *testing.T) {
 // TestEvaluateRisk_OpenFailureBlocks confirms the fail-closed contract: when the
 // verified binary cannot be opened for fd-bound execution, the command is denied
 // rather than executed via an unbound path.
+func TestApplyClassResult_DefaultBlocksUnknownClass(t *testing.T) {
+	class := risktypes.BinaryAnalysisClass(999)
+	result := risktypes.BinaryAnalysisResult{
+		Class:       class,
+		ReasonCodes: []risktypes.ReasonCode{"unknown_signal"},
+	}
+
+	assessment := risktypes.RiskAssessment{}
+	blocked := applyClassResult(&assessment, result)
+
+	require.NotNil(t, blocked, "unknown class must return a blocking assessment")
+	assert.True(t, blocked.Blocking, "unknown class must be Blocking")
+	assert.Equal(t, "unknown_signal", string(blocked.BlockingReason))
+	assert.Equal(t, []risktypes.ReasonCode{"unknown_signal"}, blocked.ReasonCodes)
+}
+
+func TestApplyClassResult_KnownClassesUnchanged(t *testing.T) {
+	tests := []struct {
+		name         string
+		class        risktypes.BinaryAnalysisClass
+		reasonCodes  []risktypes.ReasonCode
+		wantBlocking bool
+		wantLevel    runnertypes.RiskLevel
+		wantReason   risktypes.ReasonCode
+	}{
+		{
+			name:         "Uncertain",
+			class:        risktypes.BinaryAnalysisUncertain,
+			reasonCodes:  []risktypes.ReasonCode{risktypes.ReasonAnalysisDisabled},
+			wantBlocking: true,
+			wantReason:   risktypes.ReasonAnalysisDisabled,
+		},
+		{
+			name:         "Clean",
+			class:        risktypes.BinaryAnalysisClean,
+			wantBlocking: false,
+		},
+		{
+			name:        "Network",
+			class:       risktypes.BinaryAnalysisNetwork,
+			reasonCodes: []risktypes.ReasonCode{risktypes.ReasonBinaryAnalysisNetwork},
+			wantLevel:   runnertypes.RiskLevelMedium,
+		},
+		{
+			name:        "HighRisk",
+			class:       risktypes.BinaryAnalysisHighRisk,
+			reasonCodes: []risktypes.ReasonCode{risktypes.ReasonBinaryAnalysisDynamicLoad},
+			wantLevel:   runnertypes.RiskLevelHigh,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := risktypes.BinaryAnalysisResult{
+				Class:       tt.class,
+				ReasonCodes: tt.reasonCodes,
+			}
+			assessment := risktypes.RiskAssessment{}
+			blocked := applyClassResult(&assessment, result)
+
+			if tt.wantBlocking {
+				require.NotNil(t, blocked)
+				assert.True(t, blocked.Blocking)
+				if tt.wantReason != "" {
+					assert.Equal(t, tt.wantReason, blocked.BlockingReason)
+				}
+			} else {
+				assert.Nil(t, blocked)
+			}
+			if tt.wantLevel != 0 {
+				assert.Equal(t, tt.wantLevel, assessment.Level)
+			}
+		})
+	}
+}
+
 func TestEvaluateRisk_OpenFailureBlocks(t *testing.T) {
 	ev := newVerifiedEvaluator().(*StandardEvaluator)
 	openErr := errors.New("open failed")


### PR DESCRIPTION
## Summary
Phase 1 of the fail-open error handling crosscut fix (0153).

### Changes
- Extract `applyClassResult` helper from `applyBinaryAnalysis` (consistent with existing `blockingAssessment` pattern)
- Add `default` case that treats unknown `BinaryAnalysisClass` values as fail-closed (Blocking), mirroring the `Uncertain` case
- Add `TestApplyClassResult_DefaultBlocksUnknownClass` and `TestApplyClassResult_KnownClassesUnchanged`

### Verified ACs
- **AC-17**: Unknown class returns Blocking assessment
- **AC-18**: Existing 4 classes (Uncertain/Clean/Network/HighRisk) behavior unchanged

### Review 観点
- The switch default clause mirrors the Uncertain case pattern: blockingAssessment + ReasonCodes + BlockingReason
- applyClassResult is a standalone function (no receiver) to simplify testing — same pattern as blockingAssessment
- All existing tests pass with no regression