### PR TITLE
[Refactor] Mach-O マジック判定ロジックの重複を解消する

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -66,6 +66,7 @@ linters:
             - github.com/isseis/go-safe-cmd-runner/internal/fileanalysis
             - github.com/isseis/go-safe-cmd-runner/internal/libccache
             - github.com/isseis/go-safe-cmd-runner/internal/machodylib
+            - github.com/isseis/go-safe-cmd-runner/internal/machomagic
             - github.com/isseis/go-safe-cmd-runner/internal/redaction
             - github.com/isseis/go-safe-cmd-runner/internal/security
             - github.com/isseis/go-safe-cmd-runner/internal/filevalidator
@@ -110,6 +111,7 @@ linters:
             - github.com/isseis/go-safe-cmd-runner/internal/libccache
             - github.com/isseis/go-safe-cmd-runner/internal/logging
             - github.com/isseis/go-safe-cmd-runner/internal/machodylib
+            - github.com/isseis/go-safe-cmd-runner/internal/machomagic
             - github.com/isseis/go-safe-cmd-runner/internal/redaction
             - github.com/isseis/go-safe-cmd-runner/internal/security
             - github.com/isseis/go-safe-cmd-runner/internal/ansicolor

--- a/internal/dynlib/machodylib/analyzer.go
+++ b/internal/dynlib/machodylib/analyzer.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/isseis/go-safe-cmd-runner/internal/dynlib"
 	"github.com/isseis/go-safe-cmd-runner/internal/fileanalysis"
+	"github.com/isseis/go-safe-cmd-runner/internal/machomagic"
 	"github.com/isseis/go-safe-cmd-runner/internal/safefileio"
 )
 
@@ -596,23 +597,6 @@ func computeFileHash(fs safefileio.FileSystem, path string) (string, error) {
 	return fmt.Sprintf("sha256:%s", hex.EncodeToString(h.Sum(nil))), nil
 }
 
-// looksLikeMachO returns true if buf starts with a recognised Mach-O magic
-// value (32/64-bit, either endianness). Fat-binary magic is excluded because
-// callers handle it via macho.NewFatFile before reaching the single-arch path.
-func looksLikeMachO(buf []byte) bool {
-	const machOMagicSize = 4
-
-	if len(buf) < machOMagicSize {
-		return false
-	}
-
-	le := binary.LittleEndian.Uint32(buf[:machOMagicSize])
-	be := binary.BigEndian.Uint32(buf[:machOMagicSize])
-
-	return le == macho.Magic32 || le == macho.Magic64 ||
-		be == macho.Magic32 || be == macho.Magic64
-}
-
 // HasDynamicLibDeps checks if the file at the given path is a Mach-O binary
 // that has at least one LC_LOAD_DYLIB or LC_LOAD_WEAK_DYLIB entry pointing to
 // a non-dyld-shared-cache library.
