### PR TITLE
refactor: consolidate slog handler test helpers into testutil

### DIFF
--- a/internal/groupmembership/manager_test.go
+++ b/internal/groupmembership/manager_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	tu "github.com/isseis/go-safe-cmd-runner/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -1005,7 +1006,7 @@ const adoptionRecordMessage = "Permission check UID taken from SUDO_UID instead 
 func TestSudoUIDAdoptionReporter_Report(t *testing.T) {
 	t.Parallel()
 
-	handler := newLogCaptureHandler(nil)
+	handler := tu.NewLogRecorder(nil)
 	logger := slog.New(handler)
 
 	var reporter sudoUIDAdoptionReporter
@@ -1015,15 +1016,15 @@ func TestSudoUIDAdoptionReporter_Report(t *testing.T) {
 	require.Len(t, records, 1)
 	rec := records[0]
 
-	assert.Equal(t, slog.LevelWarn, rec.level)
-	assert.Equal(t, adoptionRecordMessage, rec.message)
+	assert.Equal(t, slog.LevelWarn, rec.Level)
+	assert.Equal(t, adoptionRecordMessage, rec.Message)
 	assert.Equal(t, map[string]any{
 		"permission_check_uid":        int64(1000),
 		"real_uid":                    int64(0),
 		"source_env_var":              sudoUIDEnvVar,
 		"permission_check_uid_policy": SudoUIDAware.String(),
 		"user_database_source":        userDatabaseSource,
-	}, rec.attributes)
+	}, rec.Attrs)
 }
 
 // TestSudoUIDAdoptionReporter_ReportsOnlyOnce verifies that a single
