### PR TITLE
fix: address PR #905 review nits in fd-anchored move

### DIFF
--- a/internal/safefileio/errors.go
+++ b/internal/safefileio/errors.go
@@ -38,4 +38,12 @@ var (
 	// This is distinct from ErrInvalidFilePath, which signals a problem with
 	// the path itself rather than with the type of the file handle.
 	ErrUnsupportedFileHandle = errors.New("unsupported file handle type")
+
+	// ErrSourceIdentityMismatch indicates that the directory entry at a source
+	// path no longer refers to the inode that was previously verified (e.g. an
+	// fd was opened and validated, then the path was replaced before a later
+	// operation). This is distinct from ErrInvalidFilePath, which signals a
+	// problem with the path's syntax or structure rather than a runtime
+	// TOCTOU-detected identity change.
+	ErrSourceIdentityMismatch = errors.New("source path no longer refers to the verified inode")
 )

--- a/internal/safefileio/safe_file_linux.go
+++ b/internal/safefileio/safe_file_linux.go
@@ -116,6 +116,9 @@ var generateTempLinkName = randomTempName
 // force deterministic non-EEXIST failures (e.g. EPERM from
 // fs.protected_hardlinks, or ETXTBSY) without depending on environment-
 // specific privilege setups to trigger them for real.
+//
+// Tests must not call t.Parallel() in this package: this variable (and
+// generateTempLinkName) is mutated by tests and shared package-wide.
 var linkatFunc = unix.Linkat
 
 // moveFileAnchored moves the inode referenced by srcFile to absDst without

--- a/internal/safefileio/safe_file_linux.go
+++ b/internal/safefileio/safe_file_linux.go
@@ -111,6 +111,13 @@ const tmpNameRandBytes = 12
 // exercise the EEXIST retry path.
 var generateTempLinkName = randomTempName
 
+// linkatFunc performs the linkat syscall used by linkFileToTempName. It is a
+// package variable (rather than a direct call to unix.Linkat) so tests can
+// force deterministic non-EEXIST failures (e.g. EPERM from
+// fs.protected_hardlinks, or ETXTBSY) without depending on environment-
+// specific privilege setups to trigger them for real.
+var linkatFunc = unix.Linkat
+
 // moveFileAnchored moves the inode referenced by srcFile to absDst without
 // resolving absSrc by path name at move time. Invariant: whenever a file
 // ends up at absDst, it is always the exact inode that srcFile refers to; if
@@ -203,7 +210,7 @@ func verifySameFile(fd *os.File, path string) error {
 	}
 
 	if fdStat.Dev != pathStat.Dev || fdStat.Ino != pathStat.Ino {
-		return fmt.Errorf("%w: path %q no longer refers to the expected inode", ErrInvalidFilePath, path)
+		return fmt.Errorf("%w: path %q no longer refers to the expected inode", ErrSourceIdentityMismatch, path)
 	}
 
 	return nil
@@ -226,7 +233,7 @@ func linkFileToTempName(srcFile *os.File, dstDir string) (string, error) {
 		}
 		tmpPath := filepath.Join(dstDir, name)
 
-		err = unix.Linkat(unix.AT_FDCWD, procPath, unix.AT_FDCWD, tmpPath, unix.AT_SYMLINK_FOLLOW)
+		err = linkatFunc(unix.AT_FDCWD, procPath, unix.AT_FDCWD, tmpPath, unix.AT_SYMLINK_FOLLOW)
 		switch {
 		case err == nil:
 			return tmpPath, nil

--- a/internal/safefileio/safe_file_linux_test.go
+++ b/internal/safefileio/safe_file_linux_test.go
@@ -11,6 +11,7 @@ import (
 	tu "github.com/isseis/go-safe-cmd-runner/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
 )
 
 // inodeOf returns the (dev, ino) pair identifying the file at path, following
@@ -264,4 +265,36 @@ func TestLinkFileToTempName_ExhaustsAttempts(t *testing.T) {
 
 	_, err = linkFileToTempName(osFile, dir)
 	require.Error(t, err)
+}
+
+// TestLinkFileToTempName_NonEEXISTErrorIsNotRetried verifies that a linkat
+// failure other than EEXIST (e.g. EPERM from fs.protected_hardlinks, or
+// ETXTBSY) is returned immediately rather than being retried as if it were a
+// name collision. Real EPERM/ETXTBSY conditions depend on privilege/fs state
+// that isn't reliably reproducible in a test sandbox, so linkatFunc is
+// stubbed to force the failure deterministically.
+func TestLinkFileToTempName_NonEEXISTErrorIsNotRetried(t *testing.T) {
+	dir := tu.SafeTempDir(t)
+	srcPath := filepath.Join(dir, "src.txt")
+	require.NoError(t, os.WriteFile(srcPath, []byte("content"), 0o600))
+
+	fs := NewFileSystem(FileSystemConfig{})
+	srcFile, err := fs.SafeOpenFile(srcPath, os.O_RDONLY, 0)
+	require.NoError(t, err)
+	defer func() { _ = srcFile.Close() }()
+	osFile, ok := srcFile.(*os.File)
+	require.True(t, ok)
+
+	calls := 0
+	origLinkat := linkatFunc
+	linkatFunc = func(_ int, _ string, _ int, _ string, _ int) error {
+		calls++
+		return unix.EPERM
+	}
+	t.Cleanup(func() { linkatFunc = origLinkat })
+
+	_, err = linkFileToTempName(osFile, dir)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, unix.EPERM)
+	assert.Equal(t, 1, calls, "a non-EEXIST linkat error must not be retried")
 }


### PR DESCRIPTION
Use a dedicated ErrSourceIdentityMismatch sentinel instead of ErrInvalidFilePath when verifySameFile detects that a source path no longer refers to the verified inode, and add a linkatFunc seam so a non-EEXIST linkat failure (e.g. EPERM from fs.protected_hardlinks) can be tested deterministically without depending on privilege setup.