### PR TITLE
commands: pin japrose's discovery review to Sonnet

### DIFF
--- a/.claude/commands/_lib/review-subagent-pattern.md
+++ b/.claude/commands/_lib/review-subagent-pattern.md
@@ -77,11 +77,15 @@ model:
   here misses findings, which is the expensive failure mode.
 - **Verification re-review** — confirms that a bounded, already-located set of
   Critical/Major fixes was applied correctly and introduced no regression. This is
-  a narrower check and **may run on a cheaper model**. When spawning the
-  verification subagent, pass the explicit list of fixes to confirm and request a
-  cheaper model (the Agent tool's `model` parameter, e.g. a faster/cheaper tier);
-  if the cheaper pass reports anything ambiguous or a new Critical/Major issue,
-  re-run that pass once on the default model before trusting it.
+  a narrower check and **may run on a cheaper model than the discovery pass**. When
+  spawning the verification subagent, pass the explicit list of fixes to confirm and
+  request a cheaper model (the Agent tool's `model` parameter, e.g. a faster/cheaper
+  tier); if the cheaper pass reports anything ambiguous or a new Critical/Major
+  issue, re-run that pass once on the default model before trusting it. If the
+  calling command supplied MODEL for the discovery pass, that MODEL is already the
+  minimum competence the task requires — use the same MODEL for verification too,
+  rather than downgrading further (e.g. to haiku); a task pinned to Sonnet because it
+  needs Sonnet-level judgment needs that same judgment to verify a fix, not less.
 
 This keeps recall where it matters (discovery) while cutting cost on the repeated
 confirmation passes. It composes with panel mode below: the discovery panel runs

--- a/.claude/commands/_lib/review-subagent-pattern.md
+++ b/.claude/commands/_lib/review-subagent-pattern.md
@@ -23,6 +23,12 @@ This is project-independent. It depends on nothing in `_context.md`.
   absolute path strings so the subagent does not rely on the caller's context.
 - **CRITERIA** — the checklist(s) the caller defines, to be copied verbatim into
   the subagent prompt.
+- **MODEL** (optional) — pins the discovery-pass model (the Agent tool's `model`
+  parameter) instead of inheriting the session's default model. Use this when the
+  reviewed task is known to be within a lighter model's competence regardless of
+  which model is driving the calling command (e.g. a fixed checklist-style prose or
+  style review, as opposed to open-ended architectural judgment). Omit MODEL to keep
+  the default behavior in "Model tiering" below.
 
 ## Procedure
 
@@ -65,8 +71,10 @@ model:
 
 - **Initial (discovery) review** — searches the whole ARTIFACT for unknown
   problems across every CRITERIA item. This is the hard, high-recall task; run it
-  on the session's default model. Do **not** downgrade it — a cheaper model here
-  misses findings, which is the expensive failure mode.
+  on the session's default model, unless the calling command supplies MODEL (see
+  "Inputs" above) to pin a specific model for a task it has judged suitable for a
+  lighter tier. Absent an explicit MODEL, do **not** downgrade it — a cheaper model
+  here misses findings, which is the expensive failure mode.
 - **Verification re-review** — confirms that a bounded, already-located set of
   Critical/Major fixes was applied correctly and introduced no regression. This is
   a narrower check and **may run on a cheaper model**. When spawning the

--- a/.claude/commands/japrose.md
+++ b/.claude/commands/japrose.md
@@ -77,6 +77,10 @@ these inputs:
   target document is edited.
 - **CRITERIA**: every item from the Prose-quality checklist and the Hard constraints
   below, copied verbatim.
+- **MODEL**: `sonnet`. This review is a fixed-checklist Japanese prose/terminology
+  check, not open-ended architectural judgment, so it does not need the calling
+  command's model tier (e.g. Opus when invoked from `mkarch` / `mkplan`) — pin it to
+  Sonnet regardless of what model is driving the caller.
 
 **Prose-quality checklist (use verbatim as evaluation criteria in the subagent prompt above):**
 - [ ] 直訳調・英語語順の直訳（無生物主語の直訳、過剰な受動態、英語イディオムの逐語訳）が、意味を変えずに自然な日本語へ書き換えられている。


### PR DESCRIPTION
Add an optional MODEL input to the shared review-subagent pattern so a calling command can pin the discovery-pass model instead of inheriting the session's default. japrose uses it to force Sonnet, since Japanese prose/terminology review is a fixed-checklist task that doesn't need Opus even when invoked from mkarch/mkplan under Opus.