### PR TITLE
docs: record the review lessons from the 0163 redaction PR

### DIFF
--- a/.claude/commands/weakreview.md
+++ b/.claude/commands/weakreview.md
@@ -172,7 +172,7 @@ and the thing it builds is rarely load-bearing)
 **Inference where declaration belongs**
 - [ ] No code path is selected by inspecting the content of caller-supplied
       data (`strings.Contains(x, ":")`, `HasPrefix`, length checks) where
-      the intent could be carried in the type. Tell: the intent is
+      the intent could be carried in the type. The tell: the intent is
       documented in a comment next to the data's definition while the
       routing lives in a condition in a different file, so nothing ties the
       two together and a value that happens to contain the sniffed

--- a/.claude/commands/weakreview.md
+++ b/.claude/commands/weakreview.md
@@ -148,6 +148,62 @@ superficially.)
       only the success path. Read the actual `defer`/`recover` placement,
       don't infer it from a comment saying it does.
 
+**Unearned mechanism** (a weak model closes a finding by building something,
+and the thing it builds is rarely load-bearing)
+- [ ] Every optimization in this range (cache, pre-filter, fast path, pooled
+      buffer) is justified against an absolute budget stated in the commit
+      message, not against a relative delta versus the previous commit
+      ("1.9x slower" with no conversion to real wall time is a finding).
+      Check whether the stage optimized is even a significant fraction of
+      its path's cost, and whether the cached step leaves the expensive
+      setup still running per call.
+- [ ] For each mechanism added in this range, ask what deleting it would
+      change. If the answer is only a benchmark number, it is a finding —
+      especially where the regression it offsets was introduced by an
+      earlier commit in this same range (the model creating and then
+      solving its own problem).
+- [ ] No optimization added here carries an unstated correctness
+      obligation: byte-wise case folding where the real path folds under
+      Unicode rules, an ASCII assumption over arbitrary input, a fast path
+      that must agree with the slow path, a cache whose key omits an input.
+      Read the fast path against the slow one; do not trust a comment.
+- [ ] No behavior change and its motivating optimization share a commit.
+
+**Inference where declaration belongs**
+- [ ] No code path is selected by inspecting the content of caller-supplied
+      data (`strings.Contains(x, ":")`, `HasPrefix`, length checks) where
+      the intent could be carried in the type. Tell: the intent is
+      documented in a comment next to the data's definition while the
+      routing lives in a condition in a different file, so nothing ties the
+      two together and a value that happens to contain the sniffed
+      character silently takes the wrong path.
+- [ ] Any `switch` added over a kind/mode enum has a `default` branch, and
+      that branch fails secure rather than falling through to the most
+      permissive case.
+- [ ] Any invariant this range claims ("patterns are always validated",
+      "this is only ever built by X") is enforced by the type — unexported
+      fields plus a constructor — not by convention. If an exported field
+      was kept as an extension point, the range shows the count of its
+      actual uses.
+- [ ] No helper added here silently repairs a malformed caller input
+      (trimming, defaulting, coercing) where rejecting it would surface a
+      programming mistake.
+
+**Tests that cannot fail**
+- [ ] Every test added in this range can fail for the reason it names.
+      Spot-check by nil-ing the collaborator or reverting the branch it
+      covers; a test that still passes is a finding. Highest-yield targets:
+      tests over a layered path (two mechanisms that produce the same
+      output) whose assertions are only "output differs from input" or
+      "output contains the placeholder" — those cannot say which layer ran.
+- [ ] No test asserts that a constant equals its own literal, that a field
+      holds what was just assigned to it, or that two literals are equal.
+- [ ] No table test added for a helper duplicates rows the caller's table
+      already covers with the same literals, where the helper differs from
+      the caller only by a loop.
+- [ ] Any test deleted in this range is accompanied by evidence that
+      coverage is unchanged function by function, not just in total.
+
 **Cross-document synchronization**
 - [ ] If this diff's implementation diverges from `02_architecture.md` or
       the corresponding step description in `03_implementation_plan.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,49 @@ See [Package Reference](docs/dev/developer_guide/package_reference.md) for detai
 - **Error Handling**: Comprehensive error types and validation
 - **YAGNI**: Use simple and clear approach to satisfy the requirement. Don't take complex approach for not-yet-planned features.
  - **DRY**: Don't repeat yourself. Before adding new code, check the codebase and prefer reusing existing implementations.
+- **Declare, don't infer**: Do not choose behavior by inspecting the content of a
+  string supplied by a caller (`strings.Contains`/`HasPrefix` over caller data to
+  pick a code path). Put the choice in the type: an enum field whose zero value is
+  the interpretation that assumes least about its input, dispatched by a `switch`
+  whose `default` fails secure. Changing a struct's shape is cheap here — the
+  project has no consumers outside the repository, so "it would change the exported
+  API" is not on its own a reason to keep inferring.
+- **Enforce invariants with the type, not with convention**: if a value must pass
+  validation before use, make the compiler the thing that guarantees it —
+  unexported fields plus a mandatory constructor — rather than relying on "every
+  production path happens to call `DefaultConfig`". Before preserving an exported
+  field as an extension point, count its real uses; an extension point nobody uses
+  costs the guarantee and buys nothing.
+- **Reject, don't normalize**: when code can either quietly repair a caller's
+  malformed input or reject it, reject it. Silent repair makes a wrong definition
+  indistinguishable from a right one, so the mistake never surfaces and propagates
+  into whatever someone copies next. Prefer a `validate` method returning a
+  sentinel error, rejection at the construction boundary, and a test over the real
+  defaults that fails the build when they are edited into an invalid shape.
+
+### Performance
+
+- **A benchmark regression is not by itself a defect.** Justify an optimization
+  against an *absolute* budget — wall time of a real run, allocations per log line
+  — never against a relative delta versus the previous commit. "1.9x slower" means
+  nothing until it is converted to an absolute number and compared with what the
+  runner already spends (a `fork`/`exec` is tens of microseconds; a 1,000-line run's
+  whole logging budget is milliseconds). If the honest conclusion is "the regression
+  does not show up in wall time", record that and close it — do not add a mechanism.
+- **Profile before optimizing** to confirm the cost is where you assume. If the
+  stage you are about to optimize is a small fraction of its path's total cost,
+  stop; also check that the work you are caching is actually all of the work (a
+  cache in front of one step that leaves the expensive setup running per call buys
+  nothing).
+- **An optimization that adds a correctness obligation** — case folding, encoding
+  assumptions, cache invalidation, a fast path that must agree with the slow path —
+  must clear a much higher bar. State the obligation in the commit message and pin
+  it with a test that fails if the optimization is later changed unsafely.
+- **Optimizations go in their own commit**, separable by revert, and never in the
+  same commit as the behavior change that motivated them.
+- **Do not close a review finding by adding a mechanism until the finding's premise
+  is verified.** Measure whether the reported cost is real harm in absolute terms
+  first; a self-inflicted regression is not an obligation to build something.
 
 ### Security Features
 - Command path validation and sanitization
@@ -100,6 +143,25 @@ See [Package Reference](docs/dev/developer_guide/package_reference.md) for detai
 - File system abstraction for testing
 - Output capture and verification
 - **Error Testing**: Use `errors.Is()` to validate error types, not string matching on error messages
+- **Every test must be able to fail for its stated reason.** Before committing a
+  test, disable the thing it claims to cover — nil the collaborator, revert the
+  branch, break the default — and confirm it fails. Say in the commit message that
+  you did.
+- **A layered path needs inputs only one layer can handle.** Where two mechanisms
+  can produce the same output (e.g. key-name redaction and value-format detection),
+  an input both layers match proves nothing about either: assertions like "output
+  differs from input" or "output contains the placeholder" cannot say which layer
+  ran. Construct the input so only the layer under test can act, and assert first
+  that the other layer alone leaves it untouched — that makes the test
+  self-policing.
+- **Do not assert that a constant equals its own literal**, or that a struct field
+  holds what was just assigned to it. These pass unconditionally and reach nothing.
+- **Check for duplication before adding a table test for a helper.** If the helper
+  differs from its caller only by a loop, and the caller's table already covers the
+  same rows with the same literals, one table is enough. Keep the helper-level test
+  only for cases the caller's table cannot reach.
+- **Deleting a test is a claim that must be checked**: confirm `go tool cover -func`
+  is unchanged function by function afterwards, and say so.
 
 See [Test Organization Guide](docs/dev/developer_guide/test_organization.md) for test helper file structure.
 


### PR DESCRIPTION
## 背景

タスク 0163 (redaction coverage / Slack async) の PR について、Claude Opus 5 が生成した時点の `b1728e5` と、人間のレビューを経てマージされた `25065f6` を比較しました。

間の 18 コミットに**新機能は 1 件もありません**。全部が生成物の欠陥修正・設計やり直し・無効なテストの作り直し・誤ったドキュメントの訂正でした。

| | main → b1728e5 (生成時点) | b1728e5 → 25065f6 (レビュー後) |
|---|---|---|
| コミット数 | 3 | 18 |
| 内訳 | key 名リダクションの 4 択拡張 | fix 3 / refactor 4 / perf 2 / test 1 / docs 8 |
| 差分 | +782/-45 | +1410/-738 |

この PR は、同じ指摘が次も出ないようにするためのルールを言語化したものです。ドキュメントのみで、コードの変更はありません。

## レビューが潰したものの類型

**本番に届いていた fail-open / 過剰抑制** (3 件)
- `processKindAny` が error 属性を構造体として歩き、`*errorString` に公開フィールドがないため**全 error ログが `[REDACTION FAILED - OUTPUT SUPPRESSED]` に置換**されていた。`bootstrap` が `slog.SetDefault` するので本番の全ログ経路、error 属性を渡す非テスト箇所 57 個に影響
- `password="p@ss\"w0rd"` が `password="[REDACTED]"w0rd"` になり尻尾が平文で漏れる。しかも 02_architecture 3.2.5 が「エスケープ引用符は YAGNI で対象外」と判断済みで、置き換え前より劣化する点を見落としていた
- `Authorization: ` を literal に持つとセパレータを二重要求する正規表現になり何にもマッチしない

