### PR TITLE
feat(0161): add sentinel errors, adoption reporter and existence memo

### DIFF
--- a/docs/tasks/0161_sudo_uid_validation_and_logging/03_implementation_plan.md
+++ b/docs/tasks/0161_sudo_uid_validation_and_logging/03_implementation_plan.md
@@ -99,10 +99,10 @@
 
 **変更ファイル**: `internal/groupmembership/membership_cgo.go`、`internal/groupmembership/membership_nocgo.go`、`internal/groupmembership/membership_cgo_test.go`、`internal/groupmembership/membership_nocgo_test.go`
 
-- [ ] `membership_cgo.go` に `const userDatabaseSource = "nss"` を、参照先が NSS であることを述べる英語のコメント付きで追加する
-- [ ] `membership_nocgo.go` に `const userDatabaseSource = "passwd-file"` を、参照先が `/etc/passwd` のみであることを述べる英語のコメント付きで追加する
-- [ ] `membership_cgo_test.go`（`//go:build cgo`）に `TestUserDatabaseSource` を追加し、値が `"nss"` であることを検証する
-- [ ] `membership_nocgo_test.go`（`//go:build !cgo`）に `TestUserDatabaseSource` を追加し、値が `"passwd-file"` であることを検証する。このテストの目的は、定数の値を固定して不注意な書き換えを防ぐことにある。当該ビルドが実際にどのユーザーデータベースを参照するかを証明するものではない。この趣旨は、CGO 版のテストにも英語のコメントとして書く
+- [x] `membership_cgo.go` に `const userDatabaseSource = "nss"` を、参照先が NSS であることを述べる英語のコメント付きで追加する
+- [x] `membership_nocgo.go` に `const userDatabaseSource = "passwd-file"` を、参照先が `/etc/passwd` のみであることを述べる英語のコメント付きで追加する
+- [x] `membership_cgo_test.go`（`//go:build cgo`）に `TestUserDatabaseSource` を追加し、値が `"nss"` であることを検証する
+- [x] `membership_nocgo_test.go`（`//go:build !cgo`）に `TestUserDatabaseSource` を追加し、値が `"passwd-file"` であることを検証する。このテストの目的は、定数の値を固定して不注意な書き換えを防ぐことにある。当該ビルドが実際にどのユーザーデータベースを参照するかを証明するものではない。この趣旨は、CGO 版のテストにも英語のコメントとして書く
 
 **完了条件**: `make test` が CGO 有効・無効の両方で通る（`Makefile:454-460` の `unit-test` が両方を実行する）。ただし macOS では CGO 無効の回が実行されない（`Makefile:456-460`）ため、両ビルドの検証は Linux で行う。
 
@@ -110,8 +110,8 @@
 
 **変更ファイル**: `internal/groupmembership/manager.go`
 
-- [ ] `ErrSudoUIDOutOfRange`（49行目）の直後に `ErrSudoUIDUserNotFound` を 02 §4.1 のメッセージ `"SUDO_UID does not refer to an existing user"` で追加する
-- [ ] 同じ位置に `ErrSudoUIDUserLookupFailed` を 02 §4.1 のメッセージ `"failed to verify that SUDO_UID refers to an existing user"` で追加する
+- [x] `ErrSudoUIDOutOfRange`（49行目）の直後に `ErrSudoUIDUserNotFound` を 02 §4.1 のメッセージ `"SUDO_UID does not refer to an existing user"` で追加する
+- [x] 同じ位置に `ErrSudoUIDUserLookupFailed` を 02 §4.1 のメッセージ `"failed to verify that SUDO_UID refers to an existing user"` で追加する
 
 **完了条件**: `go build ./...` と `make lint` が通る（この時点では未使用の公開変数だが、公開識別子なので未使用検出の対象外）。
 
@@ -119,22 +119,24 @@
 
 **変更ファイル**: `internal/groupmembership/manager.go`
 
-- [ ] `sudoUIDAdoptionReporter` 構造体（`reported atomic.Bool`）を 02 §3.3 のドキュメントコメント付きで追加する
-- [ ] `report(logger *slog.Logger, policy PermissionCheckUIDPolicy, realUID, permissionCheckUID int)` メソッドを追加する。`reported.CompareAndSwap(false, true)` が成功したときのみ出力し、戻り値は持たない
-- [ ] 出力内容を 02 §4.3「採用事実の記録」の表どおりに実装する。レベルは `slog.LevelWarn` とし、メッセージは同表の1文をそのまま用いる。属性は次の5つとする。`permission_check_uid`、`real_uid`、`source_env_var`（値は定数 `sudoUIDEnvVar`）、`permission_check_uid_policy`（値は `policy.String()`）、`user_database_source`（値は定数 `userDatabaseSource`）
-- [ ] パッケージレベルの実体 `processSudoUIDAdoptionReporter sudoUIDAdoptionReporter` を追加し、プロセス全体で共有される唯一の実体であることをコメントで述べる
-- [ ] `import` に `log/slog` と `sync/atomic` を追加する
+- [x] `sudoUIDAdoptionReporter` 構造体（`reported atomic.Bool`）を 02 §3.3 のドキュメントコメント付きで追加する
+- [x] `report(logger *slog.Logger, realUID, permissionCheckUID int)` メソッドを追加する。`reported.CompareAndSwap(false, true)` が成功したときのみ出力し、戻り値は持たない
+- [x] 出力内容を 02 §4.3「採用事実の記録」の表どおりに実装する。レベルは `slog.LevelWarn` とし、メッセージは同表の1文をそのまま用いる。属性は次の5つとする。`permission_check_uid`、`real_uid`、`source_env_var`（値は定数 `sudoUIDEnvVar`）、`permission_check_uid_policy`（値は `SudoUIDAware.String()`）、`user_database_source`（値は定数 `userDatabaseSource`）
+- [x] パッケージレベルの実体 `processSudoUIDAdoptionReporter sudoUIDAdoptionReporter` を追加し、プロセス全体で共有される唯一の実体であることをコメントで述べる
+- [x] `import` に `log/slog` と `sync/atomic` を追加する
 
 **完了条件**: ステップ1-5 のテストが通る。
+
+> **02 §3.3 との差異**: 02 §3.3 は `report` のシグネチャを `(logger *slog.Logger, policy PermissionCheckUIDPolicy, realUID, permissionCheckUID int)` と定める。本実装では `policy` 引数を省き、レコーダが出力する `permission_check_uid_policy` 属性は `SudoUIDAware.String()` を直接用いる。理由は2つ。(1) `sudoUIDAdoptionReporter` の責務は SudoUIDAware 経路の採用事実だけであり、他のポリシーがこの型から呼ばれる設計ではない（呼び出し側 `getPermissionCheckUID` が SudoUIDAware 分岐内に閉じる）ため、引数は技術的に冗長である。(2) `unparam` リンタが「policy always receives SudoUIDAware」を検出して本タスクの導入する構文ではないが、リント警告を増やす。本差分は §1.2「YAGNI」の原則と整合する。
 
 #### ステップ1-4: 実在確認のメモ
 
 **変更ファイル**: `internal/groupmembership/manager.go`
 
