### PR TITLE
docs: cut guidance a linter or another file already owns, and enable the linter

### DIFF
--- a/.claude/commands/fixpr.md
+++ b/.claude/commands/fixpr.md
@@ -81,13 +81,10 @@ Agent prompt (inline the fetched `threads` JSON from Phase 1):
 
 > Triage these unresolved PR review threads for `OWNER/REPO#NUMBER`.
 >
-> Project conventions:
-> - Go 1.26 codebase (per go.mod), security-focused, interface-driven design
-> - YAGNI/DRY: no premature abstractions
-> - Modern Go idioms: slices/maps packages, errors.Is/AsType, `any` instead of
->   `interface{}`, etc.
-> - Comments: English only; one-line max; explain WHY, not WHAT
-> - Build checks: `make fmt && make test && make lint`
+> Project conventions: read `CLAUDE.md` for the design principles, Go idioms, and
+> testing rules this codebase holds itself to, and judge each comment against
+> those. Beyond it: source comments are English only, one line where possible, and
+> explain WHY rather than WHAT. Build checks are `make fmt && make test && make lint`.
 >
 > For EACH thread: read the source file at `path:line` for context, then
 > classify two independent dimensions.

--- a/.claude/commands/mkarch.md
+++ b/.claude/commands/mkarch.md
@@ -1,14 +1,8 @@
-> **Project context (read first)**: Read `.claude/commands/_context.md`. It is the
-> single source of truth for every project-specific value below — the task root,
-> guide paths, document names (`01_requirements.md`, `02_architecture.md`, …),
-> status values (`draft`/`approved`), source layout (`cmd/`/`internal/`), and
-> document language. Where this command names such a path or value, treat the
-> entry in `_context.md` as canonical. When porting, follow the porting steps in
-> `_context.md`. Note that this command body also contains Go/project-specific
-> references (`cmd/`/`internal/` layout inspection in step 6) that may need
-> updating when porting to a different tech stack or project structure. The review
-> step uses the shared procedure in
-> `.claude/commands/_lib/review-subagent-pattern.md`.
+> **Project context (read first)**: Read `.claude/commands/_context.md` — it is
+> canonical for every project-specific path, document name, status value, and
+> layout this command names. Porting instructions live there too; this body's
+> `cmd/`/`internal/` inspection (step 6) is one of the parts that needs editing.
+> The review step follows `.claude/commands/_lib/review-subagent-pattern.md`.
 
 Your goal is to create `02_architecture.md` for one task under `docs/tasks/`.
 

--- a/.claude/commands/mkplan.md
+++ b/.claude/commands/mkplan.md
@@ -1,16 +1,11 @@
-> **Project context (read first)**: Read `.claude/commands/_context.md`. It is the
-> single source of truth for every project-specific value below — the task root,
-> guide paths, document names, status values (`draft`/`approved`), build checks,
-> source layout (`cmd/`/`internal/`, `testutil/`), and document language. Where
-> this command names such a path or value, treat the entry in `_context.md` as
-> canonical. The domain-specific examples in steps 5–6 (the symbol-verification
-> `rg` example and the `FormatLogFileHint` before/after string-literal example)
-> are illustrative for this project; see `_context.md` (Domain-specific) before
-> reusing them elsewhere. When porting, follow the porting steps in `_context.md`:
-> that includes editing this command body for domain-specific examples (steps 5–6)
-> and for Go-specific test-helper rules (`testutil/`, `test_helpers.go`,
-> `//go:build test`) when changing tech stacks. The review step uses the shared
-> procedure in `.claude/commands/_lib/review-subagent-pattern.md`.
+> **Project context (read first)**: Read `.claude/commands/_context.md` — it is
+> canonical for every project-specific path, document name, status value, build
+> check, and layout this command names. Porting instructions live there too; this
+> body's parts that need editing are the domain-specific examples in steps 5–6
+> (the symbol-verification `rg` example, the `FormatLogFileHint` before/after
+> example) and the Go test-helper rules (`testutil/`, `test_helpers.go`,
+> `//go:build test`). The review step follows
+> `.claude/commands/_lib/review-subagent-pattern.md`.
 
 Your goal is to create `03_implementation_plan.md` for one task under `docs/tasks/`.
 

--- a/.claude/commands/mkplan2.md
+++ b/.claude/commands/mkplan2.md
@@ -1,13 +1,9 @@
-> **Project context (read first)**: Read `.claude/commands/_context.md`. It is the
-> single source of truth for every project-specific value below — the task root,
-> document names, status values, the green gate (see `_context.md`), source
-> layout (`internal/`/`cmd/`), and the PR marker label/format conventions. Where
-> this command names such a value, treat the entry in `_context.md` as canonical.
-> When porting, follow the porting steps in `_context.md`. Note that this command
-> body also contains Go-specific design principles (`internal/`→`cmd/` ordering
-> rule, build-independence gate) that must be updated when porting to a non-Go or
-> non-`cmd/`/`internal/` layout. The review step uses the shared procedure in
-> `.claude/commands/_lib/review-subagent-pattern.md`.
+> **Project context (read first)**: Read `.claude/commands/_context.md` — it is
+> canonical for every project-specific value this command names, including the
+> green gate and the PR marker label/format conventions. Porting instructions live
+> there too; this body's parts that need editing are the Go-specific design
+> principles (the `internal/`→`cmd/` ordering rule, the build-independence gate).
+> The review step follows `.claude/commands/_lib/review-subagent-pattern.md`.
 
 Your goal is to design PR boundaries for an existing `03_implementation_plan.md` and embed them directly into the document.
 

--- a/.claude/commands/runplan.md
+++ b/.claude/commands/runplan.md
@@ -1,16 +1,11 @@
-> **Project context (read first)**: Read `.claude/commands/_context.md`. It is the
-> single source of truth for every project-specific value below — the task root,
-> guide paths, document/status conventions, build checks (`make fmt`/`make test`/
-> `make lint`/`make deadcode`), the green gate, source layout, and test-helper
-> placement (`testutil/`, `test_helpers.go`, `//go:build test`). Where this command
-> names such a path or command, treat the entry in `_context.md` as canonical. The
-> domain-specific invariant examples in step 5 (ULID test IDs, `--dry-run`
-> side-effects, privilege-restoration teardown) are illustrative for this project; see
-> `_context.md` (Domain-specific) before reusing them elsewhere. When porting,
-> follow the porting steps in `_context.md`: that includes editing this command body
-> for domain-specific examples (step 5) and for Go-specific rules (`testutil/`,
-> `test_helpers.go`, `//go:build test`) when changing tech stacks. The review step
-> uses the shared procedure in `.claude/commands/_lib/review-subagent-pattern.md`.
+> **Project context (read first)**: Read `.claude/commands/_context.md` — it is
+> canonical for every project-specific path, build check, green gate, and
+> test-helper placement this command names. Porting instructions live there too;
+> this body's parts that need editing are the domain-specific invariant examples
+> in step 5 (ULID test IDs, `--dry-run` side effects, privilege-restoration
+> teardown) and the Go test-helper rules. The review step follows
+> `.claude/commands/_lib/review-subagent-pattern.md`.
+>
 > Before starting an implementation session, check the `**実装モデル要件**` field of
 > the `### PR-N 作成ポイント` marker covering the work you are about to pick up (see
 > `_context.md`, "PR marker conventions"): `frontier-required` means run this session

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,6 +23,13 @@ linters:
     - "unconvert" # Detect unnecessary type conversions
     - "unparam"   # Detect unused function parameters
 
+    # Modern-idiom enforcement. These replace the prose "Modern Go Idioms" list
+    # that CLAUDE.md used to carry, which the codebase violated 51 times.
+    - "modernize"     # Suggest modern language/library features
+    - "intrange"      # for i := 0; i < n; i++  ->  for range n
+    - "copyloopvar"   # Drop the pre-Go-1.22 `i := i` loop-variable copy
+    - "usestdlibvars" # Use stdlib constants (http.MethodPost) over string literals
+
     # Optional
     - "bodyclose"  # Check whether HTTP response bodies are closed
     - "err113"     # Enforce standard error handling practices
@@ -33,6 +40,13 @@ linters:
     - "nakedret"   # Detect naked returns
 
   settings:
+    modernize:
+      # newexpr rewrites the testutil StringPtr/Int32Ptr/Int64Ptr helpers into
+      # new(x) at every call site, which is a real API change across packages
+      # rather than an idiom fix. Tracked separately; see the GitHub issue.
+      disable:
+        - "newexpr"
+
     gocyclo:
       min-complexity: 20
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,30 +14,19 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Documents should be placed under docs
 - Default language is Japanese (exceptions: README.md, CLAUDE.md)
 - Default format is markdown
- - Use Mermaid syntax for diagrams.
-  - Follow the style and legend used in `docs/tasks/0030_verify_files_variable_expansion/02_architecture.md`.
-  - Use a cylinder shape for "data" nodes instead of the default rectangle (in Mermaid flowcharts a cylinder node can be written as `[(data)]`).
-  - **Node label quoting**: Always wrap node labels in double quotes if they contain special characters (parentheses, brackets, colons, slashes, etc.). Example: `A["label (with parens)"]`
-  - **Line breaks in labels**: Use `<br>` for line breaks inside node labels, not `\n`. Example: `A["line1<br>line2"]`
+- Use Mermaid for diagrams, following the conventions in
+  [mermaid_reference.md](docs/dev/developer_guide/mermaid_reference.md) (node-label
+  quoting, `<br>` line breaks, cylinder `[(...)]` data nodes, the standard classDef
+  palette, and Legend blocks). `docs/tasks/0030_verify_files_variable_expansion/02_architecture.md`
+  is a worked example.
 
 ### Translation Guidelines (Japanese to English)
 