**過度なマイクロ最適化** — 足して消して正味ゼロ
1. パターンを 4 択に拡張 → 自前ベンチが 1.91x / 2.14x 悪化
2. 悪化を塞ぐ義務と解釈し、key 部分文字列プレフィルタ + ヘルパー 4 本を追加。**同じコミット内で、Go の regexp が Unicode 折り畳みするため `paſſword=s3cr3t` が漏れる穴を作って塞いでいる**
3. そのプレフィルタをさらに最適化
4. **全部削除**

殺した論拠は新しいベンチではなく絶対予算との比較でした（1 行あたり 23µs 節約 → 1,000 行で 23ms ≒ fork/exec 1 回分。効く唯一の場所ですら残りコストの 98% は `ValueDetector.Mask`）。**1.91x という相対値が判断基準になっていたのが根本原因**です。

**その他** — 文字列の中身から分岐を推論 (`strings.Contains(key, ":")`)、規約に頼った不変条件（公開フィールドで検証を迂回可能、ただし実際の外部構築は `DefaultConfig()` 2 箇所のみ）、**何も証明しないテスト**（`TestRedactText_ValueBasedDetection` は 7 行中 4 行が value detector を nil にしても通る。削除後もカバレッジは関数単位で完全一致 = 一行も独自に到達していなかった）。