-- [ ] `sudoUIDExistenceMemo` 構造体（`mu sync.Mutex`、`confirmed map[int]struct{}`）を 02 §3.4 のドキュメントコメント付きで追加する
-- [ ] `verify(uid int, lookup func(uid int) error) error` メソッドを追加する。`confirmed` に `uid` があれば `nil` を返す。なければ `lookup(uid)` を呼び、`lookup` が `nil` を返したときだけ `uid` を `confirmed` へ登録する。失敗は登録しない
-- [ ] `GroupMembership` 構造体に `sudoUIDExistence sudoUIDExistenceMemo` フィールドを追加する
-- [ ] `New`（92行目）の構造体リテラルに `sudoUIDExistence: sudoUIDExistenceMemo{confirmed: make(map[int]struct{})}` を追加する
+- [x] `sudoUIDExistenceMemo` 構造体（`mu sync.Mutex`、`confirmed map[int]struct{}`）を 02 §3.4 のドキュメントコメント付きで追加する
+- [x] `verify(uid int, lookup func(uid int) error) error` メソッドを追加する。`confirmed` に `uid` があれば `nil` を返す。なければ `lookup(uid)` を呼び、`lookup` が `nil` を返したときだけ `uid` を `confirmed` へ登録する。失敗は登録しない
+- [x] `GroupMembership` 構造体に `sudoUIDExistence sudoUIDExistenceMemo` フィールドを追加する
+- [x] `New`（92行目）の構造体リテラルに `sudoUIDExistence: sudoUIDExistenceMemo{confirmed: make(map[int]struct{})}` を追加する
 
 > **02 §8 との差異**: 02 §8 は `GroupMembership` へのフィールド追加と `New` の初期化をフェーズ2に置いている。本計画では上の2項目をフェーズ1へ前倒しした。ステップ1-5 の `TestNewInitializesSudoUIDExistenceMemo` が `New()` 経由の初期化を検証対象とするためである。フェーズの順序と各フェーズの目的は 02 §8 のままであり、前後関係は変わらない。
 
@@ -144,16 +146,17 @@
 
 **変更ファイル**: `internal/groupmembership/membership_common_test.go`（捕捉ハンドラ）、`internal/groupmembership/manager_test.go`（テスト本体）
 
-- [ ] `slog.Handler` を実装する捕捉ハンドラを `membership_common_test.go` へ追加する。捕捉するのは、レベルとメッセージ、および属性名から値へのマップの3つとする。あわせて、`Handle` が固定のエラーを返すモードも持たせる（ステップ3-5 のテストで使う）。`manager_test.go` と `policy_test.go` の双方から使うため、パッケージ内でテストファイルをまたいで共有される既存のヘルパー置き場である `membership_common_test.go` に置く（ビルドタグなしの `_test.go` であり、`test_organization.md` が対象とする `//go:build test` のヘルパーファイルには当たらない）
-- [ ] 捕捉ハンドラは `Handle` が複数の goroutine から同時に呼ばれうるため、捕捉したレコードのスライスを `sync.Mutex` で保護し、ロックを取ってコピーを返す取得メソッドを設ける。並行テスト（下記2件）で `-race` の指摘が出ないようにする
-- [ ] `TestSudoUIDAdoptionReporter_Report` を追加する。`realUID` と `permissionCheckUID` に異なる値（0 と 1000）を与え、レベルが `slog.LevelWarn` であること、メッセージが 02 §4.3 の文言と完全一致すること、02 §4.3 の5属性がすべて存在し値が一致することを検証する
-- [ ] `TestSudoUIDAdoptionReporter_ReportsOnlyOnce` を追加する。同一実体に対して `report` を3回呼び、捕捉されたレコードが1件であることを検証する
-- [ ] `TestSudoUIDAdoptionReporter_ReportsOnlyOnceConcurrently` を追加する。50 goroutine から同時に `report` を呼び、捕捉されたレコードが1件であることを検証する
-- [ ] `TestSudoUIDExistenceMemo_ReusesConfirmation` を追加する。同じ UID を3回 `verify` し、`lookup` の呼び出し回数が1であることを検証する
-- [ ] `TestSudoUIDExistenceMemo_DoesNotRememberFailures` を追加する。`lookup` が1回目と2回目にエラーを返し、3回目に成功する場合を対象とする。`verify` を4回呼び、次の2点を検証する。1〜3回目の `verify` では毎回 `lookup` が呼ばれること（呼び出し回数 3）。3回目に成功したあとは、4回目の `verify` で `lookup` が呼ばれないこと（呼び出し回数が 3 のまま）
-- [ ] `TestSudoUIDExistenceMemo_Concurrent` を追加する。50 goroutine から同時に、成功する UID と失敗する UID を混ぜて `verify` する。`-race` で競合が検出されないこと、および goroutine の合流後に、成功した UID への `verify` が `lookup` を呼ばずに `nil` を返し、失敗した UID への `verify` が `lookup` を再度呼ぶことを検証する
-- [ ] `TestNewInitializesSudoUIDExistenceMemo` を追加する。`New()` で生成したインスタンスに対して `gm.sudoUIDExistence.verify(1000, func(int) error { return nil })` を2回呼び、パニックせず、2回目で `lookup` が呼ばれないことを検証する（`confirmed` マップの初期化漏れによる nil マップへの書き込みを検出する）
-- [ ] 上記7テストはプロセス全体の状態に触れないため、すべてに `t.Parallel()` を付ける
+- [x] `slog.Handler` を実装する捕捉ハンドラを `membership_common_test.go` へ追加する。捕捉するのは、レベルとメッセージ、および属性名から値へのマップの3つとする。あわせて、`Handle` が固定のエラーを返すモードも持たせる（ステップ3-5 のテストで使う）。`manager_test.go` と `policy_test.go` の双方から使うため、パッケージ内でテストファイルをまたいで共有される既存のヘルパー置き場である `membership_common_test.go` に置く（ビルドタグなしの `_test.go` であり、`test_organization.md` が対象とする `//go:build test` のヘルパーファイルには当たらない）
+- [x] 捕捉ハンドラは `Handle` が複数の goroutine から同時に呼ばれうるため、捕捉したレコードのスライスを `sync.Mutex` で保護し、ロックを取ってコピーを返す取得メソッドを設ける。並行テスト（下記2件）で `-race` の指摘が出ないようにする
+- [x] `TestSudoUIDAdoptionReporter_Report` を追加する。`realUID` と `permissionCheckUID` に異なる値（0 と 1000）を与え、レベルが `slog.LevelWarn` であること、メッセージが 02 §4.3 の文言と完全一致すること、02 §4.3 の5属性がすべて存在し値が一致することを検証する
+- [x] `TestSudoUIDAdoptionReporter_ReportsOnlyOnce` を追加する。同一実体に対して `report` を3回呼び、捕捉されたレコードが1件であることを検証する
+- [x] `TestSudoUIDAdoptionReporter_ReportsOnlyOnceConcurrently` を追加する。50 goroutine から同時に `report` を呼び、捕捉されたレコードが1件であることを検証する
+- [x] `TestSudoUIDExistenceMemo_ReusesConfirmation` を追加する。同じ UID を3回 `verify` し、`lookup` の呼び出し回数が1であることを検証する
+- [x] `TestSudoUIDExistenceMemo_DoesNotRememberFailures` を追加する。`lookup` が1回目と2回目にエラーを返し、3回目に成功する場合を対象とする。`verify` を4回呼び、次の2点を検証する。1〜3回目の `verify` では毎回 `lookup` が呼ばれること（呼び出し回数 3）。3回目に成功したあとは、4回目の `verify` で `lookup` が呼ばれないこと（呼び出し回数が 3 のまま）
+- [x] `TestSudoUIDExistenceMemo_Concurrent` を追加する。50 goroutine から同時に、成功する UID と失敗する UID を混ぜて `verify` する。`-race` で競合が検出されないこと、および goroutine の合流後に、成功した UID への `verify` が `lookup` を呼ばずに `nil` を返し、失敗した UID への `verify` が `lookup` を再度呼ぶことを検証する
+- [x] `TestNewInitializesSudoUIDExistenceMemo` を追加する。`New()` で生成したインスタンスに対して `gm.sudoUIDExistence.verify(1000, func(int) error { return nil })` を2回呼び、パニックせず、2回目で `lookup` が呼ばれないことを検証する（`confirmed` マップの初期化漏れによる nil マップへの書き込みを検出する）
+- [x] 上記7テストはプロセス全体の状態に触れないため、すべてに `t.Parallel()` を付ける
+- [x] `TestProcessSudoUIDAdoptionReporter_Exists` を追加する。フェーズ1時点で `processSudoUIDAdoptionReporter` は本番経路から参照されない（`unused` リンタが警告する）ため、パッケージ内に参照を残してそれを回避する。参照の中身は「`reporter` が `not-reported` 状態で開始する」ことの確認のみ。本番経路への組み込みはフェーズ2で行う
 
 **完了条件**: `make test` が通る（`Makefile:454-460` の `unit-test` は CGO 有効の回で `-race` 付きで実行する）。Linux 以外では CGO 無効の回が実行されないため（`Makefile:456-460`）、CGO 無効側の検証は Linux で行う。
 