@@ -1031,7 +1032,7 @@ func TestSudoUIDAdoptionReporter_Report(t *testing.T) {
 func TestSudoUIDAdoptionReporter_ReportsOnlyOnce(t *testing.T) {
 	t.Parallel()
 
-	handler := newLogCaptureHandler(nil)
+	handler := tu.NewLogRecorder(nil)
 	logger := slog.New(handler)
 
 	var reporter sudoUIDAdoptionReporter
@@ -1048,7 +1049,7 @@ func TestSudoUIDAdoptionReporter_ReportsOnlyOnce(t *testing.T) {
 func TestSudoUIDAdoptionReporter_ReportsOnlyOnceConcurrently(t *testing.T) {
 	t.Parallel()
 
-	handler := newLogCaptureHandler(nil)
+	handler := tu.NewLogRecorder(nil)
 	logger := slog.New(handler)
 
 	var reporter sudoUIDAdoptionReporter
@@ -1229,7 +1230,7 @@ func TestSudoUIDAdoptionRecordReachesDefaultLogger(t *testing.T) {
 	previous := slog.Default()
 	t.Cleanup(func() { slog.SetDefault(previous) })
 
-	handler := newLogCaptureHandler(nil)
+	handler := tu.NewLogRecorder(nil)
 	slog.SetDefault(slog.New(handler))
 
 	t.Setenv(sudoUIDEnvVar, "1000")
@@ -1251,13 +1252,13 @@ func TestSudoUIDAdoptionRecordReachesDefaultLogger(t *testing.T) {
 	records := handler.Records()
 	require.Len(t, records, 1)
 	rec := records[0]
-	assert.Equal(t, slog.LevelWarn, rec.level)
+	assert.Equal(t, slog.LevelWarn, rec.Level)
 	// The distinct real and permission check UIDs (0 vs 1000) also pin the
 	// argument order of the production call site
 	// deps.reportAdoption(policy, realUID, parsedUID): a swapped call would
 	// surface here as real_uid=1000 / permission_check_uid=0.
-	assert.Equal(t, int64(0), rec.attributes["real_uid"])
-	assert.Equal(t, int64(1000), rec.attributes["permission_check_uid"])
+	assert.Equal(t, int64(0), rec.Attrs["real_uid"])
+	assert.Equal(t, int64(1000), rec.Attrs["permission_check_uid"])
 }
 
 // TestNewInitializesSudoUIDExistenceMemo verifies that New initializes the

--- a/internal/groupmembership/membership_common_test.go
+++ b/internal/groupmembership/membership_common_test.go
@@ -1,13 +1,9 @@
 package groupmembership
 
 import (
-	"context"
-	"log/slog"
-	"maps"
 	"os"
 	"os/user"
 	"strconv"
-	"sync"
 	"syscall"
 	"testing"
 
@@ -16,82 +12,6 @@ import (
 )
 
 // Common test helper functions
-
-// logCaptureRecord holds one captured slog record: its level, its message,
-// and a map of attribute name to value.
-type logCaptureRecord struct {
-	level      slog.Level
-	message    string
-	attributes map[string]any
-}
-
-// logCaptureHandler is a slog.Handler that captures records for tests that
-// need to assert on log output. It records the level, message, and
-// attribute name-to-value map of each record, and is safe for concurrent
-// use. When failErr is non-nil, Handle returns it for every record instead
-// of capturing, allowing tests to exercise handler failure paths.
-type logCaptureHandler struct {
-	mu      sync.Mutex
-	records []logCaptureRecord
-	failErr error
-}
-
-// newLogCaptureHandler returns a handler that captures records. A non-nil
-// failErr makes Handle return it for every record.
-func newLogCaptureHandler(failErr error) *logCaptureHandler {
-	return &logCaptureHandler{failErr: failErr}
-}
-
-// Enabled implements slog.Handler.
-func (h *logCaptureHandler) Enabled(context.Context, slog.Level) bool { return true }
-
-// Handle implements slog.Handler.
-func (h *logCaptureHandler) Handle(_ context.Context, r slog.Record) error {
-	if h.failErr != nil {
-		return h.failErr
-	}
-	attrs := make(map[string]any)
-	r.Attrs(func(a slog.Attr) bool {
-		attrs[a.Key] = a.Value.Any()
-		return true
-	})
-	record := logCaptureRecord{level: r.Level, message: r.Message, attributes: attrs}
-
-	h.mu.Lock()
-	defer h.mu.Unlock()
-	h.records = append(h.records, record)
-	return nil
-}
-
-// WithAttrs implements slog.Handler. Handle captures only the attributes
-// carried by the record itself, so attributes attached here would be dropped
-// silently and an assertion on them would pass vacuously. Panic instead, so
-// that a test reaching for slog.Logger.With fails loudly and the capture
-// support is extended deliberately.
-func (h *logCaptureHandler) WithAttrs([]slog.Attr) slog.Handler {
-	panic("logCaptureHandler does not capture WithAttrs attributes")
-}
-
-// WithGroup implements slog.Handler. Groups are not captured, for the same
-// reason as WithAttrs.
-func (h *logCaptureHandler) WithGroup(string) slog.Handler {
-	panic("logCaptureHandler does not capture WithGroup groups")
-}
-
-// Records returns a deep copy of the records captured so far.
-func (h *logCaptureHandler) Records() []logCaptureRecord {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-	result := make([]logCaptureRecord, len(h.records))
-	for i, rec := range h.records {
-		result[i] = logCaptureRecord{
-			level:      rec.level,
-			message:    rec.message,
-			attributes: maps.Clone(rec.attributes),
-		}
-	}
-	return result
-}
 
 // getCurrentUserGID returns the current user's primary group ID
 func getCurrentUserGID(t *testing.T) uint32 {

--- a/internal/groupmembership/policy_test.go
+++ b/internal/groupmembership/policy_test.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"testing"
 
+	tu "github.com/isseis/go-safe-cmd-runner/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -546,7 +547,7 @@ func TestResolvePermissionCheckUID_AdoptionRecordConditions(t *testing.T) {
 // times still yields the correct base UID every time and exactly one record
 // (architecture document §7.1).
 func TestResolvePermissionCheckUID_ReportsAdoptionOnlyOncePerReporter(t *testing.T) {
-	handler := newLogCaptureHandler(nil)
+	handler := tu.NewLogRecorder(nil)
 	logger := slog.New(handler)
 	reporter := &sudoUIDAdoptionReporter{}
 	deps := permissionCheckUIDDeps{
@@ -616,7 +617,7 @@ func TestResolvePermissionCheckUID_VerifiesEvenWhenSudoUIDIsZero(t *testing.T) {
 // handler fails on every record, the base UID is still resolved correctly and
 // no error is returned (architecture document §1.2).
 func TestResolvePermissionCheckUID_RecordFailureDoesNotChangeVerdict(t *testing.T) {
-	handler := newLogCaptureHandler(errors.New("injected handler failure"))
+	handler := tu.NewLogRecorder(errors.New("injected handler failure"))
 	logger := slog.New(handler)
 	reporter := &sudoUIDAdoptionReporter{}
 	deps := permissionCheckUIDDeps{

--- a/internal/logging/pre_execution_error_test.go
+++ b/internal/logging/pre_execution_error_test.go
@@ -1,7 +1,6 @@
 package logging
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -10,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	tu "github.com/isseis/go-safe-cmd-runner/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -644,11 +644,9 @@ func TestExecutionError_ErrorsIs(t *testing.T) {
 func TestHandlePreExecutionError_SlackNotification(t *testing.T) {
 	// Capture slog.Error() calls using a custom handler
 	var capturedRecords []slog.Record
-	captureHandler := &mockLogHandler{
-		onHandle: func(r slog.Record) {
-			capturedRecords = append(capturedRecords, r)
-		},
-	}
+	captureHandler := tu.NewCallbackHandler(func(r slog.Record) {
+		capturedRecords = append(capturedRecords, r)
+	})
 
 	// Replace default logger with capture handler
 	originalLogger := slog.Default()
@@ -726,28 +724,4 @@ func TestHandlePreExecutionError_SlackNotification(t *testing.T) {
 			assert.Equal(t, tt.message, errorMessageAttr)
 		})
 	}
-}
-
-// mockLogHandler is a test helper that captures slog records
-type mockLogHandler struct {
-	onHandle func(slog.Record)
-}
-
-func (h *mockLogHandler) Enabled(_ context.Context, _ slog.Level) bool {
-	return true
-}
-
-func (h *mockLogHandler) Handle(_ context.Context, r slog.Record) error {
-	if h.onHandle != nil {
-		h.onHandle(r)
-	}
-	return nil
-}
-
-func (h *mockLogHandler) WithAttrs(_ []slog.Attr) slog.Handler {
-	return h
-}
-
-func (h *mockLogHandler) WithGroup(_ string) slog.Handler {
-	return h
 }

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -2325,14 +2325,12 @@ func TestLogGroupExecutionSummary_LogLevel(t *testing.T) {
 		message string
 	}
 	var capturedLogs []logRecord
-	captureHandler := &logCaptureHandler{
-		onHandle: func(r slog.Record) {
-			capturedLogs = append(capturedLogs, logRecord{
-				level:   r.Level,
-				message: r.Message,
-			})
-		},
-	}
+	captureHandler := tu.NewCallbackHandler(func(r slog.Record) {
+		capturedLogs = append(capturedLogs, logRecord{
+			level:   r.Level,
+			message: r.Message,
+		})
+	})
 
 	// Save original logger and restore after test
 	originalLogger := slog.Default()
@@ -2401,30 +2399,6 @@ func TestLogGroupExecutionSummary_LogLevel(t *testing.T) {
 		}
 		assert.True(t, found, "Should have logged execution summary")
 	})
-}
-
-// logCaptureHandler is a simple slog.Handler that captures log records for testing
-type logCaptureHandler struct {
-	onHandle func(slog.Record)
-}
-
-func (h *logCaptureHandler) Enabled(_ context.Context, _ slog.Level) bool {
-	return true
-}
-
-func (h *logCaptureHandler) Handle(_ context.Context, r slog.Record) error {
-	if h.onHandle != nil {
-		h.onHandle(r)
-	}
-	return nil
-}
-
-func (h *logCaptureHandler) WithAttrs(_ []slog.Attr) slog.Handler {
-	return h
-}
-
-func (h *logCaptureHandler) WithGroup(_ string) slog.Handler {
-	return h
 }
 
 // TestCreateNormalResourceManager_Succeeds verifies that createNormalResourceManager

--- a/internal/testutil/handlers.go
+++ b/internal/testutil/handlers.go
@@ -1,0 +1,143 @@
+//go:build test || performance || integration
+
+package tu
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+)
+
+// RecordSnapshot is a captured log record.
+type RecordSnapshot struct {
+	Level   slog.Level
+	Message string
+	Attrs   map[string]any
+}
+
+// LogRecorder captures log records with their attributes for testing.
+// If FailErr is non-nil, Handle returns it for every record instead of capturing,
+// allowing tests to exercise handler failure paths.
+type LogRecorder struct {
+	mu        sync.Mutex
+	records   []RecordSnapshot
+	pendAttrs []slog.Attr
+	pendGroup string
+	FailErr   error
+}
+
+// NewLogRecorder returns a new LogRecorder. If failErr is non-nil,
+// Handle returns it for every record instead of capturing.
+func NewLogRecorder(failErr error) *LogRecorder {
+	return &LogRecorder{
+		records:   make([]RecordSnapshot, 0),
+		pendAttrs: make([]slog.Attr, 0),
+		FailErr:   failErr,
+	}
+}
+
+// Enabled implements slog.Handler.
+func (lr *LogRecorder) Enabled(context.Context, slog.Level) bool {
+	return true
+}
+
+// Handle implements slog.Handler and captures record with accumulated attributes.
+func (lr *LogRecorder) Handle(_ context.Context, r slog.Record) error {
+	lr.mu.Lock()
+	defer lr.mu.Unlock()
+
+	if lr.FailErr != nil {
+		return lr.FailErr
+	}
+
+	attrs := make(map[string]any)
+
+	// First capture accumulated attributes from WithAttrs
+	for _, a := range lr.pendAttrs {
+		attrs[a.Key] = a.Value.Any()
+	}
+
+	// Then capture attributes from the record itself
+	r.Attrs(func(a slog.Attr) bool {
+		attrs[a.Key] = a.Value.Any()
+		return true
+	})
+
+	snapshot := RecordSnapshot{
+		Level:   r.Level,
+		Message: r.Message,
+		Attrs:   attrs,
+	}
+
+	lr.records = append(lr.records, snapshot)
+	return nil
+}
+
+// WithAttrs implements slog.Handler and returns a new handler with accumulated attributes.
+func (lr *LogRecorder) WithAttrs(attrs []slog.Attr) slog.Handler {
+	lr.mu.Lock()
+	defer lr.mu.Unlock()
+
+	newRecorder := &LogRecorder{
+		records:   lr.records,
+		pendAttrs: append(lr.pendAttrs[:len(lr.pendAttrs):len(lr.pendAttrs)], attrs...),
+		pendGroup: lr.pendGroup,
+	}
+	return newRecorder
+}
+
+// WithGroup implements slog.Handler and returns a new handler with the group name.
+func (lr *LogRecorder) WithGroup(name string) slog.Handler {
+	lr.mu.Lock()
+	defer lr.mu.Unlock()
+
+	newRecorder := &LogRecorder{
+		records:   lr.records,
+		pendAttrs: lr.pendAttrs,
+		pendGroup: name,
+	}
+	return newRecorder
+}
+
+// Records returns a copy of all captured records.
+func (lr *LogRecorder) Records() []RecordSnapshot {
+	lr.mu.Lock()
+	defer lr.mu.Unlock()
+
+	result := make([]RecordSnapshot, len(lr.records))
+	copy(result, lr.records)
+	return result
+}
+
+// CallbackHandler calls a function for each handled record without capturing.
+type CallbackHandler struct {
+	onHandle func(slog.Record)
+}
+
+// NewCallbackHandler returns a new CallbackHandler.
+func NewCallbackHandler(onHandle func(slog.Record)) *CallbackHandler {
+	return &CallbackHandler{onHandle: onHandle}
+}
+
+// Enabled implements slog.Handler.
+func (h *CallbackHandler) Enabled(context.Context, slog.Level) bool {
+	return true
+}
+
+// Handle implements slog.Handler and calls the callback.
+func (h *CallbackHandler) Handle(_ context.Context, r slog.Record) error {
+	if h.onHandle != nil {
+		h.onHandle(r)
+	}
+	return nil
+}
+
+// WithAttrs implements slog.Handler and returns itself.
+func (h *CallbackHandler) WithAttrs([]slog.Attr) slog.Handler {
+	return h
+}
+
+// WithGroup implements slog.Handler and returns itself.
+func (h *CallbackHandler) WithGroup(string) slog.Handler {
+	return h
+}

--- a/internal/testutil/handlers.go
+++ b/internal/testutil/handlers.go
@@ -19,8 +19,8 @@ type RecordSnapshot struct {
 // If FailErr is non-nil, Handle returns it for every record instead of capturing,
 // allowing tests to exercise handler failure paths.
 type LogRecorder struct {
-	mu        sync.Mutex
-	records   []RecordSnapshot
+	mu        *sync.Mutex
+	records   *[]RecordSnapshot
 	pendAttrs []slog.Attr
 	pendGroup string
 	FailErr   error
@@ -30,7 +30,8 @@ type LogRecorder struct {
 // Handle returns it for every record instead of capturing.
 func NewLogRecorder(failErr error) *LogRecorder {
 	return &LogRecorder{
-		records:   make([]RecordSnapshot, 0),
+		mu:        &sync.Mutex{},
+		records:   &[]RecordSnapshot{},
 		pendAttrs: make([]slog.Attr, 0),
 		FailErr:   failErr,
 	}
@@ -69,7 +70,7 @@ func (lr *LogRecorder) Handle(_ context.Context, r slog.Record) error {
 		Attrs:   attrs,
 	}
 
-	lr.records = append(lr.records, snapshot)
+	*lr.records = append(*lr.records, snapshot)
 	return nil
 }
 
@@ -79,9 +80,11 @@ func (lr *LogRecorder) WithAttrs(attrs []slog.Attr) slog.Handler {
 	defer lr.mu.Unlock()
 
 	newRecorder := &LogRecorder{
+		mu:        lr.mu,
 		records:   lr.records,
 		pendAttrs: append(lr.pendAttrs[:len(lr.pendAttrs):len(lr.pendAttrs)], attrs...),
 		pendGroup: lr.pendGroup,
+		FailErr:   lr.FailErr,
 	}
 	return newRecorder
 }
@@ -92,9 +95,11 @@ func (lr *LogRecorder) WithGroup(name string) slog.Handler {
 	defer lr.mu.Unlock()
 
 	newRecorder := &LogRecorder{
+		mu:        lr.mu,
 		records:   lr.records,
 		pendAttrs: lr.pendAttrs,
 		pendGroup: name,
+		FailErr:   lr.FailErr,
 	}
 	return newRecorder
 }
@@ -104,8 +109,8 @@ func (lr *LogRecorder) Records() []RecordSnapshot {
 	lr.mu.Lock()
 	defer lr.mu.Unlock()
 
-	result := make([]RecordSnapshot, len(lr.records))
-	copy(result, lr.records)
+	result := make([]RecordSnapshot, len(*lr.records))
+	copy(result, *lr.records)
 	return result
 }
 


### PR DESCRIPTION
## Summary

Resolves #955 by consolidating duplicate slog.Handler test implementations into unified helpers in `internal/testutil`.

**Problem solved:**
- Same-named `logCaptureHandler` in groupmembership and runner with opposite `WithAttrs` behavior (panic vs. passthrough)
- Multiple similar implementations (`mockHandler`, `mockLogHandler`) scattered across test files

**Solution:**
- `LogRecorder`: Captures records with accumulated attributes; replaces conflicting logCaptureHandler variants
- `CallbackHandler`: Processes records via callback without attribute capture; replaces mockLogHandler

## Changes

- New `internal/testutil/handlers.go` with unified handlers
- Updated groupmembership, runner, and logging test files to use new helpers
- Maintained test failure injection capability via `FailErr`
- multihandler_test.go and redaction_test.go retain custom mockHandler (test-specific needs)

## Testing

- ✅ All tests pass (20+ packages)
- ✅ Linting clean
- ✅ No breaking changes to test behavior

🤖 Generated with Claude Code