## この PR の内容

### CLAUDE.md

**Key Design Patterns に 3 原則**
- Declare, don't infer — 呼び出し側の文字列の中身で経路を選ばない。型に持たせ、ゼロ値は最も仮定の少ない解釈、`default` は fail-secure
- Enforce invariants with the type, not with convention — 拡張点を残す前に実際の利用数を数える
- Reject, don't normalize — 黙って直すと誤りが表に出ず、コピーされて伝播する

**新規 Performance セクション**
- ベンチの退行それ自体は欠陥ではない。絶対予算に変換してから判断する
- 最適化前にプロファイルで在り処を確認。キャッシュが処理の一部しか覆っていないかも見る
- 正しさの義務（case folding、encoding 仮定、fast/slow path の一致）を伴う最適化は基準を上げ、コミットメッセージに明記しテストで固定する
- 最適化は独立したコミットに
- **レビュー指摘に機構を足して応える前に、指摘の前提を検証する**

**Testing Strategy に 4 項目** — テストは対象を無効化して赤くなることを確認してから出す / 層が重なる経路は片方の層しか扱えない入力を作る / 定数が自身のリテラルと等しいことを確認しない / ヘルパーのテーブルを足す前に呼び出し側のテーブルを見る

### .claude/commands/weakreview.md

チェックリストに 3 グループ追加：
- **Unearned mechanism** — 「この機構を消したら何が変わるか。ベンチの数字だけなら finding」「同一レンジ内の前のコミットが作った退行を後のコミットが塞いでいないか」
- **Inference where declaration belongs** — `strings.Contains` による経路選択、`default` なし switch、規約依存の不変条件、黙って修復するヘルパー
- **Tests that cannot fail** — 協調オブジェクトを nil にして落ちるか、層が重なる経路のアサーションがどちらの層が働いたかを区別できるか

## レビュー観点

- 追加したルールが過剰でないか（特に Performance の「絶対予算」の水準感）
- weakreview のチェック項目が、実際にレビューで機能する粒度になっているか
- 「レビュー指摘への対応として機構を足す前に前提を検証する」を独立した節にせず Performance 末尾と weakreview に埋め込んだ判断の是非

## テスト

ドキュメントのみの変更です。pre-commit フックは全パス（Go ファイルなしのためコンパイル系はスキップ）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