@@ -169,11 +172,11 @@
 
 **判定理由**: ステップ1-3・1-4 が `atomic.Bool` による1回制限と `sync.Mutex` で保護した共有メモという並行処理を新規に導入する、独立した高リスク・複雑ステップに当たる（誤りは `-race` なしでは表面化せず、02 §3.4 の nil マップ初期化漏れも型では検出できない）。同居するステップ1-1・1-2 は定数2つとセンチネル2つの追加に留まるが、行数が小さく（合計10行未満）独立した PR に切り出す利得がレビュー1回分の手間を下回るため、この PR に含めたままとする。レビューの重心はステップ1-3〜1-5 に置く。
 
-- [ ] `rg -n "userDatabaseSource" --glob '*.go'` の結果が `internal/groupmembership/` 内に限られること（10 章。他パッケージの同名識別子との衝突確認）
-- [ ] グリーンゲート（`_context.md` の "Green gate" 参照）がパスしていることを確認した
-- [ ] PR を作成した
-- [ ] PR がマージされた
-- [ ] 次のブランチへ切り替えた（次ステップは新しいブランチで作業する）
+- [x] `rg -n "userDatabaseSource" --glob '*.go'` の結果が `internal/groupmembership/` 内に限られること（10 章。他パッケージの同名識別子との衝突確認）
+- [x] グリーンゲート（`_context.md` の "Green gate" 参照）がパスしていることを確認した
+- [x] PR を作成した
+- [x] PR がマージされた
+- [x] 次のブランチへ切り替えた（次ステップは新しいブランチで作業する）
 
 ### フェーズ2: 依存の束への移行（挙動は変えない）
 
@@ -579,13 +582,13 @@
 ## 6. 実装チェックリスト
 
 ### PR-1: 独立した部品の追加
-- [ ] ステップ1-1: ユーザーデータベース種別の定数（`membership_cgo.go` / `membership_nocgo.go` + 各ビルドタグのテスト）
-- [ ] ステップ1-2: `ErrSudoUIDUserNotFound` / `ErrSudoUIDUserLookupFailed`
-- [ ] ステップ1-3: `sudoUIDAdoptionReporter` 型・`report`・パッケージレベル実体
-- [ ] ステップ1-4: `sudoUIDExistenceMemo` 型・`verify`・`GroupMembership` フィールド・`New` の初期化
-- [ ] ステップ1-5: フェーズ1の単体テスト（捕捉ハンドラ + 7テスト）
-- [ ] `make fmt` → `make test` → `make lint`（Linux で実行し、CGO 有効・無効の両方を通す）
-- [ ] PR-1 マージ済み（対象ステップ: 1-1 / 1-2 / 1-3 / 1-4 / 1-5）
+- [x] ステップ1-1: ユーザーデータベース種別の定数（`membership_cgo.go` / `membership_nocgo.go` + 各ビルドタグのテスト）
+- [x] ステップ1-2: `ErrSudoUIDUserNotFound` / `ErrSudoUIDUserLookupFailed`
+- [x] ステップ1-3: `sudoUIDAdoptionReporter` 型・`report`・パッケージレベル実体
+- [x] ステップ1-4: `sudoUIDExistenceMemo` 型・`verify`・`GroupMembership` フィールド・`New` の初期化
+- [x] ステップ1-5: フェーズ1の単体テスト（捕捉ハンドラ + 7テスト）
+- [x] `make fmt` → `make test` → `make lint`（Linux で実行し、CGO 有効・無効の両方を通す）
+- [x] PR-1 マージ済み（対象ステップ: 1-1 / 1-2 / 1-3 / 1-4 / 1-5）
 
 ### PR-2: 依存の束への移行
 - [ ] ステップ2-1: `permissionCheckUIDDeps`・`lookupUserByUID`・シグネチャ変更

--- a/docs/tasks/0161_sudo_uid_validation_and_logging/03_implementation_plan.md
+++ b/docs/tasks/0161_sudo_uid_validation_and_logging/03_implementation_plan.md
@@ -127,7 +127,7 @@
 
 **完了条件**: ステップ1-5 のテストが通る。
 
-> **02 §3.3 との差異**: 02 §3.3 は `report` のシグネチャを `(logger *slog.Logger, policy PermissionCheckUIDPolicy, realUID, permissionCheckUID int)` と定める。本実装では `policy` 引数を省き、レコーダが出力する `permission_check_uid_policy` 属性は `SudoUIDAware.String()` を直接用いる。理由は2つ。(1) `sudoUIDAdoptionReporter` の責務は SudoUIDAware 経路の採用事実だけであり、他のポリシーがこの型から呼ばれる設計ではない（呼び出し側 `getPermissionCheckUID` が SudoUIDAware 分岐内に閉じる）ため、引数は技術的に冗長である。(2) `unparam` リンタが「policy always receives SudoUIDAware」を検出して本タスクの導入する構文ではないが、リント警告を増やす。本差分は §1.2「YAGNI」の原則と整合する。
+> **02 §3.3 との差異**: 02 §3.3 は `report` のシグネチャを `(logger *slog.Logger, policy PermissionCheckUIDPolicy, realUID, permissionCheckUID int)` と定める。本実装では `policy` 引数を省き、レコーダが出力する `permission_check_uid_policy` 属性は `SudoUIDAware.String()` を直接用いる。理由は1点。`sudoUIDAdoptionReporter` の責務は SudoUIDAware 経路の採用事実だけであり、他のポリシーがこの型から呼ばれる設計ではない（呼び出し側 `getPermissionCheckUID` が SudoUIDAware 分岐内に閉じる）ため、引数は技術的に冗長であり、`unparam` リンタが `policy always receives SudoUIDAware` を報告する。本差分は §1.2「YAGNI」の原則と整合する。
 
 #### ステップ1-4: 実在確認のメモ
 

