### PR TITLE
refactor: replace the *Ptr test helpers with Go 1.26 new(x)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,13 +40,6 @@ linters:
     - "nakedret"   # Detect naked returns
 
   settings:
-    modernize:
-      # newexpr rewrites the testutil StringPtr/Int32Ptr/Int64Ptr helpers into
-      # new(x) at every call site, which is a real API change across packages
-      # rather than an idiom fix. Tracked separately; see the GitHub issue.
-      disable:
-        - "newexpr"
-
     gocyclo:
       min-complexity: 20
 

--- a/internal/common/output_size_limit_test.go
+++ b/internal/common/output_size_limit_test.go
@@ -18,10 +18,6 @@ func unlimitedOutputSizeLimit() OutputSizeLimit {
 	return OutputSizeLimit{NewOptionalValue[int64](0)}
 }
 
-func int64Ptr(v int64) *int64 {
-	return &v
-}
-
 func TestErrInvalidOutputSizeLimit_Error(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -253,21 +249,21 @@ func TestNewOutputSizeLimitFromPtr(t *testing.T) {
 		},
 		{
 			name:      "zero pointer creates unlimited limit",
-			ptr:       int64Ptr(0),
+			ptr:       new(int64(0)),
 			wantSet:   true,
 			wantUnlim: true,
 			wantValue: 0,
 		},
 		{
 			name:      "positive pointer creates limit",
-			ptr:       int64Ptr(1024),
+			ptr:       new(int64(1024)),
 			wantSet:   true,
 			wantUnlim: false,
 			wantValue: 1024,
 		},
 		{
 			name:      "large limit pointer (100MB)",
-			ptr:       int64Ptr(100 * 1024 * 1024),
+			ptr:       new(int64(100 * 1024 * 1024)),
 			wantSet:   true,
 			wantUnlim: false,
 			wantValue: 100 * 1024 * 1024,

--- a/internal/common/timeout_resolver_test.go
+++ b/internal/common/timeout_resolver_test.go
@@ -4,7 +4,6 @@ package common
 import (
 	"testing"
 
-	tu "github.com/isseis/go-safe-cmd-runner/internal/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -32,9 +31,9 @@ func TestResolveTimeout(t *testing.T) {
 		},
 		{
 			name:            "command timeout takes precedence",
-			cmdTimeout:      NewFromIntPtr(tu.Int32Ptr(120)),
-			groupTimeout:    NewFromIntPtr(tu.Int32Ptr(90)),
-			globalTimeout:   NewFromIntPtr(tu.Int32Ptr(60)),
+			cmdTimeout:      NewFromIntPtr(new(int32(120))),
+			groupTimeout:    NewFromIntPtr(new(int32(90))),
+			globalTimeout:   NewFromIntPtr(new(int32(60))),
 			commandName:     "test-cmd",
 			groupName:       "test-group",
 			expectedTimeout: 120,
@@ -43,8 +42,8 @@ func TestResolveTimeout(t *testing.T) {
 		{
 			name:            "group timeout when command is unset",
 			cmdTimeout:      NewUnsetTimeout(),
-			groupTimeout:    NewFromIntPtr(tu.Int32Ptr(90)),
-			globalTimeout:   NewFromIntPtr(tu.Int32Ptr(60)),
+			groupTimeout:    NewFromIntPtr(new(int32(90))),
+			globalTimeout:   NewFromIntPtr(new(int32(60))),
 			commandName:     "test-cmd",
 			groupName:       "test-group",
 			expectedTimeout: 90,
@@ -54,7 +53,7 @@ func TestResolveTimeout(t *testing.T) {
 			name:            "global timeout when cmd and group are unset",
 			cmdTimeout:      NewUnsetTimeout(),
 			groupTimeout:    NewUnsetTimeout(),
-			globalTimeout:   NewFromIntPtr(tu.Int32Ptr(45)),
+			globalTimeout:   NewFromIntPtr(new(int32(45))),
 			commandName:     "test-cmd",
 			groupName:       "test-group",
 			expectedTimeout: 45,
@@ -62,9 +61,9 @@ func TestResolveTimeout(t *testing.T) {
 		},
 		{
 			name:            "command timeout 0 (unlimited)",
-			cmdTimeout:      NewFromIntPtr(tu.Int32Ptr(0)),
-			groupTimeout:    NewFromIntPtr(tu.Int32Ptr(90)),
-			globalTimeout:   NewFromIntPtr(tu.Int32Ptr(60)),
+			cmdTimeout:      NewFromIntPtr(new(int32(0))),
+			groupTimeout:    NewFromIntPtr(new(int32(90))),
+			globalTimeout:   NewFromIntPtr(new(int32(60))),
 			commandName:     "unlimited-cmd",
 			groupName:       "test-group",
 			expectedTimeout: 0,
@@ -73,8 +72,8 @@ func TestResolveTimeout(t *testing.T) {
 		{
 			name:            "group timeout 0 (unlimited)",
 			cmdTimeout:      NewUnsetTimeout(),
-			groupTimeout:    NewFromIntPtr(tu.Int32Ptr(0)),
-			globalTimeout:   NewFromIntPtr(tu.Int32Ptr(60)),
+			groupTimeout:    NewFromIntPtr(new(int32(0))),
+			globalTimeout:   NewFromIntPtr(new(int32(60))),
 			commandName:     "test-cmd",
 			groupName:       "test-group",
 			expectedTimeout: 0,
@@ -84,7 +83,7 @@ func TestResolveTimeout(t *testing.T) {
 			name:            "global timeout 0 (unlimited)",
 			cmdTimeout:      NewUnsetTimeout(),
 			groupTimeout:    NewUnsetTimeout(),
-			globalTimeout:   NewFromIntPtr(tu.Int32Ptr(0)),
+			globalTimeout:   NewFromIntPtr(new(int32(0))),
 			commandName:     "test-cmd",
 			groupName:       "test-group",
 			expectedTimeout: 0,
@@ -93,9 +92,9 @@ func TestResolveTimeout(t *testing.T) {
 		// Original TestResolveTimeoutWithContext test cases
 		{
 			name:            "command level resolution with context",
-			cmdTimeout:      NewFromIntPtr(tu.Int32Ptr(30)),
+			cmdTimeout:      NewFromIntPtr(new(int32(30))),
 			groupTimeout:    NewUnsetTimeout(),
-			globalTimeout:   NewFromIntPtr(tu.Int32Ptr(60)),
+			globalTimeout:   NewFromIntPtr(new(int32(60))),
 			commandName:     "test-command",
 			groupName:       "test-group",
 			expectedTimeout: 30,
@@ -105,7 +104,7 @@ func TestResolveTimeout(t *testing.T) {
 			name:            "global level resolution with context",
 			cmdTimeout:      NewUnsetTimeout(),
 			groupTimeout:    NewUnsetTimeout(),
-			globalTimeout:   NewFromIntPtr(tu.Int32Ptr(60)),
+			globalTimeout:   NewFromIntPtr(new(int32(60))),
 			commandName:     "test-command",
 			groupName:       "test-group",
 			expectedTimeout: 60,

--- a/internal/common/timeout_test.go
+++ b/internal/common/timeout_test.go
@@ -4,8 +4,6 @@ package common
 import (
 	"testing"
 
-	tu "github.com/isseis/go-safe-cmd-runner/internal/testutil"
-
 	"github.com/stretchr/testify/assert"
 )
 
@@ -148,21 +146,21 @@ func TestNewFromIntPtr(t *testing.T) {
 		},
 		{
 			name:      "zero pointer creates unlimited timeout",
-			ptr:       tu.Int32Ptr(0),
+			ptr:       new(int32(0)),
 			wantSet:   true,
 			wantUnlim: true,
 			wantValue: 0,
 		},
 		{
 			name:      "positive pointer creates timeout",
-			ptr:       tu.Int32Ptr(120),
+			ptr:       new(int32(120)),
 			wantSet:   true,
 			wantUnlim: false,
 			wantValue: 120,
 		},
 		{
 			name:      "max timeout pointer",
-			ptr:       tu.Int32Ptr(MaxTimeout),
+			ptr:       new(int32(MaxTimeout)),
 			wantSet:   true,
 			wantUnlim: false,
 			wantValue: MaxTimeout,

--- a/internal/runner/base/audit/logger_test.go
+++ b/internal/runner/base/audit/logger_test.go
@@ -463,8 +463,6 @@ func logRiskProfileEntry(t *testing.T, entry risktypes.RiskAuditEntry) map[strin
 	return logEntry
 }
 
-func strptr(s string) *string { return &s }
-
 // TestLogRiskProfile_LogLevelByRisk verifies the log level corresponds to
 // the effective risk level for allow decisions (no deny floor applies).
 func TestLogRiskProfile_LogLevelByRisk(t *testing.T) {
@@ -595,9 +593,9 @@ func TestLogRiskProfile_CorrelationFieldsAndAbsence(t *testing.T) {
 		entry := logRiskProfileEntry(t, risktypes.RiskAuditEntry{
 			CommandName:    "rm",
 			Mode:           risktypes.ModeNormal,
-			ResolvedPath:   strptr("/usr/bin/rm"),
-			ContentHash:    strptr("sha256:abc"),
-			RecordID:       strptr("schema-v1"),
+			ResolvedPath:   new("/usr/bin/rm"),
+			ContentHash:    new("sha256:abc"),
+			RecordID:       new("schema-v1"),
 			MaxAllowedRisk: runnertypes.RiskLevelLow,
 			Decision:       risktypes.DecisionDeny,
 			Assessment: risktypes.RiskAssessment{
@@ -808,8 +806,8 @@ func TestLogRiskProfile_Chain(t *testing.T) {
 		Decision:    risktypes.DecisionAllow,
 		Assessment:  risktypes.RiskAssessment{Level: runnertypes.RiskLevelMedium},
 		Chain: []risktypes.ExecutedArtifact{
-			{Path: "/usr/bin/env", Role: risktypes.RoleWrapper, Disposition: risktypes.DispVerified, ContentHash: strptr("sha256:env")},
-			{Path: "/usr/bin/curl", Role: risktypes.RoleInner, Disposition: risktypes.DispVerified, ContentHash: strptr("sha256:curl")},
+			{Path: "/usr/bin/env", Role: risktypes.RoleWrapper, Disposition: risktypes.DispVerified, ContentHash: new("sha256:env")},
+			{Path: "/usr/bin/curl", Role: risktypes.RoleInner, Disposition: risktypes.DispVerified, ContentHash: new("sha256:curl")},
 		},
 	})
 

--- a/internal/runner/base/executor/testutil/helpers.go
+++ b/internal/runner/base/executor/testutil/helpers.go
@@ -144,7 +144,7 @@ func WithOutputFile(outputFile string) RuntimeCommandOption {
 // WithRiskLevel sets the risk level for the command.
 func WithRiskLevel(riskLevel string) RuntimeCommandOption {
 	return func(c *runtimeCommandConfig) {
-		c.riskLevel = runnertypes.StringPtr(riskLevel)
+		c.riskLevel = new(riskLevel)
 	}
 }
 

--- a/internal/runner/base/runnertypes/config.go
+++ b/internal/runner/base/runnertypes/config.go
@@ -60,14 +60,14 @@ const (
 )
 
 // Risk level string pointers for use in configuration structs that require *string.
-// These should be used instead of StringPtr("low") etc. to ensure consistency.
+// These should be used instead of new("low") etc. to ensure consistency.
 var (
 	// RiskLevelLowPtr is a pointer to the "low" risk level string.
-	RiskLevelLowPtr = StringPtr(LowRiskLevelString)
+	RiskLevelLowPtr = new(LowRiskLevelString)
 	// RiskLevelMediumPtr is a pointer to the "medium" risk level string.
-	RiskLevelMediumPtr = StringPtr(MediumRiskLevelString)
+	RiskLevelMediumPtr = new(MediumRiskLevelString)
 	// RiskLevelHighPtr is a pointer to the "high" risk level string.
-	RiskLevelHighPtr = StringPtr(HighRiskLevelString)
+	RiskLevelHighPtr = new(HighRiskLevelString)
 )
 
 // String returns a string representation of RiskLevel

--- a/internal/runner/base/runnertypes/config_test.go
+++ b/internal/runner/base/runnertypes/config_test.go
@@ -84,7 +84,7 @@ func TestParseRiskLevel_UnknownError(t *testing.T) {
 // TestParseRiskLevel_UnknownConfigRejected verifies that a command configured
 // with risk_level="unknown" surfaces the error through GetRiskLevel.
 func TestParseRiskLevel_UnknownConfigRejected(t *testing.T) {
-	cmd := &CommandSpec{RiskLevel: StringPtr("unknown")}
+	cmd := &CommandSpec{RiskLevel: new("unknown")}
 	level, err := cmd.GetRiskLevel()
 	assert.ErrorIs(t, err, ErrInvalidRiskLevel)
 	assert.Equal(t, RiskLevelUnknown, level)
@@ -179,7 +179,7 @@ func TestCommandGetRiskLevel(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cmd := &CommandSpec{
-				RiskLevel: StringPtr(tt.riskStr),
+				RiskLevel: new(tt.riskStr),
 			}
 
 			result, err := cmd.GetRiskLevel()

--- a/internal/runner/base/runnertypes/runtime_test.go
+++ b/internal/runner/base/runnertypes/runtime_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/isseis/go-safe-cmd-runner/internal/common"
 	"github.com/isseis/go-safe-cmd-runner/internal/common/testutil"
-	tu "github.com/isseis/go-safe-cmd-runner/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -118,14 +117,14 @@ func TestRuntimeCommand_Output(t *testing.T) {
 		{
 			name: "output path specified",
 			spec: &CommandSpec{
-				OutputFile: StringPtr("/tmp/output.log"),
+				OutputFile: new("/tmp/output.log"),
 			},
 			want: "/tmp/output.log",
 		},
 		{
 			name: "no output specified",
 			spec: &CommandSpec{
-				OutputFile: StringPtr(""),
+				OutputFile: new(""),
 			},
 			want: "",
 		},
@@ -184,7 +183,7 @@ func TestRuntimeCommand_GetRiskLevel(t *testing.T) {
 		{
 			name: "invalid risk level",
 			spec: &CommandSpec{
-				RiskLevel: StringPtr("invalid"),
+				RiskLevel: new("invalid"),
 			},
 			want:    RiskLevelUnknown,
 			wantErr: true,
@@ -261,7 +260,7 @@ func TestRuntimeCommand_HasUserGroupSpecification(t *testing.T) {
 func TestRuntimeGlobal_Structure(t *testing.T) {
 	// Test that RuntimeGlobal can be created with proper structure
 	spec := &GlobalSpec{
-		Timeout: tu.Int32Ptr(300),
+		Timeout: new(int32(300)),
 		EnvVars: []string{"PATH=/usr/bin"},
 		Vars:    map[string]any{"VAR1": "value1"},
 	}
@@ -320,8 +319,8 @@ func TestRuntimeCommand_Structure(t *testing.T) {
 		Name:    "test-cmd",
 		Cmd:     "/usr/bin/echo",
 		Args:    []string{"hello", "world"},
-		WorkDir: StringPtr("/tmp"),
-		Timeout: tu.Int32Ptr(60),
+		WorkDir: new("/tmp"),
+		Timeout: new(int32(60)),
 		EnvVars: []string{"TEST=value"},
 	}
 
@@ -353,7 +352,7 @@ func TestRuntimeCommand_HelperMethods(t *testing.T) {
 		Name:    "test-cmd",
 		Cmd:     "/usr/bin/echo",
 		Args:    []string{"hello", "world"},
-		Timeout: tu.Int32Ptr(60),
+		Timeout: new(int32(60)),
 	}
 
 	runtime, err := NewRuntimeCommand(spec, common.NewUnsetTimeout(), commontestutil.NewUnsetOutputSizeLimit(), "test-group")
@@ -376,7 +375,7 @@ func TestRuntimeCommand_HelperMethods(t *testing.T) {
 // TestRuntimeGlobal_HelperMethods tests the helper methods for RuntimeGlobal
 func TestRuntimeGlobal_HelperMethods(t *testing.T) {
 	spec := &GlobalSpec{
-		Timeout:    tu.Int32Ptr(300),
+		Timeout:    new(int32(300)),
 		EnvAllowed: []string{"PATH", "HOME"},
 	}
 

--- a/internal/runner/base/runnertypes/spec.go
+++ b/internal/runner/base/runnertypes/spec.go
@@ -297,12 +297,6 @@ func (s *CommandSpec) GetRiskLevel() (RiskLevel, error) {
 	return ParseRiskLevel(*s.RiskLevel)
 }
 
-// StringPtr is a helper function to create *string from string literal.
-// This is useful for test code when setting RiskLevel field.
-func StringPtr(s string) *string {
-	return &s
-}
-
 // HasUserGroupSpecification returns true if either run_as_user or run_as_group is specified.
 func (s *CommandSpec) HasUserGroupSpecification() bool {
 	return s.RunAsUser != "" || s.RunAsGroup != ""

--- a/internal/runner/base/runnertypes/spec_test.go
+++ b/internal/runner/base/runnertypes/spec_test.go
@@ -4,7 +4,6 @@ import (
 	"reflect"
 	"testing"
 
-	tu "github.com/isseis/go-safe-cmd-runner/internal/testutil"
 	"github.com/pelletier/go-toml/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -29,7 +28,7 @@ output_size_limit = 2097152
 				EnvVars:         []string{"DEBUG=1"},
 				EnvAllowed:      []string{"DEBUG"},
 				EnvImport:       []string{},
-				OutputSizeLimit: tu.Int64Ptr(2097152),
+				OutputSizeLimit: new(int64(2097152)),
 			},
 		},
 	}
@@ -107,7 +106,7 @@ output_file = "/tmp/output.log"
 				EnvVars:    []string{"CMD_VAR=test"},
 				EnvImport:  []string{"cmd_user=USER"},
 				RiskLevel:  RiskLevelLowPtr,
-				OutputFile: StringPtr("/tmp/output.log"),
+				OutputFile: new("/tmp/output.log"),
 			},
 		},
 	}
@@ -151,7 +150,7 @@ args = ["hello"]
 			want: &ConfigSpec{
 				Version: "1.0",
 				Global: GlobalSpec{
-					Timeout: tu.Int32Ptr(300),
+					Timeout: new(int32(300)),
 				},
 				Groups: []GroupSpec{
 					{
@@ -189,7 +188,7 @@ cmd = "/bin/echo"
 			want: &ConfigSpec{
 				Version: "1.0",
 				Global: GlobalSpec{
-					Timeout: tu.Int32Ptr(300),
+					Timeout: new(int32(300)),
 				},
 				Security: SecuritySpec{
 					TrustedGIDs: []uint32{10, 20},
@@ -229,7 +228,7 @@ cmd = "/bin/echo"
 			want: &ConfigSpec{
 				Version: "1.0",
 				Global: GlobalSpec{
-					Timeout: tu.Int32Ptr(300),
+					Timeout: new(int32(300)),
 				},
 				Security: SecuritySpec{
 					TrustedDirectories: []string{"/srv/run/work", "/opt/run/tmp"},
@@ -266,7 +265,7 @@ cmd = "/bin/echo"
 			want: &ConfigSpec{
 				Version: "1.0",
 				Global: GlobalSpec{
-					Timeout: tu.Int32Ptr(120),
+					Timeout: new(int32(120)),
 				},
 				Security: SecuritySpec{},
 				Groups: []GroupSpec{
@@ -310,8 +309,8 @@ cmd = "/bin/echo"
 			want: &ConfigSpec{
 				Version: "1.0",
 				Global: GlobalSpec{
-					Timeout:         tu.Int32Ptr(300),
-					OutputSizeLimit: tu.Int64Ptr(1048576),
+					Timeout:         new(int32(300)),
+					OutputSizeLimit: new(int64(1048576)),
 					VerifyFiles:     []string{"/usr/bin/python3", "/usr/bin/gcc"},
 					EnvAllowed:      []string{"PATH", "HOME"},
 					EnvVars:         []string{"PATH=/usr/bin:/bin", "HOME=/root"},
@@ -359,7 +358,7 @@ cmd = "/usr/bin/make"
 			want: &ConfigSpec{
 				Version: "1.0",
 				Global: GlobalSpec{
-					Timeout: tu.Int32Ptr(300),
+					Timeout: new(int32(300)),
 				},
 				Groups: []GroupSpec{
 					{
@@ -413,7 +412,7 @@ TEST_VAR = "value"
 			want: &ConfigSpec{
 				Version: "1.0",
 				Global: GlobalSpec{
-					Timeout: tu.Int32Ptr(300),
+					Timeout: new(int32(300)),
 				},
 				Groups: []GroupSpec{
 					{
@@ -424,12 +423,12 @@ TEST_VAR = "value"
 								Description: "Test command",
 								Cmd:         "/usr/bin/python3",
 								Args:        []string{"-m", "pytest"},
-								WorkDir:     StringPtr("/tmp/test"),
-								Timeout:     tu.Int32Ptr(60),
+								WorkDir:     new("/tmp/test"),
+								Timeout:     new(int32(60)),
 								RunAsUser:   "testuser",
 								RunAsGroup:  "testgroup",
 								RiskLevel:   RiskLevelMediumPtr,
-								OutputFile:  StringPtr("/tmp/output.log"),
+								OutputFile:  new("/tmp/output.log"),
 								EnvVars:     []string{"PYTHONPATH=/opt/lib"},
 								EnvImport:   []string{"path=PATH"},
 								Vars:        map[string]any{"TEST_VAR": "value"},
@@ -502,7 +501,7 @@ cmd = "/bin/date"
 			want: &ConfigSpec{
 				Version: "1.0",
 				Global: GlobalSpec{
-					Timeout: tu.Int32Ptr(300),
+					Timeout: new(int32(300)),
 				},
 				Groups: []GroupSpec{
 					{
@@ -608,7 +607,7 @@ func TestCommandSpec_GetRiskLevel(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var riskLevelPtr *string
 			if tt.riskLevel != "" {
-				riskLevelPtr = StringPtr(tt.riskLevel)
+				riskLevelPtr = new(tt.riskLevel)
 			}
 			spec := &CommandSpec{
 				RiskLevel: riskLevelPtr,

--- a/internal/runner/base/runnertypes/timeout_test.go
+++ b/internal/runner/base/runnertypes/timeout_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/isseis/go-safe-cmd-runner/internal/common"
 	"github.com/isseis/go-safe-cmd-runner/internal/common/testutil"
-	tu "github.com/isseis/go-safe-cmd-runner/internal/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -18,14 +17,14 @@ func TestNewRuntimeCommand_TimeoutResolution(t *testing.T) {
 	}{
 		{
 			name:              "command timeout takes precedence",
-			commandTimeout:    tu.Int32Ptr(120),
-			globalTimeout:     tu.Int32Ptr(60),
+			commandTimeout:    new(int32(120)),
+			globalTimeout:     new(int32(60)),
 			expectedEffective: 120,
 		},
 		{
 			name:              "global timeout when command is nil",
 			commandTimeout:    nil,
-			globalTimeout:     tu.Int32Ptr(90),
+			globalTimeout:     new(int32(90)),
 			expectedEffective: 90,
 		},
 		{
@@ -36,14 +35,14 @@ func TestNewRuntimeCommand_TimeoutResolution(t *testing.T) {
 		},
 		{
 			name:              "command unlimited timeout (0)",
-			commandTimeout:    tu.Int32Ptr(0),
-			globalTimeout:     tu.Int32Ptr(60),
+			commandTimeout:    new(int32(0)),
+			globalTimeout:     new(int32(60)),
 			expectedEffective: 0,
 		},
 		{
 			name:              "global unlimited timeout (0)",
 			commandTimeout:    nil,
-			globalTimeout:     tu.Int32Ptr(0),
+			globalTimeout:     new(int32(0)),
 			expectedEffective: 0,
 		},
 	}
@@ -81,10 +80,10 @@ func TestNewRuntimeCommand_CommandTimeoutZero(t *testing.T) {
 		Name:    "unlimited-command",
 		Cmd:     "/bin/sleep",
 		Args:    []string{"999999"},
-		Timeout: tu.Int32Ptr(0), // Unlimited execution
+		Timeout: new(int32(0)), // Unlimited execution
 	}
 
-	globalTimeout := tu.Int32Ptr(60) // 60 seconds global timeout
+	globalTimeout := new(int32(60)) // 60 seconds global timeout
 
 	runtime, err := NewRuntimeCommand(spec, common.NewFromIntPtr(globalTimeout), commontestutil.NewUnsetOutputSizeLimit(), "test-group")
 	assert.NoError(t, err, "NewRuntimeCommand() should not fail")
@@ -108,7 +107,7 @@ func TestNewRuntimeCommand_GlobalTimeoutZero(t *testing.T) {
 		Timeout: nil, // Inherit from global
 	}
 
-	globalTimeout := tu.Int32Ptr(0) // Unlimited global timeout
+	globalTimeout := new(int32(0)) // Unlimited global timeout
 
 	runtime, err := NewRuntimeCommand(spec, common.NewFromIntPtr(globalTimeout), commontestutil.NewUnsetOutputSizeLimit(), "test-group")
 	assert.NoError(t, err, "NewRuntimeCommand() should not fail")
@@ -124,7 +123,7 @@ func TestNewRuntimeCommand_GlobalTimeoutZero(t *testing.T) {
 
 func TestNewRuntimeCommand_ErrorHandling(t *testing.T) {
 	// Test with nil spec
-	runtime, err := NewRuntimeCommand(nil, common.NewFromIntPtr(tu.Int32Ptr(60)), commontestutil.NewUnsetOutputSizeLimit(), "test-group")
+	runtime, err := NewRuntimeCommand(nil, common.NewFromIntPtr(new(int32(60))), commontestutil.NewUnsetOutputSizeLimit(), "test-group")
 	assert.ErrorIs(t, err, ErrNilSpec, "NewRuntimeCommand(nil, ...) should return ErrNilSpec")
 	assert.Nil(t, runtime, "NewRuntimeCommand(nil, ...) should return nil runtime")
 }
@@ -141,8 +140,8 @@ func TestNewRuntimeCommand_TimeoutResolutionContext(t *testing.T) {
 	}{
 		{
 			name:          "command level resolution",
-			cmdTimeout:    tu.Int32Ptr(30),
-			globalTimeout: tu.Int32Ptr(60),
+			cmdTimeout:    new(int32(30)),
+			globalTimeout: new(int32(60)),
 			commandName:   "test-cmd",
 			groupName:     "test-group",
 			wantValue:     30,
@@ -151,7 +150,7 @@ func TestNewRuntimeCommand_TimeoutResolutionContext(t *testing.T) {
 		{
 			name:          "global level resolution",
 			cmdTimeout:    nil,
-			globalTimeout: tu.Int32Ptr(60),
+			globalTimeout: new(int32(60)),
 			commandName:   "test-cmd",
 			groupName:     "test-group",
 			wantValue:     60,

--- a/internal/runner/command_output_capture_test.go
+++ b/internal/runner/command_output_capture_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/security/testutil"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/resource"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/resource/testutil"
-	tu "github.com/isseis/go-safe-cmd-runner/internal/testutil"
 	"github.com/isseis/go-safe-cmd-runner/internal/verification"
 	"github.com/isseis/go-safe-cmd-runner/internal/verification/testutil"
 	"github.com/stretchr/testify/assert"
@@ -71,7 +70,7 @@ func TestIntegration_CommandOutputCapture(t *testing.T) {
 	}
 
 	runtimeGlobal := &runnertypes.RuntimeGlobal{
-		Spec: &runnertypes.GlobalSpec{Timeout: tu.Int32Ptr(30)},
+		Spec: &runnertypes.GlobalSpec{Timeout: new(int32(30))},
 	}
 
 	// Create real executor and resource manager
@@ -247,7 +246,7 @@ func TestIntegration_SensitiveDataRedaction(t *testing.T) {
 			}
 
 			runtimeGlobal := &runnertypes.RuntimeGlobal{
-				Spec: &runnertypes.GlobalSpec{Timeout: tu.Int32Ptr(30)},
+				Spec: &runnertypes.GlobalSpec{Timeout: new(int32(30))},
 			}
 
 			// Create real executor and resource manager

--- a/internal/runner/config/config_test.go
+++ b/internal/runner/config/config_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/isseis/go-safe-cmd-runner/internal/common"
 	"github.com/isseis/go-safe-cmd-runner/internal/common/testutil"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/runnertypes"
-	tu "github.com/isseis/go-safe-cmd-runner/internal/testutil"
 	"github.com/pelletier/go-toml/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -111,7 +110,7 @@ func TestGlobalConfigMaxOutputSizeParsing(t *testing.T) {
 [global]
 output_size_limit = 10485760
 `,
-			wantMaxSize: tu.Int64Ptr(10485760), // 10MB
+			wantMaxSize: new(int64(10485760)), // 10MB
 			wantErr:     false,
 		},
 		{
@@ -129,7 +128,7 @@ timeout = 30
 [global]
 output_size_limit = 0
 `,
-			wantMaxSize: tu.Int64Ptr(0), // Explicitly set to 0 (unlimited)
+			wantMaxSize: new(int64(0)), // Explicitly set to 0 (unlimited)
 			wantErr:     false,
 		},
 	}

--- a/internal/runner/config/end_to_end_expansion_test.go
+++ b/internal/runner/config/end_to_end_expansion_test.go
@@ -235,7 +235,7 @@ func TestEndToEndExpansion_TemplateValidationErrors(t *testing.T) {
 		templates := map[string]runnertypes.CommandTemplate{
 			"bad_template": {
 				Cmd:     "echo",
-				WorkDir: runnertypes.StringPtr("%{local_dir}"), // Local variable not allowed
+				WorkDir: new("%{local_dir}"), // Local variable not allowed
 			},
 		}
 

--- a/internal/runner/config/expansion_integration_test.go
+++ b/internal/runner/config/expansion_integration_test.go
@@ -119,13 +119,13 @@ func TestExpandTemplateToSpec(t *testing.T) {
 			},
 			template: &runnertypes.CommandTemplate{
 				Cmd:     "make",
-				WorkDir: runnertypes.StringPtr("/projects/${project}"),
+				WorkDir: new("/projects/${project}"),
 			},
 			templateName: "workdir_tmpl",
 			expectSpec: &runnertypes.CommandSpec{
 				Name:    "workdir_cmd",
 				Cmd:     "make",
-				WorkDir: runnertypes.StringPtr("/projects/myapp"),
+				WorkDir: new("/projects/myapp"),
 			},
 			expectWarns: []string{},
 		},
@@ -134,20 +134,20 @@ func TestExpandTemplateToSpec(t *testing.T) {
 			command: &runnertypes.CommandSpec{
 				Name:     "custom_workdir_cmd",
 				Template: "workdir_tmpl",
-				WorkDir:  runnertypes.StringPtr("/custom/dir"),
+				WorkDir:  new("/custom/dir"),
 				Params: map[string]any{
 					"project": "myapp",
 				},
 			},
 			template: &runnertypes.CommandTemplate{
 				Cmd:     "make",
-				WorkDir: runnertypes.StringPtr("/projects/${project}"),
+				WorkDir: new("/projects/${project}"),
 			},
 			templateName: "workdir_tmpl",
 			expectSpec: &runnertypes.CommandSpec{
 				Name:    "custom_workdir_cmd",
 				Cmd:     "make",
-				WorkDir: runnertypes.StringPtr("/custom/dir"),
+				WorkDir: new("/custom/dir"),
 			},
 			expectWarns: []string{},
 		},
@@ -156,7 +156,7 @@ func TestExpandTemplateToSpec(t *testing.T) {
 			command: &runnertypes.CommandSpec{
 				Name:     "cmd_only_workdir",
 				Template: "no_workdir_tmpl",
-				WorkDir:  runnertypes.StringPtr("/my/workdir"),
+				WorkDir:  new("/my/workdir"),
 				Params:   map[string]any{},
 			},
 			template: &runnertypes.CommandTemplate{
@@ -166,7 +166,7 @@ func TestExpandTemplateToSpec(t *testing.T) {
 			expectSpec: &runnertypes.CommandSpec{
 				Name:    "cmd_only_workdir",
 				Cmd:     "echo",
-				WorkDir: runnertypes.StringPtr("/my/workdir"),
+				WorkDir: new("/my/workdir"),
 			},
 			expectWarns: []string{},
 		},
@@ -397,7 +397,7 @@ func TestExpandTemplateToSpec_ArrayInEnvWorkdir(t *testing.T) {
 			},
 			template: &runnertypes.CommandTemplate{
 				Cmd:     "echo",
-				WorkDir: runnertypes.StringPtr("${@dirs}"),
+				WorkDir: new("${@dirs}"),
 			},
 			templateName: "workdir_tmpl",
 			expectErr:    true,
@@ -431,7 +431,7 @@ func TestExpandTemplateToSpec_ArrayInEnvWorkdir(t *testing.T) {
 			},
 			template: &runnertypes.CommandTemplate{
 				Cmd:     "echo",
-				WorkDir: runnertypes.StringPtr("${@dir}"),
+				WorkDir: new("${@dir}"),
 			},
 			templateName: "workdir_tmpl",
 			expectErr:    true,
@@ -464,7 +464,7 @@ func TestExpandTemplateToSpec_ArrayInEnvWorkdir(t *testing.T) {
 			},
 			template: &runnertypes.CommandTemplate{
 				Cmd:     "echo",
-				WorkDir: runnertypes.StringPtr("${path}"),
+				WorkDir: new("${path}"),
 			},
 			templateName: "workdir_tmpl",
 			expectErr:    false,

--- a/internal/runner/config/expansion_test.go
+++ b/internal/runner/config/expansion_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/environment"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/runnertypes"
-	tu "github.com/isseis/go-safe-cmd-runner/internal/testutil"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -22,17 +22,17 @@ func TestApplyTemplateInheritance_WorkDir(t *testing.T) {
 	}{
 		{
 			name:            "command overrides template",
-			cmdWorkDir:      tu.StringPtr("/cmd/dir"),
-			templateWorkDir: tu.StringPtr("/tmpl/dir"),
-			expandedWorkDir: tu.StringPtr("/tmpl/dir"),
-			expectedWorkDir: tu.StringPtr("/cmd/dir"),
+			cmdWorkDir:      new("/cmd/dir"),
+			templateWorkDir: new("/tmpl/dir"),
+			expandedWorkDir: new("/tmpl/dir"),
+			expectedWorkDir: new("/cmd/dir"),
 		},
 		{
 			name:            "command inherits from template",
 			cmdWorkDir:      nil,
-			templateWorkDir: tu.StringPtr("/tmpl/dir"),
-			expandedWorkDir: tu.StringPtr("/tmpl/dir"),
-			expectedWorkDir: tu.StringPtr("/tmpl/dir"),
+			templateWorkDir: new("/tmpl/dir"),
+			expandedWorkDir: new("/tmpl/dir"),
+			expectedWorkDir: new("/tmpl/dir"),
 		},
 		{
 			name:            "both nil",
@@ -43,10 +43,10 @@ func TestApplyTemplateInheritance_WorkDir(t *testing.T) {
 		},
 		{
 			name:            "command empty string overrides template",
-			cmdWorkDir:      tu.StringPtr(""),
-			templateWorkDir: tu.StringPtr("/tmpl/dir"),
-			expandedWorkDir: tu.StringPtr("/tmpl/dir"),
-			expectedWorkDir: tu.StringPtr(""),
+			cmdWorkDir:      new(""),
+			templateWorkDir: new("/tmpl/dir"),
+			expandedWorkDir: new("/tmpl/dir"),
+			expectedWorkDir: new(""),
 		},
 	}
 
@@ -77,17 +77,17 @@ func TestApplyTemplateInheritance_OutputFile(t *testing.T) {
 	}{
 		{
 			name:               "command overrides template",
-			cmdOutputFile:      tu.StringPtr("/cmd/output.txt"),
-			templateOutputFile: tu.StringPtr("/tmpl/output.txt"),
-			expandedOutputFile: tu.StringPtr("/tmpl/output.txt"),
-			expectedOutputFile: tu.StringPtr("/cmd/output.txt"),
+			cmdOutputFile:      new("/cmd/output.txt"),
+			templateOutputFile: new("/tmpl/output.txt"),
+			expandedOutputFile: new("/tmpl/output.txt"),
+			expectedOutputFile: new("/cmd/output.txt"),
 		},
 		{
 			name:               "command inherits from template",
 			cmdOutputFile:      nil,
-			templateOutputFile: tu.StringPtr("/tmpl/output.txt"),
-			expandedOutputFile: tu.StringPtr("/tmpl/output.txt"),
-			expectedOutputFile: tu.StringPtr("/tmpl/output.txt"),
+			templateOutputFile: new("/tmpl/output.txt"),
+			expandedOutputFile: new("/tmpl/output.txt"),
+			expectedOutputFile: new("/tmpl/output.txt"),
 		},
 		{
 			name:               "both nil",
@@ -98,10 +98,10 @@ func TestApplyTemplateInheritance_OutputFile(t *testing.T) {
 		},
 		{
 			name:               "command empty string overrides template",
-			cmdOutputFile:      tu.StringPtr(""),
-			templateOutputFile: tu.StringPtr("/tmpl/output.txt"),
-			expandedOutputFile: tu.StringPtr("/tmpl/output.txt"),
-			expectedOutputFile: tu.StringPtr(""),
+			cmdOutputFile:      new(""),
+			templateOutputFile: new("/tmpl/output.txt"),
+			expandedOutputFile: new("/tmpl/output.txt"),
+			expectedOutputFile: new(""),
 		},
 	}
 
@@ -229,12 +229,12 @@ func TestApplyTemplateInheritance_Combined(t *testing.T) {
 	expandedSpec := &runnertypes.CommandSpec{}
 	cmdSpec := &runnertypes.CommandSpec{
 		WorkDir:    nil,                                    // Inherit from template
-		OutputFile: tu.StringPtr("/cmd/output.txt"),        // Override template
+		OutputFile: new("/cmd/output.txt"),                 // Override template
 		EnvImport:  []string{"CMD_VAR", "SHARED"},          // Merge with template
 		Vars:       map[string]any{"cmd_key": "cmd_value"}, // Merge with template
 	}
-	expandedWorkDir := tu.StringPtr("/tmpl/dir")
-	expandedOutputFile := tu.StringPtr("/tmpl/output.txt")
+	expandedWorkDir := new("/tmpl/dir")
+	expandedOutputFile := new("/tmpl/output.txt")
 	expandedEnvImport := []string{"TMPL_VAR", "SHARED"}
 	expandedVars := map[string]any{"tmpl_key": "tmpl_value", "cmd_key": "tmpl_override"}
 
@@ -263,7 +263,7 @@ func TestExpandGlobal_SystemEnvIncludesAllParsableEntries(t *testing.T) {
 	t.Setenv("TEST_NOT_IN_ALLOWLIST", "test_value")
 
 	spec := &runnertypes.GlobalSpec{
-		Timeout:    tu.Int32Ptr(30),
+		Timeout:    new(int32(30)),
 		EnvAllowed: []string{},
 		EnvImport:  []string{},
 		Vars:       map[string]any{},

--- a/internal/runner/config/template_execution_settings_test.go
+++ b/internal/runner/config/template_execution_settings_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/isseis/go-safe-cmd-runner/internal/common"
 	"github.com/isseis/go-safe-cmd-runner/internal/common/testutil"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/runnertypes"
-	tu "github.com/isseis/go-safe-cmd-runner/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -50,8 +49,8 @@ template = "full_settings"
 [groups.commands.params]
 msg = "hello"
 `,
-			expectedTimeout:          tu.Int32Ptr(30),
-			expectedOutputSizeLimit:  tu.Int64Ptr(2048),
+			expectedTimeout:          new(int32(30)),
+			expectedOutputSizeLimit:  new(int64(2048)),
 			expectedRiskLevel:        runnertypes.RiskLevelMediumPtr,
 			expectedEffectiveTimeout: 30,
 		},
@@ -74,7 +73,7 @@ template = "unlimited"
 [groups.commands.params]
 msg = "hello"
 `,
-			expectedTimeout:          tu.Int32Ptr(0),
+			expectedTimeout:          new(int32(0)),
 			expectedOutputSizeLimit:  nil,
 			expectedRiskLevel:        nil, // Neither template nor command set it, so nil (default from GetRiskLevel())
 			expectedEffectiveTimeout: 0,
@@ -99,7 +98,7 @@ timeout = 0
 [groups.commands.params]
 msg = "hello"
 `,
-			expectedTimeout:          tu.Int32Ptr(0),
+			expectedTimeout:          new(int32(0)),
 			expectedOutputSizeLimit:  nil,
 			expectedRiskLevel:        nil, // Neither template nor command set it, so nil (default from GetRiskLevel())
 			expectedEffectiveTimeout: 0,

--- a/internal/runner/config/template_expansion_validation_test.go
+++ b/internal/runner/config/template_expansion_validation_test.go
@@ -26,7 +26,7 @@ func TestValidateTemplateVars(t *testing.T) {
 			template: runnertypes.CommandTemplate{
 				Cmd:     "echo",
 				Args:    []string{"hello", "world"},
-				WorkDir: runnertypes.StringPtr("/tmp"),
+				WorkDir: new("/tmp"),
 				EnvVars: []string{"KEY=value"},
 			},
 			templateName: "test",
@@ -38,7 +38,7 @@ func TestValidateTemplateVars(t *testing.T) {
 			template: runnertypes.CommandTemplate{
 				Cmd:     "echo %{GREETING}",
 				Args:    []string{"%{NAME}", "%{MESSAGE}"},
-				WorkDir: runnertypes.StringPtr("%{WORK_DIR}"),
+				WorkDir: new("%{WORK_DIR}"),
 				EnvVars: []string{"KEY=%{VALUE}"},
 			},
 			templateName: "test",
@@ -56,7 +56,7 @@ func TestValidateTemplateVars(t *testing.T) {
 			template: runnertypes.CommandTemplate{
 				Cmd:     "echo %{MSG}",
 				Args:    []string{"%{ARG1}", "%{ARG2}"},
-				WorkDir: runnertypes.StringPtr("%{DIR}"),
+				WorkDir: new("%{DIR}"),
 				EnvVars: []string{"KEY1=%{VAL1}", "KEY2=%{VAL2}"},
 			},
 			templateName: "test",
@@ -95,7 +95,7 @@ func TestValidateTemplateVars(t *testing.T) {
 			name: "error: local variable in workdir",
 			template: runnertypes.CommandTemplate{
 				Cmd:     "echo",
-				WorkDir: runnertypes.StringPtr("%{local_dir}"),
+				WorkDir: new("%{local_dir}"),
 			},
 			templateName: "test",
 			globalVars:   map[string]string{},
@@ -138,7 +138,7 @@ func TestValidateTemplateVars(t *testing.T) {
 			name: "error: undefined global variable in workdir",
 			template: runnertypes.CommandTemplate{
 				Cmd:     "echo",
-				WorkDir: runnertypes.StringPtr("%{UNDEFINED_DIR}"),
+				WorkDir: new("%{UNDEFINED_DIR}"),
 			},
 			templateName: "test",
 			globalVars:   map[string]string{},
@@ -340,7 +340,7 @@ func TestValidateAllTemplates(t *testing.T) {
 				},
 				"template2": {
 					Cmd:     "ls %{DIR}",
-					WorkDir: runnertypes.StringPtr("%{WORK_DIR}"),
+					WorkDir: new("%{WORK_DIR}"),
 				},
 			},
 			globalVars: map[string]string{

--- a/internal/runner/config/template_field_constraints_test.go
+++ b/internal/runner/config/template_field_constraints_test.go
@@ -245,7 +245,7 @@ func TestTemplateFieldConstraints(t *testing.T) {
 			case "workdir":
 				template = &runnertypes.CommandTemplate{
 					Cmd:     "test",
-					WorkDir: runnertypes.StringPtr(tt.placeholder),
+					WorkDir: new(tt.placeholder),
 				}
 				setupParams(params, tt.placeholder)
 			}

--- a/internal/runner/config/template_inheritance_test.go
+++ b/internal/runner/config/template_inheritance_test.go
@@ -3,7 +3,6 @@ package config
 import (
 	"testing"
 
-	tu "github.com/isseis/go-safe-cmd-runner/internal/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -25,29 +24,29 @@ func TestOverrideStringPointer(t *testing.T) {
 		{
 			name:          "command nil, template non-nil",
 			cmdValue:      nil,
-			templateValue: tu.StringPtr("/template/dir"),
-			want:          tu.StringPtr("/template/dir"),
+			templateValue: new("/template/dir"),
+			want:          new("/template/dir"),
 			description:   "When command is nil, should inherit from template",
 		},
 		{
 			name:          "command non-nil, template non-nil",
-			cmdValue:      tu.StringPtr("/command/dir"),
-			templateValue: tu.StringPtr("/template/dir"),
-			want:          tu.StringPtr("/command/dir"),
+			cmdValue:      new("/command/dir"),
+			templateValue: new("/template/dir"),
+			want:          new("/command/dir"),
 			description:   "When command is non-nil, should use command value",
 		},
 		{
 			name:          "command empty string, template non-nil",
-			cmdValue:      tu.StringPtr(""),
-			templateValue: tu.StringPtr("/template/dir"),
-			want:          tu.StringPtr(""),
+			cmdValue:      new(""),
+			templateValue: new("/template/dir"),
+			want:          new(""),
 			description:   "When command is empty string (non-nil), should use empty string",
 		},
 		{
 			name:          "command non-nil, template nil",
-			cmdValue:      tu.StringPtr("/command/dir"),
+			cmdValue:      new("/command/dir"),
 			templateValue: nil,
-			want:          tu.StringPtr("/command/dir"),
+			want:          new("/command/dir"),
 			description:   "When command is non-nil and template is nil, should use command value",
 		},
 	}

--- a/internal/runner/config/template_optional_test.go
+++ b/internal/runner/config/template_optional_test.go
@@ -228,7 +228,7 @@ func TestOptionalParameter_InWorkDir(t *testing.T) {
 			},
 			template: &runnertypes.CommandTemplate{
 				Cmd:     "echo",
-				WorkDir: runnertypes.StringPtr("${?dir}"),
+				WorkDir: new("${?dir}"),
 			},
 			expectDir:   "/my/dir",
 			description: "Pure optional should return the value when provided",
@@ -242,7 +242,7 @@ func TestOptionalParameter_InWorkDir(t *testing.T) {
 			},
 			template: &runnertypes.CommandTemplate{
 				Cmd:     "echo",
-				WorkDir: runnertypes.StringPtr("${?dir}"),
+				WorkDir: new("${?dir}"),
 			},
 			expectDir:   "",
 			description: "Pure optional workdir should be empty when parameter missing",
@@ -258,7 +258,7 @@ func TestOptionalParameter_InWorkDir(t *testing.T) {
 			},
 			template: &runnertypes.CommandTemplate{
 				Cmd:     "echo",
-				WorkDir: runnertypes.StringPtr("/home/${?subdir}"),
+				WorkDir: new("/home/${?subdir}"),
 			},
 			expectDir:   "/home/myproject",
 			description: "Mixed context optional should substitute value",
@@ -272,7 +272,7 @@ func TestOptionalParameter_InWorkDir(t *testing.T) {
 			},
 			template: &runnertypes.CommandTemplate{
 				Cmd:     "echo",
-				WorkDir: runnertypes.StringPtr("/home/${?subdir}"),
+				WorkDir: new("/home/${?subdir}"),
 			},
 			expectDir:   "/home/",
 			description: "Mixed context optional should substitute empty string when missing",

--- a/internal/runner/config/template_security_test.go
+++ b/internal/runner/config/template_security_test.go
@@ -10,11 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// int32Ptr is a helper function to create a pointer to an int32 value.
-func int32Ptr(v int32) *int32 {
-	return &v
-}
-
 // TestValidateTemplateName tests template name validation
 func TestValidateTemplateName(t *testing.T) {
 	tests := []struct {
@@ -77,7 +72,7 @@ func TestValidateTemplateDefinition(t *testing.T) {
 		{
 			name:     "valid template with workdir",
 			tmplName: "with_workdir",
-			template: runnertypes.CommandTemplate{Cmd: "cmd", WorkDir: runnertypes.StringPtr("/tmp/${path}")},
+			template: runnertypes.CommandTemplate{Cmd: "cmd", WorkDir: new("/tmp/${path}")},
 			wantErr:  false,
 		},
 		{
@@ -101,37 +96,37 @@ func TestValidateTemplateDefinition(t *testing.T) {
 		{
 			name:     "allowed global variable in workdir",
 			tmplName: "good_template",
-			template: runnertypes.CommandTemplate{Cmd: "cmd", WorkDir: runnertypes.StringPtr("%{BaseDir}/work")},
+			template: runnertypes.CommandTemplate{Cmd: "cmd", WorkDir: new("%{BaseDir}/work")},
 			wantErr:  false,
 		},
 		{
 			name:     "absolute path workdir without variables",
 			tmplName: "absolute_workdir",
-			template: runnertypes.CommandTemplate{Cmd: "cmd", WorkDir: runnertypes.StringPtr("/opt/app")},
+			template: runnertypes.CommandTemplate{Cmd: "cmd", WorkDir: new("/opt/app")},
 			wantErr:  false,
 		},
 		{
 			name:     "relative path workdir - validated at expansion time",
 			tmplName: "relative_workdir",
-			template: runnertypes.CommandTemplate{Cmd: "cmd", WorkDir: runnertypes.StringPtr("relative/path")},
+			template: runnertypes.CommandTemplate{Cmd: "cmd", WorkDir: new("relative/path")},
 			wantErr:  false, // Validation deferred to expansion time in group_executor.go
 		},
 		{
 			name:     "relative path workdir with dot - validated at expansion time",
 			tmplName: "relative_workdir_dot",
-			template: runnertypes.CommandTemplate{Cmd: "cmd", WorkDir: runnertypes.StringPtr("./relative/path")},
+			template: runnertypes.CommandTemplate{Cmd: "cmd", WorkDir: new("./relative/path")},
 			wantErr:  false, // Validation deferred to expansion time in group_executor.go
 		},
 		{
 			name:     "empty workdir string is allowed",
 			tmplName: "empty_workdir",
-			template: runnertypes.CommandTemplate{Cmd: "cmd", WorkDir: runnertypes.StringPtr("")},
+			template: runnertypes.CommandTemplate{Cmd: "cmd", WorkDir: new("")},
 			wantErr:  false, // Empty string means current directory
 		},
 		{
 			name:     "workdir with variable reference is allowed (validation deferred to expansion)",
 			tmplName: "variable_workdir",
-			template: runnertypes.CommandTemplate{Cmd: "cmd", WorkDir: runnertypes.StringPtr("${base_dir}/relative")},
+			template: runnertypes.CommandTemplate{Cmd: "cmd", WorkDir: new("${base_dir}/relative")},
 			wantErr:  false, // Variable references are allowed - validation happens after expansion
 		},
 		{
@@ -158,7 +153,7 @@ func TestValidateTemplateDefinition(t *testing.T) {
 		{
 			name:     "forbidden local variable in workdir",
 			tmplName: "bad_template",
-			template: runnertypes.CommandTemplate{Cmd: "cmd", WorkDir: runnertypes.StringPtr("%{base_dir}/work")},
+			template: runnertypes.CommandTemplate{Cmd: "cmd", WorkDir: new("%{base_dir}/work")},
 			wantErr:  true,
 			errType:  &ErrLocalVariableInTemplate{},
 		},
@@ -240,17 +235,17 @@ func TestValidateCmdSpec(t *testing.T) {
 		},
 		{
 			name:    "template + workdir (valid - override allowed)",
-			spec:    runnertypes.CommandSpec{Name: "backup", Template: "restic_backup", WorkDir: runnertypes.StringPtr("/tmp")},
+			spec:    runnertypes.CommandSpec{Name: "backup", Template: "restic_backup", WorkDir: new("/tmp")},
 			wantErr: false,
 		},
 		{
 			name:    "template + output_file (valid - override allowed)",
-			spec:    runnertypes.CommandSpec{Name: "backup", Template: "restic_backup", OutputFile: runnertypes.StringPtr("/tmp/output.txt")},
+			spec:    runnertypes.CommandSpec{Name: "backup", Template: "restic_backup", OutputFile: new("/tmp/output.txt")},
 			wantErr: false,
 		},
 		{
 			name:    "template + timeout (valid - override allowed)",
-			spec:    runnertypes.CommandSpec{Name: "backup", Template: "restic_backup", Timeout: int32Ptr(120)},
+			spec:    runnertypes.CommandSpec{Name: "backup", Template: "restic_backup", Timeout: new(int32(120))},
 			wantErr: false,
 		},
 		{
@@ -326,7 +321,7 @@ func TestCollectUsedParams(t *testing.T) {
 			name: "param in workdir",
 			template: runnertypes.CommandTemplate{
 				Cmd:     "cmd",
-				WorkDir: runnertypes.StringPtr("${base_dir}/work"),
+				WorkDir: new("${base_dir}/work"),
 			},
 			expected: map[string]struct{}{
 				"base_dir": {},

--- a/internal/runner/config/validation_test.go
+++ b/internal/runner/config/validation_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/runnertypes"
-	tu "github.com/isseis/go-safe-cmd-runner/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -401,41 +400,41 @@ func TestValidateTimeouts(t *testing.T) {
 		},
 		{
 			name:        "valid - positive global timeout",
-			config:      makeConfig(tu.Int32Ptr(30), makeGroup("test_group", makeCommand("test_cmd", nil))),
+			config:      makeConfig(new(int32(30)), makeGroup("test_group", makeCommand("test_cmd", nil))),
 			expectError: false,
 		},
 		{
 			name:        "valid - zero global timeout",
-			config:      makeConfig(tu.Int32Ptr(0), makeGroup("test_group", makeCommand("test_cmd", nil))),
+			config:      makeConfig(new(int32(0)), makeGroup("test_group", makeCommand("test_cmd", nil))),
 			expectError: false,
 		},
 		{
 			name:        "invalid - negative global timeout",
-			config:      makeConfig(tu.Int32Ptr(-10), makeGroup("test_group", makeCommand("test_cmd", nil))),
+			config:      makeConfig(new(int32(-10)), makeGroup("test_group", makeCommand("test_cmd", nil))),
 			expectError: true,
 			expectedErr: ErrNegativeTimeout,
 		},
 		{
 			name:        "valid - positive command timeout",
-			config:      makeConfig(nil, makeGroup("test_group", makeCommand("test_cmd", tu.Int32Ptr(60)))),
+			config:      makeConfig(nil, makeGroup("test_group", makeCommand("test_cmd", new(int32(60))))),
 			expectError: false,
 		},
 		{
 			name:        "valid - zero command timeout",
-			config:      makeConfig(nil, makeGroup("test_group", makeCommand("test_cmd", tu.Int32Ptr(0)))),
+			config:      makeConfig(nil, makeGroup("test_group", makeCommand("test_cmd", new(int32(0))))),
 			expectError: false,
 		},
 		{
 			name:        "invalid - negative command timeout",
-			config:      makeConfig(nil, makeGroup("test_group", makeCommand("test_cmd", tu.Int32Ptr(-5)))),
+			config:      makeConfig(nil, makeGroup("test_group", makeCommand("test_cmd", new(int32(-5))))),
 			expectError: true,
 			expectedErr: ErrNegativeTimeout,
 		},
 		{
 			name: "invalid - multiple negative command timeouts",
 			config: makeConfig(nil, makeGroup("test_group",
-				makeCommand("cmd1", tu.Int32Ptr(-1)),
-				makeCommand("cmd2", tu.Int32Ptr(-2)),
+				makeCommand("cmd1", new(int32(-1))),
+				makeCommand("cmd2", new(int32(-2))),
 			)),
 			expectError: true,
 			expectedErr: ErrNegativeTimeout,
@@ -443,17 +442,17 @@ func TestValidateTimeouts(t *testing.T) {
 		{
 			name: "invalid - negative timeout in second group",
 			config: makeConfig(nil,
-				makeGroup("group1", makeCommand("cmd1", tu.Int32Ptr(30))),
-				makeGroup("group2", makeCommand("cmd2", tu.Int32Ptr(-15))),
+				makeGroup("group1", makeCommand("cmd1", new(int32(30)))),
+				makeGroup("group2", makeCommand("cmd2", new(int32(-15)))),
 			),
 			expectError: true,
 			expectedErr: ErrNegativeTimeout,
 		},
 		{
 			name: "invalid - multiple errors reported together",
-			config: makeConfig(tu.Int32Ptr(-5),
-				makeGroup("group1", makeCommand("cmd1", tu.Int32Ptr(-10))),
-				makeGroup("group2", makeCommand("cmd2", tu.Int32Ptr(-20))),
+			config: makeConfig(new(int32(-5)),
+				makeGroup("group1", makeCommand("cmd1", new(int32(-10)))),
+				makeGroup("group2", makeCommand("cmd2", new(int32(-20)))),
 			),
 			expectError: true,
 			expectedErr: ErrNegativeTimeout,
@@ -471,7 +470,7 @@ func TestValidateTimeouts(t *testing.T) {
 				CommandTemplates: map[string]runnertypes.CommandTemplate{
 					"test_template": {
 						Cmd:     "echo",
-						Timeout: tu.Int32Ptr(-1),
+						Timeout: new(int32(-1)),
 					},
 				},
 				Groups: []runnertypes.GroupSpec{
@@ -491,7 +490,7 @@ func TestValidateTimeouts(t *testing.T) {
 				CommandTemplates: map[string]runnertypes.CommandTemplate{
 					"test_template": {
 						Cmd:     "echo",
-						Timeout: tu.Int32Ptr(30),
+						Timeout: new(int32(30)),
 					},
 				},
 				Groups: []runnertypes.GroupSpec{
@@ -506,7 +505,7 @@ func TestValidateTimeouts(t *testing.T) {
 				CommandTemplates: map[string]runnertypes.CommandTemplate{
 					"test_template": {
 						Cmd:     "echo",
-						Timeout: tu.Int32Ptr(0),
+						Timeout: new(int32(0)),
 					},
 				},
 				Groups: []runnertypes.GroupSpec{
@@ -521,11 +520,11 @@ func TestValidateTimeouts(t *testing.T) {
 				CommandTemplates: map[string]runnertypes.CommandTemplate{
 					"template1": {
 						Cmd:     "echo",
-						Timeout: tu.Int32Ptr(-10),
+						Timeout: new(int32(-10)),
 					},
 					"template2": {
 						Cmd:     "cat",
-						Timeout: tu.Int32Ptr(-20),
+						Timeout: new(int32(-20)),
 					},
 				},
 				Groups: []runnertypes.GroupSpec{
@@ -543,16 +542,16 @@ func TestValidateTimeouts(t *testing.T) {
 			name: "invalid - negative timeouts in global, template, and command",
 			config: &runnertypes.ConfigSpec{
 				Global: runnertypes.GlobalSpec{
-					Timeout: tu.Int32Ptr(-5),
+					Timeout: new(int32(-5)),
 				},
 				CommandTemplates: map[string]runnertypes.CommandTemplate{
 					"bad_template": {
 						Cmd:     "echo",
-						Timeout: tu.Int32Ptr(-15),
+						Timeout: new(int32(-15)),
 					},
 				},
 				Groups: []runnertypes.GroupSpec{
-					makeGroup("test_group", makeCommand("bad_cmd", tu.Int32Ptr(-25))),
+					makeGroup("test_group", makeCommand("bad_cmd", new(int32(-25)))),
 				},
 			},
 			expectError: true,

--- a/internal/runner/e2e_dynlib_verification_test.go
+++ b/internal/runner/e2e_dynlib_verification_test.go
@@ -59,7 +59,7 @@ func TestGroupExecutor_F001_HashMismatchBlocksExecution(t *testing.T) {
 	configSpec := &runnertypes.ConfigSpec{
 		Version: "1.0",
 		Global: runnertypes.GlobalSpec{
-			Timeout: tu.Int32Ptr(30),
+			Timeout: new(int32(30)),
 		},
 		Groups: []runnertypes.GroupSpec{
 			{
@@ -134,7 +134,7 @@ func TestGroupExecutor_F004_LibraryShadowingBlocksExecution(t *testing.T) {
 	configSpec := &runnertypes.ConfigSpec{
 		Version: "1.0",
 		Global: runnertypes.GlobalSpec{
-			Timeout: tu.Int32Ptr(30),
+			Timeout: new(int32(30)),
 		},
 		Groups: []runnertypes.GroupSpec{
 			{

--- a/internal/runner/e2e_shebang_test.go
+++ b/internal/runner/e2e_shebang_test.go
@@ -197,7 +197,7 @@ func TestIntegration_ShebangChainRunnerExecution(t *testing.T) {
 	configSpec := &runnertypes.ConfigSpec{
 		Version: "1.0",
 		Global: runnertypes.GlobalSpec{
-			Timeout: tu.Int32Ptr(30),
+			Timeout: new(int32(30)),
 		},
 		Groups: []runnertypes.GroupSpec{
 			{

--- a/internal/runner/e2e_slack_redaction_test.go
+++ b/internal/runner/e2e_slack_redaction_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/security"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/resource"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/resource/testutil"
-	tu "github.com/isseis/go-safe-cmd-runner/internal/testutil"
 	"github.com/isseis/go-safe-cmd-runner/internal/verification"
 	"github.com/isseis/go-safe-cmd-runner/internal/verification/testutil"
 	"github.com/stretchr/testify/assert"
@@ -124,7 +123,7 @@ func TestIntegration_SlackRedaction(t *testing.T) {
 	}
 
 	runtimeGlobal := &runnertypes.RuntimeGlobal{
-		Spec: &runnertypes.GlobalSpec{Timeout: tu.Int32Ptr(30)},
+		Spec: &runnertypes.GlobalSpec{Timeout: new(int32(30))},
 	}
 
 	// Create real executor and resource manager
@@ -249,7 +248,7 @@ func TestE2E_MultiHandlerLogging(t *testing.T) {
 	}
 
 	runtimeGlobal := &runnertypes.RuntimeGlobal{
-		Spec: &runnertypes.GlobalSpec{Timeout: tu.Int32Ptr(30)},
+		Spec: &runnertypes.GlobalSpec{Timeout: new(int32(30))},
 	}
 
 	// Create executor and resource manager

--- a/internal/runner/e2e_slack_webhook_separation_test.go
+++ b/internal/runner/e2e_slack_webhook_separation_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/isseis/go-safe-cmd-runner/internal/logging"
 	"github.com/isseis/go-safe-cmd-runner/internal/redaction"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/runnertypes"
-	tu "github.com/isseis/go-safe-cmd-runner/internal/testutil"
 	"github.com/isseis/go-safe-cmd-runner/internal/verification"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -92,7 +91,7 @@ func TestE2E_SlackWebhookSeparation_SuccessOnly(t *testing.T) {
 	config := &runnertypes.ConfigSpec{
 		Version: "1.0",
 		Global: runnertypes.GlobalSpec{
-			Timeout: tu.Int32Ptr(30),
+			Timeout: new(int32(30)),
 		},
 		Groups: []runnertypes.GroupSpec{
 			{
@@ -194,7 +193,7 @@ func TestE2E_SlackWebhookSeparation_ErrorOnly(t *testing.T) {
 	config := &runnertypes.ConfigSpec{
 		Version: "1.0",
 		Global: runnertypes.GlobalSpec{
-			Timeout: tu.Int32Ptr(30),
+			Timeout: new(int32(30)),
 		},
 		Groups: []runnertypes.GroupSpec{
 			{
@@ -457,7 +456,7 @@ func TestE2E_SlackWebhookSeparation_MessageFormat(t *testing.T) {
 	config := &runnertypes.ConfigSpec{
 		Version: "1.0",
 		Global: runnertypes.GlobalSpec{
-			Timeout: tu.Int32Ptr(30),
+			Timeout: new(int32(30)),
 		},
 		Groups: []runnertypes.GroupSpec{
 			{

--- a/internal/runner/e2e_slack_webhook_test.go
+++ b/internal/runner/e2e_slack_webhook_test.go
@@ -22,13 +22,14 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/isseis/go-safe-cmd-runner/internal/logging"
 	"github.com/isseis/go-safe-cmd-runner/internal/redaction"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/runnertypes"
-	tu "github.com/isseis/go-safe-cmd-runner/internal/testutil"
+
 	"github.com/isseis/go-safe-cmd-runner/internal/verification"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -113,7 +114,7 @@ func TestE2E_SlackWebhookWithMockServer(t *testing.T) {
 	config := &runnertypes.ConfigSpec{
 		Version: "1.0",
 		Global: runnertypes.GlobalSpec{
-			Timeout: tu.Int32Ptr(30),
+			Timeout: new(int32(30)),
 		},
 		Groups: []runnertypes.GroupSpec{
 			{
@@ -149,15 +150,15 @@ func TestE2E_SlackWebhookWithMockServer(t *testing.T) {
 	// Verify: Check payloads received by mock HTTP server
 	require.NotEmpty(t, receivedPayloads, "should have sent HTTP requests to mock Slack endpoint")
 
-	allPayloads := ""
+	var allPayloads strings.Builder
 	for i, payload := range receivedPayloads {
 		t.Logf("Payload %d: %s", i+1, payload)
-		allPayloads += payload + "\n"
+		allPayloads.WriteString(payload + "\n")
 	}
 
 	// Verify the HTTP flow worked
-	assert.Contains(t, allPayloads, "e2e-mock-test-group", "payload should contain group name")
-	assert.Contains(t, allPayloads, "SUCCESS", "payload should indicate success")
+	assert.Contains(t, allPayloads.String(), "e2e-mock-test-group", "payload should contain group name")
+	assert.Contains(t, allPayloads.String(), "SUCCESS", "payload should indicate success")
 
 	// Note: This test verifies the HTTP webhook flow works correctly.
 	// It does NOT verify command execution or redaction because the Runner

--- a/internal/runner/e2e_slack_webhook_test.go
+++ b/internal/runner/e2e_slack_webhook_test.go
@@ -153,7 +153,8 @@ func TestE2E_SlackWebhookWithMockServer(t *testing.T) {
 	var allPayloads strings.Builder
 	for i, payload := range receivedPayloads {
 		t.Logf("Payload %d: %s", i+1, payload)
-		allPayloads.WriteString(payload + "\n")
+		allPayloads.WriteString(payload)
+		allPayloads.WriteByte('\n')
 	}
 
 	// Verify the HTTP flow worked

--- a/internal/runner/group_executor_test.go
+++ b/internal/runner/group_executor_test.go
@@ -36,7 +36,7 @@ import (
 func newDefaultRuntimeGlobal() *runnertypes.RuntimeGlobal {
 	return &runnertypes.RuntimeGlobal{
 		Spec: &runnertypes.GlobalSpec{
-			Timeout: tu.Int32Ptr(30),
+			Timeout: new(int32(30)),
 		},
 	}
 }
@@ -191,7 +191,7 @@ func TestExecuteGroup_WorkDirPriority(t *testing.T) {
 
 			config := &runnertypes.ConfigSpec{
 				Global: runnertypes.GlobalSpec{
-					Timeout: tu.Int32Ptr(30),
+					Timeout: new(int32(30)),
 				},
 			}
 
@@ -204,13 +204,13 @@ func TestExecuteGroup_WorkDirPriority(t *testing.T) {
 					{
 						Name:    "test-cmd",
 						Cmd:     "/bin/echo",
-						WorkDir: runnertypes.StringPtr(tt.commandDir),
+						WorkDir: new(tt.commandDir),
 					},
 				},
 			}
 
 			runtimeGlobal := &runnertypes.RuntimeGlobal{
-				Spec: &runnertypes.GlobalSpec{Timeout: tu.Int32Ptr(30)},
+				Spec: &runnertypes.GlobalSpec{Timeout: new(int32(30))},
 			}
 
 			// Setup mocks
@@ -279,7 +279,7 @@ func TestExecuteGroup_TempDirCleanup(t *testing.T) {
 
 			config := &runnertypes.ConfigSpec{
 				Global: runnertypes.GlobalSpec{
-					Timeout: tu.Int32Ptr(30),
+					Timeout: new(int32(30)),
 				},
 			}
 
@@ -296,7 +296,7 @@ func TestExecuteGroup_TempDirCleanup(t *testing.T) {
 			}
 
 			runtimeGlobal := &runnertypes.RuntimeGlobal{
-				Spec: &runnertypes.GlobalSpec{Timeout: tu.Int32Ptr(30)},
+				Spec: &runnertypes.GlobalSpec{Timeout: new(int32(30))},
 			}
 
 			// Setup mocks
@@ -341,7 +341,7 @@ func TestExecuteGroup_CreateTempDirFailure(t *testing.T) {
 
 	config := &runnertypes.ConfigSpec{
 		Global: runnertypes.GlobalSpec{
-			Timeout: tu.Int32Ptr(30),
+			Timeout: new(int32(30)),
 		},
 	}
 
@@ -358,7 +358,7 @@ func TestExecuteGroup_CreateTempDirFailure(t *testing.T) {
 	}
 
 	runtimeGlobal := &runnertypes.RuntimeGlobal{
-		Spec: &runnertypes.GlobalSpec{Timeout: tu.Int32Ptr(30)},
+		Spec: &runnertypes.GlobalSpec{Timeout: new(int32(30))},
 	}
 
 	// Setup mock to fail temp dir creation
@@ -381,7 +381,7 @@ func TestExecuteGroup_CommandExecutionFailure(t *testing.T) {
 
 	config := &runnertypes.ConfigSpec{
 		Global: runnertypes.GlobalSpec{
-			Timeout: tu.Int32Ptr(30),
+			Timeout: new(int32(30)),
 		},
 	}
 
@@ -411,7 +411,7 @@ func TestExecuteGroup_CommandExecutionFailure(t *testing.T) {
 	}
 
 	runtimeGlobal := &runnertypes.RuntimeGlobal{
-		Spec: &runnertypes.GlobalSpec{Timeout: tu.Int32Ptr(30)},
+		Spec: &runnertypes.GlobalSpec{Timeout: new(int32(30))},
 	}
 
 	// Mock validator to allow all validations
@@ -455,7 +455,7 @@ func TestExecuteGroup_CommandExecutionFailure_NonStandardExitCode(t *testing.T) 
 
 	config := &runnertypes.ConfigSpec{
 		Global: runnertypes.GlobalSpec{
-			Timeout: tu.Int32Ptr(30),
+			Timeout: new(int32(30)),
 		},
 	}
 
@@ -485,7 +485,7 @@ func TestExecuteGroup_CommandExecutionFailure_NonStandardExitCode(t *testing.T) 
 	}
 
 	runtimeGlobal := &runnertypes.RuntimeGlobal{
-		Spec: &runnertypes.GlobalSpec{Timeout: tu.Int32Ptr(30)},
+		Spec: &runnertypes.GlobalSpec{Timeout: new(int32(30))},
 	}
 
 	// Mock validator to allow all validations
@@ -540,7 +540,7 @@ func TestExecuteGroup_SuccessNotification(t *testing.T) {
 
 	config := &runnertypes.ConfigSpec{
 		Global: runnertypes.GlobalSpec{
-			Timeout: tu.Int32Ptr(30),
+			Timeout: new(int32(30)),
 		},
 	}
 
@@ -572,7 +572,7 @@ func TestExecuteGroup_SuccessNotification(t *testing.T) {
 	}
 
 	runtimeGlobal := &runnertypes.RuntimeGlobal{
-		Spec: &runnertypes.GlobalSpec{Timeout: tu.Int32Ptr(30)},
+		Spec: &runnertypes.GlobalSpec{Timeout: new(int32(30))},
 	}
 
 	// Mock verification manager to resolve paths
@@ -613,7 +613,7 @@ func TestExecuteCommandInGroup_OutputPathValidationFailure(t *testing.T) {
 
 	config := &runnertypes.ConfigSpec{
 		Global: runnertypes.GlobalSpec{
-			Timeout: tu.Int32Ptr(30),
+			Timeout: new(int32(30)),
 		},
 	}
 
@@ -629,8 +629,8 @@ func TestExecuteCommandInGroup_OutputPathValidationFailure(t *testing.T) {
 	spec := &runnertypes.CommandSpec{
 		Name:       "test-cmd",
 		Cmd:        "/bin/echo",
-		OutputFile: runnertypes.StringPtr("/invalid/output/path"),
-		WorkDir:    runnertypes.StringPtr("/work"),
+		OutputFile: new("/invalid/output/path"),
+		WorkDir:    new("/work"),
 	}
 	// Create minimal RuntimeCommand for this test
 	cmd := &runnertypes.RuntimeCommand{
@@ -654,7 +654,7 @@ func TestExecuteCommandInGroup_OutputPathValidationFailure(t *testing.T) {
 	mockRM.On("ValidateOutputPath", "/invalid/output/path", "/work").Return(expectedErr)
 
 	runtimeGlobal := &runnertypes.RuntimeGlobal{
-		Spec: &runnertypes.GlobalSpec{Timeout: tu.Int32Ptr(30)},
+		Spec: &runnertypes.GlobalSpec{Timeout: new(int32(30))},
 	}
 
 	ctx := context.Background()
@@ -673,7 +673,7 @@ func TestExecuteGroup_MultipleCommands(t *testing.T) {
 
 	config := &runnertypes.ConfigSpec{
 		Global: runnertypes.GlobalSpec{
-			Timeout: tu.Int32Ptr(30),
+			Timeout: new(int32(30)),
 		},
 	}
 
@@ -705,7 +705,7 @@ func TestExecuteGroup_MultipleCommands(t *testing.T) {
 	}
 
 	runtimeGlobal := &runnertypes.RuntimeGlobal{
-		Spec: &runnertypes.GlobalSpec{Timeout: tu.Int32Ptr(30)},
+		Spec: &runnertypes.GlobalSpec{Timeout: new(int32(30))},
 	}
 
 	// Mock verification manager to resolve paths (all commands use /bin/echo)
@@ -733,7 +733,7 @@ func TestExecuteGroup_StopOnFirstFailure(t *testing.T) {
 
 	config := &runnertypes.ConfigSpec{
 		Global: runnertypes.GlobalSpec{
-			Timeout: tu.Int32Ptr(30),
+			Timeout: new(int32(30)),
 		},
 	}
 
@@ -765,7 +765,7 @@ func TestExecuteGroup_StopOnFirstFailure(t *testing.T) {
 	}
 
 	runtimeGlobal := &runnertypes.RuntimeGlobal{
-		Spec: &runnertypes.GlobalSpec{Timeout: tu.Int32Ptr(30)},
+		Spec: &runnertypes.GlobalSpec{Timeout: new(int32(30))},
 	}
 
 	// Mock verification manager to resolve paths for all commands
@@ -928,7 +928,7 @@ func TestResolveCommandWorkDir(t *testing.T) {
 	}{
 		{
 			name:                  "command workdir takes priority",
-			commandWorkDir:        runnertypes.StringPtr("/cmd/workdir"),
+			commandWorkDir:        new("/cmd/workdir"),
 			commandVars:           map[string]string{},
 			groupEffectiveWorkDir: "/group/workdir",
 			expectedWorkDir:       "/cmd/workdir",
@@ -944,7 +944,7 @@ func TestResolveCommandWorkDir(t *testing.T) {
 		},
 		{
 			name:                  "empty command workdir overrides group workdir",
-			commandWorkDir:        runnertypes.StringPtr(""),
+			commandWorkDir:        new(""),
 			commandVars:           map[string]string{},
 			groupEffectiveWorkDir: "/group/workdir",
 			expectedWorkDir:       "", // Empty string is valid (current directory)
@@ -952,7 +952,7 @@ func TestResolveCommandWorkDir(t *testing.T) {
 		},
 		{
 			name:                  "both empty returns empty",
-			commandWorkDir:        runnertypes.StringPtr(""),
+			commandWorkDir:        new(""),
 			commandVars:           map[string]string{},
 			groupEffectiveWorkDir: "",
 			expectedWorkDir:       "",
@@ -960,7 +960,7 @@ func TestResolveCommandWorkDir(t *testing.T) {
 		},
 		{
 			name:                  "command workdir with variable expansion",
-			commandWorkDir:        runnertypes.StringPtr("/opt/%{project}"),
+			commandWorkDir:        new("/opt/%{project}"),
 			commandVars:           map[string]string{"project": "myapp"},
 			groupEffectiveWorkDir: "/group/workdir",
 			expectedWorkDir:       "/opt/myapp",
@@ -968,7 +968,7 @@ func TestResolveCommandWorkDir(t *testing.T) {
 		},
 		{
 			name:                  "variable expansion error stops execution",
-			commandWorkDir:        runnertypes.StringPtr("/opt/%{undefined_var}"),
+			commandWorkDir:        new("/opt/%{undefined_var}"),
 			commandVars:           map[string]string{},
 			groupEffectiveWorkDir: "/group/workdir",
 			expectedWorkDir:       "",
@@ -976,7 +976,7 @@ func TestResolveCommandWorkDir(t *testing.T) {
 		},
 		{
 			name:                  "relative command workdir rejected",
-			commandWorkDir:        runnertypes.StringPtr("./relative/path"),
+			commandWorkDir:        new("./relative/path"),
 			commandVars:           map[string]string{},
 			groupEffectiveWorkDir: "/group/workdir",
 			expectedWorkDir:       "",
@@ -984,7 +984,7 @@ func TestResolveCommandWorkDir(t *testing.T) {
 		},
 		{
 			name:                  "variable expansion resulting in relative path rejected",
-			commandWorkDir:        runnertypes.StringPtr("%{relative}"),
+			commandWorkDir:        new("%{relative}"),
 			commandVars:           map[string]string{"relative": "not/absolute"},
 			groupEffectiveWorkDir: "/group/workdir",
 			expectedWorkDir:       "",
@@ -1099,7 +1099,7 @@ func TestExecuteGroup_RunnerWorkdirExpansion(t *testing.T) {
 
 			configSpec := &runnertypes.ConfigSpec{
 				Global: runnertypes.GlobalSpec{
-					Timeout: tu.Int32Ptr(30),
+					Timeout: new(int32(30)),
 				},
 			}
 
@@ -1128,13 +1128,13 @@ func TestExecuteGroup_RunnerWorkdirExpansion(t *testing.T) {
 						Name:    "test-cmd",
 						Cmd:     "echo",
 						Args:    tt.commandArgs,
-						WorkDir: runnertypes.StringPtr(tt.commandWorkDir),
+						WorkDir: new(tt.commandWorkDir),
 					},
 				},
 			}
 
 			runtimeGlobal := &runnertypes.RuntimeGlobal{
-				Spec:         &runnertypes.GlobalSpec{Timeout: tu.Int32Ptr(30)},
+				Spec:         &runnertypes.GlobalSpec{Timeout: new(int32(30))},
 				ExpandedVars: map[string]string{},
 			}
 
@@ -1245,7 +1245,7 @@ func TestExecuteCommandInGroup_ValidateEnvironmentVarsFailure(t *testing.T) {
 
 	config := &runnertypes.ConfigSpec{
 		Global: runnertypes.GlobalSpec{
-			Timeout: tu.Int32Ptr(30),
+			Timeout: new(int32(30)),
 		},
 	}
 
@@ -1286,7 +1286,7 @@ func TestExecuteCommandInGroup_ValidateEnvironmentVarsFailure(t *testing.T) {
 	require.NoError(t, err)
 
 	runtimeGlobal := &runnertypes.RuntimeGlobal{
-		Spec:         &runnertypes.GlobalSpec{Timeout: tu.Int32Ptr(30)},
+		Spec:         &runnertypes.GlobalSpec{Timeout: new(int32(30))},
 		ExpandedVars: map[string]string{},
 	}
 
@@ -1316,7 +1316,7 @@ func TestVerifyGroupFiles_ResolvePathFailure(t *testing.T) {
 
 	config := &runnertypes.ConfigSpec{
 		Global: runnertypes.GlobalSpec{
-			Timeout: tu.Int32Ptr(30),
+			Timeout: new(int32(30)),
 		},
 	}
 
@@ -1353,7 +1353,7 @@ func TestVerifyGroupFiles_ResolvePathFailure(t *testing.T) {
 	runtimeGroup.Commands = []*runnertypes.RuntimeCommand{cmd}
 
 	runtimeGlobal := &runnertypes.RuntimeGlobal{
-		Spec:         &runnertypes.GlobalSpec{Timeout: tu.Int32Ptr(30)},
+		Spec:         &runnertypes.GlobalSpec{Timeout: new(int32(30))},
 		ExpandedVars: map[string]string{},
 	}
 
@@ -1381,7 +1381,7 @@ func TestGroupExecutor_IdentityBoundNoReResolve(t *testing.T) {
 	mockRM := new(runnertestutil.MockResourceManager)
 
 	config := &runnertypes.ConfigSpec{
-		Global: runnertypes.GlobalSpec{Timeout: tu.Int32Ptr(30)},
+		Global: runnertypes.GlobalSpec{Timeout: new(int32(30))},
 	}
 
 	mockValidator.On("ValidateAllEnvironmentVars", mock.Anything).Return(nil)
@@ -1408,7 +1408,7 @@ func TestGroupExecutor_IdentityBoundNoReResolve(t *testing.T) {
 	runtimeGroup, err := runnertypes.NewRuntimeGroup(groupSpec)
 	require.NoError(t, err)
 	runtimeGlobal := &runnertypes.RuntimeGlobal{
-		Spec:         &runnertypes.GlobalSpec{Timeout: tu.Int32Ptr(30)},
+		Spec:         &runnertypes.GlobalSpec{Timeout: new(int32(30))},
 		ExpandedVars: map[string]string{},
 	}
 
@@ -1429,7 +1429,7 @@ func TestGroupExecutor_ExecIdentityBound(t *testing.T) {
 	mockRM := new(runnertestutil.MockResourceManager)
 
 	config := &runnertypes.ConfigSpec{
-		Global: runnertypes.GlobalSpec{Timeout: tu.Int32Ptr(30)},
+		Global: runnertypes.GlobalSpec{Timeout: new(int32(30))},
 	}
 
 	const unresolved = "/bin/echo"
@@ -1465,7 +1465,7 @@ func TestGroupExecutor_ExecIdentityBound(t *testing.T) {
 	require.NoError(t, err)
 	runtimeGroup.Commands = []*runnertypes.RuntimeCommand{cmd}
 	runtimeGlobal := &runnertypes.RuntimeGlobal{
-		Spec:         &runnertypes.GlobalSpec{Timeout: tu.Int32Ptr(30)},
+		Spec:         &runnertypes.GlobalSpec{Timeout: new(int32(30))},
 		ExpandedVars: map[string]string{},
 	}
 
@@ -1524,7 +1524,7 @@ func TestExecuteCommandInGroup_DryRunDetailLevelFull(t *testing.T) {
 
 	config := &runnertypes.ConfigSpec{
 		Global: runnertypes.GlobalSpec{
-			Timeout: tu.Int32Ptr(30),
+			Timeout: new(int32(30)),
 		},
 	}
 
@@ -1567,7 +1567,7 @@ func TestExecuteCommandInGroup_DryRunDetailLevelFull(t *testing.T) {
 	require.NoError(t, err)
 
 	runtimeGlobal := &runnertypes.RuntimeGlobal{
-		Spec:         &runnertypes.GlobalSpec{Timeout: tu.Int32Ptr(30)},
+		Spec:         &runnertypes.GlobalSpec{Timeout: new(int32(30))},
 		ExpandedVars: map[string]string{},
 	}
 
@@ -1614,7 +1614,7 @@ func TestExecuteGroup_DryRunVariableExpansion(t *testing.T) {
 
 	config := &runnertypes.ConfigSpec{
 		Global: runnertypes.GlobalSpec{
-			Timeout: tu.Int32Ptr(30),
+			Timeout: new(int32(30)),
 		},
 	}
 
@@ -1643,7 +1643,7 @@ func TestExecuteGroup_DryRunVariableExpansion(t *testing.T) {
 	}
 
 	runtimeGlobal := &runnertypes.RuntimeGlobal{
-		Spec:         &runnertypes.GlobalSpec{Timeout: tu.Int32Ptr(30)},
+		Spec:         &runnertypes.GlobalSpec{Timeout: new(int32(30))},
 		ExpandedVars: map[string]string{},
 	}
 
@@ -1677,7 +1677,7 @@ func TestExecuteCommandInGroup_VerificationManagerNil(t *testing.T) {
 
 	config := &runnertypes.ConfigSpec{
 		Global: runnertypes.GlobalSpec{
-			Timeout: tu.Int32Ptr(30),
+			Timeout: new(int32(30)),
 		},
 	}
 
@@ -1707,7 +1707,7 @@ func TestExecuteCommandInGroup_VerificationManagerNil(t *testing.T) {
 	require.NoError(t, err)
 
 	runtimeGlobal := &runnertypes.RuntimeGlobal{
-		Spec:         &runnertypes.GlobalSpec{Timeout: tu.Int32Ptr(30)},
+		Spec:         &runnertypes.GlobalSpec{Timeout: new(int32(30))},
 		ExpandedVars: map[string]string{},
 	}
 
@@ -1737,7 +1737,7 @@ func TestExecuteGroup_KeepTempDirs(t *testing.T) {
 
 	config := &runnertypes.ConfigSpec{
 		Global: runnertypes.GlobalSpec{
-			Timeout: tu.Int32Ptr(30),
+			Timeout: new(int32(30)),
 		},
 	}
 
@@ -1763,7 +1763,7 @@ func TestExecuteGroup_KeepTempDirs(t *testing.T) {
 	}
 
 	runtimeGlobal := &runnertypes.RuntimeGlobal{
-		Spec:         &runnertypes.GlobalSpec{Timeout: tu.Int32Ptr(30)},
+		Spec:         &runnertypes.GlobalSpec{Timeout: new(int32(30))},
 		ExpandedVars: map[string]string{},
 	}
 
@@ -1793,7 +1793,7 @@ func TestExecuteGroup_NoNotificationFunc(t *testing.T) {
 
 	config := &runnertypes.ConfigSpec{
 		Global: runnertypes.GlobalSpec{
-			Timeout: tu.Int32Ptr(30),
+			Timeout: new(int32(30)),
 		},
 	}
 
@@ -1818,7 +1818,7 @@ func TestExecuteGroup_NoNotificationFunc(t *testing.T) {
 	}
 
 	runtimeGlobal := &runnertypes.RuntimeGlobal{
-		Spec:         &runnertypes.GlobalSpec{Timeout: tu.Int32Ptr(30)},
+		Spec:         &runnertypes.GlobalSpec{Timeout: new(int32(30))},
 		ExpandedVars: map[string]string{},
 	}
 
@@ -1847,7 +1847,7 @@ func TestExecuteGroup_EmptyDescription(t *testing.T) {
 
 	config := &runnertypes.ConfigSpec{
 		Global: runnertypes.GlobalSpec{
-			Timeout: tu.Int32Ptr(30),
+			Timeout: new(int32(30)),
 		},
 	}
 
@@ -1873,7 +1873,7 @@ func TestExecuteGroup_EmptyDescription(t *testing.T) {
 	}
 
 	runtimeGlobal := &runnertypes.RuntimeGlobal{
-		Spec:         &runnertypes.GlobalSpec{Timeout: tu.Int32Ptr(30)},
+		Spec:         &runnertypes.GlobalSpec{Timeout: new(int32(30))},
 		ExpandedVars: map[string]string{},
 	}
 
@@ -1902,7 +1902,7 @@ func TestExecuteGroup_VariableExpansionError(t *testing.T) {
 
 	configSpec := &runnertypes.ConfigSpec{
 		Global: runnertypes.GlobalSpec{
-			Timeout: tu.Int32Ptr(30),
+			Timeout: new(int32(30)),
 		},
 	}
 
@@ -1924,7 +1924,7 @@ func TestExecuteGroup_VariableExpansionError(t *testing.T) {
 	}
 
 	runtimeGlobal := &runnertypes.RuntimeGlobal{
-		Spec:         &runnertypes.GlobalSpec{Timeout: tu.Int32Ptr(30)},
+		Spec:         &runnertypes.GlobalSpec{Timeout: new(int32(30))},
 		ExpandedVars: map[string]string{}, // No UNDEFINED_VAR defined
 	}
 
@@ -1954,7 +1954,7 @@ func TestExecuteGroup_FileVerificationResultLog(t *testing.T) {
 
 	config := &runnertypes.ConfigSpec{
 		Global: runnertypes.GlobalSpec{
-			Timeout: tu.Int32Ptr(30),
+			Timeout: new(int32(30)),
 		},
 	}
 
@@ -1986,7 +1986,7 @@ func TestExecuteGroup_FileVerificationResultLog(t *testing.T) {
 	}
 
 	runtimeGlobal := &runnertypes.RuntimeGlobal{
-		Spec:         &runnertypes.GlobalSpec{Timeout: tu.Int32Ptr(30)},
+		Spec:         &runnertypes.GlobalSpec{Timeout: new(int32(30))},
 		ExpandedVars: map[string]string{},
 	}
 
@@ -2016,7 +2016,7 @@ func TestExecuteGroup_ExpandCommandError(t *testing.T) {
 
 	configSpec := &runnertypes.ConfigSpec{
 		Global: runnertypes.GlobalSpec{
-			Timeout: tu.Int32Ptr(30),
+			Timeout: new(int32(30)),
 		},
 	}
 
@@ -2042,7 +2042,7 @@ func TestExecuteGroup_ExpandCommandError(t *testing.T) {
 	}
 
 	runtimeGlobal := &runnertypes.RuntimeGlobal{
-		Spec:         &runnertypes.GlobalSpec{Timeout: tu.Int32Ptr(30)},
+		Spec:         &runnertypes.GlobalSpec{Timeout: new(int32(30))},
 		ExpandedVars: map[string]string{}, // No UNDEFINED_VAR defined
 	}
 
@@ -2071,7 +2071,7 @@ func TestExecuteGroup_ResolveCommandWorkDirError(t *testing.T) {
 
 	configSpec := &runnertypes.ConfigSpec{
 		Global: runnertypes.GlobalSpec{
-			Timeout: tu.Int32Ptr(30),
+			Timeout: new(int32(30)),
 		},
 	}
 
@@ -2091,13 +2091,13 @@ func TestExecuteGroup_ResolveCommandWorkDirError(t *testing.T) {
 			{
 				Name:    "test-cmd",
 				Cmd:     "/bin/echo",
-				WorkDir: runnertypes.StringPtr("/tmp/%{UNDEFINED_VAR}/path"), // Undefined variable in command WorkDir
+				WorkDir: new("/tmp/%{UNDEFINED_VAR}/path"), // Undefined variable in command WorkDir
 			},
 		},
 	}
 
 	runtimeGlobal := &runnertypes.RuntimeGlobal{
-		Spec:         &runnertypes.GlobalSpec{Timeout: tu.Int32Ptr(30)},
+		Spec:         &runnertypes.GlobalSpec{Timeout: new(int32(30))},
 		ExpandedVars: map[string]string{}, // No UNDEFINED_VAR defined
 	}
 
@@ -2220,7 +2220,7 @@ func TestGroupExecutorOptions(t *testing.T) {
 func TestNewDefaultGroupExecutor_WithOptions(t *testing.T) {
 	config := &runnertypes.ConfigSpec{
 		Global: runnertypes.GlobalSpec{
-			Timeout: tu.Int32Ptr(30),
+			Timeout: new(int32(30)),
 		},
 	}
 	mockRM := new(runnertestutil.MockResourceManager)
@@ -2289,7 +2289,7 @@ func TestNewDefaultGroupExecutor_WithOptions(t *testing.T) {
 func TestNewDefaultGroupExecutor_Validation(t *testing.T) {
 	config := &runnertypes.ConfigSpec{
 		Global: runnertypes.GlobalSpec{
-			Timeout: tu.Int32Ptr(30),
+			Timeout: new(int32(30)),
 		},
 	}
 	mockRM := new(runnertestutil.MockResourceManager)
@@ -2317,7 +2317,7 @@ func TestNewDefaultGroupExecutor_Validation(t *testing.T) {
 func TestNewTestGroupExecutor(t *testing.T) {
 	config := &runnertypes.ConfigSpec{
 		Global: runnertypes.GlobalSpec{
-			Timeout: tu.Int32Ptr(30),
+			Timeout: new(int32(30)),
 		},
 	}
 	mockRM := new(runnertestutil.MockResourceManager)
@@ -2352,7 +2352,7 @@ func TestNewTestGroupExecutor(t *testing.T) {
 func TestNewDefaultGroupExecutor_Performance(t *testing.T) {
 	config := &runnertypes.ConfigSpec{
 		Global: runnertypes.GlobalSpec{
-			Timeout: tu.Int32Ptr(30),
+			Timeout: new(int32(30)),
 		},
 	}
 	mockRM := new(runnertestutil.MockResourceManager)
@@ -2374,7 +2374,7 @@ func TestNewDefaultGroupExecutor_Performance(t *testing.T) {
 func BenchmarkNewDefaultGroupExecutor(b *testing.B) {
 	config := &runnertypes.ConfigSpec{
 		Global: runnertypes.GlobalSpec{
-			Timeout: tu.Int32Ptr(30),
+			Timeout: new(int32(30)),
 		},
 	}
 	mockRM := new(runnertestutil.MockResourceManager)
@@ -2399,7 +2399,7 @@ func BenchmarkNewDefaultGroupExecutor(b *testing.B) {
 func BenchmarkNewDefaultGroupExecutor_NoOptions(b *testing.B) {
 	config := &runnertypes.ConfigSpec{
 		Global: runnertypes.GlobalSpec{
-			Timeout: tu.Int32Ptr(30),
+			Timeout: new(int32(30)),
 		},
 	}
 	mockRM := new(runnertestutil.MockResourceManager)
@@ -2437,7 +2437,7 @@ func TestWithCurrentUser(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			config := &runnertypes.ConfigSpec{
 				Global: runnertypes.GlobalSpec{
-					Timeout: tu.Int32Ptr(30),
+					Timeout: new(int32(30)),
 				},
 			}
 			mockRM := new(runnertestutil.MockResourceManager)
@@ -2456,7 +2456,7 @@ func TestWithCurrentUser(t *testing.T) {
 func TestDefaultCurrentUser(t *testing.T) {
 	config := &runnertypes.ConfigSpec{
 		Global: runnertypes.GlobalSpec{
-			Timeout: tu.Int32Ptr(30),
+			Timeout: new(int32(30)),
 		},
 	}
 	mockRM := new(runnertestutil.MockResourceManager)
@@ -2578,7 +2578,7 @@ func TestExecuteGroup_TimeoutExceeded_SecurityLogging(t *testing.T) {
 
 	config := &runnertypes.ConfigSpec{
 		Global: runnertypes.GlobalSpec{
-			Timeout: tu.Int32Ptr(30),
+			Timeout: new(int32(30)),
 		},
 	}
 
@@ -2600,13 +2600,13 @@ func TestExecuteGroup_TimeoutExceeded_SecurityLogging(t *testing.T) {
 				Name:    "timeout-cmd",
 				Cmd:     "/bin/sleep",
 				Args:    []string{"1000"},
-				Timeout: tu.Int32Ptr(1), // 1 second timeout
+				Timeout: new(int32(1)), // 1 second timeout
 			},
 		},
 	}
 
 	runtimeGlobal := &runnertypes.RuntimeGlobal{
-		Spec: &runnertypes.GlobalSpec{Timeout: tu.Int32Ptr(30)},
+		Spec: &runnertypes.GlobalSpec{Timeout: new(int32(30))},
 	}
 
 	// Mock verification manager to resolve paths
@@ -2656,7 +2656,7 @@ func TestExecuteGroup_MultipleCommands_TimeoutLogging(t *testing.T) {
 
 	config := &runnertypes.ConfigSpec{
 		Global: runnertypes.GlobalSpec{
-			Timeout: tu.Int32Ptr(30),
+			Timeout: new(int32(30)),
 		},
 	}
 
@@ -2677,18 +2677,18 @@ func TestExecuteGroup_MultipleCommands_TimeoutLogging(t *testing.T) {
 			{
 				Name:    "unlimited-cmd",
 				Cmd:     "/bin/echo",
-				Timeout: tu.Int32Ptr(0), // Unlimited timeout
+				Timeout: new(int32(0)), // Unlimited timeout
 			},
 			{
 				Name:    "normal-cmd",
 				Cmd:     "/bin/echo",
-				Timeout: tu.Int32Ptr(10), // Normal timeout
+				Timeout: new(int32(10)), // Normal timeout
 			},
 		},
 	}
 
 	runtimeGlobal := &runnertypes.RuntimeGlobal{
-		Spec: &runnertypes.GlobalSpec{Timeout: tu.Int32Ptr(30)},
+		Spec: &runnertypes.GlobalSpec{Timeout: new(int32(30))},
 	}
 
 	// Mock verification manager to resolve paths
@@ -2795,7 +2795,7 @@ func TestCommandFailureLogging_StderrInErrorLog(t *testing.T) {
 			}
 
 			runtimeGlobal := &runnertypes.RuntimeGlobal{
-				Spec: &runnertypes.GlobalSpec{Timeout: tu.Int32Ptr(30)},
+				Spec: &runnertypes.GlobalSpec{Timeout: new(int32(30))},
 			}
 
 			mockRM := new(runnertestutil.MockResourceManager)
@@ -3117,7 +3117,7 @@ func TestPreExpandCommands_Error(t *testing.T) {
 					{
 						Name:    "cmd1",
 						Cmd:     "/bin/echo",
-						WorkDir: runnertypes.StringPtr("%{undefined_workdir}"),
+						WorkDir: new("%{undefined_workdir}"),
 					},
 				},
 			},
@@ -3165,7 +3165,7 @@ func TestVerifyGroupFiles_DynLibNotCalledForVerifyFiles(t *testing.T) {
 
 	config := &runnertypes.ConfigSpec{
 		Global: runnertypes.GlobalSpec{
-			Timeout: tu.Int32Ptr(30),
+			Timeout: new(int32(30)),
 		},
 	}
 
@@ -3189,7 +3189,7 @@ func TestVerifyGroupFiles_DynLibNotCalledForVerifyFiles(t *testing.T) {
 	}
 
 	runtimeGlobal := &runnertypes.RuntimeGlobal{
-		Spec: &runnertypes.GlobalSpec{Timeout: tu.Int32Ptr(30)},
+		Spec: &runnertypes.GlobalSpec{Timeout: new(int32(30))},
 	}
 
 	// Mock validator
@@ -3238,7 +3238,7 @@ func TestVerifyGroupFiles_DynLibResolvePathFailure(t *testing.T) {
 
 	config := &runnertypes.ConfigSpec{
 		Global: runnertypes.GlobalSpec{
-			Timeout: tu.Int32Ptr(30),
+			Timeout: new(int32(30)),
 		},
 	}
 
@@ -3259,7 +3259,7 @@ func TestVerifyGroupFiles_DynLibResolvePathFailure(t *testing.T) {
 	}
 
 	runtimeGlobal := &runnertypes.RuntimeGlobal{
-		Spec: &runnertypes.GlobalSpec{Timeout: tu.Int32Ptr(30)},
+		Spec: &runnertypes.GlobalSpec{Timeout: new(int32(30))},
 	}
 
 	mockValidator.On("ValidateAllEnvironmentVars", mock.Anything).Return(nil)
@@ -3304,7 +3304,7 @@ func TestVerifyGroupFiles_ContentHashPropagatedToCommand(t *testing.T) {
 
 	config := &runnertypes.ConfigSpec{
 		Global: runnertypes.GlobalSpec{
-			Timeout: tu.Int32Ptr(30),
+			Timeout: new(int32(30)),
 		},
 	}
 
@@ -3325,7 +3325,7 @@ func TestVerifyGroupFiles_ContentHashPropagatedToCommand(t *testing.T) {
 	}
 
 	runtimeGlobal := &runnertypes.RuntimeGlobal{
-		Spec: &runnertypes.GlobalSpec{Timeout: tu.Int32Ptr(30)},
+		Spec: &runnertypes.GlobalSpec{Timeout: new(int32(30))},
 	}
 
 	// VerifyGroupFiles returns a ContentHashes entry for the resolved command path.
@@ -3371,7 +3371,7 @@ func TestVerifyGroupFiles_ShebangInterpreter_OK(t *testing.T) {
 
 	config := &runnertypes.ConfigSpec{
 		Global: runnertypes.GlobalSpec{
-			Timeout: tu.Int32Ptr(30),
+			Timeout: new(int32(30)),
 		},
 	}
 
@@ -3392,7 +3392,7 @@ func TestVerifyGroupFiles_ShebangInterpreter_OK(t *testing.T) {
 	}
 
 	runtimeGlobal := &runnertypes.RuntimeGlobal{
-		Spec: &runnertypes.GlobalSpec{Timeout: tu.Int32Ptr(30)},
+		Spec: &runnertypes.GlobalSpec{Timeout: new(int32(30))},
 	}
 
 	mockValidator.On("ValidateAllEnvironmentVars", mock.Anything).Return(nil)
@@ -3425,7 +3425,7 @@ func TestVerifyGroupFiles_ShebangInterpreter_Error(t *testing.T) {
 
 	config := &runnertypes.ConfigSpec{
 		Global: runnertypes.GlobalSpec{
-			Timeout: tu.Int32Ptr(30),
+			Timeout: new(int32(30)),
 		},
 	}
 
@@ -3446,7 +3446,7 @@ func TestVerifyGroupFiles_ShebangInterpreter_Error(t *testing.T) {
 	}
 
 	runtimeGlobal := &runnertypes.RuntimeGlobal{
-		Spec: &runnertypes.GlobalSpec{Timeout: tu.Int32Ptr(30)},
+		Spec: &runnertypes.GlobalSpec{Timeout: new(int32(30))},
 	}
 
 	shebangErr := &verification.ErrInterpreterRecordNotFound{Path: "/usr/bin/python3"}
@@ -3487,7 +3487,7 @@ func TestVerifyGroupFiles_ShebangInterpreter_UsesEffectiveEnvPATH(t *testing.T) 
 
 	cfg := &runnertypes.ConfigSpec{
 		Global: runnertypes.GlobalSpec{
-			Timeout: tu.Int32Ptr(30),
+			Timeout: new(int32(30)),
 		},
 	}
 
@@ -3513,7 +3513,7 @@ func TestVerifyGroupFiles_ShebangInterpreter_UsesEffectiveEnvPATH(t *testing.T) 
 	}
 
 	runtimeGlobal := &runnertypes.RuntimeGlobal{
-		Spec: &runnertypes.GlobalSpec{Timeout: tu.Int32Ptr(30)},
+		Spec: &runnertypes.GlobalSpec{Timeout: new(int32(30))},
 	}
 
 	mockValidator.On("ValidateAllEnvironmentVars", mock.Anything).Return(nil)
@@ -3645,7 +3645,7 @@ func TestVerifyCommandCallOrder_DynLibBeforeShebang(t *testing.T) {
 	mockRM.On("ValidateOutputPath", mock.Anything, mock.Anything).Return(nil).Maybe()
 
 	config := &runnertypes.ConfigSpec{
-		Global: runnertypes.GlobalSpec{Timeout: tu.Int32Ptr(30)},
+		Global: runnertypes.GlobalSpec{Timeout: new(int32(30))},
 	}
 	ge := NewTestGroupExecutorWithConfig(TestGroupExecutorConfig{
 		Config:              config,
@@ -3662,7 +3662,7 @@ func TestVerifyCommandCallOrder_DynLibBeforeShebang(t *testing.T) {
 		},
 	}
 	runtimeGlobal := &runnertypes.RuntimeGlobal{
-		Spec: &runnertypes.GlobalSpec{Timeout: tu.Int32Ptr(30)},
+		Spec: &runnertypes.GlobalSpec{Timeout: new(int32(30))},
 	}
 
 	err := ge.ExecuteGroup(context.Background(), group, runtimeGlobal)

--- a/internal/runner/integration_dual_defense_test.go
+++ b/internal/runner/integration_dual_defense_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/security/testutil"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/resource"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/resource/testutil"
-	tu "github.com/isseis/go-safe-cmd-runner/internal/testutil"
 	"github.com/isseis/go-safe-cmd-runner/internal/verification"
 	"github.com/isseis/go-safe-cmd-runner/internal/verification/testutil"
 	"github.com/stretchr/testify/assert"
@@ -60,7 +59,7 @@ func TestIntegration_DualDefense(t *testing.T) {
 	}
 
 	runtimeGlobal := &runnertypes.RuntimeGlobal{
-		Spec: &runnertypes.GlobalSpec{Timeout: tu.Int32Ptr(30)},
+		Spec: &runnertypes.GlobalSpec{Timeout: new(int32(30))},
 	}
 
 	// Create real executor and resource manager
@@ -169,7 +168,7 @@ func TestIntegration_Case1Only(t *testing.T) {
 	}
 
 	runtimeGlobal := &runnertypes.RuntimeGlobal{
-		Spec: &runnertypes.GlobalSpec{Timeout: tu.Int32Ptr(30)},
+		Spec: &runnertypes.GlobalSpec{Timeout: new(int32(30))},
 	}
 
 	// Create real executor and resource manager
@@ -271,7 +270,7 @@ func TestIntegration_Case2Only(t *testing.T) {
 	}
 
 	runtimeGlobal := &runnertypes.RuntimeGlobal{
-		Spec: &runnertypes.GlobalSpec{Timeout: tu.Int32Ptr(30)},
+		Spec: &runnertypes.GlobalSpec{Timeout: new(int32(30))},
 	}
 
 	// Create real executor and resource manager
@@ -376,7 +375,7 @@ func TestIntegration_Case2Only_DebugLeakage(t *testing.T) {
 	}
 
 	runtimeGlobal := &runnertypes.RuntimeGlobal{
-		Spec: &runnertypes.GlobalSpec{Timeout: tu.Int32Ptr(30)},
+		Spec: &runnertypes.GlobalSpec{Timeout: new(int32(30))},
 	}
 
 	// Create real executor and resource manager

--- a/internal/runner/output_capture_integration_test.go
+++ b/internal/runner/output_capture_integration_test.go
@@ -60,8 +60,8 @@ func TestRunner_OutputCaptureIntegration(t *testing.T) {
 			cfg := &runnertypes.ConfigSpec{
 				Version: "1.0",
 				Global: runnertypes.GlobalSpec{
-					Timeout:         tu.Int32Ptr(30),
-					OutputSizeLimit: tu.Int64Ptr(1024),
+					Timeout:         new(int32(30)),
+					OutputSizeLimit: new(int64(1024)),
 				},
 				Groups: []runnertypes.GroupSpec{
 					{
@@ -71,7 +71,7 @@ func TestRunner_OutputCaptureIntegration(t *testing.T) {
 								Name:       "test-cmd",
 								Cmd:        "echo",
 								Args:       []string{"test"},
-								OutputFile: tu.StringPtr("output.txt"),
+								OutputFile: new("output.txt"),
 							},
 						},
 					},
@@ -159,8 +159,8 @@ func TestRunner_OutputCaptureSecurityValidation(t *testing.T) {
 			cfg := &runnertypes.ConfigSpec{
 				Version: "1.0",
 				Global: runnertypes.GlobalSpec{
-					Timeout:         tu.Int32Ptr(30),
-					OutputSizeLimit: tu.Int64Ptr(1024),
+					Timeout:         new(int32(30)),
+					OutputSizeLimit: new(int64(1024)),
 				},
 				Groups: []runnertypes.GroupSpec{
 					{

--- a/internal/runner/resource/normal_manager_test.go
+++ b/internal/runner/resource/normal_manager_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/output"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/risk"
 	"github.com/isseis/go-safe-cmd-runner/internal/runner/base/runnertypes"
-	tu "github.com/isseis/go-safe-cmd-runner/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -241,7 +240,7 @@ func TestNormalResourceManager_ExecuteCommand_PrivilegeEscalationBlocked(t *test
 				tc.args,
 				executortestutil.WithName("test-privilege-command"),
 				executortestutil.WithWorkDir("/tmp"),
-				executortestutil.WithTimeout(tu.Int32Ptr(30)),
+				executortestutil.WithTimeout(new(int32(30))),
 				executortestutil.WithRiskLevel("low"),
 			)
 			group := createTestCommandGroup()
@@ -345,7 +344,7 @@ func TestNormalResourceManager_ExecuteCommand_RiskLevelControl(t *testing.T) {
 				tc.args,
 				executortestutil.WithName("test-command"),
 				executortestutil.WithWorkDir("/tmp"),
-				executortestutil.WithTimeout(tu.Int32Ptr(30)),
+				executortestutil.WithTimeout(new(int32(30))),
 				executortestutil.WithRiskLevel(tc.riskLevel),
 			)
 

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -57,7 +57,7 @@ func TestNewRunner(t *testing.T) {
 	config := &runnertypes.ConfigSpec{
 		Version: "1.0",
 		Global: runnertypes.GlobalSpec{
-			Timeout: tu.Int32Ptr(3600),
+			Timeout: new(int32(3600)),
 		},
 	}
 
@@ -176,7 +176,7 @@ func TestRunner_ExecuteGroup(t *testing.T) {
 			config := &runnertypes.ConfigSpec{
 				Version: "1.0",
 				Global: runnertypes.GlobalSpec{
-					Timeout: tu.Int32Ptr(3600),
+					Timeout: new(int32(3600)),
 				},
 				Groups: []runnertypes.GroupSpec{tt.group},
 			}
@@ -228,7 +228,7 @@ func TestRunner_ExecuteGroup_ComplexErrorScenarios(t *testing.T) {
 		config := &runnertypes.ConfigSpec{
 			Version: "1.0",
 			Global: runnertypes.GlobalSpec{
-				Timeout: tu.Int32Ptr(3600),
+				Timeout: new(int32(3600)),
 			},
 			Groups: []runnertypes.GroupSpec{group},
 		}
@@ -263,7 +263,7 @@ func TestRunner_ExecuteGroup_ComplexErrorScenarios(t *testing.T) {
 		config := &runnertypes.ConfigSpec{
 			Version: "1.0",
 			Global: runnertypes.GlobalSpec{
-				Timeout: tu.Int32Ptr(3600),
+				Timeout: new(int32(3600)),
 			},
 			Groups: []runnertypes.GroupSpec{group},
 		}
@@ -302,7 +302,7 @@ func TestRunner_ExecuteGroup_ComplexErrorScenarios(t *testing.T) {
 		config := &runnertypes.ConfigSpec{
 			Version: "1.0",
 			Global: runnertypes.GlobalSpec{
-				Timeout: tu.Int32Ptr(3600),
+				Timeout: new(int32(3600)),
 			},
 			Groups: []runnertypes.GroupSpec{group},
 		}
@@ -335,7 +335,7 @@ func TestRunner_ExecuteAll(t *testing.T) {
 	config := &runnertypes.ConfigSpec{
 		Version: "1.0",
 		Global: runnertypes.GlobalSpec{
-			Timeout: tu.Int32Ptr(3600),
+			Timeout: new(int32(3600)),
 		},
 		Groups: []runnertypes.GroupSpec{
 			{
@@ -375,7 +375,7 @@ func TestRunner_ExecuteAll_ComplexErrorScenarios(t *testing.T) {
 		config := &runnertypes.ConfigSpec{
 			Version: "1.0",
 			Global: runnertypes.GlobalSpec{
-				Timeout: tu.Int32Ptr(3600),
+				Timeout: new(int32(3600)),
 			},
 			Groups: []runnertypes.GroupSpec{
 				{
@@ -427,7 +427,7 @@ func TestRunner_ExecuteAll_ComplexErrorScenarios(t *testing.T) {
 		config := &runnertypes.ConfigSpec{
 			Version: "1.0",
 			Global: runnertypes.GlobalSpec{
-				Timeout: tu.Int32Ptr(3600),
+				Timeout: new(int32(3600)),
 			},
 			Groups: []runnertypes.GroupSpec{
 				{
@@ -479,7 +479,7 @@ func TestRunner_ExecuteAll_ComplexErrorScenarios(t *testing.T) {
 		config := &runnertypes.ConfigSpec{
 			Version: "1.0",
 			Global: runnertypes.GlobalSpec{
-				Timeout: tu.Int32Ptr(3600),
+				Timeout: new(int32(3600)),
 			},
 			Groups: []runnertypes.GroupSpec{
 				{
@@ -528,7 +528,7 @@ func TestRunner_ExecuteAll_ComplexErrorScenarios(t *testing.T) {
 		config := &runnertypes.ConfigSpec{
 			Version: "1.0",
 			Global: runnertypes.GlobalSpec{
-				Timeout: tu.Int32Ptr(3600),
+				Timeout: new(int32(3600)),
 			},
 			Groups: []runnertypes.GroupSpec{
 				{
@@ -570,7 +570,7 @@ func TestRunner_ExecuteAll_ComplexErrorScenarios(t *testing.T) {
 		config := &runnertypes.ConfigSpec{
 			Version: "1.0",
 			Global: runnertypes.GlobalSpec{
-				Timeout: tu.Int32Ptr(3600),
+				Timeout: new(int32(3600)),
 			},
 			Groups: []runnertypes.GroupSpec{
 				{
@@ -607,7 +607,7 @@ func TestRunner_ExecuteAll_ComplexErrorScenarios(t *testing.T) {
 		config := &runnertypes.ConfigSpec{
 			Version: "1.0",
 			Global: runnertypes.GlobalSpec{
-				Timeout: tu.Int32Ptr(3600),
+				Timeout: new(int32(3600)),
 			},
 			Groups: []runnertypes.GroupSpec{}, // Empty groups
 		}
@@ -636,7 +636,7 @@ func TestRunner_CommandTimeoutBehavior(t *testing.T) {
 	config := &runnertypes.ConfigSpec{
 		Version: "1.0",
 		Global: runnertypes.GlobalSpec{
-			Timeout: tu.Int32Ptr(1), // 1 second timeout
+			Timeout: new(int32(1)), // 1 second timeout
 		},
 		Groups: []runnertypes.GroupSpec{
 			{
@@ -673,14 +673,14 @@ func TestRunner_CommandTimeoutBehavior(t *testing.T) {
 		// Create config with command-specific shorter timeout
 		shortTimeoutCmd := runnertypes.CommandSpec{
 			Cmd:     "sleep",
-			Args:    []string{"5"},  // Sleep for 5 seconds
-			Timeout: tu.Int32Ptr(1), // But timeout after 1 second
+			Args:    []string{"5"}, // Sleep for 5 seconds
+			Timeout: new(int32(1)), // But timeout after 1 second
 		}
 
 		configWithCmdTimeout := &runnertypes.ConfigSpec{
 			Version: "1.0",
 			Global: runnertypes.GlobalSpec{
-				Timeout: tu.Int32Ptr(10), // 10 seconds global timeout
+				Timeout: new(int32(10)), // 10 seconds global timeout
 			},
 			Groups: []runnertypes.GroupSpec{
 				{
@@ -772,7 +772,7 @@ func TestCommandGroup_NewFields(t *testing.T) {
 				Name:    "test-existing-dir",
 				WorkDir: "/tmp",
 				Commands: []runnertypes.CommandSpec{
-					{Name: "test", Cmd: "echo", Args: []string{"hello"}, WorkDir: runnertypes.StringPtr("/usr")},
+					{Name: "test", Cmd: "echo", Args: []string{"hello"}, WorkDir: new("/usr")},
 				},
 				EnvAllowed: []string{"PATH"},
 			},
@@ -885,7 +885,7 @@ func TestRunner_EnvironmentVariablePriority_GroupLevelSupport(t *testing.T) {
 			config := &runnertypes.ConfigSpec{
 				Version: "1.0",
 				Global: runnertypes.GlobalSpec{
-					Timeout:    tu.Int32Ptr(3600),
+					Timeout:    new(int32(3600)),
 					EnvAllowed: []string{"TEST_VAR"},
 					EnvVars:    tt.globalEnv,
 				},
@@ -960,7 +960,7 @@ func TestSlackNotification(t *testing.T) {
 			config := &runnertypes.ConfigSpec{
 				Version: "1.0",
 				Global: runnertypes.GlobalSpec{
-					Timeout: tu.Int32Ptr(30),
+					Timeout: new(int32(30)),
 				},
 				Groups: []runnertypes.GroupSpec{
 					{
@@ -1045,7 +1045,7 @@ func TestRunner_OutputCaptureEndToEnd(t *testing.T) {
 					Name:       "test-echo",
 					Cmd:        "echo",
 					Args:       []string{"Hello World"},
-					OutputFile: runnertypes.StringPtr("test-output.txt"),
+					OutputFile: new("test-output.txt"),
 				},
 			},
 			expectError: false, // Note: This may fail due to output capture implementation, which is expected
@@ -1071,7 +1071,7 @@ func TestRunner_OutputCaptureEndToEnd(t *testing.T) {
 					Name:       "with-output",
 					Cmd:        "echo",
 					Args:       []string{"Captured"},
-					OutputFile: runnertypes.StringPtr("mixed-output.txt"),
+					OutputFile: new("mixed-output.txt"),
 				},
 				{
 					Name: "without-output",
@@ -1091,8 +1091,8 @@ func TestRunner_OutputCaptureEndToEnd(t *testing.T) {
 			config := &runnertypes.ConfigSpec{
 				Version: "1.0",
 				Global: runnertypes.GlobalSpec{
-					Timeout:         tu.Int32Ptr(30),
-					OutputSizeLimit: tu.Int64Ptr(1024 * 1024), // 1MB limit
+					Timeout:         new(int32(30)),
+					OutputSizeLimit: new(int64(1024 * 1024)), // 1MB limit
 				},
 				Groups: []runnertypes.GroupSpec{
 					{
@@ -1143,12 +1143,12 @@ func TestRunner_OutputCaptureErrorScenarios(t *testing.T) {
 					Name:       "path-traversal",
 					Cmd:        "echo",
 					Args:       []string{"attempt"},
-					OutputFile: runnertypes.StringPtr("../../../etc/passwd"),
+					OutputFile: new("../../../etc/passwd"),
 				},
 			},
 			globalConfig: runnertypes.GlobalSpec{
-				Timeout:         tu.Int32Ptr(30),
-				OutputSizeLimit: tu.Int64Ptr(1024),
+				Timeout:         new(int32(30)),
+				OutputSizeLimit: new(int64(1024)),
 			},
 			expectError: "path traversal",
 			description: "Path traversal attempts should be rejected",
@@ -1160,12 +1160,12 @@ func TestRunner_OutputCaptureErrorScenarios(t *testing.T) {
 					Name:       "non-existent-dir",
 					Cmd:        "echo",
 					Args:       []string{"test"},
-					OutputFile: runnertypes.StringPtr("/non/existent/directory/output.txt"),
+					OutputFile: new("/non/existent/directory/output.txt"),
 				},
 			},
 			globalConfig: runnertypes.GlobalSpec{
-				Timeout:         tu.Int32Ptr(30),
-				OutputSizeLimit: tu.Int64Ptr(1024),
+				Timeout:         new(int32(30)),
+				OutputSizeLimit: new(int64(1024)),
 			},
 			expectError: "directory",
 			description: "Non-existent directories should cause error",
@@ -1177,12 +1177,12 @@ func TestRunner_OutputCaptureErrorScenarios(t *testing.T) {
 					Name:       "permission-denied",
 					Cmd:        "echo",
 					Args:       []string{"test"},
-					OutputFile: runnertypes.StringPtr("/root/output.txt"),
+					OutputFile: new("/root/output.txt"),
 				},
 			},
 			globalConfig: runnertypes.GlobalSpec{
-				Timeout:         tu.Int32Ptr(30),
-				OutputSizeLimit: tu.Int64Ptr(1024),
+				Timeout:         new(int32(30)),
+				OutputSizeLimit: new(int64(1024)),
 			},
 			expectError: "permission",
 			description: "Permission denied should cause error",
@@ -1230,8 +1230,8 @@ func TestRunner_OutputCaptureDryRun(t *testing.T) {
 	config := &runnertypes.ConfigSpec{
 		Version: "1.0",
 		Global: runnertypes.GlobalSpec{
-			Timeout:         tu.Int32Ptr(30),
-			OutputSizeLimit: tu.Int64Ptr(1024),
+			Timeout:         new(int32(30)),
+			OutputSizeLimit: new(int64(1024)),
 		},
 		Groups: []runnertypes.GroupSpec{
 			{
@@ -1242,7 +1242,7 @@ func TestRunner_OutputCaptureDryRun(t *testing.T) {
 						Name:       "dryrun-echo",
 						Cmd:        "echo",
 						Args:       []string{"Dry run test"},
-						OutputFile: runnertypes.StringPtr("dryrun-output.txt"),
+						OutputFile: new("dryrun-output.txt"),
 					},
 				},
 			},
@@ -1526,8 +1526,8 @@ func TestRunner_OutputCaptureErrorTypes(t *testing.T) {
 			cfg := &runnertypes.ConfigSpec{
 				Version: "1.0",
 				Global: runnertypes.GlobalSpec{
-					Timeout:         tu.Int32Ptr(30),
-					OutputSizeLimit: tu.Int64Ptr(1024),
+					Timeout:         new(int32(30)),
+					OutputSizeLimit: new(int64(1024)),
 				},
 				Groups: []runnertypes.GroupSpec{
 					{
@@ -1537,7 +1537,7 @@ func TestRunner_OutputCaptureErrorTypes(t *testing.T) {
 								Name:       "test-cmd",
 								Cmd:        "echo",
 								Args:       []string{"test"},
-								OutputFile: runnertypes.StringPtr("output.txt"),
+								OutputFile: new("output.txt"),
 							},
 						},
 					},
@@ -1632,8 +1632,8 @@ func TestRunner_OutputCaptureExecutionStages(t *testing.T) {
 			cfg := &runnertypes.ConfigSpec{
 				Version: "1.0",
 				Global: runnertypes.GlobalSpec{
-					Timeout:         tu.Int32Ptr(30),
-					OutputSizeLimit: tu.Int64Ptr(1024),
+					Timeout:         new(int32(30)),
+					OutputSizeLimit: new(int64(1024)),
 				},
 				Groups: []runnertypes.GroupSpec{
 					{
@@ -1643,7 +1643,7 @@ func TestRunner_OutputCaptureExecutionStages(t *testing.T) {
 								Name:       "test-cmd",
 								Cmd:        "echo",
 								Args:       []string{"test"},
-								OutputFile: runnertypes.StringPtr("output.txt"),
+								OutputFile: new("output.txt"),
 							},
 						},
 					},
@@ -1811,8 +1811,8 @@ func TestRunner_OutputCaptureSecurityIntegration(t *testing.T) {
 			cfg := &runnertypes.ConfigSpec{
 				Version: "1.0",
 				Global: runnertypes.GlobalSpec{
-					Timeout:         tu.Int32Ptr(30),
-					OutputSizeLimit: tu.Int64Ptr(1024),
+					Timeout:         new(int32(30)),
+					OutputSizeLimit: new(int64(1024)),
 				},
 				Groups: []runnertypes.GroupSpec{
 					{
@@ -1822,7 +1822,7 @@ func TestRunner_OutputCaptureSecurityIntegration(t *testing.T) {
 								Name:       "security-test-cmd",
 								Cmd:        "echo",
 								Args:       []string{"test"},
-								OutputFile: runnertypes.StringPtr(tt.outputPath),
+								OutputFile: new(tt.outputPath),
 							},
 						},
 					},
@@ -1961,7 +1961,7 @@ func TestRunner_ExecutorUsesDefaultLogger(t *testing.T) {
 	config := &runnertypes.ConfigSpec{
 		Version: "1.0",
 		Global: runnertypes.GlobalSpec{
-			Timeout: tu.Int32Ptr(3600),
+			Timeout: new(int32(3600)),
 		},
 		Groups: []runnertypes.GroupSpec{
 			{
@@ -2343,7 +2343,7 @@ func TestLogGroupExecutionSummary_LogLevel(t *testing.T) {
 	config := &runnertypes.ConfigSpec{
 		Version: "1.0",
 		Global: runnertypes.GlobalSpec{
-			Timeout: tu.Int32Ptr(30),
+			Timeout: new(int32(30)),
 		},
 	}
 	runner, err := NewRunner(config,

--- a/internal/testutil/helpers.go
+++ b/internal/testutil/helpers.go
@@ -11,15 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Int32Ptr returns a pointer to v.
-func Int32Ptr(v int32) *int32 { return &v }
-
-// Int64Ptr returns a pointer to v.
-func Int64Ptr(v int64) *int64 { return &v }
-
-// StringPtr returns a pointer to s.
-func StringPtr(s string) *string { return &s }
-
 // StringPtrOrNil returns nil for an empty string, otherwise a pointer to s.
 func StringPtrOrNil(s string) *string {
 	if s == "" {

--- a/test/performance/output_capture_test.go
+++ b/test/performance/output_capture_test.go
@@ -244,7 +244,7 @@ func TestLongRunningStability(t *testing.T) {
 		[]string{"-c", "for i in $(seq 1 10); do echo \"Line $i\"; sleep 0.1; done"},
 		executortestutil.WithName("long_running_test"),
 		executortestutil.WithOutputFile(outputPath),
-		executortestutil.WithTimeout(tu.Int32Ptr(30)),
+		executortestutil.WithTimeout(new(int32(30))),
 		executortestutil.WithRiskLevel("medium"),
 	)
 


### PR DESCRIPTION
Closes #1005.

Go 1.26 generalized `new` to take an arbitrary expression, so the `*Ptr` helpers
no longer earn their keep. This removes them and re-enables modernize's
`newexpr` analyzer.

## What changed

Three commits, each green on its own:

1. **`refactor: inline the *Ptr test helpers at their call sites`** — the
   mechanical bulk. The helpers were annotated `//go:fix inline` (the fix
   `newexpr` itself suggests) and `go fix` rewrote every call site across the
   `test`, `e2e`, `integration` and `performance` build tags. Where the argument
   was an untyped constant the rewrite carries the conversion
   (`new(int32(30))`), so no pointer changes its pointee type.
2. **`refactor: remove the exported *Ptr helpers`** — deletion only.
3. **`build: stop disabling modernize's newexpr analyzer`** — drops the
   `modernize.disable` block from `.golangci.yml`.

## Decisions the issue asked to settle

- **Both exported `StringPtr`s go.** `runnertypes.StringPtr` lives in a
  production file, but its only non-test callers were the three `RiskLevel*Ptr`
  package variables in `runnertypes/config.go`; the other 57 call sites were
  tests. Nothing justified keeping it.
- **`tu.StringPtrOrNil` stays.** Its nil branch for the empty string is not
  expressible as `new(x)`. It has one caller
  (`output_capture_integration_test.go:173`), and `internal/testutil/helpers.go`
  keeps its other helpers (`SafeTempDir`, `WriteExecutableFile`, …) regardless,
  so the file was never in question.
- **Three package-local helpers the issue did not list** were also removed:
  `int32Ptr` (`config/template_security_test.go`), `int64Ptr`
  (`common/output_size_limit_test.go`) and `strptr` (`base/audit/logger_test.go`).
  Their deletions ride in commit 1 rather than a separate commit, because a
  definition left without callers trips the `unused` linter — so splitting them
  out would have produced a commit that fails `make lint`.

## Verification

- `make lint` → `0 issues`, with no `modernize` analyzer disabled.
- `make test` passes; the pre-commit hook ran the suite for each of the three
  commits.
- `go vet` under `e2e,test` / `integration,test` / `performance,test` is clean,
  covering the call sites `--build-tags test` alone does not compile.
  (`internal/libccache/integration_darwin_test.go` fails to build under
  `integration` on `main` too — pre-existing and unrelated.)
- `grep` for the helper names across the repo returns nothing but
  `StringPtrOrNil`.

Out of scope, so reverted rather than kept: `go fix` also wanted to rewrite
`reflect.Ptr` → `reflect.Pointer` in `internal/redaction/redactor.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
