### PR TITLE
fix(verification): gate isDeferredHashDirUnavailable skip on dry-run

### DIFF
--- a/docs/tasks/0149_security_code_smell_audit_fable/98_remaining_issues.md
+++ b/docs/tasks/0149_security_code_smell_audit_fable/98_remaining_issues.md
@@ -14,9 +14,7 @@ E1（エントリポイント: `cmd/runner`・`cmd/record`・`cmd/verify`・`boo
 
 > **D1 M-3 について**: 0160（基準UID決定方針の明示化）・0161（`SUDO_UID` の実在確認・記録）で解消済み。0161 は「呼び出し元の実 UID との突き合わせ」を対象外としたが、これは信頼できる突き合わせ手段が存在しないという技術的な結論であり（0161 要件定義書「突き合わせを対象外とする根拠」参照）、[#921](https://github.com/isseis/go-safe-cmd-runner/issues/921)（`runner` の native root 実行サポート）を実施しないと決定したことで、この残余リスクは今後再検討すべき残件ではなく恒久的に受容する既決事項として確定した。したがって D1 M-3 は本ドキュメントの一覧から除外する（D1 の他所見 L-2/L-3 は §2 に残る）。
 
-### B3（verification）M2: `isDeferredHashDirUnavailable` のゲート漏れ
-
-0153（P1 fail-open 横断修正）・0155（P3 TOCTOU 修正）のいずれの対象にも含まれず未着手。dry-run 限定でない箇所でのゲート漏れが残る。→ [#972](https://github.com/isseis/go-safe-cmd-runner/issues/972) を作成済み。
+> **B3 M2 について**: [#972](https://github.com/isseis/go-safe-cmd-runner/issues/972) で対応済み。`isDeferredHashDirUnavailable` を `Manager.isDeferredHashDirUnavailable` メソッド化し、`m.isDryRun` が true の場合にのみ skip（fail-open）を許可するようゲートした。dry-run 以外で `VerifyCommandDynLibDeps` / `VerifyCommandShebangInterpreter` が単独で呼ばれるコードパスでも、hash directory 不在・権限エラーはエラーとして伝播し fail-closed になる。したがって B3 M2 は本ドキュメントの一覧から除外する。
 
 ### E1（entrypoints）M-1: `--run-id` が未検証のままログファイル名・ログ行に埋め込まれる
 

--- a/internal/verification/manager.go
+++ b/internal/verification/manager.go
@@ -617,13 +617,24 @@ func (m *Manager) VerifyCommandDynLibDeps(cmdPath string) error {
 }
 
 // isDeferredHashDirUnavailable reports whether err is a deferred error raised by
-// a read-only Validator because the hash directory was absent or unreadable.
+// a read-only Validator because the hash directory was absent or unreadable, and
+// whether that condition is safe to soft-fail here.
 // During dry-run, LoadRecord surfaces both filevalidator.ErrHashDirNotExist (the
 // directory does not exist) and a raw os.ErrPermission (the directory exists but
 // is not readable). Both mean per-file verification already reports the condition
 // as hash_directory_not_found, so dependent checks (dynlib, shebang) must soft-fail
 // rather than abort the dry-run preview.
-func isDeferredHashDirUnavailable(err error) bool {
+//
+// This soft-fail is gated on m.isDryRun: outside dry-run, VerifyGroupFiles reading
+// the same record normally fails closed before these dependent checks ever run, but
+// that is an implicit ordering assumption of the current callers, not a guarantee.
+// A future caller that invokes VerifyCommandDynLibDeps / VerifyCommandShebangInterpreter
+// standalone must not silently skip verification on a permission error, so in
+// production mode this reports false and the caller propagates the error instead.
+func (m *Manager) isDeferredHashDirUnavailable(err error) bool {
+	if !m.isDryRun {
+		return false
+	}
 	return errors.Is(err, filevalidator.ErrHashDirNotExist) || errors.Is(err, os.ErrPermission)
 }
 
@@ -644,7 +655,7 @@ func (m *Manager) verifyDynLibDeps(cmdPath string) error {
 		// that captured the absence/inaccessibility as a deferred error): per-file
 		// verification already reports this as hash_directory_not_found; the dynlib
 		// check is not applicable and must not abort the dry-run preview.
-		if isDeferredHashDirUnavailable(err) {
+		if m.isDeferredHashDirUnavailable(err) {
 			return nil
 		}
 		// Old schema record (schema_version < CurrentSchemaVersion): predates dynlib
@@ -926,7 +937,7 @@ func (m *Manager) VerifyCommandShebangInterpreter(cmdPath string, envVars map[st
 		// that captured the absence/inaccessibility as a deferred error): per-file
 		// verification already reports this as hash_directory_not_found; the shebang
 		// check is not applicable and must not abort the dry-run preview.
-		if isDeferredHashDirUnavailable(err) {
+		if m.isDeferredHashDirUnavailable(err) {
 			return nil
 		}
 		if schemaErr, ok := errors.AsType[*fileanalysis.SchemaVersionMismatchError](err); ok && schemaErr.Actual < schemaErr.Expected {

--- a/internal/verification/manager_shebang_test.go
+++ b/internal/verification/manager_shebang_test.go
@@ -298,6 +298,47 @@ func TestVerifyCommandShebangInterpreter_OldSchema(t *testing.T) {
 	assert.True(t, errors.As(err, &schemaErr), "expected SchemaVersionMismatchError, got: %v", err)
 }
 
+// TestVerifyCommandShebangInterpreter_HashDirUnavailable_Production verifies that
+// outside dry-run, a deferred hash-directory-unavailable error from LoadRecord
+// (ErrHashDirNotExist or a raw os.ErrPermission) is propagated as an error rather
+// than silently skipped. See issue #972: skipping unconditionally would fail-open
+// for a future caller that invokes shebang verification standalone.
+func TestVerifyCommandShebangInterpreter_HashDirUnavailable_Production(t *testing.T) {
+	for name, deferredErr := range map[string]error{
+		"HashDirNotExist": filevalidator.ErrHashDirNotExist,
+		"Permission":      os.ErrPermission,
+	} {
+		t.Run(name, func(t *testing.T) {
+			mockFV := newMockFVForShebang()
+			mockFV.schemaErr["/usr/local/bin/script.sh"] = deferredErr
+
+			m := setupManagerWithMockValidator(t, mockFV)
+			err := m.VerifyCommandShebangInterpreter("/usr/local/bin/script.sh", map[string]string{})
+			require.Error(t, err, "production mode must fail closed, not skip")
+		})
+	}
+}
+
+// TestVerifyCommandShebangInterpreter_HashDirUnavailable_DryRun verifies that in
+// dry-run mode, the same deferred hash-directory-unavailable errors are still
+// soft-failed (skip, no error) so the dry-run preview is not aborted.
+func TestVerifyCommandShebangInterpreter_HashDirUnavailable_DryRun(t *testing.T) {
+	for name, deferredErr := range map[string]error{
+		"HashDirNotExist": filevalidator.ErrHashDirNotExist,
+		"Permission":      os.ErrPermission,
+	} {
+		t.Run(name, func(t *testing.T) {
+			mockFV := newMockFVForShebang()
+			mockFV.schemaErr["/usr/local/bin/script.sh"] = deferredErr
+
+			m := setupManagerWithMockValidator(t, mockFV)
+			m.isDryRun = true
+			err := m.VerifyCommandShebangInterpreter("/usr/local/bin/script.sh", map[string]string{})
+			assert.NoError(t, err, "dry-run mode must soft-fail, not abort the preview")
+		})
+	}
+}
+
 // TestVerifyCommandShebangInterpreter_EnvForm_HashMismatch verifies that a hash
 // mismatch on the env-form resolved_path binary (i.e. the interpreter found via
 // PATH has been tampered with) is propagated as ErrMismatch.

--- a/internal/verification/manager_test.go
+++ b/internal/verification/manager_test.go
@@ -2110,3 +2110,32 @@ func TestHasMachODynamicLibraryDeps_ErrorPropagation(t *testing.T) {
 	assert.False(t, hasDeps)
 	assert.Contains(t, err.Error(), "injected I/O error")
 }
+
+// TestIsDeferredHashDirUnavailable_GatedByDryRun verifies that
+// isDeferredHashDirUnavailable only reports true (skip) when the manager is in
+// dry-run mode. Outside dry-run, dependent checks (dynlib, shebang) must fail
+// closed on a missing/unreadable hash directory rather than silently skip, since
+// a future caller invoking those checks standalone (not preceded by
+// VerifyGroupFiles) would otherwise fail-open. See issue #972.
+func TestIsDeferredHashDirUnavailable_GatedByDryRun(t *testing.T) {
+	deferredErrs := map[string]error{
+		"HashDirNotExist": filevalidator.ErrHashDirNotExist,
+		"Permission":      os.ErrPermission,
+	}
+
+	for name, err := range deferredErrs {
+		t.Run(name+"/DryRun", func(t *testing.T) {
+			m := &Manager{isDryRun: true}
+			assert.True(t, m.isDeferredHashDirUnavailable(err))
+		})
+		t.Run(name+"/Production", func(t *testing.T) {
+			m := &Manager{isDryRun: false}
+			assert.False(t, m.isDeferredHashDirUnavailable(err))
+		})
+	}
+
+	// An unrelated error is never treated as deferred, in either mode.
+	other := errors.New("some other error")
+	assert.False(t, (&Manager{isDryRun: true}).isDeferredHashDirUnavailable(other))
+	assert.False(t, (&Manager{isDryRun: false}).isDeferredHashDirUnavailable(other))
+}


### PR DESCRIPTION
## Summary
- `isDeferredHashDirUnavailable` previously let dynlib/shebang verification silently skip on `filevalidator.ErrHashDirNotExist` or `os.ErrPermission` from `LoadRecord` in *any* mode, not just dry-run. In production this was masked only by `VerifyGroupFiles` failing closed first on the same error — an implicit caller-ordering assumption, not a guarantee, that would fail-open for a future standalone caller of `VerifyCommandDynLibDeps` / `VerifyCommandShebangInterpreter`.
- Gated the skip on `m.isDryRun`: outside dry-run the error now propagates and the caller fails closed, matching the recommendation in the issue.
- Updated `98_remaining_issues.md` to mark B3 M2 as resolved.

## Test plan
- [x] `make test`
- [x] `make lint`
- [x] Added `TestVerifyCommandShebangInterpreter_HashDirUnavailable_Production` / `_DryRun` covering both `ErrHashDirNotExist` and `os.ErrPermission`
- [x] Added `TestIsDeferredHashDirUnavailable_GatedByDryRun` as a direct unit test of the gating logic

Fixes #972

🤖 Generated with [Claude Code](https://claude.com/claude-code)