-When translating Japanese documentation to English:
-
-1. **Translation Workflow**:
-   - First create and commit the Japanese version
-   - Then create the English version based on the Japanese original
-
-2. **Translation Principles**:
-   - **Accuracy over fluency**: Prioritize precise translation over natural-sounding English
-   - **Faithful translation**: Do not delete content from the Japanese version or add content not present in the original
-   - **Structural consistency**: Match chapter headings and sentence structure between Japanese and English versions
-
-3. **Terminology Management**:
-   - Create and maintain a glossary file under `docs/` directory
-   - Use consistent terminology from the glossary
-   - Add new terms to the glossary as needed
-   - Glossary location: `docs/translation_glossary.md`
+Create and commit the Japanese version first, then write the English version from
+it. The translation principles (accuracy over fluency, faithful translation,
+structural consistency) and the glossary workflow live in
+[mktrans.md](.claude/commands/mktrans.md), which automates this; the glossary is
+[docs/translation_glossary.md](docs/translation_glossary.md).
 
 ## Commands
 
@@ -56,20 +45,13 @@ When translating Japanese documentation to English:
 - `golangci-lint run` - Run linter directly
 - `make fmt` - Run formatter with gofumpt
 
-### Individual Binary Builds
-- Build record binary: `go build -o build/record -v cmd/record/main.go`
-- Build verify binary: `go build -o build/verify -v cmd/verify/main.go`
-
 ## Architecture Overview
 
-This is a Go-based secure command runner with the following core components:
-
-### Core Architecture
-- **Command Runner**: Safe execution wrapper for batch processing with security controls
-- **File Validator**: Integrity verification using hash validation (`internal/filevalidator`)
-- **Safe File I/O**: Secure file operations with symlink protection (`internal/safefileio`)
-- **Command Executor**: Core execution engine with output handling (`internal/runner/executor`)
-- **Config Management**: TOML-based configuration loading (`internal/runner/config`)
+A Go-based secure command runner: it executes batches of configured commands under
+integrity, path, and privilege controls. Entry points are `internal/filevalidator`
+(hash-based integrity verification), `internal/safefileio` (file operations with
+symlink-attack prevention), `internal/runner/executor` (execution and output
+handling), and `internal/runner/config` (TOML configuration loading).
 
 See [Package Reference](docs/dev/developer_guide/package_reference.md) for detailed package structure.
 
@@ -124,25 +106,14 @@ See [Package Reference](docs/dev/developer_guide/package_reference.md) for detai
   is verified.** Measure whether the reported cost is real harm in absolute terms
   first; a self-inflicted regression is not an obligation to build something.
 
-### Security Features
-- Command path validation and sanitization
-- Environment variable isolation
-- Working directory validation
-- File integrity verification with hash validation
-- Safe file operations with symlink attack prevention
-
-### Configuration
-- Uses TOML format for configuration files
-- Supports environment variable management
-- Template-based command definitions
-- Group-based command execution with dependency management
-
 ### Testing Strategy
-- Unit tests for all core components
-- Mock implementations for external dependencies
-- File system abstraction for testing
-- Output capture and verification
-- **Error Testing**: Use `errors.Is()` to validate error types, not string matching on error messages
+
+Interfaces (`CommandExecutor`, `FileSystem`, `OutputWriter`) exist so external
+dependencies can be mocked and the file system abstracted; tests capture and verify
+command output.
+
+- **Error Testing**: Use `errors.Is` / `errors.AsType[T]` to validate error types,
+  never string matching on error messages.
 - **Every test must be able to fail for its stated reason.** Before committing a
   test, disable the thing it claims to cover — nil the collaborator, revert the
   branch, break the default — and confirm it fails. Say in the commit message that
@@ -167,49 +138,22 @@ See [Test Organization Guide](docs/dev/developer_guide/test_organization.md) for
 
 ## Development Notes
 
-- Uses Go modules with Go 1.23.10
-- Dependencies: go-toml/v2, stretchr/testify
-- Security-focused codebase with extensive validation
-- Comprehensive error handling with custom error types
-- Interface-driven design for testability and modularity
+- Go 1.26.2 (see `go.mod`); dependencies: go-toml/v2, stretchr/testify, oklog/ulid.
 - After editing go files, make sure to run `make fmt` to format the files.
 - After editing files, make sure to run `make test` and `make lint` and fix errors.
 
-## Modern Go Idioms (Go 1.21+)
+## Go Idioms
 
-When writing or modifying Go code in this repository, prefer the following modern idioms over older equivalents. These improve readability, reduce boilerplate, and leverage standard library improvements.
+Modern-idiom drift (`any` over `interface{}`, `for range n`, `min`/`max`, the
+`slices`/`maps` packages, `strings.Cut`, `slices.SortFunc` over `sort.Slice`, …) is
+enforced mechanically by the `modernize`, `intrange`, `copyloopvar`, and
+`usestdlibvars` linters in `.golangci.yml`, most of them auto-fixable with
+`golangci-lint run --fix`. Run `make lint` rather than working from a list here.
 
-### Language Features
-- Use `any` instead of `interface{}`.
-- Use `for range n` (Go 1.22+) instead of `for i := 0; i < n; i++` when the index is unused or only counts iterations.
-- Rely on per-iteration loop variable scope (Go 1.22+); do not write `i := i` shadowing inside loop bodies.
-- Use range-over-function iterators (Go 1.23+) for custom traversal where appropriate.
+Only the conventions a linter does not check are worth stating:
 
-### Built-in Functions
-- Use `min(a, b)` / `max(a, b)` instead of hand-written comparisons or `math.Max`/`math.Min`.
-- Use `clear(m)` to clear maps and slices instead of manual `for k := range m { delete(m, k) }`.
-
-### Standard Library
-- Use the `slices` package: `slices.Contains`, `slices.Index`, `slices.Sort`, `slices.SortFunc`, `slices.Equal`, `slices.Clone`, `slices.Concat`, `slices.Delete`, `slices.Insert`, etc., instead of explicit loops.
-- Use the `maps` package: `maps.Keys`, `maps.Values`, `maps.Clone`, `maps.Equal`, `maps.Copy`.
-- Use `cmp.Or(a, b, c)` to return the first non-zero value instead of chained `if x == zero { x = y }`.
-- Use `cmp.Compare` for three-way comparisons, especially in `slices.SortFunc`.
-- Use `errors.Join(err1, err2)` for combining multiple errors.
-- Use `fmt.Errorf("...: %w", err)` for error wrapping.
-- Use `strings.Cut` / `bytes.Cut` instead of `SplitN(s, sep, 2)`.
-- Use `strings.CutPrefix` / `strings.CutSuffix` instead of `HasPrefix` + `TrimPrefix` combinations.
-- Use `sync.OnceFunc` / `sync.OnceValue` / `sync.OnceValues` instead of `sync.Once` + closure boilerplate.
-- Use `log/slog` for structured logging.
-- Use `context.WithoutCancel` to detach cancellation propagation.
-- Use `reflect.TypeFor[T]()` instead of `reflect.TypeOf((*T)(nil)).Elem()`.
-
-### Generics
-- Use type parameters (Go 1.18+) to consolidate duplicated `int`/`int64`/`float64` helpers.
-- Prefer `slices.SortFunc` over `sort.Slice` for type-safe, faster sorting without reflection.
-
-### Other Patterns
-- Use `map[T]struct{}` instead of `map[T]bool` for set semantics (saves memory).
-- Use `errors.Is` / `errors.AsType[T]` instead of string matching on error messages. Prefer `errors.AsType[T]` over `errors.As` — it eliminates the `var target T` declaration:
+- Prefer `errors.AsType[T]` over `errors.As` — it eliminates the `var target T`
+  declaration. This is a Go 1.26 API, so it is not what habit produces:
   ```go
   // Before
   var pathErr *fs.PathError
@@ -218,7 +162,9 @@ When writing or modifying Go code in this repository, prefer the following moder
   // After
   if pathErr, ok := errors.AsType[*fs.PathError](err); ok { ... }
   ```
-- In tests, use `t.Cleanup` instead of manual `defer` chains, and `t.TempDir` instead of `os.MkdirTemp` + `defer os.RemoveAll`.
+- Use `map[T]struct{}` rather than `map[T]bool` for set semantics.
+- In tests, prefer `t.Cleanup` over manual `defer` chains and `t.TempDir` over
+  `os.MkdirTemp` + `defer os.RemoveAll`.
 
 ## Requirements and Acceptance Criteria
 

--- a/cmd/runner/integration_dryrun_verification_test.go
+++ b/cmd/runner/integration_dryrun_verification_test.go
@@ -266,8 +266,8 @@ args = ["hello"]
 	// The output should not contain the command's actual output (which would be "hello" on its own line)
 	// However, "hello" will appear in the args field as `args: ["hello"]`, which is expected
 	// We verify that the command wasn't executed by checking it's not printed as actual output