@@ -699,7 +683,9 @@ func checkSingleArchMachO(file safefileio.File) (bool, error) {
 
 	machoFile, err := macho.NewFile(file)
 	if err != nil {
-		if looksLikeMachO(magic[:]) {
+		// Fat-binary magic is excluded because the caller handles it via
+		// macho.NewFatFile before reaching this single-arch path.
+		if machomagic.Is(magic[:]) && !machomagic.IsFat(magic[:]) {
 			return false, fmt.Errorf("failed to parse Mach-O binary: %w", err)
 		}
 

--- a/internal/machomagic/machomagic.go
+++ b/internal/machomagic/machomagic.go
@@ -1,0 +1,42 @@
+// Package machomagic provides Mach-O magic number detection.
+package machomagic
+
+import (
+	"debug/macho"
+	"encoding/binary"
+)
+
+// Len is the length of the Mach-O magic number in bytes.
+const Len = 4
+
+// Byte-swapped magic values not exported by debug/macho
+// (see <mach-o/loader.h> MH_CIGAM_64 / MH_CIGAM / FAT_CIGAM).
+const (
+	magicCigam64  = 0xcffaedfe // byte-swapped Magic64
+	magicCigam32  = 0xcefaedfe // byte-swapped Magic32
+	magicFatCigam = 0xbebafeca // byte-swapped MagicFat
+)
+
+// Is reports whether b starts with any recognized Mach-O or Fat binary magic
+// value (32-bit, 64-bit, or Fat, in either byte order).
+func Is(b []byte) bool {
+	if len(b) < Len {
+		return false
+	}
+	m := binary.LittleEndian.Uint32(b[:Len])
+	switch m {
+	case macho.Magic32, macho.Magic64, macho.MagicFat,
+		magicCigam32, magicCigam64, magicFatCigam:
+		return true
+	}
+	return false
+}
+
+// IsFat reports whether b starts with a Fat binary magic value (either byte order).
+func IsFat(b []byte) bool {
+	if len(b) < Len {
+		return false
+	}
+	m := binary.LittleEndian.Uint32(b[:Len])
+	return m == macho.MagicFat || m == magicFatCigam
+}

--- a/internal/machomagic/machomagic_test.go
+++ b/internal/machomagic/machomagic_test.go
@@ -1,0 +1,128 @@
+//go:build test
+
+package machomagic
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestIs verifies that Is recognizes every supported Mach-O / Fat binary
+// magic value in both byte orders and rejects other formats. (AC: スコープ(案)
+// の整理結果 — isMachOMagic / isMachOMagicAll の差分(32bit除外)は実装上の揺れで
+// あり、両者を統合した全マジック集合 {32/64-bit, Fat} × {native, swapped} を
+// 判定すること)
+func TestIs(t *testing.T) {
+	tests := []struct {
+		name string
+		b    []byte
+		want bool
+	}{
+		{
+			name: "64-bit Mach-O (native endian)",
+			b:    []byte("\xcf\xfa\xed\xfe"),
+			want: true,
+		},
+		{
+			name: "64-bit Mach-O (byte-swapped)",
+			b:    []byte("\xfe\xed\xfa\xcf"),
+			want: true,
+		},
+		{
+			name: "32-bit Mach-O (native endian)",
+			b:    []byte("\xce\xfa\xed\xfe"),
+			want: true,
+		},
+		{
+			name: "32-bit Mach-O (byte-swapped)",
+			b:    []byte("\xfe\xed\xfa\xce"),
+			want: true,
+		},
+		{
+			name: "Fat binary (native endian)",
+			b:    []byte("\xca\xfe\xba\xbe"),
+			want: true,
+		},
+		{
+			name: "Fat binary (byte-swapped)",
+			b:    []byte("\xbe\xba\xfe\xca"),
+			want: true,
+		},
+		{
+			name: "ELF magic",
+			b:    []byte("\x7fELF"),
+			want: false,
+		},
+		{
+			name: "PE magic (MZ)",
+			b:    []byte("MZ\x90\x00"),
+			want: false,
+		},
+		{
+			name: "too short",
+			b:    []byte("\xcf\xfa"),
+			want: false,
+		},
+		{
+			name: "empty",
+			b:    []byte{},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, Is(tt.b))
+		})
+	}
+}
+
+// TestIsFat verifies that IsFat recognizes only Fat binary magic values
+// (both byte orders) and rejects single-arch Mach-O magic. (AC: machodylib の
+// looksLikeMachO が Fat を除外するのはコメント明記の意図的差分であるため、
+// IsFat として分離し「Is && !IsFat」で単一アーキテクチャ判定を維持できること)
+func TestIsFat(t *testing.T) {
+	tests := []struct {
+		name string
+		b    []byte
+		want bool
+	}{
+		{
+			name: "Fat binary (native endian)",
+			b:    []byte("\xca\xfe\xba\xbe"),
+			want: true,
+		},
+		{
+			name: "Fat binary (byte-swapped)",
+			b:    []byte("\xbe\xba\xfe\xca"),
+			want: true,
+		},
+		{
+			name: "64-bit Mach-O",
+			b:    []byte("\xcf\xfa\xed\xfe"),
+			want: false,
+		},
+		{
+			name: "32-bit Mach-O",
+			b:    []byte("\xce\xfa\xed\xfe"),
+			want: false,
+		},
+		{
+			name: "too short",
+			b:    []byte("\xca\xfe"),
+			want: false,
+		},
+		{
+			name: "empty",
+			b:    []byte{},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsFat(tt.b))
+		})
+	}
+}

--- a/internal/machomagic/machomagic_test.go
+++ b/internal/machomagic/machomagic_test.go
@@ -9,10 +9,10 @@ import (
 )
 
 // TestIs verifies that Is recognizes every supported Mach-O / Fat binary