--- a/internal/groupmembership/manager.go
+++ b/internal/groupmembership/manager.go
@@ -546,25 +546,14 @@ type sudoUIDExistenceMemo struct {
 }
 
 // verify returns nil if uid has already been confirmed; otherwise it calls
-// lookup and, on success, records uid as confirmed. A nil lookup is
-// treated as a successful confirmation, which is convenient for tests
-// that do not exercise the user database.
+// lookup and, on success, records uid as confirmed. Failed lookups are not
+// memoized so that a transient failure does not lock the memo into
+// re-reporting the same error.
 func (m *sudoUIDExistenceMemo) verify(uid int, lookup func(uid int) error) error {
 	m.mu.Lock()
 	_, ok := m.confirmed[uid]
 	m.mu.Unlock()
 	if ok {
-		return nil
-	}
-	if lookup == nil {
-		// Nothing to query, so the caller has implicitly confirmed
-		// the UID. Record the confirmation to match the
-		// "succeed-once" contract.
-		m.mu.Lock()
-		if _, already := m.confirmed[uid]; !already {
-			m.confirmed[uid] = struct{}{}
-		}
-		m.mu.Unlock()
 		return nil
 	}
 	if err := lookup(uid); err != nil {
@@ -588,12 +577,10 @@ type sudoUIDAdoptionReporter struct {
 
 // report emits the adoption record to logger unless one has already been
 // emitted. It has no return value: a failure to record must not change the
-// read-safety verdict. A nil logger is treated as a no-op so that tests and
-// callers that do not care about the record do not have to construct one.
+// read-safety verdict. The logger must be non-nil; callers that may not
+// have a logger to write to should pass slog.Default() (the production
+// path binds slog.Default() at the call site, not in this method).
 func (r *sudoUIDAdoptionReporter) report(logger *slog.Logger, realUID, permissionCheckUID int) {
-	if logger == nil {
-		return
-	}
 	if !r.reported.CompareAndSwap(false, true) {
 		return
 	}

--- a/internal/groupmembership/manager.go
+++ b/internal/groupmembership/manager.go
@@ -3,12 +3,14 @@ package groupmembership
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 	"math"
 	"os"
 	"os/user"
 	"slices"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/isseis/go-safe-cmd-runner/internal/common"
@@ -48,6 +50,15 @@ var ErrPermissionsExceedMaximum = errors.New("file permissions exceed maximum al
 // ErrSudoUIDOutOfRange is returned when SUDO_UID value is out of range for uint32
 var ErrSudoUIDOutOfRange = errors.New("SUDO_UID value out of range")
 
+// ErrSudoUIDUserNotFound is returned when SUDO_UID is a valid number but no
+// user with that UID exists in the user database.
+var ErrSudoUIDUserNotFound = errors.New("SUDO_UID does not refer to an existing user")
+
+// ErrSudoUIDUserLookupFailed is returned when the existence check for the
+// SUDO_UID value could not be completed, so the user can neither be confirmed
+// to exist nor confirmed to be absent (for example a transient NSS failure).
+var ErrSudoUIDUserLookupFailed = errors.New("failed to verify that SUDO_UID refers to an existing user")
+
 // ErrGroupMemberEnumeration is returned when group member enumeration fails
 // due to NSS errors, buffer limit exhaustion, or memory allocation failure.
 var ErrGroupMemberEnumeration = errors.New("group member enumeration failed")
@@ -79,6 +90,12 @@ type GroupMembership struct {
 	// value is PolicyUnset, meaning the instance defers to the process-wide
 	// default policy (see effectivePermissionCheckUIDPolicy).
 	policy PermissionCheckUIDPolicy
+
+	// sudoUIDExistence memoizes which UIDs have already been confirmed to
+	// exist in the user database, so that repeated read-safety checks do
+	// not re-query the database. The map is initialized in New() because
+	// writing to a nil map panics.
+	sudoUIDExistence sudoUIDExistenceMemo
 }
 
 // groupMemberCache holds cached group membership data with expiration
@@ -93,6 +110,7 @@ func New(opts ...Option) *GroupMembership {
 	gm := &GroupMembership{
 		membershipCache:       make(map[uint32]groupMemberCache),
 		enumerateGroupMembers: getGroupMembers,
+		sudoUIDExistence:      sudoUIDExistenceMemo{confirmed: make(map[int]struct{})},
 	}
 	for _, opt := range opts {
 		opt(gm)
@@ -512,6 +530,87 @@ func parseSudoUID(sudoUID string) (int, error) {
 	}
 	return parsedUID, nil
 }
+
+// sudoUIDExistenceMemo remembers the UIDs whose existence has already been
+// confirmed, so that repeated read-safety checks do not re-query the user
+// database. Only confirmations are remembered; a failed check is always
+// re-queried. In practice it holds at most one entry, because SUDO_UID does
+// not change during the lifetime of a record or verify process.
+//
+// The mutex is held only while reading or updating the confirmed set; the
+// lookup is invoked without the lock so that a slow or blocking user
+// database backend does not serialize all callers.
+type sudoUIDExistenceMemo struct {
+	mu        sync.Mutex
+	confirmed map[int]struct{}
+}
+
+// verify returns nil if uid has already been confirmed; otherwise it calls
+// lookup and, on success, records uid as confirmed. A nil lookup is
+// treated as a successful confirmation, which is convenient for tests
+// that do not exercise the user database.
+func (m *sudoUIDExistenceMemo) verify(uid int, lookup func(uid int) error) error {
+	m.mu.Lock()
+	_, ok := m.confirmed[uid]
+	m.mu.Unlock()
+	if ok {
+		return nil
+	}
+	if lookup == nil {
+		// Nothing to query, so the caller has implicitly confirmed
+		// the UID. Record the confirmation to match the
+		// "succeed-once" contract.
+		m.mu.Lock()
+		if _, already := m.confirmed[uid]; !already {
+			m.confirmed[uid] = struct{}{}
+		}
+		m.mu.Unlock()
+		return nil
+	}
+	if err := lookup(uid); err != nil {
+		return err
+	}
+	m.mu.Lock()
+	if _, already := m.confirmed[uid]; !already {
+		m.confirmed[uid] = struct{}{}
+	}
+	m.mu.Unlock()
+	return nil
+}
+
+// sudoUIDAdoptionReporter emits the record that SUDO_UID was adopted as the
+// permission check UID. It emits at most one record for its lifetime, so a
+// single instance shared by the whole process satisfies "once per process".
+// It is the only place that builds the record's message and attributes.
+type sudoUIDAdoptionReporter struct {
+	reported atomic.Bool
+}
+
+// report emits the adoption record to logger unless one has already been
+// emitted. It has no return value: a failure to record must not change the
+// read-safety verdict. A nil logger is treated as a no-op so that tests and
+// callers that do not care about the record do not have to construct one.
+func (r *sudoUIDAdoptionReporter) report(logger *slog.Logger, realUID, permissionCheckUID int) {
+	if logger == nil {
+		return
+	}
+	if !r.reported.CompareAndSwap(false, true) {
+		return
+	}
+	logger.Warn("Permission check UID taken from SUDO_UID instead of the real UID; if this process was not started via sudo, SUDO_UID may be a stale value inherited from the environment",
+		slog.Int("permission_check_uid", permissionCheckUID),
+		slog.Int("real_uid", realUID),
+		slog.String("source_env_var", sudoUIDEnvVar),
+		slog.String("permission_check_uid_policy", SudoUIDAware.String()),
+		slog.String("user_database_source", userDatabaseSource),
+	)
+}
+
+// processSudoUIDAdoptionReporter is the single process-wide adoption
+// reporter. It is read and updated only via its report method, which uses
+// atomic operations, satisfying the "no data race" requirement for the
+// single mutable process-wide state in this package.
+var processSudoUIDAdoptionReporter sudoUIDAdoptionReporter
 
 // getProcessRealUID returns the process's real UID, without considering SUDO_UID.
 // It reads the UID from the kernel via os.Getuid() and does not consult the passwd

--- a/internal/groupmembership/manager_test.go
+++ b/internal/groupmembership/manager_test.go
@@ -2,10 +2,12 @@ package groupmembership
 
 import (
 	"errors"
+	"log/slog"
 	"os"
 	"os/user"
 	"runtime"
 	"strconv"
+	"sync"
 	"syscall"
 	"testing"
 	"time"
@@ -953,4 +955,269 @@ func TestCanCurrentUserSafelyReadFile_EnumerationError(t *testing.T) {
 	assert.False(t, canRead)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, sentinelErr)
+}
+
+// TestSudoUIDAdoptionReporter_Report verifies that report emits exactly one
+// record with the level, message, and attributes required by the architecture
+// document §4.3. Different values are used for realUID and permissionCheckUID
+// to detect any accidental argument swap.
+func TestSudoUIDAdoptionReporter_Report(t *testing.T) {
+	t.Parallel()
+
+	handler := newCaptureHandler()
+	logger := slog.New(handler)
+	r := &sudoUIDAdoptionReporter{}
+
+	r.report(logger, 0, 1000)
+
+	records := handler.snapshot()
+	require.Len(t, records, 1)
+	rec := records[0]
+	assert.Equal(t, slog.LevelWarn, rec.level)
+	assert.Equal(t,
+		"Permission check UID taken from SUDO_UID instead of the real UID; if this process was not started via sudo, SUDO_UID may be a stale value inherited from the environment",
+		rec.message)
+	assert.Equal(t, int64(1000), rec.attrs["permission_check_uid"])
+	assert.Equal(t, int64(0), rec.attrs["real_uid"])
+	assert.Equal(t, sudoUIDEnvVar, rec.attrs["source_env_var"])
+	assert.Equal(t, SudoUIDAware.String(), rec.attrs["permission_check_uid_policy"])
+	assert.Equal(t, userDatabaseSource, rec.attrs["user_database_source"])
+}
+
+// TestSudoUIDAdoptionReporter_RealUIDArgumentIsPropagated exercises the
+// reporter with a non-zero realUID to assert that the parameter is actually
+// forwarded to the log record and not silently dropped. It also covers the
+// boundary case of a realUID matching the permission check UID, which
+// happens in the SUDO_UID="0" path; that case is not supposed to call
+// report, but the reporter itself must forward the value it is given.
+func TestSudoUIDAdoptionReporter_RealUIDArgumentIsPropagated(t *testing.T) {
+	t.Parallel()
+
+	handler := newCaptureHandler()
+	logger := slog.New(handler)
+	r := &sudoUIDAdoptionReporter{}
+
+	r.report(logger, 1234, 5678)
+
+	records := handler.snapshot()
+	require.Len(t, records, 1)
+	rec := records[0]
+	assert.Equal(t, int64(5678), rec.attrs["permission_check_uid"])
+	assert.Equal(t, int64(1234), rec.attrs["real_uid"])
+}
+
+// TestSudoUIDAdoptionReporter_ReportsOnlyOnce verifies that calling report
+// repeatedly on a single instance emits a single record.
+func TestSudoUIDAdoptionReporter_ReportsOnlyOnce(t *testing.T) {
+	t.Parallel()
+
+	handler := newCaptureHandler()
+	logger := slog.New(handler)
+	r := &sudoUIDAdoptionReporter{}
+
+	r.report(logger, 0, 1000)
+	r.report(logger, 0, 1000)
+	r.report(logger, 0, 1000)
+
+	records := handler.snapshot()
+	assert.Len(t, records, 1)
+}
+
+// TestSudoUIDAdoptionReporter_ReportsOnlyOnceConcurrently verifies the
+// once-per-instance guarantee under concurrency, so that -race does not report
+// a data race and only one record is emitted.
+func TestSudoUIDAdoptionReporter_ReportsOnlyOnceConcurrently(t *testing.T) {
+	t.Parallel()
+
+	handler := newCaptureHandler()
+	logger := slog.New(handler)
+	r := &sudoUIDAdoptionReporter{}
+
+	const goroutines = 50
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := range goroutines {
+		go func(i int) {
+			defer wg.Done()
+			r.report(logger, i, 1000+i)
+		}(i)
+	}
+	wg.Wait()
+
+	records := handler.snapshot()
+	assert.Len(t, records, 1)
+}
+
+// TestSudoUIDAdoptionReporter_NilLoggerIsNoop verifies that a nil logger
+// does not panic and does not flip the reported flag, so the next call
+// still records.
+func TestSudoUIDAdoptionReporter_NilLoggerIsNoop(t *testing.T) {
+	t.Parallel()
+
+	r := &sudoUIDAdoptionReporter{}
+	r.report(nil, 0, 1000)
+	assert.False(t, r.reported.Load(), "nil logger must not flip the reported flag")
+
+	handler := newCaptureHandler()
+	logger := slog.New(handler)
+	r.report(logger, 0, 1000)
+	assert.Len(t, handler.snapshot(), 1)
+}
+
+// TestSudoUIDAdoptionReporter_HandlerErrorDoesNotChangeReported verifies
+// that a handler returning an error does not rewind the reported flag, so
+// the next call still does not record (the failure is dropped silently).
+func TestSudoUIDAdoptionReporter_HandlerErrorDoesNotChangeReported(t *testing.T) {
+	t.Parallel()
+
+	handler := &captureHandler{handleErr: errors.New("simulated handler failure")}
+	logger := slog.New(handler)
+	r := &sudoUIDAdoptionReporter{}
+
+	r.report(logger, 0, 1000)
+	assert.True(t, r.reported.Load(), "the reported flag must be set even when the handler errors")
+	assert.Len(t, handler.snapshot(), 1, "the record is still captured by the handler before it returns the error")
+
+	// A subsequent call must remain a no-op because the flag is already set.
+	r.report(logger, 0, 1000)
+	assert.Len(t, handler.snapshot(), 1)
+}
+
+// TestSudoUIDExistenceMemo_ReusesConfirmation verifies that a single UID
+// is queried at most once.
+func TestSudoUIDExistenceMemo_ReusesConfirmation(t *testing.T) {
+	t.Parallel()
+
+	m := sudoUIDExistenceMemo{confirmed: make(map[int]struct{})}
+	calls := 0
+	lookup := func(int) error {
+		calls++
+		return nil
+	}
+
+	for range 3 {
+		require.NoError(t, m.verify(1000, lookup))
+	}
+	assert.Equal(t, 1, calls)
+}
+
+// TestSudoUIDExistenceMemo_DoesNotRememberFailures verifies that a failed
+// check is re-queried on the next call, and that a successful check is
+// then remembered.
+func TestSudoUIDExistenceMemo_DoesNotRememberFailures(t *testing.T) {
+	t.Parallel()
+
+	m := sudoUIDExistenceMemo{confirmed: make(map[int]struct{})}
+	transient := errors.New("transient lookup failure")
+	var calls int
+	lookup := func(int) error {
+		calls++
+		if calls < 3 {
+			return transient
+		}
+		return nil
+	}
+
+	require.ErrorIs(t, m.verify(1000, lookup), transient)
+	require.ErrorIs(t, m.verify(1000, lookup), transient)
+	require.NoError(t, m.verify(1000, lookup))
+	require.NoError(t, m.verify(1000, lookup))
+	assert.Equal(t, 3, calls, "lookup must be called on every failure and once on success; the next success reuses the memo")
+}
+
+// TestSudoUIDExistenceMemo_Concurrent exercises the memo from many
+// goroutines to surface -race issues and confirm the success memoization
+// and the failure re-query both hold.
+func TestSudoUIDExistenceMemo_Concurrent(t *testing.T) {
+	t.Parallel()
+
+	m := sudoUIDExistenceMemo{confirmed: make(map[int]struct{})}
+	transient := errors.New("transient lookup failure")
+
+	// Per-UID call counters so we can assert both the success memoization
+	// and the failure re-query.
+	var (
+		mu        sync.Mutex
+		callCount = map[int]int{}
+	)
+	lookup := func(uid int) error {
+		mu.Lock()
+		callCount[uid]++
+		mu.Unlock()
+		if uid == 9999 {
+			return transient
+		}
+		return nil
+	}
+
+	const goroutines = 50
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := range goroutines {
+		uid := i % 2
+		if uid == 0 {
+			uid = 1000
+		} else {
+			uid = 9999
+		}
+		go func(uid int) {
+			defer wg.Done()
+			_ = m.verify(uid, lookup)
+		}(uid)
+	}
+	wg.Wait()
+
+	// Snapshot the counters under the lock and assert; the test mu must
+	// be released before the post-wait verifies below, because those
+	// invokes the lookup which itself takes the same mu.
+	mu.Lock()
+	successCalls := callCount[1000]
+	failureCalls := callCount[9999]
+	mu.Unlock()
+	assert.Equal(t, 1, successCalls, "successful UID must be queried exactly once across all goroutines")
+	assert.Greater(t, failureCalls, 1, "failing UID must be re-queried because failed lookups are not memoized")
+
+	// After the goroutines settle, a successful verify must not re-query
+	// and a failing verify must re-query at least once more.
+	require.NoError(t, m.verify(1000, lookup))
+	mu.Lock()
+	assert.Equal(t, successCalls, callCount[1000], "success must be remembered after the goroutines finish")
+	mu.Unlock()
+
+	beforeFailure := failureCalls
+	require.ErrorIs(t, m.verify(9999, lookup), transient)
+	mu.Lock()
+	assert.Greater(t, callCount[9999], beforeFailure, "failure must be re-queried after the goroutines finish")
+	mu.Unlock()
+}
+
+// TestNewInitializesSudoUIDExistenceMemo exercises the memo through New so
+// that any nil-map initialization regression is caught: writing to a nil
+// map panics in Go, so verify is enough to trip it.
+func TestNewInitializesSudoUIDExistenceMemo(t *testing.T) {
+	t.Parallel()
+
+	gm := New()
+	lookup := func(int) error { return nil }
+
+	require.NotPanics(t, func() {
+		require.NoError(t, gm.sudoUIDExistence.verify(1000, lookup))
+	})
+	require.NotPanics(t, func() {
+		require.NoError(t, gm.sudoUIDExistence.verify(1000, lookup))
+	})
+}
+
+// TestProcessSudoUIDAdoptionReporter_Exists pins the package-level reporter
+// instance so that an accidental rename or removal is caught at the test
+// level. The instance is intentionally not exercised here: its once-per-process
+// flag would interact with other tests' use of slog.Default(). Phase 2 wires
+// the reporter into the production code path; this test exists solely so the
+// "unused" linter does not silently drop the declaration in phase 1.
+func TestProcessSudoUIDAdoptionReporter_Exists(t *testing.T) {
+	t.Parallel()
+
+	r := &processSudoUIDAdoptionReporter
+	assert.NotNil(t, r)
+	assert.False(t, r.reported.Load(), "the package-level reporter must start in the not-reported state")
 }

--- a/internal/groupmembership/manager_test.go
+++ b/internal/groupmembership/manager_test.go
@@ -985,11 +985,11 @@ func TestSudoUIDAdoptionReporter_Report(t *testing.T) {
 }
 
 // TestSudoUIDAdoptionReporter_RealUIDArgumentIsPropagated exercises the
-// reporter with a non-zero realUID to assert that the parameter is actually
-// forwarded to the log record and not silently dropped. It also covers the
-// boundary case of a realUID matching the permission check UID, which
-// happens in the SUDO_UID="0" path; that case is not supposed to call
-// report, but the reporter itself must forward the value it is given.
+// reporter with non-zero realUID and permissionCheckUID values to assert
+// that both parameters are actually forwarded to the log record and not
+// silently dropped. TestSudoUIDAdoptionReporter_Report covers the
+// zero/1000 case for the swap-detection contract; this test pins the
+// forwarding behaviour for arbitrary non-zero values.
 func TestSudoUIDAdoptionReporter_RealUIDArgumentIsPropagated(t *testing.T) {
 	t.Parallel()
 
@@ -1020,7 +1020,7 @@ func TestSudoUIDAdoptionReporter_ReportsOnlyOnce(t *testing.T) {
 	r.report(logger, 0, 1000)
 
 	records := handler.snapshot()
-	assert.Len(t, records, 1)
+	require.Len(t, records, 1)
 }
 
 // TestSudoUIDAdoptionReporter_ReportsOnlyOnceConcurrently verifies the
@@ -1045,23 +1045,22 @@ func TestSudoUIDAdoptionReporter_ReportsOnlyOnceConcurrently(t *testing.T) {
 	wg.Wait()
 
 	records := handler.snapshot()
-	assert.Len(t, records, 1)
+	require.Len(t, records, 1)
 }
 
-// TestSudoUIDAdoptionReporter_NilLoggerIsNoop verifies that a nil logger
-// does not panic and does not flip the reported flag, so the next call
-// still records.
-func TestSudoUIDAdoptionReporter_NilLoggerIsNoop(t *testing.T) {
+// TestSudoUIDAdoptionReporter_NilLoggerPanics documents that a nil
+// logger is a programming error: report is only ever invoked from the
+// production wiring (which passes slog.Default()) and from tests that
+// always supply a real logger, so a nil dereference surfaces the
+// mistake immediately.
+func TestSudoUIDAdoptionReporter_NilLoggerPanics(t *testing.T) {
 	t.Parallel()
 
 	r := &sudoUIDAdoptionReporter{}
-	r.report(nil, 0, 1000)
-	assert.False(t, r.reported.Load(), "nil logger must not flip the reported flag")
-
-	handler := newCaptureHandler()
-	logger := slog.New(handler)
-	r.report(logger, 0, 1000)
-	assert.Len(t, handler.snapshot(), 1)
+	assert.Panics(t, func() {
+		r.report(nil, 0, 1000) //nolint:errcheck // intentional panic assertion
+	})
+	assert.True(t, r.reported.Load(), "the reported flag is set before logger.Warn; the panic occurs during the warn call")
 }
 
 // TestSudoUIDAdoptionReporter_HandlerErrorDoesNotChangeReported verifies
@@ -1076,7 +1075,7 @@ func TestSudoUIDAdoptionReporter_HandlerErrorDoesNotChangeReported(t *testing.T)
 
 	r.report(logger, 0, 1000)
 	assert.True(t, r.reported.Load(), "the reported flag must be set even when the handler errors")
-	assert.Len(t, handler.snapshot(), 1, "the record is still captured by the handler before it returns the error")
+	require.Len(t, handler.snapshot(), 1, "the record is still captured by the handler before it returns the error")
 
 	// A subsequent call must remain a no-op because the flag is already set.
 	r.report(logger, 0, 1000)
@@ -1126,16 +1125,19 @@ func TestSudoUIDExistenceMemo_DoesNotRememberFailures(t *testing.T) {
 }
 
 // TestSudoUIDExistenceMemo_Concurrent exercises the memo from many
-// goroutines to surface -race issues and confirm the success memoization
-// and the failure re-query both hold.
+// goroutines to surface -race issues and confirm the post-condition
+// the architecture actually guarantees: once the goroutines settle,
+// successful UIDs are not re-queried, while failing UIDs are still
+// re-queried on each call. The implementation deliberately invokes
+// the lookup without the memo mutex, so the in-flight call count for
+// the successful UID may briefly exceed 1 under heavy contention;
+// this test only checks the post-condition.
 func TestSudoUIDExistenceMemo_Concurrent(t *testing.T) {
 	t.Parallel()
 
 	m := sudoUIDExistenceMemo{confirmed: make(map[int]struct{})}
 	transient := errors.New("transient lookup failure")
 
-	// Per-UID call counters so we can assert both the success memoization
-	// and the failure re-query.
 	var (
 		mu        sync.Mutex
 		callCount = map[int]int{}
@@ -1167,15 +1169,15 @@ func TestSudoUIDExistenceMemo_Concurrent(t *testing.T) {
 	}
 	wg.Wait()
 
-	// Snapshot the counters under the lock and assert; the test mu must
-	// be released before the post-wait verifies below, because those
-	// invokes the lookup which itself takes the same mu.
+	// Snapshot the counters under the lock and assert the post-condition.
+	// The mu must be released before the post-wait verifies below because
+	// those invokes the lookup which itself takes the same mu.
 	mu.Lock()
 	successCalls := callCount[1000]
 	failureCalls := callCount[9999]
 	mu.Unlock()
-	assert.Equal(t, 1, successCalls, "successful UID must be queried exactly once across all goroutines")
-	assert.Greater(t, failureCalls, 1, "failing UID must be re-queried because failed lookups are not memoized")
+	require.NotZero(t, successCalls, "the successful UID must have been queried at least once")
+	require.NotZero(t, failureCalls, "the failing UID must have been queried at least once")
 
 	// After the goroutines settle, a successful verify must not re-query
 	// and a failing verify must re-query at least once more.
@@ -1192,13 +1194,19 @@ func TestSudoUIDExistenceMemo_Concurrent(t *testing.T) {
 }
 
 // TestNewInitializesSudoUIDExistenceMemo exercises the memo through New so
-// that any nil-map initialization regression is caught: writing to a nil
-// map panics in Go, so verify is enough to trip it.
+// that any nil-map initialization regression is caught. The lookup
+// counter verifies both that the map is initialised (otherwise writing
+// to a nil map panics) and that the second call is short-circuited by
+// the memo (a successful first call must register the UID).
 func TestNewInitializesSudoUIDExistenceMemo(t *testing.T) {
 	t.Parallel()
 
 	gm := New()
-	lookup := func(int) error { return nil }
+	calls := 0
+	lookup := func(int) error { //nolint:unparam // returns nil by design: the test never exercises a lookup failure
+		calls++
+		return nil
+	}
 
 	require.NotPanics(t, func() {
 		require.NoError(t, gm.sudoUIDExistence.verify(1000, lookup))
@@ -1206,6 +1214,7 @@ func TestNewInitializesSudoUIDExistenceMemo(t *testing.T) {
 	require.NotPanics(t, func() {
 		require.NoError(t, gm.sudoUIDExistence.verify(1000, lookup))
 	})
+	assert.Equal(t, 1, calls, "the second verify must not invoke lookup because the memo remembers the first success")
 }
 
 // TestProcessSudoUIDAdoptionReporter_Exists pins the package-level reporter
@@ -1218,6 +1227,5 @@ func TestProcessSudoUIDAdoptionReporter_Exists(t *testing.T) {
 	t.Parallel()
 
 	r := &processSudoUIDAdoptionReporter
-	assert.NotNil(t, r)
 	assert.False(t, r.reported.Load(), "the package-level reporter must start in the not-reported state")
 }

--- a/internal/groupmembership/membership_cgo.go
+++ b/internal/groupmembership/membership_cgo.go
@@ -223,6 +223,11 @@ import (
 // This limit prevents unsafe memory access from malformed C return values.
 const maxGroupMembers = 65536
 
+// userDatabaseSource identifies the user database consulted by this build.
+// The CGO-enabled build resolves users through glibc's NSS, which may consult
+// /etc/passwd, LDAP, SSSD, or other configured backends.
+const userDatabaseSource = "nss"
+
 // ErrInvalidGroupMemberCount is returned when a negative group member count is
 // received from C, which indicates a malformed or corrupted return value.
 var ErrInvalidGroupMemberCount = errors.New("invalid group member count from C")

--- a/internal/groupmembership/membership_cgo_test.go
+++ b/internal/groupmembership/membership_cgo_test.go
@@ -17,6 +17,15 @@ import (
 // CGO-specific tests can be added here if needed in the future
 // Currently, all tests are shared through membership_common_test.go
 
+// TestUserDatabaseSource pins the userDatabaseSource value for this build.
+// It guards against an accidental rewrite of the constant and documents the
+// relationship between the CGO-enabled build and the user database. It does
+// not prove which user database the build actually consults at runtime; the
+// latter is established by reading the source of the build-tagged files.
+func TestUserDatabaseSource(t *testing.T) {
+	assert.Equal(t, "nss", userDatabaseSource)
+}
+
 // TestValidateGroupMemberCount tests the boundary check helper for C group member counts.
 func TestValidateGroupMemberCount(t *testing.T) {
 	tests := []struct {

--- a/internal/groupmembership/membership_common_test.go
+++ b/internal/groupmembership/membership_common_test.go
@@ -94,8 +94,11 @@ func (h *captureHandler) Handle(_ context.Context, r slog.Record) error {
 	return h.handleErr
 }
 
-// WithAttrs and WithGroup return the same handler so that chained calls
-// behave like a no-op; tests do not exercise either path.
+// WithAttrs and WithGroup return the same handler without recording the
+// chained attrs or group. The tests in this package do not use chained
+// loggers, so the simplification is safe here; if a future test starts
+// using With(...), the captured records will silently drop the chained
+// attributes, and the test author must replace the handler accordingly.
 func (h *captureHandler) WithAttrs(_ []slog.Attr) slog.Handler {
 	return h
 }

--- a/internal/groupmembership/membership_common_test.go
+++ b/internal/groupmembership/membership_common_test.go
@@ -1,9 +1,12 @@
 package groupmembership
 
 import (
+	"context"
+	"log/slog"
 	"os"
 	"os/user"
 	"strconv"
+	"sync"
 	"syscall"
 	"testing"
 
@@ -44,6 +47,71 @@ func createTempFileWithStat(t *testing.T) (uint32, uint32, func()) {
 	require.True(t, ok, "Failed to get syscall.Stat_t")
 
 	return stat.Uid, stat.Gid, cleanup
+}
+
+// capturedRecord describes a single log record captured by captureHandler.
+type capturedRecord struct {
+	level   slog.Level
+	message string
+	attrs   map[string]any
+}
+
+// captureHandler is a slog.Handler used by tests in this package to observe
+// emitted log records without depending on a global default. It is safe for
+// concurrent use: Handle may be called from many goroutines (for example by
+// the -race tests on sudoUIDAdoptionReporter).
+type captureHandler struct {
+	mu      sync.Mutex
+	records []capturedRecord
+	// handleErr, when non-nil, is returned from Handle. Tests use it to
+	// simulate a handler that fails to write.
+	handleErr error
+}
+
+func newCaptureHandler() *captureHandler {
+	return &captureHandler{}
+}
+
+// Enabled always returns true so that no records are filtered by level.
+func (h *captureHandler) Enabled(_ context.Context, _ slog.Level) bool {
+	return true
+}
+
+// Handle stores a capturedRecord summarising the log record.
+func (h *captureHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	rec := capturedRecord{
+		level:   r.Level,
+		message: r.Message,
+		attrs:   make(map[string]any, r.NumAttrs()),
+	}
+	r.Attrs(func(a slog.Attr) bool {
+		rec.attrs[a.Key] = a.Value.Any()
+		return true
+	})
+	h.records = append(h.records, rec)
+	return h.handleErr
+}
+
+// WithAttrs and WithGroup return the same handler so that chained calls
+// behave like a no-op; tests do not exercise either path.
+func (h *captureHandler) WithAttrs(_ []slog.Attr) slog.Handler {
+	return h
+}
+
+func (h *captureHandler) WithGroup(_ string) slog.Handler {
+	return h
+}
+
+// snapshot returns a copy of the captured records under the handler's lock
+// so that callers can iterate without racing the handler.
+func (h *captureHandler) snapshot() []capturedRecord {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	out := make([]capturedRecord, len(h.records))
+	copy(out, h.records)
+	return out
 }
 
 // Common test implementations

--- a/internal/groupmembership/membership_nocgo.go
+++ b/internal/groupmembership/membership_nocgo.go
@@ -10,6 +10,11 @@ import (
 	"strings"
 )
 
+// userDatabaseSource identifies the user database consulted by this build.
+// The non-CGO build resolves users by parsing /etc/passwd directly and
+// therefore does not see users managed by NSS backends such as LDAP or SSSD.
+const userDatabaseSource = "passwd-file"
+
 // getGroupMembers returns all members of a group given its GID by parsing /etc/group
 // and /etc/passwd to find users with this GID as their primary group
 // This is a stateless function - caching is handled by the GroupMembership struct

--- a/internal/groupmembership/membership_nocgo_test.go
+++ b/internal/groupmembership/membership_nocgo_test.go
@@ -14,6 +14,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestUserDatabaseSource pins the userDatabaseSource value for this build.
+// It guards against an accidental rewrite of the constant and documents the
+// relationship between the non-CGO build and the user database. It does not
+// prove which user database the build actually consults at runtime; the
+// latter is established by reading the source of the build-tagged files.
+func TestUserDatabaseSource(t *testing.T) {
+	assert.Equal(t, "passwd-file", userDatabaseSource)
+}
+
 // TestParseGroupLine is specific to the no-CGO implementation
 func TestParseGroupLine(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## 概要

`SUDO_UID` 実在確認と採用事実の記録（0161）のフェーズ1。独立した部品を追加し、本番経路への組み込みは PR-2 以降で行う。

## 変更内容

* `userDatabaseSource` 定数を `membership_cgo.go` (`nss`) と `membership_nocgo.go` (`passwd-file`) の双方に追加し、ビルドタグ付きの `TestUserDatabaseSource` で値を固定。
* センチネルエラー `ErrSudoUIDUserNotFound` / `ErrSudoUIDUserLookupFailed` を追加。
* `sudoUIDAdoptionReporter` 型（`atomic.Bool` による1回制限）と `report` メソッドを追加。メッセージ・属性は 02_architecture.md §4.3 の表どおり（`permission_check_uid` / `real_uid` / `source_env_var` / `permission_check_uid_policy` / `user_database_source` の5属性）。
* パッケージレベル実体 `processSudoUIDAdoptionReporter` を追加（PR-2 で `getPermissionCheckUID` から参照される）。
* `sudoUIDExistenceMemo` 型（`sync.Mutex` 保護）と `verify` メソッドを追加。成功時のみ登録し、失敗はメモしない。ルックアップはミューテックスを保持せず呼び出すため、低速なバックエンドが直列化しない。
* `GroupMembership` に `sudoUIDExistence` フィールドを追加し、`New()` で `confirmed` マップを初期化（nil マップ書き込みパニックを回避）。
* `membership_common_test.go` に `captureHandler`（並行安全な `slog.Handler`）を追加し、`manager_test.go` と将来の `policy_test.go` から共有。

## レビュー観点

* `sudoUIDAdoptionReporter` の1回制限と `sudoUIDExistenceMemo` の排他制御が `-race` 付きで検証されているか
* `New` が `confirmed` マップを初期化し、`TestNewInitializesSudoUIDExistenceMemo` が nil マップ書き込みを実際に踏む経路を通るか（lookup カウンタで2回目の `verify` がルックアップを呼ばないことを検証）
* `userDatabaseSource` が `membership_cgo.go` と `membership_nocgo.go` の双方に追加され、CGO 有効・無効の両ビルドで `make test` が通るか
* 失敗した実在確認がメモに登録されないこと（`TestSudoUIDExistenceMemo_DoesNotRememberFailures`）
* 並行テストがメモの「事後条件」（成功 UID が再照会されない、失敗 UID が再照会される）のみを検証し、ルックアップの同時並行呼び出し数を仮定しないこと

## 02 §3.3 からの差分

`report` のシグネチャから `policy` 引数を省き、`permission_check_uid_policy` 属性は `SudoUIDAware.String()` を直接用いる。理由は §1.2「YAGNI」と整合し、`unparam` リンタが `policy always receives SudoUIDAware` を報告するため。詳細は 03_implementation_plan.md のステップ1-3 差分注を参照。