### PR TITLE
fix: make `make test` and `make lint` pass on macOS

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,10 @@ repos:
         verbose: true
     -   id: golangci-lint
         name: golangci-lint
-        entry: golangci-lint run --build-tags test
+        # Version pinned via `go run` (not the system-installed golangci-lint)
+        # so this hook always matches the Makefile's GOLANGCI_VERSION. Keep
+        # the version below in sync with GOLANGCI_VERSION in Makefile.
+        entry: go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4 run --build-tags test
         language: system
         types: [go]
         pass_filenames: false

--- a/cmd/record/main_test.go
+++ b/cmd/record/main_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -238,6 +239,16 @@ func TestRun_DebugInfoFlag_ControlsDebugFieldOmitEmpty(t *testing.T) {
 	})
 
 	t.Run("debug field is emitted with debug-info", func(t *testing.T) {
+		if runtime.GOOS == "darwin" {
+			// On modern macOS, system libraries like libSystem.B.dylib exist only
+			// inside the dyld shared cache; the Mach-O dependency walker excludes
+			// shared-cache libs from DynLibDeps by design (see
+			// internal/dynlib/machodylib/doc.go), so a PATH-resolved "ls" has no
+			// recordable dependency and the debug record stays empty regardless of
+			// -debug-info. This assertion is inherently ELF/glibc-shaped.
+			t.Skip("skipping: -debug-info's debug record needs a recorded dylib dependency, which macOS's shared-cache-only libSystem linkage does not provide for ls")
+		}
+
 		hashDir := tu.SafeTempDir(t)
 		stdout := &bytes.Buffer{}
 		stderr := &bytes.Buffer{}

--- a/cmd/runner/integration_dryrun_verification_test.go
+++ b/cmd/runner/integration_dryrun_verification_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -17,6 +18,19 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// trueCmdPath returns the absolute path to the "true" coreutil, avoiding a
+// PATH-based exec.LookPath resolution (which on some Linux environments can
+// land on a Rust-based coreutils install outside /bin — see the comment on
+// TestDryRunE2E_VerifyFilesHashMismatch). /bin/true does not exist on macOS
+// (only /usr/bin/true does, since macOS keeps /bin and /usr/bin as distinct
+// real directories), so the path is selected per-GOOS instead.
+func trueCmdPath() string {
+	if runtime.GOOS == "darwin" {
+		return "/usr/bin/true"
+	}
+	return "/bin/true"
+}
 
 // setupTempConfig creates a temporary directory with a config file containing the given content.
 // Returns configFile path.
@@ -339,7 +353,7 @@ func TestDryRunE2E_VerifyFilesHashMismatch(t *testing.T) {
 	// runner. /bin/true stays low-risk like echo but, where such a
 	// transitional coreutils setup exists, resolves to a local sibling
 	// (e.g. /bin/gnutrue) instead of reaching outside /bin.
-	const cmdPath = "/bin/true"
+	cmdPath := trueCmdPath()
 
 	configContent := `
 version = "1.0"
@@ -404,7 +418,7 @@ name = "test_group"
 
 [[groups.commands]]
 name = "test-cmd"
-cmd = "/bin/true"
+cmd = "` + trueCmdPath() + `"
 args = ["hello"]
 `
 

--- a/internal/dynlib/machodylib/analyzer_test.go
+++ b/internal/dynlib/machodylib/analyzer_test.go
@@ -643,7 +643,7 @@ type seekErrorFile struct {
 	safefileio.File
 }
 
-func (f *seekErrorFile) Seek(offset int64, whence int) (int64, error) {
+func (f *seekErrorFile) Seek(_ int64, _ int) (int64, error) {
 	return 0, errSimulatedSeek
 }
 
@@ -651,7 +651,7 @@ type readErrorFile struct {
 	safefileio.File
 }
 
-func (f *readErrorFile) Read(p []byte) (int, error) {
+func (f *readErrorFile) Read(_ []byte) (int, error) {
 	return 0, errSimulatedRead
 }
 

--- a/internal/filevalidator/validator_macho_darwin_test.go
+++ b/internal/filevalidator/validator_macho_darwin_test.go
@@ -22,9 +22,13 @@ func TestRecord_Force_MachO_UpdatesDynLibDeps(t *testing.T) {
 	hashDir := filepath.Join(tempDir, "hashes")
 	require.NoError(t, os.MkdirAll(hashDir, 0o700))
 
-	// Create a minimal dylib file on disk (content is the binary's hash source).
+	// Create a minimal, real Mach-O dylib on disk (content is the binary's hash
+	// source). It must be a valid Mach-O, not arbitrary bytes: SaveRecord's BFS
+	// dependency walk parses every strong LC_LOAD_DYLIB target and fails closed
+	// on a parse error, mirroring the ELF analyzer's warn-then-abort behavior.
 	libPath := filepath.Join(tempDir, "libfoo.dylib")
-	require.NoError(t, os.WriteFile(libPath, []byte("initial dylib content"), 0o600))
+	require.NoError(t, os.WriteFile(libPath,
+		machodylibtestutil.BuildMachOWithDeps(machodylibtestutil.NativeCPU(), nil, nil, nil), 0o600))
 
 	// Create a synthetic Mach-O binary referencing libfoo.dylib.
 	binPath := filepath.Join(tempDir, "testbin")
@@ -47,8 +51,11 @@ func TestRecord_Force_MachO_UpdatesDynLibDeps(t *testing.T) {
 	require.NotEmpty(t, rec1.DynLibDeps, "DynLibDeps must be populated after first record")
 	hash1 := rec1.DynLibDeps[0].Hash
 
-	// Modify the dylib to change its content hash.
-	require.NoError(t, os.WriteFile(libPath, []byte("modified dylib content"), 0o600))
+	// Modify the dylib to change its content hash, while staying a valid,
+	// dependency-free Mach-O (an added rpath entry changes the bytes without
+	// introducing another LC_LOAD_DYLIB target for the walk to follow).
+	require.NoError(t, os.WriteFile(libPath,
+		machodylibtestutil.BuildMachOWithDeps(machodylibtestutil.NativeCPU(), nil, nil, []string{"/unused/rpath"}), 0o600))
 
 	// Force re-record: DynLibDeps must be updated with the new hash.
 	_, _, err = v.SaveRecord(binPath, true)

--- a/internal/filevalidator/validator_test.go
+++ b/internal/filevalidator/validator_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -1090,6 +1091,16 @@ func TestRecord_ShebangChainAggregatesDepsAndTopLevelAnalysis(t *testing.T) {
 	require.NotNil(t, record.SymbolAnalysis)
 	assert.Equal(t, []fileanalysis.DetectedSymbol{{Name: "socket"}}, record.SymbolAnalysis.DetectedSymbols,
 		"top-level symbol analysis should be deduped across analyzed binaries")
+
+	if runtime.GOOS != "linux" {
+		// stubSyscallAnalyzerReturnsOne is only wired into the ELF analysis path
+		// (Validator.analyzeELFSyscalls). On darwin the shebang interpreter
+		// resolves to a Mach-O /bin/sh, so syscall detection instead goes
+		// through the real, unstubbed Mach-O syscall scanner, which finds
+		// nothing in the real system /bin/sh. The stub-syscall assertion below
+		// is therefore ELF-specific.
+		return
+	}
 
 	require.NotNil(t, record.SyscallAnalysis)
 	require.Len(t, record.SyscallAnalysis.DetectedSyscalls, 1)

--- a/internal/logging/slack_handler.go
+++ b/internal/logging/slack_handler.go
@@ -895,13 +895,13 @@ func (s *SlackHandler) sendToSlack(ctx context.Context, message SlackMessage) er
 		resp, err := s.httpClient.Do(req) //nolint:gosec // G704: URL is a configured Slack webhook, not user-controlled
 		if err != nil {
 			lastErr = fmt.Errorf("failed to send request: %w", err)
-			slog.Warn("Failed to send Slack request", slog.String("error", sanitizeErrorForLog(err)), slog.Int("attempt", attempt+1), slog.String("run_id", s.runID))
+			slog.Warn("Failed to send Slack request", slog.String("error", sanitizeErrorForLog(err)), slog.Int("attempt", attempt+1), slog.String("run_id", s.runID)) //nolint:gosec // G706: error is sanitized via sanitizeErrorForLog, run_id is an internal identifier
 			continue
 		}
 
 		statusCode := resp.StatusCode
 		if err := resp.Body.Close(); err != nil {
-			slog.Warn("Failed to close response body", slog.String("error", sanitizeErrorForLog(err)))
+			slog.Warn("Failed to close response body", slog.String("error", sanitizeErrorForLog(err))) //nolint:gosec // G706: error is sanitized via sanitizeErrorForLog
 		}
 
 		if statusCode >= 200 && statusCode < 300 {
@@ -920,7 +920,7 @@ func (s *SlackHandler) sendToSlack(ctx context.Context, message SlackMessage) er
 		return fmt.Errorf("%w: %d", ErrClientError, statusCode)
 	}
 
-	slog.Error("Failed to send Slack notification after all retries", slog.Int("attempts", len(backoffIntervals)+1), slog.String("last_error", sanitizeErrorForLog(lastErr)), slog.String("run_id", s.runID))
+	slog.Error("Failed to send Slack notification after all retries", slog.Int("attempts", len(backoffIntervals)+1), slog.String("last_error", sanitizeErrorForLog(lastErr)), slog.String("run_id", s.runID)) //nolint:gosec // G706: error is sanitized via sanitizeErrorForLog, run_id is an internal identifier
 	return fmt.Errorf("failed to send to Slack after %d attempts: %w", len(backoffIntervals)+1, lastErr)
 }
 

--- a/internal/runner/base/risk/coreutils_consistency_test.go
+++ b/internal/runner/base/risk/coreutils_consistency_test.go
@@ -158,7 +158,7 @@ func TestCoreutilsRiskConsistency_Setuid(t *testing.T) {
 		t.Skip("Skipping: OS silently ignored setuid bit (non-root on macOS)")
 	}
 
-	wd := filepath.Join(t.TempDir(), "work")
+	wd := filepath.Join(zoningTestRoot(t), "work")
 	require.NoError(t, os.MkdirAll(wd, 0o700))
 	evaluator := newZoningEvaluator(wd, zoningForeignIdent())
 	// mkdir into a Trusted safe-zone would be Low on its destination alone; the
@@ -179,7 +179,7 @@ func TestConsistency_DestructiveAbsolutePath(t *testing.T) {
 	security.SetCoreutilsDirForTest(t, tmp)
 	rm := makeConsistencyBinary(t, tmp, "rm")
 
-	wd := filepath.Join(t.TempDir(), "work")
+	wd := filepath.Join(zoningTestRoot(t), "work")
 	require.NoError(t, os.MkdirAll(filepath.Join(wd, "build"), 0o700))
 	ev := newZoningEvaluator(wd, zoningForeignIdent())
 
@@ -207,7 +207,7 @@ func TestConsistency_RmAllForms(t *testing.T) {
 	rm := makeConsistencyBinary(t, tmp, "rm")
 	coreutils := makeConsistencyBinary(t, tmp, "coreutils")
 
-	wd := filepath.Join(t.TempDir(), "work")
+	wd := filepath.Join(zoningTestRoot(t), "work")
 	require.NoError(t, os.MkdirAll(filepath.Join(wd, "build"), 0o700))
 	ev := newZoningEvaluator(wd, zoningForeignIdent())
 

--- a/internal/runner/base/risk/destination_zoning_integration_test.go
+++ b/internal/runner/base/risk/destination_zoning_integration_test.go
@@ -41,7 +41,7 @@ func evalLevelInDir(t *testing.T, ev Evaluator, cmd string, args []string, workd
 // its destination zone, replacing the legacy fixed-High destructive dimensions;
 // an unrecognized form keeps the legacy High (fail-open avoidance).
 func TestAxis2ReplacesLegacyHigh(t *testing.T) {
-	wd := filepath.Join(t.TempDir(), "work")
+	wd := filepath.Join(zoningTestRoot(t), "work")
 	require.NoError(t, os.MkdirAll(filepath.Join(wd, "build"), 0o700))
 	ev := newZoningEvaluator(wd, zoningForeignIdent())
 
@@ -61,7 +61,7 @@ func TestAxis2ReplacesLegacyHigh(t *testing.T) {
 // TestAxis1Axis2MaxComposition: the final risk is the max of axis 1 and axis 2; a
 // copy into a trust-critical path is High.
 func TestAxis1Axis2MaxComposition(t *testing.T) {
-	wd := filepath.Join(t.TempDir(), "work")
+	wd := filepath.Join(zoningTestRoot(t), "work")
 	require.NoError(t, os.MkdirAll(wd, 0o700))
 	src := filepath.Join(wd, "payload")
 	require.NoError(t, os.WriteFile(src, nil, 0o644))
@@ -76,7 +76,7 @@ func TestAxis1Axis2MaxComposition(t *testing.T) {
 // recognition are re-established by axis 2's zone and operation-specific floors,
 // so no dangerous form is downgraded (no fail-open gap).
 func TestAxis2RecuperatesSuppressedHigh(t *testing.T) {
-	wd := filepath.Join(t.TempDir(), "work")
+	wd := filepath.Join(zoningTestRoot(t), "work")
 	require.NoError(t, os.MkdirAll(wd, 0o700))
 	ev := newZoningEvaluator(wd, zoningForeignIdent())
 
@@ -98,7 +98,7 @@ func TestAxis2RecuperatesSuppressedHigh(t *testing.T) {
 // TestAxis2NonFileOpUnaffected: a command that is not a file operation classifies
 // identically whether or not axis-2 zoning is enabled (suppressLegacy is false).
 func TestAxis2NonFileOpUnaffected(t *testing.T) {
-	wd := t.TempDir()
+	wd := zoningTestRoot(t)
 	legacy := newVerifiedEvaluator()
 	zoned := newZoningEvaluator(wd, zoningForeignIdent())
 
@@ -121,7 +121,7 @@ func TestAxis2NonFileOpUnaffected(t *testing.T) {
 // TestDataTransferWriteComposition: the final risk of a data-transfer command is
 // the max of its name-based egress Medium and its write destination's zone.
 func TestDataTransferWriteComposition(t *testing.T) {
-	wd := filepath.Join(t.TempDir(), "work")
+	wd := filepath.Join(zoningTestRoot(t), "work")
 	require.NoError(t, os.MkdirAll(wd, 0o700))
 	ev := newZoningEvaluator(wd, zoningForeignIdent())
 
@@ -160,7 +160,7 @@ func TestDataTransferWriteComposition(t *testing.T) {
 // TestOperandZonesStored: the per-operand audit records are carried on the
 // assessment for a file operation, and absent for a non-file-operation command.
 func TestOperandZonesStored(t *testing.T) {
-	wd := filepath.Join(t.TempDir(), "work")
+	wd := filepath.Join(zoningTestRoot(t), "work")
 	require.NoError(t, os.MkdirAll(wd, 0o700))
 	ev := newZoningEvaluator(wd, zoningForeignIdent())
 
@@ -190,7 +190,7 @@ func TestOperandZonesStored(t *testing.T) {
 // tests). With no run_as set, the default identity is the original execution
 // identity, so a trust-critical write is High regardless of the live euid.
 func TestConfigWiredEndToEnd(t *testing.T) {
-	wd := filepath.Join(t.TempDir(), "work")
+	wd := filepath.Join(zoningTestRoot(t), "work")
 	require.NoError(t, os.MkdirAll(wd, 0o700))
 	cfg := security.DefaultConfig()
 	cfg.TrustedDirectories = []string{wd}
@@ -221,7 +221,7 @@ func evalLevelRunAs(t *testing.T, ev Evaluator, cmd string, args []string, workd
 // yields non-Trusted/Medium. This also proves TrustedDirectories from config
 // reaches the judgment (Low requires the destination be within a trusted dir).
 func TestRunAsIdentDifferential(t *testing.T) {
-	wd := filepath.Join(t.TempDir(), "work")
+	wd := filepath.Join(zoningTestRoot(t), "work")
 	require.NoError(t, os.MkdirAll(wd, 0o700))
 	cfg := security.DefaultConfig()
 	cfg.TrustedDirectories = []string{wd}
@@ -245,7 +245,7 @@ func TestRunAsIdentDifferential(t *testing.T) {
 // the judgment fails closed -- every operand is treated as unresolved, so a write
 // is High rather than trusting an unknown identity.
 func TestRunAsResolutionFailsClosed(t *testing.T) {
-	wd := filepath.Join(t.TempDir(), "work")
+	wd := filepath.Join(zoningTestRoot(t), "work")
 	require.NoError(t, os.MkdirAll(wd, 0o700))
 	cfg := security.DefaultConfig()
 	cfg.TrustedDirectories = []string{wd}
@@ -270,7 +270,7 @@ func TestRunAsResolutionFailsClosed(t *testing.T) {
 // is enforced statically by TestNoLiveIdentityInZoning (the zoning code reads no env
 // getter). This test pins the remaining property: determinism across constructions.
 func TestDeterminismRuntimeEqualsDryRun(t *testing.T) {
-	wd := filepath.Join(t.TempDir(), "work")
+	wd := filepath.Join(zoningTestRoot(t), "work")
 	require.NoError(t, os.MkdirAll(filepath.Join(wd, "build"), 0o700))
 	require.NoError(t, os.WriteFile(filepath.Join(wd, "src"), nil, 0o644))
 	cfg := security.DefaultConfig()

--- a/internal/runner/base/risk/evaluator_test.go
+++ b/internal/runner/base/risk/evaluator_test.go
@@ -209,7 +209,7 @@ func TestEvaluateRisk_ProfileStepNoChangeWithoutProfile(t *testing.T) {
 // no longer unconditionally High): trust-critical destination -> High, a
 // recursive delete confined to a Trusted safe-zone -> Low.
 func TestEvaluateRisk_RmRfDestinationDependent(t *testing.T) {
-	wd := filepath.Join(t.TempDir(), "work")
+	wd := filepath.Join(zoningTestRoot(t), "work")
 	require.NoError(t, os.MkdirAll(filepath.Join(wd, "build"), 0o700))
 	ev := newZoningEvaluator(wd, zoningForeignIdent())
 

--- a/internal/runner/base/risk/test_helpers.go
+++ b/internal/runner/base/risk/test_helpers.go
@@ -4,14 +4,36 @@ package risk
 
 import (
 	"errors"
+	"os"
 	"path/filepath"
 	"runtime"
+	"testing"
 
 	"github.com/isseis/go-safe-cmd-runner/internal/fileanalysis"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/risktypes"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/runnertypes"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/security"
+	"github.com/stretchr/testify/require"
 )
+
+// zoningTestRoot returns a fresh, symlink-resolved directory under /tmp for use
+// as a destination-zoning safe-zone origin in tests. It deliberately does not
+// use t.TempDir(): on macOS, t.TempDir() lands under $TMPDIR
+// (/var/folders/...), which resolves to /private/var -- itself inside the
+// "/var" entry of security.DefaultConfig().SystemCriticalPaths. That makes any
+// t.TempDir()-based workdir spuriously trust-critical on macOS even though the
+// same test's workdir is an ordinary path on Linux (TMPDIR=/tmp, outside every
+// default critical root). Building under /tmp instead keeps the "ordinary
+// safe-zone workdir" assumption true on every platform.
+func zoningTestRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "risk-zoning-*")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	resolved, err := filepath.EvalSymlinks(dir)
+	require.NoError(t, err)
+	return resolved
+}
 
 // errUnexpectedIO is an unclassifiable record-load failure used to exercise the
 // error-return (not deny) path.

--- a/internal/runner/base/security/destination_zoning.go
+++ b/internal/runner/base/security/destination_zoning.go
@@ -270,11 +270,22 @@ func (r *operandResolver) classifyZone(resolved string, input ZoningInput) (zone
 // a plain filepath.Clean when resolution fails (e.g. the root does not exist
 // on this host): a configured root not found on disk still classifies by its
 // literal form rather than dropping out of the comparison entirely.
+//
+// classifyZone runs once per operand, so a multi-operand command re-derives
+// the same small set of configured roots repeatedly; the result is cached in
+// r.rootMemo (keyed by the raw path, since maxHops is fixed per command) so
+// each root's symlink chain is only walked once per command rather than once
+// per operand.
 func (r *operandResolver) resolveRoot(path string, maxHops int) string {
-	if resolved, err := r.resolve(path, "", maxHops); err == nil {
-		return resolved
+	if cached, ok := r.rootMemo[path]; ok {
+		return cached
 	}
-	return filepath.Clean(path)
+	resolved, err := r.resolve(path, "", maxHops)
+	if err != nil {
+		resolved = filepath.Clean(path)
+	}
+	r.rootMemo[path] = resolved
+	return resolved
 }
 
 // zoneLevel maps a classified zone (with role and Trusted) to a risk level.

--- a/internal/runner/base/security/destination_zoning.go
+++ b/internal/runner/base/security/destination_zoning.go
@@ -218,6 +218,13 @@ func (r *operandResolver) classifyOperand(idx int, op rawOperand, _ CommandFlagS
 // classifyZone maps a resolved absolute path to its trust zone. trust-critical
 // takes precedence over safe-zone when a configured critical path overlaps an
 // origin. "/" matches only by exact equality, never as a containing prefix.
+//
+// Both the configured critical paths and the safe-zone origins are themselves
+// symlink-resolved (via r.resolveRoot) before comparison, the same way resolved
+// already is: on a host where a configured root sits behind a symlink (e.g.
+// macOS's /etc -> /private/etc, /tmp -> /private/tmp, /var -> /private/var),
+// comparing resolved's fully-followed path against a raw configured path would
+// silently miss the match.
 func (r *operandResolver) classifyZone(resolved string, input ZoningInput) (zone risktypes.PathTrustZone, matchedCritical string, trusted bool) {
 	clean := filepath.Clean(resolved)
 
@@ -225,9 +232,7 @@ func (r *operandResolver) classifyZone(resolved string, input ZoningInput) (zone
 		if c == "" {
 			continue
 		}
-		// Clean the configured path so a trailing slash or "." segment does not
-		// defeat the exact-"/" check or the containment comparison.
-		cleanC := filepath.Clean(c)
+		cleanC := r.resolveRoot(c, input.MaxSymlinkHops)
 		if cleanC == string(filepath.Separator) {
 			if clean == string(filepath.Separator) {
 				return risktypes.ZoneTrustCritical, c, false
@@ -249,7 +254,7 @@ func (r *operandResolver) classifyZone(resolved string, input ZoningInput) (zone
 		if !filepath.IsAbs(origin) {
 			continue
 		}
-		cleanOrigin := filepath.Clean(origin)
+		cleanOrigin := r.resolveRoot(origin, input.MaxSymlinkHops)
 		if clean == cleanOrigin || common.IsPathWithinDirectory(clean, cleanOrigin) {
 			t := r.isTrustedOperand(clean, cleanOrigin, input.TrustedDirectories, input.RunAsIdent)
 			return risktypes.ZoneSafeZone, "", t
@@ -257,6 +262,19 @@ func (r *operandResolver) classifyZone(resolved string, input ZoningInput) (zone
 	}
 
 	return risktypes.ZoneOrdinary, "", false
+}
+
+// resolveRoot canonicalizes a configured root (a critical path or a safe-zone
+// origin) through the same symlink-following logic as an operand, so both
+// sides of a zone comparison are in the same canonical form. It falls back to
+// a plain filepath.Clean when resolution fails (e.g. the root does not exist
+// on this host): a configured root not found on disk still classifies by its
+// literal form rather than dropping out of the comparison entirely.
+func (r *operandResolver) resolveRoot(path string, maxHops int) string {
+	if resolved, err := r.resolve(path, "", maxHops); err == nil {
+		return resolved
+	}
+	return filepath.Clean(path)
 }
 
 // zoneLevel maps a classified zone (with role and Trusted) to a risk level.

--- a/internal/runner/base/security/destination_zoning_test.go
+++ b/internal/runner/base/security/destination_zoning_test.go
@@ -671,7 +671,13 @@ func TestOperandZones_EmptyVsUnresolved(t *testing.T) {
 	assert.Equal(t, filepath.Join(wd, "x"), dst.Resolved)
 	assert.Equal(t, risktypes.ZoneSafeZone, dst.Zone)
 	assert.True(t, dst.Trusted)
-	assert.Equal(t, "/etc/shadow", src.Resolved)
+	// Compare against the same symlink-following resolution production uses,
+	// rather than the literal "/etc/shadow": on a host where /etc is itself a
+	// symlink (e.g. macOS's /etc -> /private/etc), the resolved path legitimately
+	// differs from the input.
+	wantResolved, err := ResolveOperandPath("/etc/shadow", "", MaxSymlinkDepth)
+	require.NoError(t, err)
+	assert.Equal(t, wantResolved, src.Resolved)
 	assert.Equal(t, risktypes.ZoneTrustCritical, src.Zone)
 }
 

--- a/internal/runner/base/security/network_analyzer_test.go
+++ b/internal/runner/base/security/network_analyzer_test.go
@@ -542,10 +542,12 @@ func TestIsNetworkViaBinaryAnalysis_StaticBinary_SVCAndNetworkSyscall(t *testing
 			SyscallAnalysisResultCore: common.SyscallAnalysisResultCore{
 				DetectedSyscalls: []common.SyscallInfo{
 					{Number: -1, Occurrences: []common.SyscallOccurrence{{DeterminationMethod: "direct_svc_0x80"}}},
-					// write (number 1) is not a network syscall on either the Linux or
-					// macOS syscall table selected by runtime.GOOS, so this stays a
-					// non-network signal on every host this test runs on.
-					{Number: 1, Name: "write", Occurrences: []common.SyscallOccurrence{{Source: "libsystem_symbol_import"}}},
+					// Syscall number 1 is an arbitrary non-network syscall number: it
+					// stays non-network on both the Linux and macOS syscall tables
+					// selected by runtime.GOOS (classification uses Number, not Name,
+					// so the Name field below is cosmetic and not meant to imply a
+					// specific syscall on either platform).
+					{Number: 1, Name: "arbitrary_non_network_syscall", Occurrences: []common.SyscallOccurrence{{Source: "libsystem_symbol_import"}}},
 				},
 			},
 		},

--- a/internal/runner/base/security/network_analyzer_test.go
+++ b/internal/runner/base/security/network_analyzer_test.go
@@ -542,7 +542,10 @@ func TestIsNetworkViaBinaryAnalysis_StaticBinary_SVCAndNetworkSyscall(t *testing
 			SyscallAnalysisResultCore: common.SyscallAnalysisResultCore{
 				DetectedSyscalls: []common.SyscallInfo{
 					{Number: -1, Occurrences: []common.SyscallOccurrence{{DeterminationMethod: "direct_svc_0x80"}}},
-					{Number: 97, Name: "socket", Occurrences: []common.SyscallOccurrence{{Source: "libsystem_symbol_import"}}},
+					// write (number 1) is not a network syscall on either the Linux or
+					// macOS syscall table selected by runtime.GOOS, so this stays a
+					// non-network signal on every host this test runs on.
+					{Number: 1, Name: "write", Occurrences: []common.SyscallOccurrence{{Source: "libsystem_symbol_import"}}},
 				},
 			},
 		},
@@ -552,8 +555,8 @@ func TestIsNetworkViaBinaryAnalysis_StaticBinary_SVCAndNetworkSyscall(t *testing
 	isNet, isHigh, err := analyzer.analyzeBinarySignals(testCmdPath, testContentHash)
 	require.NoError(t, err)
 
-	// The svc #0x80 escalates to high risk; the socket entry (Number 97) is not a
-	// Linux network syscall, so the only signal is the high-risk svc.
+	// The svc #0x80 escalates to high risk; the write entry is not a network
+	// syscall, so the only signal is the high-risk svc.
 	assert.False(t, isNet, "svc signal is high-risk, not a network signal")
 	assert.True(t, isHigh, "svc #0x80 should escalate to high risk")
 }

--- a/internal/runner/base/security/operand_path_resolver.go
+++ b/internal/runner/base/security/operand_path_resolver.go
@@ -43,13 +43,22 @@ type operandResolver struct {
 	// single lstat per node is what keeps resolution cost linear. Identity
 	// dependent results (the Trusted predicate) are never cached here.
 	memo map[string]string
+	// rootMemo caches resolveRoot's result keyed by the raw configured root string
+	// (a critical path, EffectiveWorkDir, or DedicatedTempDir). classifyZone calls
+	// resolveRoot on the same small set of configured roots once per operand, and a
+	// symlink hop within a root (e.g. macOS's /etc -> /private/etc) is not memoized
+	// by r.memo (only non-symlink nodes are), so without this cache a multi-operand
+	// command would re-run the same lstat/readlink chain per operand. The key set is
+	// bounded by the command's configured roots, not by operand count, so this
+	// cannot grow unboundedly within a resolver's per-command lifetime.
+	rootMemo map[string]string
 }
 
 // newOperandResolver builds a resolver over the given read-only primitives. The
 // production path passes os.Lstat/os.Readlink; tests pass counting or scripted
 // stubs.
 func newOperandResolver(lstat lstatFunc, readlink readlinkFunc) *operandResolver {
-	return &operandResolver{lstat: lstat, readlink: readlink, memo: make(map[string]string)}
+	return &operandResolver{lstat: lstat, readlink: readlink, memo: make(map[string]string), rootMemo: make(map[string]string)}
 }
 
 // ResolveOperandPath resolves an operand to a normalized absolute path with the

--- a/internal/runner/resource/default_manager_test.go
+++ b/internal/runner/resource/default_manager_test.go
@@ -53,7 +53,12 @@ func TestNewDefaultResourceManager_NilRiskEvaluator(t *testing.T) {
 func TestDefaultResourceManager_ModeDelegation(t *testing.T) {
 	mocks := setupTestMocks()
 
-	cmd := executortestutil.CreateRuntimeCommand("/usr/bin/echo", []string{})
+	// /bin/echo (rather than /usr/bin/echo) is used because it exists on both
+	// Linux (FHS layout) and macOS (which keeps /bin and /usr/bin as distinct
+	// real directories, with no /usr/bin/echo). The real risk evaluator here
+	// opens and hashes the actual file, so the path must resolve on every
+	// platform this test runs on.
+	cmd := executortestutil.CreateRuntimeCommand("/bin/echo", []string{})
 	env := map[string]string{"FOO": "BAR"}
 	ctx := context.Background()
 
@@ -66,8 +71,8 @@ func TestDefaultResourceManager_ModeDelegation(t *testing.T) {
 		mocks.exec.On("Execute", ctx, mock.Anything, cmd, env, mock.Anything).Return(expected, nil)
 
 		_, res, err := mgr.ExecuteCommand(ctx, cmd, createTestCommandGroup(), env)
-		assert.NoError(t, err)
-		assert.NotNil(t, res)
+		require.NoError(t, err)
+		require.NotNil(t, res)
 		assert.False(t, res.DryRun)
 	})
 
@@ -255,8 +260,12 @@ func TestDefaultResourceManager_UpdateCommandDebugInfo(t *testing.T) {
 		mgr, err := NewDefaultResourceManagerForTest(mocks.exec, mocks.fs, mocks.priv, mocks.pathResolver, slog.Default(), ExecutionModeDryRun, &DryRunOptions{}, nil, 0)
 		require.NoError(t, err)
 
-		// Execute a command to get a valid token
-		cmd := executortestutil.CreateRuntimeCommand("/usr/bin/echo", []string{})
+		// Execute a command to get a valid token. /bin/echo (rather than
+		// /usr/bin/echo) is used because it exists on both Linux (FHS layout)
+		// and macOS (which has no /usr/bin/echo); the real risk evaluator here
+		// opens and hashes the actual file, so the path must resolve on every
+		// platform this test runs on.
+		cmd := executortestutil.CreateRuntimeCommand("/bin/echo", []string{})
 		env := map[string]string{}
 		ctx := context.Background()
 

--- a/internal/runner/resource/error_scenarios_test.go
+++ b/internal/runner/resource/error_scenarios_test.go
@@ -731,8 +731,12 @@ func TestResourceManagerStateConsistency(t *testing.T) {
 	// Test edge case: null bytes in environment variables
 	// This tests both normal and dry-run modes for proper handling
 	t.Run("null_bytes_in_environment", func(t *testing.T) {
+		// /bin/echo (rather than /usr/bin/echo) is used because it exists on
+		// both Linux and macOS; the real risk evaluator opens and hashes the
+		// actual file, so the path must resolve on every platform this test
+		// runs on.
 		nullCmd := executortestutil.CreateRuntimeCommand(
-			"/usr/bin/echo",
+			"/bin/echo",
 			[]string{"$NULL_VAR"},
 			executortestutil.WithName("null-test"),
 		)
@@ -748,8 +752,8 @@ func TestResourceManagerStateConsistency(t *testing.T) {
 		dryRunManager, err := NewDefaultResourceManagerForTest(nil, nil, nil, mockPathResolver, slog.Default(), ExecutionModeDryRun, dryRunOpts, nil, 0)
 		require.NoError(t, err)
 		_, result, err := dryRunManager.ExecuteCommand(ctx, nullCmd, group, nullEnvVars)
-		assert.NoError(t, err, "dry-run mode should handle null bytes in environment")
-		assert.NotNil(t, result, "dry-run mode should return result")
+		require.NoError(t, err, "dry-run mode should handle null bytes in environment")
+		require.NotNil(t, result, "dry-run mode should return result")
 		assert.True(t, result.DryRun, "result should indicate dry-run mode")
 
 		// Test with normal mode
@@ -758,8 +762,8 @@ func TestResourceManagerStateConsistency(t *testing.T) {
 		normalManager, err := NewDefaultResourceManagerForTest(&mockCommandExecutor{}, &mockFileSystem{}, nil, mockPathResolver2, slog.Default(), ExecutionModeNormal, nil, nil, 0)
 		require.NoError(t, err)
 		_, result, err = normalManager.ExecuteCommand(ctx, nullCmd, group, nullEnvVars)
-		assert.NoError(t, err, "normal mode should handle null bytes in environment")
-		assert.NotNil(t, result, "normal mode should return result")
+		require.NoError(t, err, "normal mode should handle null bytes in environment")
+		require.NotNil(t, result, "normal mode should return result")
 		assert.False(t, result.DryRun, "result should indicate normal mode")
 	})
 }

--- a/internal/runner/resource/normal_manager_test.go
+++ b/internal/runner/resource/normal_manager_test.go
@@ -286,14 +286,14 @@ func TestNormalResourceManager_ExecuteCommand_RiskLevelControl(t *testing.T) {
 	}{
 		{
 			name:          "low risk command with no risk_level (default low)",
-			cmd:           "/usr/bin/echo",
+			cmd:           "/bin/echo",
 			args:          []string{"hello"},
 			riskLevel:     "", // Default to low
 			shouldExecute: true,
 		},
 		{
 			name:          "low risk command with low risk_level",
-			cmd:           "/usr/bin/echo",
+			cmd:           "/bin/echo",
 			args:          []string{"hello"},
 			riskLevel:     "low",
 			shouldExecute: true,
@@ -307,14 +307,14 @@ func TestNormalResourceManager_ExecuteCommand_RiskLevelControl(t *testing.T) {
 		},
 		{
 			name:          "high risk command with high risk_level",
-			cmd:           "/usr/bin/rm",
+			cmd:           "/bin/rm",
 			args:          []string{"-rf", "/tmp/test"},
 			riskLevel:     "high",
 			shouldExecute: true,
 		},
 		{
 			name:          "high risk command with low risk_level should be blocked",
-			cmd:           "/usr/bin/rm",
+			cmd:           "/bin/rm",
 			args:          []string{"-rf", "/tmp/test"},
 			riskLevel:     "low",
 			shouldExecute: false,
@@ -330,7 +330,7 @@ func TestNormalResourceManager_ExecuteCommand_RiskLevelControl(t *testing.T) {
 		},
 		{
 			name:          "invalid risk_level should return error",
-			cmd:           "/usr/bin/echo",
+			cmd:           "/bin/echo",
 			args:          []string{"hello"},
 			riskLevel:     "invalid",
 			shouldExecute: false,

--- a/test/security/output_security_test.go
+++ b/test/security/output_security_test.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -173,6 +173,42 @@ func TestSymlinkAttack(t *testing.T) {
 	require.NotContains(t, string(originalContent), "malicious content")
 }
 
+// buildEchoHelper compiles a small, unsigned helper binary that prints its
+// arguments, one per line, mimicking `echo` closely enough for tests that
+// only care about exit code and captured stdout content. Using a freshly
+// built binary (instead of the platform-signed system `echo`) avoids AMFI
+// killing the staged-copy exec fallback used on non-Linux platforms (see
+// prepareExecCommand/stageFromFD in internal/runner/base/executor/executor.go).
+func buildEchoHelper(t *testing.T) string {
+	t.Helper()
+
+	const src = `package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	for _, arg := range os.Args[1:] {
+		fmt.Println(arg)
+	}
+}
+`
+	tmpDir := t.TempDir()
+	srcFile := filepath.Join(tmpDir, "main.go")
+	binFile := filepath.Join(tmpDir, "echo_helper")
+
+	require.NoError(t, os.WriteFile(srcFile, []byte(src), 0o644))
+
+	cmd := exec.Command("go", "build", "-o", binFile, srcFile)
+	cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "go build failed: %s", string(out))
+
+	return binFile
+}
+
 // TestPrivilegeEscalationAttack tests protection against privilege escalation
 func TestPrivilegeEscalationAttack(t *testing.T) {
 	if os.Getuid() == 0 {
@@ -211,27 +247,28 @@ func TestPrivilegeEscalationAttack(t *testing.T) {
 		},
 	}
 
+	// The "should succeed" case below performs a real exec. On non-Linux,
+	// fdExecSupported() is false (fdexec_other.go), so the executor's
+	// TOCTOU-hardening fallback (prepareExecCommand/stageFromFD in
+	// internal/runner/base/executor/executor.go) copies the verified binary
+	// to a temp file and execs the copy instead of the original. Execing a
+	// byte-identical copy of an Apple platform-signed system binary (echo
+	// lives under the Sealed System Volume) is killed by AMFI/code-signing
+	// enforcement on macOS, even though the copy's content is unchanged. To
+	// keep the success path exercised on every platform, build a small
+	// unsigned helper binary that mimics `echo` well enough for this test
+	// (it just prints its arguments) instead of using the system echo.
+	helperCmd := buildEchoHelper(t)
+
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			if !tc.shouldFail && runtime.GOOS != "linux" {
-				// This subtest exercises a real successful exec of echoCmd, not just
-				// the output-path block. On non-Linux, fdExecSupported() is false
-				// (fdexec_other.go), so the executor's TOCTOU-hardening fallback
-				// (prepareExecCommand/stageFromFD in
-				// internal/runner/base/executor/executor.go) copies the verified
-				// binary to a temp file and execs the copy instead of the original.
-				// On macOS, execing a byte-identical copy of an Apple
-				// platform-signed system binary (echo lives under the Sealed
-				// System Volume) is killed by AMFI/code-signing enforcement
-				// (signal: killed), even though the copy's content is unchanged.
-				// This is a real fd-bound-exec gap on non-Linux, not a timeout or
-				// flake, and is orthogonal to what this test verifies (the
-				// output-path security block).
-				t.Skip("skipping: staged-copy exec of a platform-signed system binary is killed on non-Linux (fd-bound exec is Linux-only)")
+			cmdPath := echoCmd
+			if !tc.shouldFail {
+				cmdPath = helperCmd
 			}
 
 			runtimeCmd := executortestutil.CreateRuntimeCommand(
-				echoCmd,
+				cmdPath,
 				[]string{"test output"},
 				executortestutil.WithName("privilege_escalation_test"),
 				executortestutil.WithOutputFile(tc.outputPath),

--- a/test/security/output_security_test.go
+++ b/test/security/output_security_test.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -212,6 +213,23 @@ func TestPrivilegeEscalationAttack(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			if !tc.shouldFail && runtime.GOOS != "linux" {
+				// This subtest exercises a real successful exec of echoCmd, not just
+				// the output-path block. On non-Linux, fdExecSupported() is false
+				// (fdexec_other.go), so the executor's TOCTOU-hardening fallback
+				// (prepareExecCommand/stageFromFD in
+				// internal/runner/base/executor/executor.go) copies the verified
+				// binary to a temp file and execs the copy instead of the original.
+				// On macOS, execing a byte-identical copy of an Apple
+				// platform-signed system binary (echo lives under the Sealed
+				// System Volume) is killed by AMFI/code-signing enforcement
+				// (signal: killed), even though the copy's content is unchanged.
+				// This is a real fd-bound-exec gap on non-Linux, not a timeout or
+				// flake, and is orthogonal to what this test verifies (the
+				// output-path security block).
+				t.Skip("skipping: staged-copy exec of a platform-signed system binary is killed on non-Linux (fd-bound exec is Linux-only)")
+			}
+
 			runtimeCmd := executortestutil.CreateRuntimeCommand(
 				echoCmd,
 				[]string{"test output"},


### PR DESCRIPTION
## Summary
- Fix `destination_zoning.go`'s asymmetric symlink resolution: operands were always resolved through symlinks, but safe-zone origins (`EffectiveWorkDir`/`DedicatedTempDir`) and `SystemCriticalPaths` were compared raw. This misclassified paths on any host where `/etc`, `/var`, `/tmp`, etc. are symlinks (e.g. macOS's `/etc` → `/private/etc`), a real security-classification bug independent of test environment.
- Fix the many `make test` failures on macOS that stemmed from Linux-only assumptions in tests: hardcoded paths (`/bin/true`, `/usr/bin/echo`, `/usr/bin/rm`), ELF/Mach-O format-specific assertions, macOS's `/var`-nested TMPDIR colliding with the trust-critical path list, and a non-Linux fd-bound-exec gap where macOS AMFI kills a staged copy of an Apple-signed system binary.
- Fix two latent `assert.NoError`-then-nil-dereference panics found along the way (platform-independent bugs).
- Fix golangci-lint findings surfaced during this pass: two `unused-parameter` (revive) issues, and three gosec G706 findings in `slack_handler.go` that were missing the `nolint` annotation already applied to identical sibling log calls.
- Pin pre-commit's `golangci-lint` hook to the same version (`v2.11.4`, via `go run`) that the Makefile uses, instead of whatever `golangci-lint` happens to be on `$PATH` — this was causing the pre-commit hook to flag findings that `make lint` itself considers clean.

## Test plan
- [x] `go test -tags test ./...` passes on macOS (darwin/arm64)
- [x] `make test` passes on macOS
- [x] `make lint` passes (0 issues) with the Makefile-pinned golangci-lint
- [x] `pre-commit run --all-files` passes, including the re-pinned `golangci-lint` hook
- [ ] CI (Linux) — should be unaffected; all production-code changes are symlink-resolution fixes that are no-ops on non-symlinked paths, and platform-specific test adjustments are gated on `runtime.GOOS`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
