### PR TITLE
docs(record): state current behavior in two cmd/record doc comments

### DIFF
--- a/cmd/record/main.go
+++ b/cmd/record/main.go
@@ -1,5 +1,5 @@
 // Package main provides the record command for the go-safe-cmd-runner.
-// It records file hashes for later verification and now supports multiple files.
+// It records the hashes of one or more files for later verification.
 package main
 
 import (
@@ -70,10 +70,10 @@ func defaultDeps() deps {
 	}
 }
 
-// hashRecorder records the hash of a file and returns the hash file path,
-// the content hash in prefixed format (e.g., "sha256:<hex>"), and any error.
-// Implementations must return the content hash in "<algorithm>:<hex>" format,
-// as it is passed directly to syscall analysis storage.
+// hashRecorder records the hash of a file and returns the hash file path, the
+// content hash, and any error. Implementations must return the content hash in
+// "<algorithm>:<hex>" form (e.g. "sha256:abc..."), as it is passed directly to
+// syscall analysis storage.
 type hashRecorder interface {
 	SaveRecord(filePath string, force bool) (string, string, error)
 }


### PR DESCRIPTION
`cmd/record/main.go` の doc コメント2件を、現状を述べる形に直します。挙動の変更はありません。

タスク 0164 の PR-3 でこのファイルのコメントを整理した際に見つけたもので、いずれも 0164 由来ではないため別 PR にしました。

## 変更内容

- **パッケージコメント**: 「and **now** supports multiple files」の "now" は変更履歴の名残です。読む人はどのリリースを基準にした "now" か特定できませんし、複数ファイル対応は現在の仕様そのものです。CLAUDE.md の「本文は現状を述べ、新旧比較は変更履歴へ」に揃えました。
- **`hashRecorder`**: 内容ハッシュの形式を `"sha256:<hex>"` と `"<algorithm>:<hex>"` の2回書いていました。契約は後者なので、前者はその例として位置づけ直しました。

## 対象外

同じく PR-3 で見つけた `deps` の「This makes the dependency graph visible at call sites and simplifies testing.」（どの DI にも言える一般論で、この型固有の情報がない）は、[#1026](https://github.com/isseis/go-safe-cmd-runner/pull/1026) がこの doc コメント自体に行を追加しているため、含めていません。並行する2つの PR が同じコメントを書き換えると衝突するので、#1026 のマージ後に扱うのが妥当と判断しました。

## テスト

`make test` / `make lint` が緑であることを確認済みです。コメントのみの変更のため、テストの追加はありません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
