### PR TITLE
refactor: Eliminate redundant and verbose docstring comments

### DIFF
--- a/internal/common/slice.go
+++ b/internal/common/slice.go
@@ -9,13 +9,6 @@ import (
 // CloneOrEmpty returns a copy of the slice or an empty slice if nil.
 // This is useful when you need to ensure a non-nil slice is always returned,
 // avoiding potential nil pointer issues in downstream code.
-//
-// Parameters:
-//   - slice: input slice to copy (can be nil)
-//
-// Returns:
-//   - []string: a copy of the input slice, or empty slice if input is nil
-//
 // Example:
 //
 //	var nilSlice []string
@@ -32,18 +25,8 @@ func CloneOrEmpty(slice []string) []string {
 	return slices.Clone(slice)
 }
 
-// SetDifferenceToSlice returns elements in setA that are not in setB.
-// The result is sorted for deterministic output.
-//
+// SetDifferenceToSlice returns elements in setA that are not in setB, sorted for deterministic output.
 // This is a generic function that works with any comparable type T.
-//
-// Parameters:
-//   - setA: first set (elements to check)
-//   - setB: second set (elements to exclude)
-//
-// Returns:
-//   - []T: sorted slice of elements in setA but not in setB
-//
 // Example:
 //
 //	setA := map[string]struct{}{"a": {}, "b": {}, "c": {}}
@@ -61,18 +44,9 @@ func SetDifferenceToSlice[T cmp.Ordered](setA, setB map[T]struct{}) []T {
 	return result
 }
 
-// SliceToSet converts a slice to a set (map with struct{} values).
-// This is useful for creating efficient O(1) lookup structures from slices.
-//
+// SliceToSet converts a slice to a set (map with struct{} values) for efficient O(1) lookup.
 // The function is generic and works with any comparable type T.
 // Using struct{} as the value type minimizes memory usage (0 bytes per entry).
-//
-// Parameters:
-//   - slice: input slice to convert
-//
-// Returns:
-//   - map[T]struct{}: set representation of the input slice
-//
 // Example:
 //
 //	strings := []string{"a", "b", "c", "a"}

--- a/internal/groupmembership/manager.go
+++ b/internal/groupmembership/manager.go
@@ -216,25 +216,10 @@ func (gm *GroupMembership) isUserOnlyGroupMember(userUID int, groupGID uint32) (
 }
 
 // CanUserSafelyWriteFile checks if a user can safely write to a file based on file permissions, ownership and group membership.
-//
-// This function implements the comprehensive security policy:
-// 1. Deny if file has other writable permissions (world writable)
-// 2. If file has group writable permissions: allow only if user owns file AND user is the only member of file's group
-// 3. If file has owner writable permissions: allow only if user owns the file
-//
-// This prevents potential security issues where files could be modified by unintended users.
-//
-// Parameters:
-//   - userUID: The user ID to check (as int)
-//   - fileUID: The file owner's user ID (as uint32)
-//   - fileGID: The file's group ID (as uint32)
-//   - filePerm: The file permissions (as os.FileMode)
-//
-// Returns:
-//   - bool: true if the user can safely write to the file, false otherwise
-//   - error: non-nil if there was an error checking user or group information, or if write is not safe
-//
-// This is the core security policy for determining write permissions in a multi-user environment.
+// It implements the core security policy: deny if file has other writable permissions (world writable);
+// if group writable, allow only if user owns file and is the only group member;
+// if owner writable, allow only if user owns the file.
+// Returns ErrFileWorldWritable, ErrFileNotOwner, ErrFileNotWritable, or ErrGroupWritableNonMember on check failure.
 func (gm *GroupMembership) CanUserSafelyWriteFile(userUID int, fileUID, fileGID uint32, filePerm os.FileMode) (bool, error) {
 	// Validate userUID is within bounds for uint32 before conversion.
 	// Reject negative UIDs to avoid underflow when converting to uint32.
@@ -277,20 +262,8 @@ func (gm *GroupMembership) CanUserSafelyWriteFile(userUID int, fileUID, fileGID 
 	return false, fmt.Errorf("%w UID %d", ErrFileNotWritable, userUID)
 }
 
-// CanCurrentUserSafelyWriteFile is a convenience wrapper for the current user.
-//
-// This function checks if the current user can safely write to a file, using the same
-// security policy as CanUserSafelyWriteFile.
-//
-// Parameters:
-//   - fileUID: The file owner's user ID (as uint32)
-//   - fileGID: The file's group ID (as uint32)
-//   - filePerm: The file permissions (as os.FileMode)
-//
-// Returns:
-//   - bool: true if the current user can safely write to the file, false otherwise
-//   - error: non-nil if the process UID could not be determined or the permission check failed
-//
+// CanCurrentUserSafelyWriteFile is a convenience wrapper for the current user,
+// using the same security policy as CanUserSafelyWriteFile.
 // Example usage:
 //
 //	canWrite, err := gm.CanCurrentUserSafelyWriteFile(stat.Uid, stat.Gid, fileInfo.Mode())
@@ -313,22 +286,10 @@ func (gm *GroupMembership) CanCurrentUserSafelyWriteFile(fileUID, fileGID uint32
 }
 
 // CanCurrentUserSafelyReadFile checks if the current user can safely read from a file
-// with more relaxed permissions compared to write operations.
-//
-// This function implements the read-specific security policy:
-//  1. Deny if file has world writable permissions (security risk)
-//  2. If file has group writable permissions: deny only if current user is NOT in the file's group
-//  3. Allow reading for files with standard read permissions (up to 0o6755)
-//
-// This is more permissive than write operations, as reading generally poses lower security risks.
-//
-// Parameters:
-//   - fileGID: The file's group ID (as uint32)
-//   - filePerm: The file permissions (as os.FileMode)
-//
-// Returns:
-//   - bool: true if the current user can safely read from the file, false otherwise
-//   - error: non-nil if there was an error checking user or group information
+// with more relaxed permissions than write operations. It denies world writable files,
+// denies group writable files if the current user is not in the group,
+// and allows reading with permissions up to 0o6755.
+// Returns ErrFileWorldWritable, ErrGroupWritableNonMember, or ErrPermissionsExceedMaximum on check failure.
 func (gm *GroupMembership) CanCurrentUserSafelyReadFile(fileGID uint32, filePerm os.FileMode) (bool, error) {
 	permissionCheckUID, err := gm.getPermissionCheckUID()
 	if err != nil {
@@ -376,16 +337,8 @@ func (gm *GroupMembership) CanCurrentUserSafelyReadFile(fileGID uint32, filePerm
 	return true, nil
 }
 
-// ValidateRequestedPermissions validates the requested permissions before file creation/modification
-// This performs permission validation to ensure requested permissions don't exceed security limits
-// for the specified operation type.
-//
-// Parameters:
-//   - perm: The requested file permissions
-//   - operation: The intended file operation (read/write)
-//
-// Returns:
-//   - error: Validation error if permissions exceed maximum allowed for the operation
+// ValidateRequestedPermissions validates that requested permissions don't exceed security limits
+// for the specified operation type. Returns ErrPermissionsExceedMaximum if they do.
 func (gm *GroupMembership) ValidateRequestedPermissions(perm os.FileMode, operation FileOperation) error {
 	// Select maximum allowed permissions based on operation type
 	var maxAllowedPerms os.FileMode
@@ -559,20 +512,12 @@ func lookupUserByUID(uid int) error {
 	return err
 }
 
-// getPermissionCheckUID returns the user ID to use for permission checks.
-// The base UID is resolved according to gm's effective permission check UID
-// policy (see effectivePermissionCheckUIDPolicy); SUDO_UID is only consulted
-// when that policy is SudoUIDAware.
-//
-// This function is primarily used for read operations where we want to verify the original
-// user has access to the file being read.
-//
-// Returns:
-//   - int: The UID to use for permission checks
-//   - error: Error if unable to determine the UID. Under the SudoUIDAware
-//     policy this includes ErrSudoUIDUserNotFound when SUDO_UID does not
-//     refer to an existing user and ErrSudoUIDUserLookupFailed when the
-//     existence check could not be completed.
+// getPermissionCheckUID returns the user ID to use for permission checks,
+// resolved according to gm's effective policy (see effectivePermissionCheckUIDPolicy);
+// SUDO_UID is only consulted when that policy is SudoUIDAware.
+// It is primarily used for read operations to verify the original user has access to the file being read.
+// Under the SudoUIDAware policy, may return ErrSudoUIDUserNotFound when SUDO_UID does not refer to an existing user,
+// or ErrSudoUIDUserLookupFailed when the existence check could not be completed.
 func (gm *GroupMembership) getPermissionCheckUID() (int, error) {
 	realUID, err := getProcessRealUID()
 	if err != nil {
@@ -605,34 +550,13 @@ func (gm *GroupMembership) EnsurePermissionCheckUID() error {
 }
 
 // resolvePermissionCheckUID resolves the UID to use for permission checks from
-// the effective permission check UID policy, the process's real UID, and the
-// dependencies bundled in deps.
-//
-// Under RealUIDOnly, it always returns realUID and never calls deps.getenv.
-// Under SudoUIDAware, when realUID is 0 and SUDO_UID (read via deps.getenv)
-// is set, the value must pass the numeric validity check (parseSudoUID) and
-// the existence check (deps.verifyUserExists) before it is adopted: a user
-// that does not exist yields ErrSudoUIDUserNotFound, and a failed existence
-// check yields ErrSudoUIDUserLookupFailed; in both cases no base UID is
-// returned (the resolution fails closed). Otherwise it returns realUID.
-//
-// When SUDO_UID is adopted and differs from realUID, the adoption is recorded
-// through deps.reportAdoption. The record has no return value and its
-// outcome never changes the resolved UID or error.
-//
-// This pure function is separated from getPermissionCheckUID so that all branches
-// can be tested without requiring root privileges.
-//
-// Parameters:
-//   - policy: The effective permission check UID policy
-//   - realUID: The process's real UID
-//   - deps: The external dependencies the SudoUIDAware branch consults
-//     (environment variable access, user existence check, adoption record)
-//
-// Returns:
-//   - int: The UID to use for permission checks
-//   - error: Error if SUDO_UID is present but invalid, or if the user it
-//     refers to cannot be verified to exist
+// the effective permission check UID policy, the process's real UID, and the dependencies bundled in deps.
+// Under RealUIDOnly, it always returns realUID.
+// Under SudoUIDAware, when realUID is 0 and SUDO_UID is set, the value must pass parseSudoUID and deps.verifyUserExists:
+// a user that does not exist yields ErrSudoUIDUserNotFound, and a failed existence check yields ErrSudoUIDUserLookupFailed;
+// in both cases no base UID is returned (the resolution fails closed).
+// When SUDO_UID is adopted and differs from realUID, the adoption is recorded through deps.reportAdoption.
+// This pure function is separated from getPermissionCheckUID so that all branches can be tested without requiring root privileges.
 func resolvePermissionCheckUID(policy PermissionCheckUIDPolicy, realUID int, deps permissionCheckUIDDeps) (int, error) {
 	if policy != SudoUIDAware || realUID != 0 {
 		return realUID, nil
@@ -680,14 +604,8 @@ func echoSudoUID(raw string) string {
 }
 
 // parseSudoUID parses and validates a SUDO_UID string value.
-// This is separated from resolvePermissionCheckUID to allow independent testing.
-//
-// Parameters:
-//   - sudoUID: The string value of SUDO_UID environment variable
-//
-// Returns:
-//   - int: The parsed UID value
-//   - error: Error if the value is invalid (not a number, negative, or exceeds uint32)
+// It is separated from resolvePermissionCheckUID to allow independent testing.
+// Returns an error if the value is not a number, is negative, or exceeds uint32.
 func parseSudoUID(sudoUID string) (int, error) {
 	parsedUID, err := strconv.Atoi(sudoUID)
 	if err != nil {
@@ -700,21 +618,12 @@ func parseSudoUID(sudoUID string) (int, error) {
 }
 
 // getProcessRealUID returns the process's real UID, without considering SUDO_UID.
-// It reads the UID from the kernel via os.Getuid() and does not consult the passwd
-// database, so it does not depend on NSS or /etc/passwd.
-//
-// This function is primarily used for write operations where we want to verify
-// the running process has the necessary permissions to write files.
-//
-// The bounds check below is expected to never fail on supported platforms, since
-// os.Getuid() returns -1 only on platforms without Unix-style UIDs (e.g. Windows).
-// It is kept because CanCurrentUserSafelyReadFile suppresses gosec G115 on the
-// uint32 conversion with the stated justification that the value was already
-// validated here; removing the check would remove that ground.
-//
-// Returns:
-//   - int: The process's real UID
-//   - error: ErrUIDOutOfBounds if the UID does not fit in uint32
+// It reads the UID from the kernel via os.Getuid() and does not consult the passwd database,
+// so it does not depend on NSS or /etc/passwd.
+// It is primarily used for write operations to verify the running process has permission to write files.
+// The bounds check is expected to never fail on supported platforms (os.Getuid returns -1 only on platforms without Unix-style UIDs, e.g. Windows),
+// but is kept because CanCurrentUserSafelyReadFile suppresses gosec G115 on the uint32 conversion with the stated justification that the value was already validated here.
+// Returns ErrUIDOutOfBounds if the UID does not fit in uint32.
 func getProcessRealUID() (int, error) {
 	currentUID := os.Getuid()
 

--- a/internal/groupmembership/manager.go
+++ b/internal/groupmembership/manager.go
@@ -219,7 +219,7 @@ func (gm *GroupMembership) isUserOnlyGroupMember(userUID int, groupGID uint32) (
 // It implements the core security policy: deny if file has other writable permissions (world writable);
 // if group writable, allow only if user owns file and is the only group member;
 // if owner writable, allow only if user owns the file.
-// Returns ErrFileWorldWritable, ErrFileNotOwner, ErrFileNotWritable, or ErrGroupWritableNonMember on check failure.
+// Returns ErrUIDOutOfBounds, ErrFileWorldWritable, ErrFileNotOwner, or ErrFileNotWritable on check failure.
 func (gm *GroupMembership) CanUserSafelyWriteFile(userUID int, fileUID, fileGID uint32, filePerm os.FileMode) (bool, error) {
 	// Validate userUID is within bounds for uint32 before conversion.
 	// Reject negative UIDs to avoid underflow when converting to uint32.
@@ -279,7 +279,7 @@ func (gm *GroupMembership) CanCurrentUserSafelyWriteFile(fileUID, fileGID uint32
 // CanCurrentUserSafelyReadFile checks if the current user can safely read from a file
 // with more relaxed permissions than write operations. It denies world writable files,
 // denies group writable files if the current user is not in the group,
-// and allows reading with permissions up to 0o6755.
+// and allows reading with permissions up to 0o6775.
 // Returns ErrFileWorldWritable, ErrGroupWritableNonMember, or ErrPermissionsExceedMaximum on check failure.
 func (gm *GroupMembership) CanCurrentUserSafelyReadFile(fileGID uint32, filePerm os.FileMode) (bool, error) {
 	permissionCheckUID, err := gm.getPermissionCheckUID()

--- a/internal/groupmembership/manager.go
+++ b/internal/groupmembership/manager.go
@@ -219,7 +219,7 @@ func (gm *GroupMembership) isUserOnlyGroupMember(userUID int, groupGID uint32) (
 // It implements the core security policy: deny if file has other writable permissions (world writable);
 // if group writable, allow only if user owns file and is the only group member;
 // if owner writable, allow only if user owns the file.
-// Returns ErrUIDOutOfBounds, ErrFileWorldWritable, ErrFileNotOwner, or ErrFileNotWritable on check failure.
+// Returns wrapped ErrUIDOutOfBounds, ErrFileWorldWritable, ErrFileNotOwner, ErrFileNotWritable, or errors from user/group lookups on failure.
 func (gm *GroupMembership) CanUserSafelyWriteFile(userUID int, fileUID, fileGID uint32, filePerm os.FileMode) (bool, error) {
 	// Validate userUID is within bounds for uint32 before conversion.
 	// Reject negative UIDs to avoid underflow when converting to uint32.
@@ -264,6 +264,7 @@ func (gm *GroupMembership) CanUserSafelyWriteFile(userUID int, fileUID, fileGID 
 
 // CanCurrentUserSafelyWriteFile is a convenience wrapper for the current user,
 // using the same security policy as CanUserSafelyWriteFile.
+// Returns wrapped ErrUIDOutOfBounds from getProcessRealUID, or errors from CanUserSafelyWriteFile.
 func (gm *GroupMembership) CanCurrentUserSafelyWriteFile(fileUID, fileGID uint32, filePerm os.FileMode) (bool, error) {
 	// For write operations, use the process's real UID (not SUDO_UID) to verify
 	// that the running process has permission to write to the file.
@@ -280,7 +281,8 @@ func (gm *GroupMembership) CanCurrentUserSafelyWriteFile(fileUID, fileGID uint32
 // with more relaxed permissions than write operations. It denies world writable files,
 // denies group writable files if the current user is not in the group,
 // and allows reading with permissions up to 0o6775.
-// Returns ErrFileWorldWritable, ErrGroupWritableNonMember, or ErrPermissionsExceedMaximum on check failure.
+// Returns wrapped ErrFileWorldWritable, ErrGroupWritableNonMember, ErrPermissionsExceedMaximum,
+// or errors from getPermissionCheckUID and IsUserInGroup on check failure.
 func (gm *GroupMembership) CanCurrentUserSafelyReadFile(fileGID uint32, filePerm os.FileMode) (bool, error) {
 	permissionCheckUID, err := gm.getPermissionCheckUID()
 	if err != nil {

--- a/internal/groupmembership/manager.go
+++ b/internal/groupmembership/manager.go
@@ -413,16 +413,8 @@ type sudoUIDAdoptionReporter struct {
 	reported atomic.Bool
 }
 
-// report emits the adoption record to logger unless one has already been
-// emitted. It has no return value: a failure to record must not change the
-// read-safety verdict.
-//
-// The state transition happens before the record is emitted, so a caller that
-// loses the compare-and-swap never reaches logger.Warn and the once-per-process
-// limit holds without a lock around the emission. The consequence is that a
-// handler failure consumes the single record for the lifetime of the process.
-// Emitting first would not avoid that: slog.Logger.Warn discards the handler's
-// error, so a failure cannot be detected and retried in any ordering.
+// report emits the adoption record once unless already emitted.
+// A failure to record must not change the read-safety verdict.
 func (r *sudoUIDAdoptionReporter) report(logger *slog.Logger, policy PermissionCheckUIDPolicy, realUID, permissionCheckUID int) {
 	if !r.reported.CompareAndSwap(false, true) {
 		return
@@ -454,11 +446,8 @@ type sudoUIDExistenceMemo struct {
 }
 
 // verify returns nil if uid has already been confirmed; otherwise it calls
-// lookup and, on success, records uid as confirmed. The lock is held across
-// lookup so that concurrent callers single-flight the query rather than each
-// hitting the user database. Because lookup may block (a user database query
-// is not cancellable), this makes the memo a serialization point if the
-// read-safety path is ever run concurrently.
+// lookup and records uid as confirmed. The lock is held across lookup to
+// single-flight concurrent queries.
 func (m *sudoUIDExistenceMemo) verify(uid int, lookup func(uid int) error) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -494,10 +483,7 @@ type permissionCheckUIDDeps struct {
 
 // lookupUserByUID reports whether a user with the given UID exists in the
 // user database. It returns the error from os/user unchanged so that the
-// caller can distinguish "no such user" from a lookup failure. The error is
-// deliberately not classified here: the classification rule is part of the
-// security verdict, so it lives in the resolution logic where tests can
-// exercise it directly.
+// caller can distinguish "no such user" from a lookup failure.
 func lookupUserByUID(uid int) error {
 	_, err := user.LookupId(strconv.Itoa(uid))
 	return err
@@ -532,13 +518,10 @@ func (gm *GroupMembership) EnsurePermissionCheckUID() error {
 }
 
 // resolvePermissionCheckUID resolves the UID to use for permission checks from
-// the effective permission check UID policy, the process's real UID, and the dependencies bundled in deps.
+// the effective policy, the real UID, and dependencies bundled in deps.
 // Under RealUIDOnly, it always returns realUID.
-// Under SudoUIDAware, when realUID is 0 and SUDO_UID is set, the value must pass parseSudoUID and deps.verifyUserExists:
-// a user that does not exist yields ErrSudoUIDUserNotFound, and a failed existence check yields ErrSudoUIDUserLookupFailed;
-// in both cases no base UID is returned (the resolution fails closed).
-// When SUDO_UID is adopted and differs from realUID, the adoption is recorded through deps.reportAdoption.
-// This pure function is separated from getPermissionCheckUID so that all branches can be tested without requiring root privileges.
+// Under SudoUIDAware, when realUID is 0 and SUDO_UID is set, it validates and adopts the value,
+// returning ErrSudoUIDUserNotFound or ErrSudoUIDUserLookupFailed on failure (fails closed).
 func resolvePermissionCheckUID(policy PermissionCheckUIDPolicy, realUID int, deps permissionCheckUIDDeps) (int, error) {
 	if policy != SudoUIDAware || realUID != 0 {
 		return realUID, nil
@@ -599,13 +582,9 @@ func parseSudoUID(sudoUID string) (int, error) {
 	return parsedUID, nil
 }
 
-// getProcessRealUID returns the process's real UID, without considering SUDO_UID.
-// It reads the UID from the kernel via os.Getuid() and does not consult the passwd database,
-// so it does not depend on NSS or /etc/passwd.
-// It is primarily used for write operations to verify the running process has permission to write files.
-// The bounds check is expected to never fail on supported platforms (os.Getuid returns -1 only on platforms without Unix-style UIDs, e.g. Windows),
-// but is kept because CanCurrentUserSafelyReadFile suppresses gosec G115 on the uint32 conversion with the stated justification that the value was already validated here.
-// Returns ErrUIDOutOfBounds if the UID does not fit in uint32.
+// getProcessRealUID returns the process's real UID without considering SUDO_UID.
+// It reads from the kernel (os.Getuid) without consulting /etc/passwd or NSS.
+// The bounds check is kept for CanCurrentUserSafelyReadFile's gosec G115 suppression.
 func getProcessRealUID() (int, error) {
 	currentUID := os.Getuid()
 

--- a/internal/groupmembership/manager.go
+++ b/internal/groupmembership/manager.go
@@ -264,15 +264,6 @@ func (gm *GroupMembership) CanUserSafelyWriteFile(userUID int, fileUID, fileGID 
 
 // CanCurrentUserSafelyWriteFile is a convenience wrapper for the current user,
 // using the same security policy as CanUserSafelyWriteFile.
-// Example usage:
-//
-//	canWrite, err := gm.CanCurrentUserSafelyWriteFile(stat.Uid, stat.Gid, fileInfo.Mode())
-//	if err != nil {
-//	    return fmt.Errorf("failed to check write safety: %w", err)
-//	}
-//	if !canWrite {
-//	    return fmt.Errorf("current user cannot safely write to file")
-//	}
 func (gm *GroupMembership) CanCurrentUserSafelyWriteFile(fileUID, fileGID uint32, filePerm os.FileMode) (bool, error) {
 	// For write operations, use the process's real UID (not SUDO_UID) to verify
 	// that the running process has permission to write to the file.
@@ -516,8 +507,6 @@ func lookupUserByUID(uid int) error {
 // resolved according to gm's effective policy (see effectivePermissionCheckUIDPolicy);
 // SUDO_UID is only consulted when that policy is SudoUIDAware.
 // It is primarily used for read operations to verify the original user has access to the file being read.
-// Under the SudoUIDAware policy, may return ErrSudoUIDUserNotFound when SUDO_UID does not refer to an existing user,
-// or ErrSudoUIDUserLookupFailed when the existence check could not be completed.
 func (gm *GroupMembership) getPermissionCheckUID() (int, error) {
 	realUID, err := getProcessRealUID()
 	if err != nil {
@@ -534,16 +523,9 @@ func (gm *GroupMembership) getPermissionCheckUID() (int, error) {
 	})
 }
 
-// EnsurePermissionCheckUID resolves the permission check UID and reports only
-// whether the resolution succeeded, without checking any file. Binaries
-// declaring SudoUIDAware call it once at startup so that an unverifiable
-// SUDO_UID fails before the first file is processed.
-//
-// Startup is the only reliable point: record reads its target files through
-// safefileio.SafeOpenFile, which runs no read-safety check, so a run creating
-// only new records never resolves the UID on its own (§3.7.7 of the 0161
-// architecture document). Resolving here does not duplicate the adoption
-// record, which sudoUIDAdoptionReporter limits to one per process.
+// EnsurePermissionCheckUID resolves the permission check UID at startup,
+// failing closed if SUDO_UID is unverifiable. This must be called once before processing files,
+// since record reads through safefileio.SafeOpenFile without read-safety checks.
 func (gm *GroupMembership) EnsurePermissionCheckUID() error {
 	_, err := gm.getPermissionCheckUID()
 	return err

--- a/internal/runner/config/expansion.go
+++ b/internal/runner/config/expansion.go
@@ -35,17 +35,7 @@ const (
 
 // variableResolver is a function type that resolves a variable name to its expanded value.
 // It is called during variable expansion to look up and expand variable references.
-//
-// Parameters:
-//   - varName: the variable name to resolve (without %{} syntax)
-//   - field: field name for error messages
-//   - visited: map tracking currently-being-expanded variables (for circular detection)
-//   - expansionChain: ordered list of variable names in current expansion path
-//   - depth: current recursion depth
-//
-// Returns:
-//   - string: the expanded value of the variable
-//   - error: resolution error (e.g., undefined variable, type mismatch)
+// Returns resolution error (e.g., undefined variable, type mismatch).
 type variableResolver func(
 	varName string,
 	field string,
@@ -55,16 +45,8 @@ type variableResolver func(
 ) (string, error)
 
 // ExpandWorkDir expands %{VAR} references in a workdir string and validates
-// that the result is an absolute path. Empty string is allowed and returned as-is.
-//
-// Parameters:
-//   - workdir: The workdir string to expand (may contain %{VAR} references)
-//   - expandedVars: Map of variable names to their expanded values
-//   - level: Context for error messages (e.g., "group[deploy]", "command[build]")
-//
-// Returns:
-//   - string: The expanded workdir path
-//   - error: Expansion error or ErrInvalidWorkDir if result is not absolute
+// that the result is an absolute path (empty string is allowed and returned as-is).
+// Returns ErrInvalidWorkDir if the result is not absolute.
 func ExpandWorkDir(
 	workdir string,
 	expandedVars map[string]string,
@@ -162,18 +144,7 @@ func resolveAndExpand(
 //   - For collection: resolver collects the variable name and returns empty string
 //   - For validation: resolver can perform custom checks
 //
-// Parameters:
-//   - input: the string to process (may contain %{VAR} references and escape sequences)
-//   - resolver: function to process variable names
-//   - level: context for error messages (e.g., "global", "group[deploy]")
-//   - field: field name for error messages (e.g., "vars", "env.PATH")
-//   - visited: tracks variables currently being expanded (for circular reference detection)
-//   - expansionChain: ordered list of variable names in the current expansion path
-//   - depth: current recursion depth
-//
-// Returns:
-//   - string: the processed string (expanded or empty, depending on resolver)
-//   - error: processing error (syntax error, undefined variable, circular reference, etc.)
+// Returns processing errors for syntax errors, undefined variables, circular references, etc.
 func processVarRefs(
 	input string,
 	resolver variableResolver,
@@ -383,12 +354,6 @@ func newVarExpander(
 
 // expandString expands variable references in the input string.
 // It resolves references to both already-expanded and raw variables.
-//
-// Parameters:
-//   - input: the string containing %{VAR} references to expand
-//   - field: field name for error messages (e.g., "vars.config_path")
-//
-// Returns the expanded string or an error.
 func (e *varExpander) expandString(input string, field string) (string, error) {
 	visited := make(map[string]struct{})
 	expansionChain := make([]string, 0)
@@ -502,19 +467,7 @@ func (e *varExpander) resolveVariable(
 }
 
 // ProcessVars processes vars definitions from a TOML table and expands them
-// using baseExpandedVars and baseExpandedArrays.
-//
-// Parameters:
-//   - vars: Variable definitions from TOML (map[string]any)
-//   - baseExpandedVars: Previously expanded string variables (inherited)
-//   - baseExpandedArrays: Previously expanded array variables (inherited)
-//   - envImportVars: Variables defined via env_import at any level (for conflict detection)
-//   - level: Context for error messages (e.g., "global", "group[deploy]")
-//
-// Returns:
-//   - map[string]string: Expanded string variables (includes base + new)
-//   - map[string][]string: Expanded array variables (includes base + new)
-//   - error: Validation or expansion error
+// using baseExpandedVars and baseExpandedArrays. envImportVars is used for conflict detection.
 //
 // Processing steps:
 //  1. Check total variable count against MaxVarsPerLevel
@@ -848,12 +801,7 @@ func determineEffectiveEnvAllowlist(groupAllowlist []string, globalAllowlist []s
 // 3. Env: Expands environment variables using internal variables
 // 4. VerifyFiles: Expands file paths using internal variables
 //
-// Parameters:
-//   - spec: The global configuration spec to expand
-//
-// Returns:
-//   - *RuntimeGlobal: The expanded runtime global configuration
-//   - error: An error if expansion fails (e.g., undefined variable reference)
+// Returns an error if expansion fails (e.g., undefined variable reference).
 func ExpandGlobal(spec *runnertypes.GlobalSpec) (*runnertypes.RuntimeGlobal, error) {
 	// Create RuntimeGlobal using NewRuntimeGlobal to properly initialize timeout field
 	runtime, err := runnertypes.NewRuntimeGlobal(spec)
@@ -921,14 +869,7 @@ func ExpandGlobal(spec *runnertypes.GlobalSpec) (*runnertypes.RuntimeGlobal, err
 //  6. Symbolic link resolution: filepath.EvalSymlinks
 //  7. Duplicate detection (resolved path level): detect paths pointing to same file
 //
-// Parameters:
-//   - rawPaths: List of paths to expand (may contain variable references)
-//   - vars: Variable map for expansion (%{key} -> value)
-//   - groupName: Group name for error messages
-//
-// Returns:
-//   - map[string]struct{}: Expanded and normalized path set for O(1) lookup
-//   - error: Expansion or validation error
+// Returns an expanded and normalized path set for O(1) lookup, or expansion/validation errors.
 func expandCmdAllowed(
 	rawPaths []string,
 	vars map[string]string,
@@ -1012,17 +953,8 @@ func expandCmdAllowed(
 // 5. VerifyFiles: Expands file paths using internal variables
 // 6. CmdAllowed: Expands and validates allowed command paths
 //
-// Parameters:
-//   - spec: The group configuration spec to expand
-//   - globalRuntime: The global runtime configuration
-//
-// Returns:
-//   - *RuntimeGroup: The expanded runtime group configuration
-//   - error: An error if expansion fails
-//
-// Note:
-//   - Commands are NOT expanded by this function. They are expanded separately
-//     by GroupExecutor using ExpandCommand() for each command.
+// Commands are NOT expanded by this function. They are expanded separately
+// by GroupExecutor using ExpandCommand() for each command.
 func ExpandGroup(spec *runnertypes.GroupSpec, globalRuntime *runnertypes.RuntimeGlobal) (*runnertypes.RuntimeGroup, error) {
 	runtime, err := runnertypes.NewRuntimeGroup(spec)
 	if err != nil {
@@ -1256,22 +1188,9 @@ func expandCommandFields(
 // 6. Args: Expands command arguments using internal variables
 // 7. Env: Expands environment variables using internal variables
 //
-// Parameters:
-//   - spec: The command configuration spec to expand
-//   - templates: Map of available command templates
-//   - runtimeGroup: The runtime group configuration
-//   - globalRuntime: The global runtime configuration
-//   - globalTimeout: Global timeout setting for timeout resolution hierarchy
-//   - globalOutputSizeLimit: Global output size limit setting for output size limit resolution
-//
-// Returns:
-//   - *RuntimeCommand: The expanded runtime command configuration with resolved EffectiveTimeout and EffectiveOutputSizeLimit
-//   - error: An error if expansion fails
-//
-// Note:
-//   - EffectiveTimeout is set by NewRuntimeCommand using timeout resolution hierarchy.
-//   - EffectiveOutputSizeLimit is set by NewRuntimeCommand using output size limit resolution.
-//   - EffectiveWorkDir is NOT set by this function; it is set by GroupExecutor after expansion.
+// EffectiveTimeout and EffectiveOutputSizeLimit are resolved by NewRuntimeCommand using
+// timeout and output size limit resolution hierarchies respectively.
+// EffectiveWorkDir is NOT set by this function; it is set by GroupExecutor after expansion.
 func ExpandCommand(spec *runnertypes.CommandSpec, templates map[string]runnertypes.CommandTemplate, runtimeGroup *runnertypes.RuntimeGroup, globalRuntime *runnertypes.RuntimeGlobal, globalTimeout common.Timeout, globalOutputSizeLimit common.OutputSizeLimit) (*runnertypes.RuntimeCommand, error) {
 	// 0. Resolve template if present
 	workingSpec, err := resolveAndPrepareCommandSpec(spec, templates)
@@ -1318,14 +1237,6 @@ func ExpandCommand(spec *runnertypes.CommandSpec, templates map[string]runnertyp
 //   - OutputFile: Override model (command overrides template, nil = inherit)
 //   - EnvImport: Merge model (template entries added first, command entries appended, duplicates removed)
 //   - Vars: Merge model (template vars as baseline, command vars overlay with precedence on conflicts)
-//
-// Parameters:
-//   - expandedSpec: The spec being constructed (output)
-//   - cmdSpec: The original command spec (contains command-level overrides)
-//   - expandedWorkDir: WorkDir from template after parameter expansion (nil if not set in template)
-//   - expandedOutputFile: OutputFile from template after parameter expansion (nil if not set in template)
-//   - expandedEnvImport: EnvImport from template after parameter expansion
-//   - expandedVars: Vars from template after parameter expansion
 func ApplyTemplateInheritance(
 	expandedSpec *runnertypes.CommandSpec,
 	cmdSpec *runnertypes.CommandSpec,

--- a/internal/runner/group_executor.go
+++ b/internal/runner/group_executor.go
@@ -234,8 +234,7 @@ func (ge *DefaultGroupExecutor) ExecuteGroup(ctx context.Context, groupSpec *run
 	return nil
 }
 
-// executeAllCommands executes all commands in a group sequentially
-// Returns: (commandResults, executionResult, error)
+// executeAllCommands executes all commands in a group sequentially.
 // executionResult is non-nil only when an error occurs, representing the error state.
 func (ge *DefaultGroupExecutor) executeAllCommands(
 	ctx context.Context,
@@ -299,13 +298,7 @@ func (ge *DefaultGroupExecutor) executeAllCommands(
 //  2. Resolve effective working directory via resolveCommandWorkDir
 //  3. Store the fully-expanded RuntimeCommand in runtimeGroup.Commands
 //
-// Parameters:
-//   - groupSpec: The group specification containing command definitions
-//   - runtimeGroup: The runtime group to store expanded commands
-//   - runtimeGlobal: The global runtime configuration
-//
-// Returns:
-//   - error: An error if any command expansion or workdir resolution fails
+// Returns an error if any command expansion or workdir resolution fails.
 func (ge *DefaultGroupExecutor) preExpandCommands(
 	groupSpec *runnertypes.GroupSpec,
 	runtimeGroup *runnertypes.RuntimeGroup,
@@ -718,9 +711,7 @@ func (ge *DefaultGroupExecutor) executeSingleCommand(ctx context.Context, cmd *r
 }
 
 // resolveGroupWorkDir determines the working directory for a group.
-// Returns: (workdir, tempDirManager, error)
-//   - For fixed directories: tempDirManager is nil
-//   - For temporary directories: tempDirManager is non-nil (used for cleanup)
+// For fixed directories, tempDirManager is nil; for temporary directories, it is non-nil (used for cleanup).
 func (ge *DefaultGroupExecutor) resolveGroupWorkDir(
 	runtimeGroup *runnertypes.RuntimeGroup,
 ) (string, executor.TempDirManager, error) {

--- a/internal/safefileio/safe_file.go
+++ b/internal/safefileio/safe_file.go
@@ -389,16 +389,7 @@ func readFileContent(file File, filePath string, fs FileSystem) ([]byte, error) 
 }
 
 // getFileStatInfo retrieves file statistics and validates that the file is a regular file.
-// This helper function performs common validation steps used by multiple functions.
-//
-// Parameters:
-//   - file: The file to examine
-//   - filePath: The file path for error reporting
-//
-// Returns:
-//   - os.FileInfo: File information if validation passes
-//   - *syscall.Stat_t: System-specific file statistics
-//   - error: Validation error if the file is invalid
+// This helper performs common validation steps used by multiple functions.
 func getFileStatInfo(file File, filePath string) (os.FileInfo, *syscall.Stat_t, error) {
 	fileInfo, err := file.Stat()
 	if err != nil {
@@ -420,19 +411,7 @@ func getFileStatInfo(file File, filePath string) (os.FileInfo, *syscall.Stat_t, 
 
 // canSafelyAccessFile checks if the current user can safely access a file by validating
 // file permissions, ownership, and group membership in a unified security check.
-//
-// This function performs comprehensive security validation:
-//   - Verifies the file is a regular file
-//   - Uses groupmembership to validate write permissions
-//
-// Parameters:
-//   - file: The opened file to validate
-//   - filePath: The file path (for error messages)
-//   - operation: The intended file operation (read/write)
-//   - groupMembership: Group membership checker for security validation
-//
-// Returns:
-//   - error: Validation error if the file cannot be safely accessed
+// It verifies the file is a regular file and uses groupmembership to validate permissions for the operation.
 func canSafelyAccessFile(file File, filePath string, operation groupmembership.FileOperation, groupMembership *groupmembership.GroupMembership) error {
 	fileInfo, stat, err := getFileStatInfo(file, filePath)
 	if err != nil {
@@ -467,20 +446,8 @@ func canSafelyAccessFile(file File, filePath string, operation groupmembership.F
 }
 
 // canSafelyReadFromFile checks if the current user can safely read from a file with
-// more relaxed permissions compared to write operations.
-//
-// This function performs read-specific security validation:
-//   - Verifies the file is a regular file
-//   - Uses groupmembership to validate read permissions
-//
-// Parameters:
-//   - file: The opened file to validate
-//   - filePath: The file path (for error messages)
-//   - groupMembership: Group membership checker for security validation
-//
-// Returns:
-//   - os.FileInfo: File information if validation passes
-//   - error: Validation error if the file cannot be safely read from
+// more relaxed permissions than write operations.
+// It verifies the file is a regular file and uses groupmembership to validate read permissions.
 func canSafelyReadFromFile(file File, filePath string, groupMembership *groupmembership.GroupMembership) (os.FileInfo, error) {
 	fileInfo, stat, err := getFileStatInfo(file, filePath)
 	if err != nil {


### PR DESCRIPTION
## Summary

Comprehensive refactoring of docstring comments in manager.go to eliminate redundancy:
- Remove Parameters:/Returns: blocks that merely repeat function signatures
- Trim implementation details from helper function comments
- Retain only "why" information that cannot be inferred from code

## Changes

### Issue #963 compliance (main commit)
- CanUserSafelyWriteFile: Keep security policy explanation
- CanCurrentUserSafelyWriteFile: Remove 8-line Example block
- CanCurrentUserSafelyReadFile: Keep read-policy details
- EnsurePermissionCheckUID: Shorten 10-line comment to 3 lines
- Plus 20+ other functions across 5 files

### Further refinements (follow-up commits)
- sudoUIDAdoptionReporter.report: Remove state-transition details (8→2 lines)
- sudoUIDExistenceMemo.verify: Simplify serialization explanation (5→3 lines)
- lookupUserByUID: Remove redundant classification logic
- resolvePermissionCheckUID: Consolidate error conditions (8→4 lines)
- getProcessRealUID: Shorten explanation while keeping gosec G115 justification

## Test Results
✅ All tests pass
✅ Lint checks pass
No functional changes; documentation-only refactoring

## Commit Stats
- 5 files changed
- 248 lines deleted (mostly comments)
- 54 lines added (simplified/essential comments)

🤖 Generated with Claude Code