-	lines := strings.Split(outputStr, "\n")
-	for _, line := range lines {
+	lines := strings.SplitSeq(outputStr, "\n")
+	for line := range lines {
 		trimmed := strings.TrimSpace(line)
 		// Check for standalone "hello" output (actual command execution)
 		// But exclude lines that are part of the parameter display

--- a/cmd/runner/integration_timeout_test.go
+++ b/cmd/runner/integration_timeout_test.go
@@ -365,7 +365,6 @@ args = ["1"]
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			// Create temporary config file
 			tmpFile, err := os.CreateTemp("", "test-config-*.toml")

--- a/cmd/runner/startup_privilege_test.go
+++ b/cmd/runner/startup_privilege_test.go
@@ -105,7 +105,7 @@ func runSummaryRunID(t *testing.T, stdout string) string {
 		if !strings.HasPrefix(line, "RUN_SUMMARY ") {
 			continue
 		}
-		for _, field := range strings.Fields(line) {
+		for field := range strings.FieldsSeq(line) {
 			if value, found := strings.CutPrefix(field, "run_id="); found {
 				return value
 			}
@@ -145,11 +145,9 @@ func captureStdoutStderr(t *testing.T, fn func()) (stdout, stderr string) {
 		dst *bytes.Buffer
 		src *os.File
 	}{{&outBuf, outReader}, {&errBuf, errReader}} {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			_, _ = io.Copy(drain.dst, drain.src)
-		}()
+		})
 	}
 
 	fn()

--- a/cmd/verify/main_test.go
+++ b/cmd/verify/main_test.go
@@ -344,7 +344,7 @@ func TestRunFailsClosedOnHashDirViolation_AncestorViolation(t *testing.T) {
 	// are correct, so any instruction naming it sends the operator to fix a
 	// directory that is already fine.
 	var remediations int
-	for _, line := range strings.Split(strings.TrimSpace(logs.String()), "\n") {
+	for line := range strings.SplitSeq(strings.TrimSpace(logs.String()), "\n") {
 		if !strings.Contains(line, "level=ERROR") {
 			continue
 		}
@@ -407,7 +407,7 @@ func TestRunFailsClosedOnHashDirViolation_LogsErrorLevel(t *testing.T) {
 	require.Equal(t, exitUntrustedEnvironment, exitCode)
 
 	var errorLines, warnLines []string
-	for _, line := range strings.Split(strings.TrimSpace(logs.String()), "\n") {
+	for line := range strings.SplitSeq(strings.TrimSpace(logs.String()), "\n") {
 		switch {
 		case strings.Contains(line, "level=ERROR"):
 			errorLines = append(errorLines, line)

--- a/internal/arm64util/arm64util.go
+++ b/internal/arm64util/arm64util.go
@@ -66,19 +66,13 @@ func BackwardScanX16(code []byte, svcOffset int) (int, bool) {
 
 		if word&^imm16Mask == movzX16Base {
 			lo := int((word & imm16Mask) >> imm16Shift)
-			hi := 0
-			if x16Hi >= 0 {
-				hi = x16Hi
-			}
+			hi := max(x16Hi, 0)
 			return stripBSDPrefix(hi | lo), true
 		}
 
 		if word&^imm16Mask == movzX16Lsl16 {
 			hi := int((word&imm16Mask)>>imm16Shift) << imm16HighShift
-			lo := 0
-			if x16Lo >= 0 {
-				lo = x16Lo
-			}
+			lo := max(x16Lo, 0)
 			return stripBSDPrefix(hi | lo), true
 		}
 
@@ -194,19 +188,13 @@ func backwardScanRegImm(code []byte, fromOffset int, regN uint32) (int, bool) {
 		// MOVZ xN/wN, #imm, LSL#0 — terminal: assemble hi|lo and return
 		if word&^imm16Mask == movzX0Base|regN || word&^imm16Mask == movzW0Base|regN {
 			lo := int((word & imm16Mask) >> imm16Shift)
-			hi := 0
-			if immHi >= 0 {
-				hi = immHi
-			}
+			hi := max(immHi, 0)
 			return hi | lo, true
 		}
 		// MOVZ xN, #imm, LSL#16 — terminal
 		if word&^imm16Mask == movzX0Lsl16|regN {
 			hi := int((word&imm16Mask)>>imm16Shift) << imm16HighShift
-			lo := 0
-			if immLo >= 0 {
-				lo = immLo
-			}
+			lo := max(immLo, 0)
 			return hi | lo, true
 		}
 		// MOVK xN/wN, #imm, LSL#0 — accumulate low half
@@ -318,7 +306,7 @@ func decodeORRX16XZR(word uint32) (int, bool) {
 	if esize == arm64BitsPerWord {
 		result = welem
 	} else {
-		for i := uint32(0); i < arm64BitsPerWord/esize; i++ {
+		for i := range arm64BitsPerWord / esize {
 			result |= welem << (i * esize)
 		}
 	}

--- a/internal/common/logschema_test.go
+++ b/internal/common/logschema_test.go
@@ -98,7 +98,7 @@ func TestCommandResults_LogValue(t *testing.T) {
 				assert.Equal(t, int64(100), attrs[0].Value.Int64())
 				assert.False(t, attrs[1].Value.Bool())
 
-				for i := 0; i < 100; i++ {
+				for i := range 100 {
 					assert.Equal(t, fmt.Sprintf("cmd_%d", i), attrs[i+2].Key)
 				}
 			},
@@ -135,7 +135,7 @@ func TestCommandResults_LogValue(t *testing.T) {
 
 func createTestCommandResults(count int) CommandResults {
 	results := make(CommandResults, count)
-	for i := 0; i < count; i++ {
+	for i := range count {
 		results[i] = CommandResult{
 			CommandResultFields: CommandResultFields{
 				Name:     fmt.Sprintf("cmd%d", i),

--- a/internal/dynlib/elfdynlib/ldcache.go
+++ b/internal/dynlib/elfdynlib/ldcache.go
@@ -142,7 +142,7 @@ func parseLDCacheData(data []byte) (*LDCache, error) {
 		entries: make(map[string]string, header.NLibs),
 	}
 
-	for i := uint32(0); i < header.NLibs; i++ {
+	for i := range header.NLibs {
 		offset := entryStart + int(i)*newEntrySize
 		entryReader := bytes.NewReader(data[offset:])
 

--- a/internal/dynlib/machodylib/analyzer_test.go
+++ b/internal/dynlib/machodylib/analyzer_test.go
@@ -569,7 +569,7 @@ func TestAnalyze_RecursionDepthExceeded(t *testing.T) {
 
 	// Write chain[0]..chain[MaxRecursionDepth-1]; each references the next.
 	// chain[MaxRecursionDepth-1] references chain[MaxRecursionDepth] (does not need to exist).
-	for i := 0; i < MaxRecursionDepth; i++ {
+	for i := range MaxRecursionDepth {
 		require.NoError(t, os.WriteFile(chain[i],
 			machodylibtestutil.BuildMachOWithDeps(nativeCPU, []string{chain[i+1]}, nil, nil), 0o600))
 	}

--- a/internal/dynlib/machodylib/dyld_extractor_darwin.go
+++ b/internal/dynlib/machodylib/dyld_extractor_darwin.go
@@ -260,7 +260,7 @@ func findLibSystemKernelImage(f *os.File) (*dyldImgTextInfo, error) {
 	}
 
 	const entrySize = 32 // sizeof(dyld_cache_image_text_info)
-	for i := uint64(0); i < imgTextCount; i++ {
+	for i := range imgTextCount {
 		off := int64(imgTextOff) + int64(i)*entrySize
 		var raw [32]byte
 		if _, err := f.ReadAt(raw[:], off); err != nil {
@@ -315,7 +315,7 @@ func buildSubCacheList(f *os.File, mainPath string, cacheBase uint64) ([]subCach
 
 	const entrySize = 56 // sizeof(dyld_subcache_entry)
 	result := make([]subCacheFile, 0, subCacheCount)
-	for i := uint32(0); i < subCacheCount; i++ {
+	for i := range subCacheCount {
 		off := int64(subCacheOff) + int64(i)*entrySize
 		var raw [56]byte
 		if _, err := f.ReadAt(raw[:], off); err != nil {
@@ -418,7 +418,7 @@ func readSubCacheMapping(path string, vmAddr uint64) (*dyldMappingInfo, error) {
 	}
 
 	const mappingEntrySize = 32
-	for i := uint32(0); i < mapCount; i++ {
+	for i := range mapCount {
 		off := int64(mapOff) + int64(i)*mappingEntrySize
 		var raw [32]byte
 		if _, err := f.ReadAt(raw[:], off); err != nil {
@@ -622,7 +622,7 @@ func buildCompactSymtab(linkeditPath string, symFileOff uint64, nsyms uint32, st
 	copy(compactSyms, symData)
 
 	var nameBuf [512]byte
-	for i := uint32(0); i < nsyms; i++ {
+	for i := range nsyms {
 		entOff := i * nlist64Size
 		origStrx := binary.LittleEndian.Uint32(compactSyms[entOff:])
 
@@ -745,7 +745,7 @@ func patchLoadCommands(
 				binary.LittleEndian.PutUint64(lcData[offset+40:], newTextFileOff)
 				// Update section offsets (each section_64 is section64Size bytes, starting at offset+seg64SectionsOffset).
 				nsects := binary.LittleEndian.Uint32(lcData[offset+64:])
-				for s := uint32(0); s < nsects; s++ {
+				for s := range nsects {
 					sBase := offset + seg64SectionsOffset + int(s)*section64Size //nolint:gosec // G115: s is bounded by nsects < 256
 					if sBase+section64FileOffset+4 > len(lcData) {
 						break

--- a/internal/dynlib/machodylib/resolver.go
+++ b/internal/dynlib/machodylib/resolver.go
@@ -164,10 +164,10 @@ func (r *LibraryResolver) expandRpathEntry(rpathEntry, loaderPath string) string
 // splitAtToken splits an install name like "@rpath/libFoo.dylib" into
 // ("@rpath", "libFoo.dylib"). The suffix does not include the leading separator.
 func splitAtToken(installName string) (token, suffix string) {
-	idx := strings.Index(installName, "/")
-	if idx < 0 {
+	before, after, ok := strings.Cut(installName, "/")
+	if !ok {
 		return installName, ""
 	}
 
-	return installName[:idx], installName[idx+1:]
+	return before, after
 }

--- a/internal/filevalidator/test_helpers.go
+++ b/internal/filevalidator/test_helpers.go
@@ -1,5 +1,4 @@
 //go:build test
-// +build test
 
 package filevalidator
 

--- a/internal/filevalidator/validator_shebang_cache_test.go
+++ b/internal/filevalidator/validator_shebang_cache_test.go
@@ -106,7 +106,7 @@ func TestSaveRecord_ShebangInterpreterCacheHashChangeReanalyzes(t *testing.T) {
 	validator, err := New(&SHA256{}, hashDir, ValidatorConfig{BinaryAnalyzer: spy})
 	require.NoError(t, err)
 
-	scriptA := tu.WriteExecutableFile(t, dir, "a.sh", []byte(fmt.Sprintf("#!%s\necho A\n", interpreterPath)))
+	scriptA := tu.WriteExecutableFile(t, dir, "a.sh", fmt.Appendf(nil, "#!%s\necho A\n", interpreterPath))
 	_, _, err = validator.SaveRecord(scriptA, false)
 	require.NoError(t, err)
 
@@ -118,7 +118,7 @@ func TestSaveRecord_ShebangInterpreterCacheHashChangeReanalyzes(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEqual(t, hashA, hashB)
 
-	scriptB := tu.WriteExecutableFile(t, dir, "b.sh", []byte(fmt.Sprintf("#!%s\necho B\n", interpreterPath)))
+	scriptB := tu.WriteExecutableFile(t, dir, "b.sh", fmt.Appendf(nil, "#!%s\necho B\n", interpreterPath))
 	_, _, err = validator.SaveRecord(scriptB, false)
 	require.NoError(t, err)
 

--- a/internal/filevalidator/validator_shebang_test.go
+++ b/internal/filevalidator/validator_shebang_test.go
@@ -150,7 +150,7 @@ func TestSaveRecord_ShebangRecursive(t *testing.T) {
 
 	// Create a script pointing to the fake interpreter.
 	script := tu.WriteExecutableFile(t, dir, "script.sh",
-		[]byte(fmt.Sprintf("#!%s\necho hello\n", fakeInterp)))
+		fmt.Appendf(nil, "#!%s\necho hello\n", fakeInterp))
 
 	validator, err := New(&SHA256{}, hashDir, ValidatorConfig{})
 	require.NoError(t, err)

--- a/internal/groupmembership/manager_test.go
+++ b/internal/groupmembership/manager_test.go
@@ -158,7 +158,7 @@ func TestGroupMembership(t *testing.T) {
 
 		// Trigger cleanup by making CleanupInterval cache misses
 		// clearExpiredCache is called internally after CleanupInterval misses
-		for i := 0; i < CleanupInterval; i++ {
+		for i := range CleanupInterval {
 			// Try to get a non-existent group to trigger cache misses
 			_, _ = gm.GetGroupMembers(uint32(10000 + i))
 		}
@@ -185,7 +185,7 @@ func TestGroupMembership(t *testing.T) {
 		assert.Equal(t, 0, stats.ExpiredEntries) // Entries should not be expired
 
 		// Trigger cleanup - valid entries should be preserved
-		for i := 0; i < CleanupInterval; i++ {
+		for i := range CleanupInterval {
 			_, _ = gm.GetGroupMembers(uint32(10000 + i))
 		}
 
@@ -202,7 +202,7 @@ func TestGroupMembership(t *testing.T) {
 		assert.Equal(t, 0, stats.TotalEntries)
 
 		// Trigger cleanup on empty cache - should not cause errors
-		for i := 0; i < CleanupInterval; i++ {
+		for i := range CleanupInterval {
 			_, _ = gm.GetGroupMembers(uint32(10000 + i))
 		}
 

--- a/internal/groupmembership/membership_semantics_test.go
+++ b/internal/groupmembership/membership_semantics_test.go
@@ -55,7 +55,7 @@ func nssSources(content, database string) []string {
 		}
 		sourceList := strings.TrimSpace(parts[1])
 		var sources []string
-		for _, src := range strings.Fields(sourceList) {
+		for src := range strings.FieldsSeq(sourceList) {
 			if strings.HasPrefix(src, "[") {
 				continue
 			}
@@ -182,7 +182,7 @@ func fileExpectedMembers(t *testing.T, gid uint32) []string {
 
 	set := make(map[string]struct{})
 	if entry.members != "" {
-		for _, m := range strings.Split(entry.members, ",") {
+		for m := range strings.SplitSeq(entry.members, ",") {
 			m = strings.TrimSpace(m)
 			if m != "" {
 				set[m] = struct{}{}

--- a/internal/logging/log_line_tracker.go
+++ b/internal/logging/log_line_tracker.go
@@ -19,7 +19,7 @@ type LogLineTracker interface {
 // DefaultLogLineTracker provides a thread-safe implementation of LogLineTracker
 // using atomic operations for concurrent access.
 type DefaultLogLineTracker struct {
-	lineCounter int64
+	lineCounter atomic.Int64
 }
 
 // NewDefaultLogLineTracker creates a new DefaultLogLineTracker.
@@ -29,15 +29,15 @@ func NewDefaultLogLineTracker() *DefaultLogLineTracker {
 
 // GetCurrentLine returns the current estimated log line number.
 func (t *DefaultLogLineTracker) GetCurrentLine() int {
-	return int(atomic.LoadInt64(&t.lineCounter))
+	return int(t.lineCounter.Load())
 }
 
 // IncrementLine increments the line counter and returns the new line number.
 func (t *DefaultLogLineTracker) IncrementLine() int {
-	return int(atomic.AddInt64(&t.lineCounter, 1))
+	return int(t.lineCounter.Add(1))
 }
 
 // Reset resets the line counter to zero.
 func (t *DefaultLogLineTracker) Reset() {
-	atomic.StoreInt64(&t.lineCounter, 0)
+	t.lineCounter.Store(0)
 }

--- a/internal/logging/log_line_tracker_test.go
+++ b/internal/logging/log_line_tracker_test.go
@@ -102,33 +102,27 @@ func TestDefaultLogLineTracker_ConcurrentReadWrite(t *testing.T) {
 	var wg sync.WaitGroup
 
 	// Start a goroutine that continuously increments
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		for range numOperations {
 			tracker.IncrementLine()
 		}
-	}()
+	})
 
 	// Start a goroutine that continuously reads
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		for range numOperations {
 			line := tracker.GetCurrentLine()
 			// Line should never be negative
 			assert.GreaterOrEqual(t, line, 0, "GetCurrentLine() returned negative value")
 		}
-	}()
+	})
 
 	// Start a goroutine that resets periodically
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		for range 10 {
 			tracker.Reset()
 		}
-	}()
+	})
 
 	wg.Wait()
 

--- a/internal/logging/message_formatter_test.go
+++ b/internal/logging/message_formatter_test.go
@@ -2,6 +2,7 @@ package logging
 
 import (
 	"log/slog"
+	"slices"
 	"testing"
 	"time"
 
@@ -78,13 +79,7 @@ func TestDefaultMessageFormatter_FormatRecordWithColor(t *testing.T) {
 			result := formatter.FormatRecordWithColor(tt.record, tt.useColor)
 
 			// Check if result matches any of the expected formats
-			found := false
-			for _, expected := range tt.expecteds {
-				if result == expected {
-					found = true
-					break
-				}
-			}
+			found := slices.Contains(tt.expecteds, result)
 
 			assert.True(t, found, "FormatRecordWithColor() = %q, expected one of %v", result, tt.expecteds)
 		})
@@ -253,13 +248,7 @@ func TestDefaultMessageFormatter_FormatRecordInteractive(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := formatter.FormatRecordInteractive(tt.record, tt.useColor)
-			found := false
-			for _, expected := range tt.expecteds {
-				if result == expected {
-					found = true
-					break
-				}
-			}
+			found := slices.Contains(tt.expecteds, result)
 			assert.True(t, found, "FormatRecordInteractive() = %q, expected one of %v", result, tt.expecteds)
 		})
 	}
@@ -489,7 +478,7 @@ func TestAppendInteractiveAttrs_EdgeCases(t *testing.T) {
 			name: "many attributes",
 			record: func() slog.Record {
 				r := slog.NewRecord(time.Now(), slog.LevelInfo, "test", 0)
-				for i := 0; i < 20; i++ {
+				for i := range 20 {
 					r.AddAttrs(slog.String("key"+string(rune('A'+i)), "value"))
 				}
 				return r

--- a/internal/logging/slack_handler.go
+++ b/internal/logging/slack_handler.go
@@ -883,7 +883,7 @@ func (s *SlackHandler) sendToSlack(ctx context.Context, message SlackMessage) er
 			}
 		}
 
-		req, err := http.NewRequestWithContext(ctx, "POST", s.webhookURL, bytes.NewBuffer(payload))
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.webhookURL, bytes.NewBuffer(payload))
 		if err != nil {
 			lastErr = fmt.Errorf("failed to create request: %w", err)
 			slog.Warn("Failed to create Slack request", slog.String("error", sanitizeErrorForLog(err)), slog.Int("attempt", attempt+1), slog.String("run_id", s.runID))

--- a/internal/logging/slack_handler_test.go
+++ b/internal/logging/slack_handler_test.go
@@ -931,7 +931,7 @@ func TestSlackHandler_GenerateBackoffIntervals(t *testing.T) {
 				"Should generate correct number of intervals for %s", tt.name)
 
 			// Check exponential backoff formula: base * 2^i
-			for i := range len(intervals) {
+			for i := range intervals {
 				expected := tt.base * time.Duration(1<<i)
 				assert.Equal(t, expected, intervals[i],
 					"Interval[%d] should follow exponential backoff formula (base * 2^%d)", i, i)

--- a/internal/redaction/redactor.go
+++ b/internal/redaction/redactor.go
@@ -1151,7 +1151,7 @@ func (r *RedactingHandler) processStruct(key string, structValue any, ctx redact
 	nextCtx := redactionContext{depth: ctx.depth + 1}
 	exportedFieldCount := 0
 
-	for i := 0; i < rv.NumField(); i++ {
+	for i := range rv.NumField() {
 		field := rv.Type().Field(i)
 		// Skip unexported fields
 		if !field.IsExported() {
@@ -1290,7 +1290,7 @@ func (r *RedactingHandler) processSlice(key string, sliceValue any, ctx redactio
 	elemKind := rv.Type().Elem().Kind()
 	skipPerElementReflectCheck := elemKind != reflect.Interface && !isRecursivelyRedactableKind(elemKind)
 
-	for i := 0; i < rv.Len(); i++ {
+	for i := range rv.Len() {
 		element := rv.Index(i).Interface()
 
 		// Check if element is LogValuer

--- a/internal/redaction/redactor_test.go
+++ b/internal/redaction/redactor_test.go
@@ -1689,11 +1689,9 @@ func TestRedactText_ConcurrentUse(t *testing.T) {
 	results := make([]string, goroutines)
 	var wg sync.WaitGroup
 	for i := range goroutines {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			results[i] = config.RedactText(input)
-		}()
+		})
 	}
 	wg.Wait()
 

--- a/internal/redaction/sensitive_patterns_test.go
+++ b/internal/redaction/sensitive_patterns_test.go
@@ -187,7 +187,7 @@ func BenchmarkIsSensitiveKey_Mixed_IndividualPatterns(b *testing.B) {
 	}
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		key := testKeys[i%len(testKeys)]
 		// Simulate original loop-based approach
 		found := false
@@ -213,7 +213,7 @@ func BenchmarkIsSensitiveKey_Mixed_Combined(b *testing.B) {
 	}
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		key := testKeys[i%len(testKeys)]
 		patterns.IsSensitiveKey(key)
 	}

--- a/internal/runner/base/audit/logger_test.go
+++ b/internal/runner/base/audit/logger_test.go
@@ -648,10 +648,11 @@ func TestLogRiskProfile_ArgMasking(t *testing.T) {
 
 	args, ok := entry["command_args"].([]any)
 	require.True(t, ok, "command_args should be an array")
-	joined := ""
+	var sb strings.Builder
 	for _, a := range args {
-		joined += a.(string) + " "
+		sb.WriteString(a.(string) + " ")
 	}
+	joined := sb.String()
 	assert.NotContains(t, joined, "supersecretvalue", "secret must be masked")
 	assert.Contains(t, joined, "[REDACTED]")
 	assert.Contains(t, joined, "admin", "non-sensitive arg preserved")

--- a/internal/runner/base/audit/test_helpers.go
+++ b/internal/runner/base/audit/test_helpers.go
@@ -1,5 +1,4 @@
 //go:build test
-// +build test
 
 package audit
 

--- a/internal/runner/base/executor/test_helpers.go
+++ b/internal/runner/base/executor/test_helpers.go
@@ -1,5 +1,4 @@
 //go:build test
-// +build test
 
 package executor
 

--- a/internal/runner/base/output/capture_test.go
+++ b/internal/runner/base/output/capture_test.go
@@ -332,7 +332,7 @@ func TestCapture_CloseIdempotency(t *testing.T) {
 	assert.Nil(t, capture.FileHandle, "FileHandle should be nil after Close")
 
 	// Subsequent closes should also succeed (idempotent)
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		err = capture.Close()
 		assert.NoError(t, err, "Subsequent Close() call #%d should not produce an error", i+1)
 		assert.Nil(t, capture.FileHandle, "FileHandle should remain nil after subsequent Close() call #%d", i+1)
@@ -366,12 +366,12 @@ func TestCapture_ConcurrentAccess(t *testing.T) {
 	var mu sync.Mutex
 
 	// Start concurrent writes
-	for i := 0; i < numGoroutines; i++ {
+	for i := range numGoroutines {
 		wg.Add(1)
 		go func(goroutineID int) {
 			defer wg.Done()
-			for j := 0; j < writesPerGoroutine; j++ {
-				data := []byte(fmt.Sprintf("g%02d-w%02d  ", goroutineID, j)) // 9 bytes
+			for j := range writesPerGoroutine {
+				data := fmt.Appendf(nil, "g%02d-w%02d  ", goroutineID, j) // 9 bytes
 				err := capture.WriteOutput(data)
 				if err == nil {
 					mu.Lock()

--- a/internal/runner/base/privilege/identity_mutation_guard_test.go
+++ b/internal/runner/base/privilege/identity_mutation_guard_test.go
@@ -10,6 +10,7 @@ import (
 	"go/types"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -282,12 +283,7 @@ func declaredFuncName(funcDecl *ast.FuncDecl) string {
 }
 
 func isAllowedIdentityMutationCall(call allowedIdentityMutationCall) bool {
-	for _, allowed := range allowedIdentityMutationCalls {
-		if allowed == call {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(allowedIdentityMutationCalls, call)
 }
 
 // findIdentityMutationRefs parses every production .go file in dir and returns

--- a/internal/runner/base/privilege/race_test.go
+++ b/internal/runner/base/privilege/race_test.go
@@ -34,10 +34,7 @@ func TestUnixPrivilegeManager_ConcurrentAccess(t *testing.T) {
 
 	// Launch multiple goroutines that try to use WithPrivileges concurrently
 	for range numGoroutines {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-
+		wg.Go(func() {
 			for range numOperationsPerGoroutine {
 				elevationCtx := runnertypes.ElevationContext{
 					Operation:   runnertypes.OperationFileAccess,
@@ -61,7 +58,7 @@ func TestUnixPrivilegeManager_ConcurrentAccess(t *testing.T) {
 				results = append(results, err)
 				mu.Unlock()
 			}
-		}()
+		})
 	}
 
 	// Wait for all goroutines to complete
@@ -133,10 +130,7 @@ func TestUnixPrivilegeManager_RaceConditionProtection(t *testing.T) {
 
 	// Launch many goroutines simultaneously to try to trigger race conditions
 	for range numGoroutines {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-
+		wg.Go(func() {
 			elevationCtx := runnertypes.ElevationContext{
 				Operation:   runnertypes.OperationFileAccess,
 				CommandName: "race_test",
@@ -162,7 +156,7 @@ func TestUnixPrivilegeManager_RaceConditionProtection(t *testing.T) {
 				errors = append(errors, err)
 				mu.Unlock()
 			}
-		}()
+		})
 	}
 
 	wg.Wait()
@@ -186,7 +180,7 @@ func TestUnixPrivilegeManager_LockSerialization(t *testing.T) {
 	var mu sync.Mutex
 
 	// Launch multiple goroutines to test serialization
-	for i := 0; i < numGoroutines; i++ {
+	for i := range numGoroutines {
 		wg.Add(1)
 		go func(id int) {
 			defer wg.Done()
@@ -233,16 +227,13 @@ func TestUnixPrivilegeManager_ThreadSafety(t *testing.T) {
 
 	// Test concurrent access to read-only methods
 	for range numGoroutines {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-
+		wg.Go(func() {
 			// These methods should be safe to call concurrently
 			_ = manager.GetCurrentUID()
 			_ = manager.GetOriginalUID()
 			_ = manager.IsPrivilegedExecutionSupported()
 			_ = manager.GetMetrics()
-		}()
+		})
 	}
 
 	wg.Wait()

--- a/internal/runner/base/security/command_analysis.go
+++ b/internal/runner/base/security/command_analysis.go
@@ -400,8 +400,8 @@ func containsSSHStyleAddress(args []string) bool {
 		case sshHostPathRe.MatchString(arg):
 			// host:path (no @) — require / or ~ in the path to avoid false positives
 			// with port numbers (e.g., "localhost:8080") and time formats.
-			colonIndex := strings.Index(arg, ":")
-			pathPart := arg[colonIndex+1:]
+			_, after, _ := strings.Cut(arg, ":")
+			pathPart := after
 			if strings.Contains(pathPart, "/") || strings.HasPrefix(pathPart, "~") {
 				return true
 			}

--- a/internal/runner/base/security/destination_zoning.go
+++ b/internal/runner/base/security/destination_zoning.go
@@ -3,6 +3,7 @@ package security
 import (
 	"os"
 	"path/filepath"
+	"slices"
 
 	"github.com/isseis/go-safe-cmd-runner/internal/common"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/risktypes"
@@ -340,10 +341,8 @@ func appendReason(codes []risktypes.ReasonCode, code risktypes.ReasonCode) []ris
 	if code == "" {
 		return codes
 	}
-	for _, c := range codes {
-		if c == code {
-			return codes
-		}
+	if slices.Contains(codes, code) {
+		return codes
 	}
 	return append(codes, code)
 }

--- a/internal/runner/base/security/destination_zoning_parity_test.go
+++ b/internal/runner/base/security/destination_zoning_parity_test.go
@@ -103,7 +103,6 @@ func TestExtractionRegressionCases(t *testing.T) {
 			{"mv", "-s", "src"},
 		}
 		for _, tc := range cases {
-			tc := tc
 			t.Run(tc.cmd+"/"+tc.flag, func(t *testing.T) {
 				e := runExtraction(t, tc.cmd, tc.flag, tc.operand)
 				assert.False(t, e.recognized,
@@ -171,7 +170,6 @@ func TestRemovedOverRecognizedFlagsFailClosed(t *testing.T) {
 
 	for cmd, flags := range removedOverRecognizedFlags {
 		for _, flag := range flags {
-			cmd, flag := cmd, flag
 			t.Run(cmd+"/"+flag, func(t *testing.T) {
 				e := runExtraction(t, cmd, flag, "target1", "target2")
 				assert.False(t, e.recognized,

--- a/internal/runner/base/security/destination_zoning_spec.go
+++ b/internal/runner/base/security/destination_zoning_spec.go
@@ -956,7 +956,7 @@ func chmodGrantsHigh(mode string) bool {
 	// Symbolic: a clause that ADDS or ASSIGNS (+/=) an s bit grants setuid/setgid,
 	// or grants world-write when its "who" includes other or all. The perm letters
 	// must be parsed per clause (a substring match like "+s" misses "u+xs").
-	for _, clause := range strings.Split(mode, ",") {
+	for clause := range strings.SplitSeq(mode, ",") {
 		idx := strings.IndexAny(clause, "+=-")
 		if idx < 0 {
 			continue
@@ -988,7 +988,7 @@ func isOctal(s string) bool {
 
 // aclGrantsWrite reports whether a setfacl entry grants write to group or other.
 func aclGrantsWrite(entry string) bool {
-	for _, e := range strings.Split(entry, ",") {
+	for e := range strings.SplitSeq(entry, ",") {
 		fields := strings.Split(e, ":")
 		if len(fields) < minACLFields {
 			continue

--- a/internal/runner/base/security/file_validation.go
+++ b/internal/runner/base/security/file_validation.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"syscall"
@@ -336,10 +337,8 @@ func (v *Validator) isUserInGroup(uid int, gid uint32) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("failed to get group members for GID %d: %w", gid, err)
 	}
-	for _, member := range members {
-		if member == user.Username {
-			return true, nil
-		}
+	if slices.Contains(members, user.Username) {
+		return true, nil
 	}
 
 	return false, nil

--- a/internal/runner/base/security/test_helpers.go
+++ b/internal/runner/base/security/test_helpers.go
@@ -1,5 +1,4 @@
 //go:build test
-// +build test
 
 package security
 

--- a/internal/runner/base/security/types_test.go
+++ b/internal/runner/base/security/types_test.go
@@ -2,6 +2,7 @@ package security
 
 import (
 	"reflect"
+	"slices"
 	"testing"
 
 	"github.com/isseis/go-safe-cmd-runner/internal/common"
@@ -273,13 +274,7 @@ func TestConfig_GetSuspiciousFilePatterns_Invariants(t *testing.T) {
 	// Verify expected core patterns are present
 	expectedPatterns := []string{"passwd", "shadow", "authorized_keys", "id_rsa"}
 	for _, expected := range expectedPatterns {
-		found := false
-		for _, pattern := range patterns {
-			if pattern == expected {
-				found = true
-				break
-			}
-		}
+		found := slices.Contains(patterns, expected)
 		if !found {
 			assert.Fail(t, "Expected pattern not found in suspicious patterns", "expected: %q, patterns: %v", expected, patterns)
 		}

--- a/internal/runner/bootstrap/logger_test.go
+++ b/internal/runner/bootstrap/logger_test.go
@@ -329,7 +329,7 @@ func TestSetupLoggerWithConfig_FailureLoggerCircularDependencyPrevention(t *test
 	require.NoError(t, err)
 
 	// Log multiple messages to ensure no circular dependency issues
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		slog.Info("test message", "iteration", i)
 	}
 

--- a/internal/runner/cli/filter_bench_test.go
+++ b/internal/runner/cli/filter_bench_test.go
@@ -1,5 +1,4 @@
 //go:build test
-// +build test
 
 package cli
 

--- a/internal/runner/config/expansion.go
+++ b/internal/runner/config/expansion.go
@@ -826,9 +826,7 @@ func ExpandGlobal(spec *runnertypes.GlobalSpec) (*runnertypes.RuntimeGlobal, err
 	// Store env_import variables for conflict detection
 	runtime.EnvImportVars = envImportVars
 	// Merge envImportVars into runtime.ExpandedVars (which already contains autoVars)
-	for k, v := range envImportVars {
-		runtime.ExpandedVars[k] = v
-	}
+	maps.Copy(runtime.ExpandedVars, envImportVars)
 
 	// 2. Process Vars (pass envImportVars for conflict detection)
 	expandedVars, expandedArrays, err := ProcessVars(spec.Vars, runtime.ExpandedVars, runtime.ExpandedArrayVars, runtime.EnvImportVars, "global")

--- a/internal/runner/config/expansion_bench_test.go
+++ b/internal/runner/config/expansion_bench_test.go
@@ -207,7 +207,7 @@ func BenchmarkExpandMultipleCommandsWithEnvImport(b *testing.B) {
 
 	// Prepare 10 command specs, each with env_import
 	cmdSpecs := make([]*runnertypes.CommandSpec, 10)
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		cmdSpecs[i] = &runnertypes.CommandSpec{
 			Name:      "test_command",
 			Cmd:       "/usr/bin/test",

--- a/internal/runner/config/loader_compatibility_test.go
+++ b/internal/runner/config/loader_compatibility_test.go
@@ -47,7 +47,6 @@ func TestBackwardCompatibility_AllSampleFiles(t *testing.T) {
 	}
 
 	for _, filename := range sampleFiles {
-		filename := filename // capture range variable
 		t.Run(filename, func(t *testing.T) {
 			configPath := filepath.Join("..", "..", "..", "sample", filename)
 			content, err := os.ReadFile(configPath)

--- a/internal/runner/config/template_expansion.go
+++ b/internal/runner/config/template_expansion.go
@@ -497,14 +497,14 @@ func validateEnvPre(entry, templateName, _ string) error {
 	}
 
 	// Parse KEY=VALUE to check KEY part
-	idx := strings.IndexByte(entry, '=')
-	if idx == -1 {
+	before, _, ok := strings.Cut(entry, "=")
+	if !ok {
 		// No '=' found - could be invalid format or pure placeholder
 		// Will be caught in post-validation
 		return nil
 	}
 
-	key := entry[:idx]
+	key := before
 
 	// Check that KEY part does not contain placeholders (security requirement)
 	keyPlaceholders, err := parsePlaceholders(key)
@@ -527,8 +527,8 @@ func validateEnvPre(entry, templateName, _ string) error {
 // Returns (shouldInclude=false, nil) if the entry should be skipped (empty VALUE).
 func validateEnvPost(entry, templateName, field string, expandedIndex int) (bool, error) {
 	// Check KEY=VALUE format
-	idx := strings.IndexByte(entry, '=')
-	if idx == -1 {
+	_, after, ok := strings.Cut(entry, "=")
+	if !ok {
 		return false, &ErrTemplateInvalidEnvFormat{
 			TemplateName:  templateName,
 			Field:         field,
@@ -539,7 +539,7 @@ func validateEnvPost(entry, templateName, field string, expandedIndex int) (bool
 
 	// Check if VALUE part is empty (e.g., "PATH=" from "PATH=${?path}" with empty/missing param)
 	// In this case, skip the entire entry
-	value := entry[idx+1:]
+	value := after
 	if value == "" {
 		return false, nil
 	}
@@ -557,13 +557,13 @@ func validateEnvUnique(env []string, templateName string) error {
 
 	for _, entry := range env {
 		// Extract KEY from "KEY=VALUE"
-		idx := strings.IndexByte(entry, '=')
-		if idx == -1 {
+		before, _, ok := strings.Cut(entry, "=")
+		if !ok {
 			// Format error should have been caught by validateEnvPost
 			continue
 		}
 
-		key := entry[:idx]
+		key := before
 
 		// Check for duplicate
 		if _, exists := seen[key]; exists {
@@ -942,9 +942,9 @@ func collectFromBasicFields(template *runnertypes.CommandTemplate, used map[stri
 // collectFromEnvVars collects params from env_vars array.
 func collectFromEnvVars(envVars []string, used map[string]struct{}) error {
 	for _, env := range envVars {
-		if idx := strings.IndexByte(env, '='); idx != -1 {
+		if _, after, ok := strings.Cut(env, "="); ok {
 			// KEY=VALUE format - collect from value part only
-			if err := collectFromString(env[idx+1:], used); err != nil {
+			if err := collectFromString(after, used); err != nil {
 				return err
 			}
 		} else {

--- a/internal/runner/config/test_helpers.go
+++ b/internal/runner/config/test_helpers.go
@@ -1,5 +1,4 @@
 //go:build test
-// +build test
 
 package config
 

--- a/internal/runner/e2e_slack_redaction_test.go
+++ b/internal/runner/e2e_slack_redaction_test.go
@@ -16,6 +16,7 @@ import (
 	"context"
 	"encoding/json"
 	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/isseis/go-safe-cmd-runner/internal/common"
@@ -174,10 +175,11 @@ func TestIntegration_SlackRedaction(t *testing.T) {
 	// Verify: Check messages received by mock Slack handler
 	require.NotEmpty(t, mockSlackHandler.messages, "should have sent messages to Slack handler")
 
-	allMessages := ""
+	var msgBuilder strings.Builder
 	for _, msg := range mockSlackHandler.messages {
-		allMessages += msg + "\n"
+		msgBuilder.WriteString(msg + "\n")
 	}
+	allMessages := msgBuilder.String()
 
 	// Verify sensitive data is redacted
 	assert.NotContains(t, allMessages, "secret123", "API key should be redacted in Slack messages")
@@ -296,10 +298,11 @@ func TestE2E_MultiHandlerLogging(t *testing.T) {
 	stderrOutput := stderrBuffer.String()
 	fileOutput := fileBuffer.String()
 
-	allSlackMessages := ""
+	var slackBuilder strings.Builder
 	for _, msg := range mockSlackHandler.messages {
-		allSlackMessages += msg + "\n"
+		slackBuilder.WriteString(msg + "\n")
 	}
+	allSlackMessages := slackBuilder.String()
 
 	// Check stderr output
 	assert.NotContains(t, stderrOutput, "xyz789", "token should be redacted in stderr")

--- a/internal/runner/group_executor_test.go
+++ b/internal/runner/group_executor_test.go
@@ -2845,7 +2845,7 @@ func TestCommandFailureLogging_StderrInErrorLog(t *testing.T) {
 
 			// Extract ERROR level logs
 			errorLogs := []string{}
-			for _, line := range strings.Split(logOutput, "\n") {
+			for line := range strings.SplitSeq(logOutput, "\n") {
 				if strings.Contains(line, `"level":"ERROR"`) {
 					errorLogs = append(errorLogs, line)
 				}

--- a/internal/runner/integration_inheritance_mode_test.go
+++ b/internal/runner/integration_inheritance_mode_test.go
@@ -218,7 +218,6 @@ func TestInheritanceModeTracking_CompleteFlow(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc // Capture loop variable
 		t.Run(tc.groupName, func(t *testing.T) {
 			groupSpec := &configSpec.Groups[tc.groupIndex]
 

--- a/internal/runner/resource/audit_wiring_test.go
+++ b/internal/runner/resource/audit_wiring_test.go
@@ -51,7 +51,7 @@ func newAuditingNormalManager(evaluator risk.Evaluator) (*NormalResourceManager,
 // to buf, failing the test if none is present.
 func findRiskProfileEntry(t *testing.T, buf *bytes.Buffer) map[string]any {
 	t.Helper()
-	for _, line := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+	for line := range strings.SplitSeq(strings.TrimSpace(buf.String()), "\n") {
 		if line == "" {
 			continue
 		}

--- a/internal/runner/resource/performance_test.go
+++ b/internal/runner/resource/performance_test.go
@@ -27,7 +27,7 @@ func BenchmarkDryRunPerformance(b *testing.B) {
 		b.Run(bm.name, func(b *testing.B) {
 			// Create test commands
 			commands := make([]*runnertypes.RuntimeCommand, bm.numCommands)
-			for i := 0; i < bm.numCommands; i++ {
+			for i := range bm.numCommands {
 				commands[i] = executortestutil.CreateRuntimeCommand(
 					"echo",
 					[]string{"test"},
@@ -92,7 +92,7 @@ func BenchmarkFormatterPerformance(b *testing.B) {
 	}
 
 	// Fill with test data
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		result.ResourceAnalyses[i] = Analysis{
 			Type:      TypeCommand,
 			Operation: OperationExecute,
@@ -190,7 +190,7 @@ func BenchmarkResourceManagerModeSwitch(b *testing.B) {
 // BenchmarkMemoryUsage benchmarks memory usage during dry-run execution
 func BenchmarkMemoryUsage(b *testing.B) {
 	commands := make([]*runnertypes.RuntimeCommand, 1000)
-	for i := 0; i < 1000; i++ {
+	for i := range 1000 {
 		commands[i] = executortestutil.CreateRuntimeCommand(
 			"echo",
 			[]string{"memory test"},

--- a/internal/runner/resource/test_helpers.go
+++ b/internal/runner/resource/test_helpers.go
@@ -1,5 +1,4 @@
 //go:build test || performance
-// +build test performance
 
 package resource
 

--- a/internal/runner/test_helpers.go
+++ b/internal/runner/test_helpers.go
@@ -1,5 +1,4 @@
 //go:build test
-// +build test
 
 package runner
 

--- a/internal/security/elfanalyzer/plt_analyzer.go
+++ b/internal/security/elfanalyzer/plt_analyzer.go
@@ -71,7 +71,7 @@ func findFuncPLTAddr(elfFile *elf.File, funcName string) (uint64, bool, error) {
 
 	bo := elfFile.ByteOrder
 	relaIdx := -1
-	for i := 0; i < len(relaData)/elf64RelASize; i++ {
+	for i := range len(relaData) / elf64RelASize {
 		entry := relaData[i*elf64RelASize : (i+1)*elf64RelASize]
 		rInfo := bo.Uint64(entry[8:16])
 		symIdx := int(rInfo >> elf64RelASymShift) //nolint:gosec // G115: rInfo>>32 fits int on all supported platforms

--- a/internal/security/elfanalyzer/syscall_analyzer.go
+++ b/internal/security/elfanalyzer/syscall_analyzer.go
@@ -721,10 +721,7 @@ func (a *SyscallAnalyzer) backwardScanForRegister(
 	isImmediateToReg func(DecodedInstruction) (bool, int64),
 ) (value int64, method string) {
 	// Window calculation identical to backwardScanForSyscallNumber
-	windowStart := syscallOffset - (a.maxBackwardScan * maxWindowBytesPerInstruction(decoder))
-	if windowStart < 0 {
-		windowStart = 0
-	}
+	windowStart := max(syscallOffset-(a.maxBackwardScan*maxWindowBytesPerInstruction(decoder)), 0)
 
 	instructions, _ := a.decodeWindow(
 		code, baseAddr, windowStart, syscallOffset, decoder,
@@ -803,10 +800,7 @@ func (a *SyscallAnalyzer) backwardScanX86WithRegCopy(
 	x86Decoder *X86Decoder,
 ) (int, string, string) {
 	syscallAddr := baseAddr + uint64(syscallOffset) //nolint:gosec // G115: syscallOffset is validated by caller
-	windowStart := syscallOffset - (a.maxBackwardScan * maxWindowBytesPerInstruction(x86Decoder))
-	if windowStart < 0 {
-		windowStart = 0
-	}
+	windowStart := max(syscallOffset-(a.maxBackwardScan*maxWindowBytesPerInstruction(x86Decoder)), 0)
 
 	number, method, detail, decodeFailures := a.backwardScanX86WithWindow(
 		code,
@@ -863,10 +857,7 @@ func (a *SyscallAnalyzer) resolveX86CopyChainTailConsensus(
 ) (int, string, bool) {
 	const tailProbeBytes = 128
 
-	probeStart := syscallOffset - tailProbeBytes
-	if probeStart < windowStart {
-		probeStart = windowStart
-	}
+	probeStart := max(syscallOffset-tailProbeBytes, windowStart)
 
 	resolvedValue := 0
 	resolvedDetail := ""

--- a/internal/verification/result_collector_test.go
+++ b/internal/verification/result_collector_test.go
@@ -122,7 +122,7 @@ func TestResultCollector_Concurrency(t *testing.T) {
 		go func() {
 			defer wg.Done()
 
-			for j := 0; j < numOpsPerGoroutine; j++ {
+			for j := range numOpsPerGoroutine {
 				switch j % 2 {
 				case 0:
 					rc.RecordSuccess()

--- a/internal/verification/test_helpers.go
+++ b/internal/verification/test_helpers.go
@@ -1,5 +1,4 @@
 //go:build test
-// +build test
 
 package verification
 

--- a/test/security/temp_directory_race_test.go
+++ b/test/security/temp_directory_race_test.go
@@ -24,15 +24,15 @@ func TestTempDirectory_ConcurrentAccess(t *testing.T) {
 	errorChan := make(chan error, numGoroutines*numOperations)
 
 	// Launch multiple goroutines to perform concurrent file operations
-	for i := 0; i < numGoroutines; i++ {
+	for i := range numGoroutines {
 		wg.Add(1)
 		go func(id int) {
 			defer wg.Done()
 
-			for j := 0; j < numOperations; j++ {
+			for j := range numOperations {
 				// Create a unique file for this goroutine
 				filePath := filepath.Join(tempDir, fmt.Sprintf("file_%d_%d.txt", id, j))
-				content := []byte(fmt.Sprintf("test content from goroutine %d operation %d", id, j))
+				content := fmt.Appendf(nil, "test content from goroutine %d operation %d", id, j)
 
 				// Write file
 				err := os.WriteFile(filePath, content, 0o644)
@@ -77,14 +77,14 @@ func TestTempDirectory_ConcurrentCleanup(t *testing.T) {
 	// Create multiple subdirectories
 	numDirs := 20
 	dirs := make([]string, numDirs)
-	for i := 0; i < numDirs; i++ {
+	for i := range numDirs {
 		dirPath := filepath.Join(tempDir, fmt.Sprintf("dir_%d", i))
 		err := os.MkdirAll(dirPath, 0o750)
 		require.NoError(t, err)
 		dirs[i] = dirPath
 
 		// Create some files in each directory
-		for j := 0; j < 5; j++ {
+		for j := range 5 {
 			filePath := filepath.Join(dirPath, fmt.Sprintf("file_%d.txt", j))
 			err = os.WriteFile(filePath, []byte("test content"), 0o644)
 			require.NoError(t, err)
@@ -144,7 +144,7 @@ func TestTempDirectory_RaceDetection(t *testing.T) {
 	numGoroutines := 5
 	errorChan := make(chan error, numGoroutines*2) // Buffer for potential errors
 
-	for i := 0; i < numGoroutines; i++ {
+	for i := range numGoroutines {
 		wg.Add(1)
 		go func(_ int) {
 			defer wg.Done()


### PR DESCRIPTION
#1006 の続きです。あちらが「レビューで得た判断を書き足す」PR だったのに対し、こちらは**書いてあるのに効いていない指示を落とす** PR です。

「Sonnet 5 / Opus 5 になり、以前は CLAUDE.md に個別に書く必要があったものが、書かなくても生成物が劣化しなくなった」という報告を出発点に見直しました。結論として前提は半分当たっていて、**このリポジトリで一番大きい削減余地はモデル能力ではなく「linter に移せる指示」と「重複」でした。**

## 1. Modern Go Idioms の 44 行は実際に機能していなかった

CLAUDE.md 178-221 行のルールが守られているか実測しました。

```
golangci-lint run --default=none --build-tags test \
  -E modernize,intrange,copyloopvar,usestdlibvars ./...
→ 51 issues
   modernize 39 / intrange 6 / copyloopvar 5 / usestdlibvars 1
```

うち 2 つはその節が明示的に禁止している項目です。`intrange` 6 件は「`for range n` を使え」の違反、`copyloopvar` 5 件は「`i := i` シャドウイングを書くな」の違反。**誰も diff を見ないファイルに書かれた散文は強制手段になっていません。**

一方 `golangci-lint` には `modernize` linter が存在し、有効化されていませんでした。これはモデル能力の議論とは独立に、散文より厳密に優れています（`make lint` で検出、大半が auto-fix）。

節を丸ごと消したわけではありません。趣旨を**反転**させました。現状は「古い書き方 → 新しい書き方」の一覧ですが、モデルが既定で書けるのは正にその大半で、残す価値があるのは逆に「モデルの学習時点より新しい API」です。実測で該当したのは 3 つだけでした：

- `errors.AsType[T]`（Go 1.26 の新 API。`errors.As(` が 21 箇所残存、modernize は見ない）
- `map[T]struct{}` によるセット表現
- テストでの `t.Cleanup` / `t.TempDir`

## 2. 重複（モデル能力と無関係に削れる）

| 箇所 | 重複先 |
|---|---|
| Mermaid 記法 3 ルール | `docs/dev/developer_guide/mermaid_reference.md` に全文あり |
| 翻訳の 3 原則・用語集パス | `mktrans.md` が持っていて自動化もしている |
| Individual Binary Builds | `make build` と同じ |
| `errors.Is()` ルール | Testing Strategy と Other Patterns に二重掲載 |

## 3. 古い記述（バグ）

`Go 1.23.10` と書かれていましたが go.mod は `1.26.2` です。`fixpr.md` の方は正しく 1.26 と書いてあり、両者が矛盾していました。

## 4. 説明的 boilerplate

`Core Architecture` / `Security Features` / `Configuration` / `Development Notes` の bullet は `/init` 生成物の残骸で、「security-focused」「extensive validation」「interface-driven」を 3 回言い直しているだけでした。パッケージとパスの対応は orientation として有用なので散文で残しています。**ここは「モデルが賢くなったので不要」がそのまま当てはまる箇所です。**

## 5. `.claude/commands/`

**大きくは削っていません。** これらは自分への指示ではなく subagent プロンプトに verbatim で流し込むペイロード（CRITERIA）で、長さがそのまま機能だからです。中身の多くも実地で得た知見で、賢いモデルほど知っているという性質のものではありません（`gh api` の `-f` は `@-` を受け付けず文字列 `@-` を投稿してしまう、等）。

削ったのは各ファイル冒頭の porting 手順の再掲だけです。`_context.md` が冒頭で一元的に持っているものを 5 ファイルが各自で再掲していたので、「自分の body のどこを移植時に触るか」だけ残しました。`fixpr.md` の Phase 2 にあった project conventions のインラインコピーは CLAUDE.md へのポインタに置換（subagent も CLAUDE.md を読むため）。ただし「コメントは英語・1 行・WHY を書く」はどこにも無いので残しています。

## 削減量

| | before | after |
|---|---|---|
| CLAUDE.md | 241 行 | 186 行 |
| .claude/commands（ヘッダ 5 本 + fixpr） | 145 行 | 68 行 |

## 削っていないもの

Tool Execution Safety、要件→設計→計画のプロセス、日本語既定や `[x]`/`[-]` の意味、そして #1006 で追加した設計原則・Performance・テストのルール。

前提を素直に適用するとここが危ないので明記しておきます。**#1006 で分析した 0163 の PR は Opus 5 が生成したもので、fail-open バグ 3 件と「落ちないテスト」を含み、マージまでに 18 コミットを要しました。** モデル能力が上がったのは構文・イディオム水準であって、このリポジトリ固有の判断水準ではありません。

## コミット構成

**`docs: cut the guidance that a linter or another file already owns`** — 上記 1〜5 のドキュメント変更。

**`style: enforce modern Go idioms with a linter instead of a list`** — `modernize` / `intrange` / `copyloopvar` / `usestdlibvars` を有効化し、51 件中 38 件を修正。大半は `--fix` ですが 9 件は手作業です：

- `redactor.go` の intrange 2 件。fixer は「メソッドが返す境界値に副作用があるか判断できない」として触りません。`rv.NumField()` / `rv.Len()` は reflect.Value の固定値でループ内で `rv` を再代入していないため安全で、リダクション経路のメソッド呼び出しが毎周 1 回減ります
- fixer が作った unconvert 2 件（ループ書き換えで `range uint32(x)` の x が既に uint32 になった）
- modernize の非 auto-fix 4 件 — `int64` + `atomic.LoadInt64`/`AddInt64`/`StoreInt64` → `atomic.Int64` のメソッド、テストで `+=` により haystack 文字列を組む 3 箇所 → `strings.Builder`
- 同一ファイル内の modernize 修正と競合して skip された copyloopvar 1 件

`plusbuild` 修正は test helper の legacy `// +build` 行のみを削除し、`test || performance` を含む全ての `//go:build` 行は保持しています（コンパイル対象は不変）。

## newexpr を除外した理由 → #1005

残り 13 件の `newexpr` は `.golangci.yml` で除外し、issue #1005 を立てました。イディオム修正ではなくパッケージ横断の API 変更で、機械的なパスに混ぜるとレビュー不能になるためです。

調べると想定より広く、`StringPtr` が `internal/testutil` と `internal/runner/base/runnertypes` に**独立して 2 つ定義**され、呼び出しは 33 ファイル・約 330 箇所、`runnertypes/spec.go` と `config.go` は production コードです。さらに `StringPtrOrNil` は nil 分岐があり `new(x)` に置換できないため、隣接ヘルパーだけ消す判断が要ります。手順と、完了時に `modernize.disable` を外す受け入れ条件を issue に書いてあります。

## レビュー観点

- CLAUDE.md から落とした情報のうち、実は残すべきだったものがないか（特に Core Architecture のパッケージ対応と Security Features）
- 「モデルの既定より新しい API だけ残す」という Go Idioms 節の再定義が妥当か
- `redactor.go` の intrange 2 件を安全と判断した根拠（`rv` 非再代入・`NumField()`/`Len()` の純粋性）
- commands をほぼ削らなかった判断（subagent へのペイロードなので長さが機能、という理由づけ）

## テスト

`make test` 49 パッケージ全通過、`make lint` 0 issues。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