-// magic value in both byte orders and rejects other formats. (AC: スコープ(案)
-// の整理結果 — isMachOMagic / isMachOMagicAll の差分(32bit除外)は実装上の揺れで
-// あり、両者を統合した全マジック集合 {32/64-bit, Fat} × {native, swapped} を
-// 判定すること)
+// magic value in both byte orders and rejects other formats. (AC: per the
+// scope analysis in issue #876, the 32-bit exclusion in isMachOMagic was an
+// implementation slip, so the unified set {32/64-bit, Fat} × {native,
+// swapped} must be recognized)
 func TestIs(t *testing.T) {
 	tests := []struct {
 		name string
@@ -79,9 +79,10 @@ func TestIs(t *testing.T) {
 }
 
 // TestIsFat verifies that IsFat recognizes only Fat binary magic values
-// (both byte orders) and rejects single-arch Mach-O magic. (AC: machodylib の
-// looksLikeMachO が Fat を除外するのはコメント明記の意図的差分であるため、
-// IsFat として分離し「Is && !IsFat」で単一アーキテクチャ判定を維持できること)
+// (both byte orders) and rejects single-arch Mach-O magic. (AC: per the
+// scope analysis in issue #876, the Fat exclusion in machodylib's
+// looksLikeMachO was intentional, so IsFat must be separable so that
+// "Is && !IsFat" preserves single-arch-only detection)
 func TestIsFat(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/security/machoanalyzer/standard_analyzer.go
+++ b/internal/security/machoanalyzer/standard_analyzer.go
@@ -2,7 +2,6 @@ package machoanalyzer
 
 import (
 	"debug/macho"
-	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
@@ -12,6 +11,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/isseis/go-safe-cmd-runner/internal/machomagic"
 	"github.com/isseis/go-safe-cmd-runner/internal/safefileio"
 	"github.com/isseis/go-safe-cmd-runner/internal/security/binaryanalyzer"
 )
@@ -30,38 +30,12 @@ var ErrFileTooLarge = errors.New("file too large")
 // maxFileSize is the maximum file size for Mach-O analysis (1 GB).
 const maxFileSize = 1 << 30
 
-// magicNumberSize is the number of bytes in a Mach-O magic number.
-const magicNumberSize = 4
-
-// Mach-O magic numbers (see <mach-o/loader.h>)
-const (
-	machoMagic64 = 0xFEEDFACF // 64-bit Mach-O (native endian)
-	machoCigam64 = 0xCFFAEDFE // 64-bit Mach-O (byte-swapped)
-	machoMagic32 = 0xFEEDFACE // 32-bit Mach-O (native endian)
-	machoCigam32 = 0xCEFAEDFE // 32-bit Mach-O (byte-swapped)
-	fatMagic     = 0xCAFEBABE // Fat binary
-	fatCigam     = 0xBEBAFECA // Fat binary (byte-swapped)
-)
-
 // libOrdinalMask and libOrdinalShift extract the library ordinal from a symbol's Desc field.
 // The ordinal occupies bits 15:8 of Desc (see <mach-o/nlist.h> GET_LIBRARY_ORDINAL).
 const (
 	libOrdinalMask  = 0xFF
 	libOrdinalShift = 8
 )
-
-// isMachOMagic returns true if the first 4 bytes match any Mach-O or Fat binary magic.
-func isMachOMagic(b []byte) bool {
-	if len(b) < magicNumberSize {
-		return false
-	}
-	magic := binary.LittleEndian.Uint32(b[:magicNumberSize])
-	switch magic {
-	case machoMagic64, machoCigam64, fatMagic, fatCigam:
-		return true
-	}
-	return false
-}
 
 // analyzeSlice performs symbol analysis on a single *macho.File with libSystem filtering.
 // Records all libSystem-derived symbols (both network and non-network categories).
@@ -239,21 +213,20 @@ func (a *StandardMachOAnalyzer) AnalyzeNetworkSymbolsFromReader(file safefileio.
 	// Read via ReadAt (absolute offset) rather than the sequential Reader so
 	// that this analysis does not depend on, or disturb, the file's current
 	// read offset — file may be shared with other analyses of the same content.
-	magic := make([]byte, magicNumberSize)
+	magic := make([]byte, machomagic.Len)
 	if _, err := io.ReadFull(io.NewSectionReader(file, 0, int64(len(magic))), magic); err != nil {
 		return binaryanalyzer.AnalysisOutput{
 			Result: binaryanalyzer.AnalysisError,
 			Error:  fmt.Errorf("failed to read magic: %w", err),
 		}
 	}
-	if !isMachOMagic(magic) {
+	if !machomagic.Is(magic) {
 		return binaryanalyzer.AnalysisOutput{Result: binaryanalyzer.NotSupportedBinary}
 	}
 
 	// Step 3: dispatch on binary type. macho.NewFile / macho.NewFatFile read via
 	// io.ReaderAt, so no Seek to reset the file's current offset is needed.
-	m := binary.LittleEndian.Uint32(magic)
-	if m == fatMagic || m == fatCigam {
+	if machomagic.IsFat(magic) {
 		fat, err := macho.NewFatFile(file)
 		if err != nil {
 			return binaryanalyzer.AnalysisOutput{

--- a/internal/security/machoanalyzer/svc_scanner.go
+++ b/internal/security/machoanalyzer/svc_scanner.go
@@ -10,6 +10,7 @@ import (
 	"os"
 
 	"github.com/isseis/go-safe-cmd-runner/internal/common"
+	"github.com/isseis/go-safe-cmd-runner/internal/machomagic"
 	"github.com/isseis/go-safe-cmd-runner/internal/safefileio"
 )
 
@@ -59,22 +60,6 @@ func collectSVCAddresses(f *macho.File) ([]uint64, error) {
 		return nil, nil
 	}
 	return addrs, nil
-}
-
-// isMachOMagicAll reports whether the first 4 bytes match any recognized
-// Mach-O or Fat binary magic number, covering 32-bit, 64-bit, and Fat
-// binaries in both native and byte-swapped byte orders.
-func isMachOMagicAll(b []byte) bool {
-	if len(b) < magicNumberSize {
-		return false
-	}
-	m := binary.LittleEndian.Uint32(b[:magicNumberSize])
-	switch m {
-	case machoMagic64, machoCigam64, fatMagic, fatCigam,
-		machoMagic32, machoCigam32:
-		return true
-	}
-	return false
 }
 
 // noopSyscallTable is a SyscallNumberTable that returns empty results.
@@ -190,16 +175,15 @@ func ScanSyscallInfosFromReader(f safefileio.File, table SyscallNumberTable) (di
 		table = noopSyscallTable{}
 	}
 
-	magic := make([]byte, magicNumberSize)
+	magic := make([]byte, machomagic.Len)
 	if _, err := io.ReadFull(io.NewSectionReader(f, 0, int64(len(magic))), magic); err != nil {
 		return nil, nil, nil
 	}
-	if !isMachOMagicAll(magic) {
+	if !machomagic.Is(magic) {
 		return nil, nil, nil
 	}
 
-	m := binary.LittleEndian.Uint32(magic)
-	if m == fatMagic || m == fatCigam {
+	if machomagic.IsFat(magic) {
 		fat, err := macho.NewFatFile(f)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to parse Fat binary: %w", err)


### PR DESCRIPTION
Closes #876

## 概要

ELF 側で `internal/elfmagic` に切り出したマジック判定の Mach-O 版フォローアップ。
Mach-O マジック判定が 3 箇所に独立実装されていた重複を、leaf パッケージ `internal/machomagic` に一本化する。

## 実装計画

1. **差分の整理**（スコープ案 checklist 1, 2）

   | 関数 | 対象マジック集合 | Fat |
   |---|---|---|
   | `isMachOMagic` (standard_analyzer.go) | 64-bit のみ | あり |
   | `isMachOMagicAll` (svc_scanner.go) | 32/64-bit | あり |
   | `looksLikeMachO` (machodylib/analyzer.go) | 32/64-bit | なし |

   - `isMachOMagic` の 32-bit 除外は **実装上の揺れ** と判断。
     `machoMagic32`/`machoCigam32` 定数が standard_analyzer.go で定義済みで未使用だった点、doc コメントが「any Mach-O or Fat binary magic」と記述していた点、`macho.NewFile` が 32-bit を完全サポートしている点から、意図的な差分ではない。
   - `looksLikeMachO` の Fat 除外は **意図的**（コメント明記の通り、Fat は呼び出し側が `macho.NewFatFile` で先に処理するため）。

2. **machoanalyzer 内の統一**（checklist 2）: `isMachOMagic` / `isMachOMagicAll` を全マジック集合 {32/64-bit, Fat} × {native, swapped} で統一。
   ※ 副作用として standard_analyzer が 32-bit Mach-O を `NotSupportedBinary` でなく解析対象として受け付けるようになる（svc_scanner と挙動が一致）。

3. **共有 leaf パッケージ化**（checklist 3）: `internal/elfmagic` と同様の独立 leaf パッケージ `internal/machomagic` を新設（`machodylib` の `machoanalyzer` への逆行依存を回避）。
   - `Len` (4) / `Is` (32/64-bit + Fat, 両バイトオーダー) / `IsFat` (Fat のみ)
   - `looksLikeMachO` は `Is && !IsFat` で意図を維持して置換。

4. **単体テスト追加**（checklist 4）: `internal/machomagic/machomagic_test.go` に AC コメント付きで追加。

## 変更ファイル

- `internal/machomagic/machomagic.go` / `machomagic_test.go`（新規）
- `internal/security/machoanalyzer/standard_analyzer.go` / `svc_scanner.go`
- `internal/dynlib/machodylib/analyzer.go`
- `.golangci.yml`（depguard に `machomagic` を許可）

## 検証

- `make fmt` / `make test` / `make lint` 全てパス（depguard ルールも追加済み）